### PR TITLE
Avoids calling krb5_prestash in test-kerberos-authenticator

### DIFF
--- a/waiter/test/waiter/auth/kerberos_test.clj
+++ b/waiter/test/waiter/auth/kerberos_test.clj
@@ -110,9 +110,10 @@
         (is (nil? (check-has-prestashed-tickets query-chan nil "service-id")))))))
 
 (deftest test-kerberos-authenticator
-  (let [config {:password "test-password"
-                :prestash-cache-refresh-ms 100
-                :prestash-cache-min-refresh-ms 10
-                :prestash-query-host "example.com"}
-        authenticator (kerberos-authenticator config)]
-    (is (= :kerberos (auth/auth-type authenticator)))))
+  (with-redefs [start-prestash-cache-maintainer (constantly nil)]
+    (let [config {:password "test-password"
+                  :prestash-cache-refresh-ms 100
+                  :prestash-cache-min-refresh-ms 10
+                  :prestash-query-host "example.com"}
+          authenticator (kerberos-authenticator config)]
+      (is (= :kerberos (auth/auth-type authenticator))))))


### PR DESCRIPTION
Without this PR, this unit test attempts to shell out and call `krb5_prestash`, which fails miserably on systems without kerberos.