### PR TITLE
Runs :integration-fast tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ jobs:
     - stage: unit tests
       script: cd kitchen && lein with-profiles +test do voom build-deps, test
     - stage: integration tests
-      script: echo running integration tests...
+      script: cd waiter && lein with-profiles +test voom build-deps && ./bin/ci/run-integration-tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 language: java
 jdk:
 - oraclejdk8
+services:
+  - docker
 branches:
   only:
   - master
-jobs:
-  include:
-    - stage: unit tests
-      script: cd waiter && lein with-profiles +test voom build-deps && ./bin/ci/run-unit-tests.sh
-    - stage: unit tests
-      script: cd kitchen && lein with-profiles +test do voom build-deps, test
-    - stage: integration tests
-      script: cd waiter && lein with-profiles +test voom build-deps && ./bin/ci/run-integration-tests.sh
+env:
+  global:
+    - DEPS_CMD='lein with-profiles +test voom build-deps'
+  matrix:
+    - TEST_DIR=waiter TEST_CMD=./bin/ci/run-unit-tests.sh
+    - TEST_DIR=kitchen TEST_CMD='lein test'
+    - TEST_DIR=waiter TEST_CMD=./bin/ci/run-integration-tests.sh
+before_script: (cd $TEST_DIR && $DEPS_CMD)
+script: cd $TEST_DIR && $TEST_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-language: clojure
-lein: 2.6.1
+language: java
 jdk:
 - oraclejdk8
 services:
@@ -14,5 +13,5 @@ env:
     - TEST_DIR=waiter TEST_CMD=./bin/ci/run-unit-tests.sh
     - TEST_DIR=kitchen TEST_CMD='lein test'
     - TEST_DIR=waiter TEST_CMD=./bin/ci/run-integration-tests.sh
-before_script: (cd $TEST_DIR && $DEPS_CMD)
+before_script: (lein downgrade 2.6.1 && cd $TEST_DIR && $DEPS_CMD)
 script: cd $TEST_DIR && $TEST_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,12 @@ branches:
 env:
   global:
     - DEPS_CMD='lein with-profiles +test voom build-deps'
+    - LEIN_GET='wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein'
+    - LEIN_CHMOD='chmod +x ./lein'
+    - LEIN_DOWN='lein downgrade 2.6.1'
   matrix:
     - TEST_DIR=waiter TEST_CMD=./bin/ci/run-unit-tests.sh
     - TEST_DIR=kitchen TEST_CMD='lein test'
     - TEST_DIR=waiter TEST_CMD=./bin/ci/run-integration-tests.sh
-before_script: (yes | lein downgrade 2.6.1 && cd $TEST_DIR && $DEPS_CMD)
+before_script: ($LEIN_GET && $LEIN_CHMOD && export PATH=$(pwd):$PATH && yes | $LEIN_DOWN && cd $TEST_DIR && $DEPS_CMD)
 script: cd $TEST_DIR && $TEST_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+lein: 2.6.1
 jdk:
 - oraclejdk8
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ jdk:
 branches:
   only:
   - master
-env:
-  global:
-    - DEPS_CMD='lein with-profiles +test voom build-deps'
-  matrix:
-    - TEST_DIR=waiter TEST_CMD=./bin/ci/run-unit-tests.sh
-    - TEST_DIR=kitchen TEST_CMD='lein test'
-before_script: (cd $TEST_DIR && $DEPS_CMD)
-script: cd $TEST_DIR && $TEST_CMD
+jobs:
+  include:
+    - stage: unit tests
+      before_script: (cd waiter && lein with-profiles +test voom build-deps)
+      script: cd waiter && ./bin/ci/run-unit-tests.sh
+      before_script: (cd kitchen && lein with-profiles +test voom build-deps)
+      script: cd kitchen && lein test
+    - stage: integration tests
+      script: echo running integration tests...

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,7 @@ branches:
 jobs:
   include:
     - stage: unit tests
