### PR TITLE
Adds require of clojure.core.async to make lein uberjar work

### DIFF
--- a/kitchen/src/kitchen/utils.clj
+++ b/kitchen/src/kitchen/utils.clj
@@ -1,4 +1,7 @@
 (ns kitchen.utils
+  ; Despite not being explicitly used, the clojure.core.async
+  ; require is needed because lein uberjar fails in some
+  ; environments without it (https://github.com/twosigma/waiter/pull/10).
   (:require [clj-time.core :as t]
             [clj-time.format :as f]
             [clojure.core.async :as async]

--- a/kitchen/src/kitchen/utils.clj
+++ b/kitchen/src/kitchen/utils.clj
@@ -1,6 +1,7 @@
 (ns kitchen.utils
   (:require [clj-time.core :as t]
             [clj-time.format :as f]
+            [clojure.core.async :as async]
             [clojure.data.json :as json]
             [clojure.string :as str])
   (:import clojure.core.async.impl.channels.ManyToManyChannel


### PR DESCRIPTION
Without this, I'm seeing:

```bash
$ lein do clean, uberjar
WARNING: record? already refers to: #'clojure.core/record? in namespace: clojure.core.logic, being replaced by: #'clojure.core.logic/record?
Reflection warning, leiningen/voom.clj:184:3 - reference to field getBytes can't be resolved.
Compiling kitchen.utils
java.lang.ClassNotFoundException: clojure.core.async.impl.channels.ManyToManyChannel, compiling:(utils.clj:1:1)
Exception in thread "main" java.lang.ClassNotFoundException: clojure.core.async.impl.channels.ManyToManyChannel, compiling:(utils.clj:1:1)
```
With this, all good:

```bash
$ lein do clean, uberjar
WARNING: record? already refers to: #'clojure.core/record? in namespace: clojure.core.logic, being replaced by: #'clojure.core.logic/record?
Reflection warning, leiningen/voom.clj:184:3 - reference to field getBytes can't be resolved.
Compiling kitchen.utils
Compiling kitchen.pi
Compiling kitchen.core
2017-05-31 23:40:28.036:INFO::main: Logging initialized @5835ms to org.eclipse.jetty.util.log.StdErrLog
Created /home/dpo/source/waiter-3/kitchen/target/uberjar/kitchen-0.1.0-SNAPSHOT.jar
Created /home/dpo/source/waiter-3/kitchen/target/uberjar/kitchen-0.1.0-SNAPSHOT-standalone.jar
```