-      before_script: (cd waiter && lein with-profiles +test voom build-deps)
-      script: cd waiter && ./bin/ci/run-unit-tests.sh
-      before_script: (cd kitchen && lein with-profiles +test voom build-deps)
-      script: cd kitchen && lein test
+      script: cd waiter && lein with-profiles +test voom build-deps && ./bin/ci/run-unit-tests.sh
+      script: cd kitchen && lein with-profiles +test do voom build-deps, test
     - stage: integration tests
       script: echo running integration tests...

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ env:
     - TEST_DIR=waiter TEST_CMD=./bin/ci/run-unit-tests.sh
     - TEST_DIR=kitchen TEST_CMD='lein test'
     - TEST_DIR=waiter TEST_CMD=./bin/ci/run-integration-tests.sh
-before_script: (lein downgrade 2.6.1 && cd $TEST_DIR && $DEPS_CMD)
+before_script: (yes | lein downgrade 2.6.1 && cd $TEST_DIR && $DEPS_CMD)
 script: cd $TEST_DIR && $TEST_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: java
+language: clojure
 lein: 2.6.1
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ jobs:
   include:
     - stage: unit tests
       script: cd waiter && lein with-profiles +test voom build-deps && ./bin/ci/run-unit-tests.sh
+    - stage: unit tests
       script: cd kitchen && lein with-profiles +test do voom build-deps, test
     - stage: integration tests
       script: echo running integration tests...

--- a/waiter/bin/ci/minimesos
+++ b/waiter/bin/ci/minimesos
@@ -2,7 +2,7 @@
 
 set -e
 
-MINIMESOS_TAG="0.12.0"
+MINIMESOS_TAG="0.13.0"
 PARAMS="$@"
 MINIMESOS_CLI_IMAGE="containersol/minimesos-cli"
 

--- a/waiter/bin/ci/minimesos
+++ b/waiter/bin/ci/minimesos
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -e
+
+MINIMESOS_TAG="0.12.0"
+PARAMS="$@"
+MINIMESOS_CLI_IMAGE="containersol/minimesos-cli"
+
+command_exists() {
+    command -v "$@" > /dev/null 2>&1
+}
+
+DOCKER_VERSION=$(docker version --format "{{.Server.Version}}")
+SMALLEST_VERSION=$(printf "%s\n1.11.0\n" $DOCKER_VERSION | sort -t '.' -k 1,1 -k 2,2 -k 3,3 -k 4,4 -g | head -n 1)
+
+if ! command_exists docker || [ $SMALLEST_VERSION != "1.11.0" ]; then
+    echo "Minimesos requires Docker 1.11.0 or higher"
+    exit 1
+fi
+
+if [ "$DOCKER_HOST" != "" ] && [[ $DOCKER_HOST == tcp* ]]; then
+    DOCKER_HOST_IP=$(echo "$DOCKER_HOST" | grep -o '[0-9]\+[.][0-9]\+[.][0-9]\+[.][0-9]\+')
+elif command_exists docker-machine && [ "$DOCKER_MACHINE_NAME" != "" ]; then
+    DOCKER_HOST_IP=$(docker-machine ip ${DOCKER_MACHINE_NAME})
+elif [ $(uname) != "Darwin" ]; then
+    DOCKER_HOST_IP=$(ip addr show dev docker0 | grep inet | sed -r "s/.*inet\s([0-9\.]+)\/.*/\1/" | head -n 1)
+else
+    DOCKER_HOST_IP=""
+fi
+
+pullImage() {
+    if [ "$(docker images $1 | grep $2 2> /dev/null)" = "" ]; then
+	echo "Pulling $1:$2"
+	docker pull "$1:$2"
+    fi
+}
+
+if [ "$#" -gt 0 -a "$1" = up ]; then
+    pullImage ${MINIMESOS_CLI_IMAGE} ${MINIMESOS_TAG}
+fi
+
+if [ $(uname) == "Darwin" ]; then
+  MINIMESOS_OS="Mac OS X"
+else
+  MINIMESOS_OS="Linux"
+fi
+
+MINIMESOS_HOST_DIR="$(pwd)"
+MINIMESOS_DIR="$(pwd)/.minimesos"
+if [ ! -d "${MINIMESOS_DIR}" ]; then
+    mkdir -p "${MINIMESOS_DIR}"
+    echo "# Created minimesos directory at ${MINIMESOS_DIR}."
+fi
+
+docker run --rm -v "${MINIMESOS_HOST_DIR}":"${MINIMESOS_HOST_DIR}" \
+       -v /var/run/docker.sock:/var/run/docker.sock \
+       -v /sys/fs/cgroup:/sys/fs/cgroup \
+       -i \
+       --env DOCKER_HOST_IP=${DOCKER_HOST_IP} \
+       --env MINIMESOS_OS="${MINIMESOS_OS}" \
+       --entrypoint java \
+       ${MINIMESOS_CLI_IMAGE}:${MINIMESOS_TAG} \
+       -Dminimesos.host.dir="${MINIMESOS_HOST_DIR}" \
+       -jar /usr/local/share/minimesos/minimesos-cli.jar ${PARAMS}

--- a/waiter/bin/ci/run-integration-tests.sh
+++ b/waiter/bin/ci/run-integration-tests.sh
@@ -22,8 +22,10 @@ KITCHEN_DIR=${WAITER_DIR}/../kitchen
 ${KITCHEN_DIR}/bin/build-docker-image.sh
 
 # Start minimesos
+export PATH=${DIR}:${PATH}
+which minimesos
 pushd ${WAITER_DIR}
-${DIR}/minimesos up
+minimesos up
 MINIMESOS_EXIT_CODE=$?
 popd
 if [ ${MINIMESOS_EXIT_CODE} -ne 0 ]; then

--- a/waiter/bin/ci/run-integration-tests.sh
+++ b/waiter/bin/ci/run-integration-tests.sh
@@ -16,11 +16,20 @@ export -f wait_for_waiter
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 WAITER_DIR=${DIR}/../..
+KITCHEN_DIR=${WAITER_DIR}/../kitchen
+
+# Build mesos agent with kitchen backed in
+${KITCHEN_DIR}/bin/build-docker-image.sh
 
 # Start minimesos
 pushd ${WAITER_DIR}
 ${DIR}/minimesos up
+MINIMESOS_EXIT_CODE=$?
 popd
+if [ ${MINIMESOS_EXIT_CODE} -ne 0 ]; then
+    echo "minimesos failed to startup -- exiting"
+    exit ${MINIMESOS_EXIT_CODE}
+fi
 
 # Start waiter
 ${WAITER_DIR}/bin/run-using-minimesos.sh 9091 &

--- a/waiter/bin/ci/run-integration-tests.sh
+++ b/waiter/bin/ci/run-integration-tests.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Usage: run-integration-tests.sh
+#
+# Runs the Waiter integration tests, and dumps log files if the tests fail.
+
+function wait_for_waiter {
+    WAITER_PORT=${1:-9091}
+    while ! curl -s localhost:${WAITER_PORT} >/dev/null;
+    do
+        echo "$(date +%H:%M:%S) waiter is not listening on ${WAITER_PORT} yet"
+        sleep 2.0
+    done
+    echo "$(date +%H:%M:%S) connected to waiter on ${WAITER_PORT}!"
+}
+export -f wait_for_waiter
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+WAITER_DIR=${DIR}/../..
+
+# Start minimesos
+pushd ${WAITER_DIR}
+${DIR}/minimesos up
+popd
+
+# Start waiter
+${WAITER_DIR}/bin/run-using-minimesos.sh 9091 &
+
+# Wait for waiter to be listening
+timeout 180s bash -c "wait_for_waiter 9091"
+if [ $? -ne 0 ]; then
+  echo "$(date +%H:%M:%S) timed out waiting for waiter to start listening, displaying waiter log"
+  cat ${WAITER_DIR}/log/waiter.log
+  exit 1
+fi
+
+# Run the integration tests
+WAITER_TEST_KITCHEN_CMD=/opt/kitchen/container-run.sh lein with-profiles +test-repl test :integration-fast
+TESTS_EXIT_CODE=$?
+
+# If there were failures, dump the logs
+if [ ${TESTS_EXIT_CODE} -ne 0 ]; then
+    echo "integration tests failed -- dumping logs"
+    tail -n +1 -- log/*.log
+fi
+
+exit ${TESTS_EXIT_CODE}


### PR DESCRIPTION
This PR adds running of the `:integration-fast` tests to our travis build.

## What's in here?

- building a kitchen-enabled mesos agent docker image
- starting up minimesos
- starting up one waiter router
- running `:integration-fast`

## What's not in here?

- running `:integration-slow`
- running the tests against a multi-router cluster instead of just one router
- running the tests in parallel

These items will come in follow-up PRs.