### PR TITLE
Support for nginx as a proxy for one or more waiters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,11 @@ env:
     - TEST_DIR=kitchen TEST_CMD='lein test'
     - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests.sh integration-fast'
     - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests.sh integration-slow'
+cache:
+  - apt
+addons:
+  apt:
+    packages:
+      - nginx
 before_script: ($LEIN_GET && $LEIN_CHMOD && export PATH=$(pwd):$PATH && yes | $LEIN_DOWN && cd $TEST_DIR && $DEPS_CMD)
 script: cd $TEST_DIR && $TEST_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,8 @@ env:
     - TEST_DIR=waiter TEST_CMD=./bin/ci/run-unit-tests.sh
     - TEST_DIR=kitchen TEST_CMD='lein test'
     - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests.sh integration-fast parallel-test'
-    - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests.sh integration-slow test'
-addons:
-  apt:
-    packages:
-      - nginx
+    - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests.sh integration-slow parallel-test'
 cache:
-  apt: true
   directories:
     - $HOME/.m2
     - $HOME/.voom-repos

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ env:
   matrix:
     - TEST_DIR=waiter TEST_CMD=./bin/ci/run-unit-tests.sh
     - TEST_DIR=kitchen TEST_CMD='lein test'
-    - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests.sh integration-fast'
-    - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests.sh integration-slow'
+    - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests.sh integration-fast parallel-test'
+    - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests.sh integration-slow test'
 cache:
   - apt
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ env:
   matrix:
     - TEST_DIR=waiter TEST_CMD=./bin/ci/run-unit-tests.sh
     - TEST_DIR=kitchen TEST_CMD='lein test'
-    - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests.sh integration-fast parallel-test'
-    - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests.sh integration-slow parallel-test'
+    - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests.sh parallel-test integration-fast'
+    - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests.sh parallel-test integration-slow'
 cache:
   directories:
     - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,14 @@ env:
     - TEST_DIR=kitchen TEST_CMD='lein test'
     - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests.sh integration-fast parallel-test'
     - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests.sh integration-slow test'
-cache:
-  - apt
 addons:
   apt:
     packages:
       - nginx
+cache:
+  apt: true
+  directories:
+    - $HOME/.m2
+    - $HOME/.voom-repos
 before_script: ($LEIN_GET && $LEIN_CHMOD && export PATH=$(pwd):$PATH && yes | $LEIN_DOWN && cd $TEST_DIR && $DEPS_CMD)
 script: cd $TEST_DIR && $TEST_CMD

--- a/waiter/.gitignore
+++ b/waiter/.gitignore
@@ -20,6 +20,7 @@ test2junit/
 
 # Configuration for your local environment
 *config-local.edn
+bin/generated-nginx.conf
 
 # Shell scheduler directory
 scheduler/

--- a/waiter/bin/ci/run-integration-tests.sh
+++ b/waiter/bin/ci/run-integration-tests.sh
@@ -70,11 +70,10 @@ ${WAITER_DIR}/bin/run-nginx.sh ${WAITERS} ${NGINX_PORT} ${NGINX_DAEMON}
 
 # Set WAITER_URI, which is used by the integration tests
 export WAITER_URI=localhost:${NGINX_PORT}
+curl -s ${WAITER_URI}/state | jq .routers
 
 # Nginx should be round-robin load balancing, this should show different ports
-echo "getting port from /settings once..."
 curl -s ${WAITER_URI}/settings | jq .port
-echo "getting port from /settings again..."
 curl -s ${WAITER_URI}/settings | jq .port
 
 # Run the integration tests

--- a/waiter/bin/ci/run-integration-tests.sh
+++ b/waiter/bin/ci/run-integration-tests.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# Usage: run-integration-tests.sh [TEST_SELECTOR] [TEST_COMMAND]
+# Usage: run-integration-tests.sh [TEST_COMMAND] [TEST_SELECTOR]
 #
 # Examples:
-#   run-integration-tests.sh integration parallel-test
-#   run-integration-tests.sh integration-fast
-#   run-integration-tests.sh integration-slow
+#   run-integration-tests.sh parallel-test integration-fast
+#   run-integration-tests.sh parallel-test integration-slow
+#   run-integration-tests.sh parallel-test
 #   run-integration-tests.sh
 #
 # Runs the Waiter integration tests, and dumps log files if the tests fail.
@@ -22,8 +22,8 @@ function wait_for_waiter {
 }
 export -f wait_for_waiter
 
-TEST_SELECTOR=${1:-integration}
-TEST_COMMAND=${2:-parallel-test}
+TEST_COMMAND=${1:-parallel-test}
+TEST_SELECTOR=${2:-integration}
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 WAITER_DIR=${DIR}/../..
@@ -43,7 +43,6 @@ if [ ${MINIMESOS_EXIT_CODE} -ne 0 ]; then
     echo "minimesos failed to startup -- exiting"
     exit ${MINIMESOS_EXIT_CODE}
 fi
-$(minimesos info | grep MINIMESOS)
 
 # Start waiter
 WAITER_PORT=9091
@@ -58,7 +57,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # Set WAITER_URI, which is used by the integration tests
-export WAITER_URI=localhost:${WAITER_PORT}
+export WAITER_URI=127.0.0.1:${WAITER_PORT}
 curl -s ${WAITER_URI}/state | jq .routers
 curl -s ${WAITER_URI}/settings | jq .port
 

--- a/waiter/bin/ci/run-integration-tests.sh
+++ b/waiter/bin/ci/run-integration-tests.sh
@@ -9,6 +9,8 @@
 #
 # Runs the Waiter integration tests, and dumps log files if the tests fail.
 
+set -v
+
 function wait_for_waiter {
     WAITER_PORT=${1:-9091}
     while ! curl -s localhost:${WAITER_PORT} >/dev/null;
@@ -61,7 +63,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # Start nginx
-WAITERS=${MINIMESOS_NETWORK_GATEWAY}:9091;${MINIMESOS_NETWORK_GATEWAY}:9092
+WAITERS="${MINIMESOS_NETWORK_GATEWAY}:9091;${MINIMESOS_NETWORK_GATEWAY}:9092"
 NGINX_PORT=9300
 NGINX_DAEMON=on
 ${WAITER_DIR}/bin/run-nginx.sh ${WAITERS} ${NGINX_PORT} ${NGINX_DAEMON}

--- a/waiter/bin/ci/run-integration-tests.sh
+++ b/waiter/bin/ci/run-integration-tests.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# Usage: run-integration-tests.sh [TEST_SELECTOR]
+# Usage: run-integration-tests.sh [TEST_SELECTOR] [TEST_COMMAND]
 #
 # Examples:
-#   run-integration-tests.sh integration
+#   run-integration-tests.sh integration parallel-test
 #   run-integration-tests.sh integration-fast
 #   run-integration-tests.sh integration-slow
 #   run-integration-tests.sh
@@ -23,6 +23,7 @@ function wait_for_waiter {
 export -f wait_for_waiter
 
 TEST_SELECTOR=${1:-integration}
+TEST_COMMAND=${2:-parallel-test}
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 WAITER_DIR=${DIR}/../..
@@ -77,7 +78,7 @@ curl -s ${WAITER_URI}/settings | jq .port
 curl -s ${WAITER_URI}/settings | jq .port
 
 # Run the integration tests
-WAITER_TEST_KITCHEN_CMD=/opt/kitchen/container-run.sh lein with-profiles +test-repl parallel-test :${TEST_SELECTOR}
+WAITER_TEST_KITCHEN_CMD=/opt/kitchen/container-run.sh lein with-profiles +test-console ${TEST_COMMAND} :${TEST_SELECTOR}
 TESTS_EXIT_CODE=$?
 
 # If there were failures, dump the logs

--- a/waiter/bin/nginx.conf
+++ b/waiter/bin/nginx.conf
@@ -1,0 +1,36 @@
+daemon {NGINX_DAEMON};
+error_log log/nginx-error.log;
+pid log/nginx.pid;
+
+events {
+  worker_connections 4096;
+}
+
+http {
+    access_log log/nginx-access.log;
+
+    upstream localhost {
+        {NGINX_HTTP_UPSTREAM}
+    }
+
+    server {
+        listen {NGINX_HTTP_SERVER_PORT};
+
+        # Accept large headers from clients
+        large_client_header_buffers 4 32k;
+
+        # Accept large bodies from clients
+        client_body_buffer_size 1024k;
+
+        location / {
+            # Don't buffer responses from proxied Waiters
+            proxy_buffering off;
+
+            # Proxy to the upstream defined above
+            proxy_pass http://localhost;
+
+            # Pass the appropriate Host header through to Waiter
+            proxy_set_header Host $host:$server_port;
+        }
+    }
+}

--- a/waiter/bin/nginx.conf
+++ b/waiter/bin/nginx.conf
@@ -1,5 +1,5 @@
 daemon {NGINX_DAEMON};
-error_log log/nginx-error.log;
+error_log log/nginx.log info;
 pid log/nginx.pid;
 
 events {
@@ -8,6 +8,11 @@ events {
 
 http {
     access_log log/nginx-access.log;
+
+    # Set the timeout period to upstream Waiters
+    proxy_connect_timeout 300;
+    proxy_send_timeout 300;
+    proxy_read_timeout 300;
 
     upstream localhost {
         {NGINX_HTTP_UPSTREAM}
@@ -31,12 +36,6 @@ http {
 
             # Pass the appropriate Host header through to Waiter
             proxy_set_header Host $host:$server_port;
-
-            # Set the timeout period to upstream Waiters
-            proxy_connect_timeout 300;
-            proxy_send_timeout 300;
-            proxy_read_timeout 300;
-            send_timeout 300;
         }
     }
 }

--- a/waiter/bin/nginx.conf
+++ b/waiter/bin/nginx.conf
@@ -25,7 +25,8 @@ http {
         large_client_header_buffers 4 32k;
 
         # Accept large bodies from clients
-        client_body_buffer_size 1024k;
+        client_body_buffer_size 16M;
+        client_max_body_size 16M;
 
         location / {
             # Don't buffer responses from proxied Waiters

--- a/waiter/bin/nginx.conf
+++ b/waiter/bin/nginx.conf
@@ -31,6 +31,12 @@ http {
 
             # Pass the appropriate Host header through to Waiter
             proxy_set_header Host $host:$server_port;
+
+            # Set the timeout period to upstream Waiters
+            proxy_connect_timeout 300;
+            proxy_send_timeout 300;
+            proxy_read_timeout 300;
+            send_timeout 300;
         }
     }
 }

--- a/waiter/bin/run-nginx.sh
+++ b/waiter/bin/run-nginx.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Usage: run-nginx.sh [WAITER_SERVERS] [NGINX_HTTP_SERVER_PORT] [NGINX_DAEMON]
+#
+# Examples:
+#   run-nginx.sh 172.17.0.1:9091;172.17.0.1:9092 9300 off
+#   run-nginx.sh 172.17.0.1:9091;172.17.0.1:9092 9300
+#   run-nginx.sh 172.17.0.1:9091;172.17.0.1:9092
+#   run-nginx.sh
+#
+# Runs nginx, configured to proxy the provided Waiters and to listen on the provided port.
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+WAITER_DIR=${DIR}/..
+
+WAITER_SERVERS=${1:-172.17.0.1:9091;172.17.0.1:9092}
+NGINX_HTTP_SERVER_PORT=${2:-9300}
+NGINX_DAEMON=${3:-off}
+
+while IFS=';' read -ra SERVERS; do
+      for server in "${SERVERS[@]}"; do
+          NGINX_HTTP_UPSTREAM="${NGINX_HTTP_UPSTREAM}server ${server}; "
+      done
+done <<< "${WAITER_SERVERS}"
+
+echo "NGINX_HTTP_UPSTREAM = ${NGINX_HTTP_UPSTREAM}"
+echo "NGINX_HTTP_SERVER_PORT = ${NGINX_HTTP_SERVER_PORT}"
+echo "NGINX_DAEMON = ${NGINX_DAEMON}"
+
+function generate_from_template {
+    sed \
+        -e "s|{NGINX_HTTP_UPSTREAM}|${NGINX_HTTP_UPSTREAM}|g" \
+        -e "s|{NGINX_HTTP_SERVER_PORT}|${NGINX_HTTP_SERVER_PORT}|g" \
+        -e "s|{NGINX_DAEMON}|${NGINX_DAEMON}|g" \
+        < $1 > $2
+}
+
+NGINX_GENERATED_CONF=${DIR}/generated-nginx.conf
+generate_from_template "${DIR}/nginx.conf" "${NGINX_GENERATED_CONF}"
+nginx -c ${NGINX_GENERATED_CONF} -p ${WAITER_DIR}

--- a/waiter/bin/run-using-minimesos.sh
+++ b/waiter/bin/run-using-minimesos.sh
@@ -26,4 +26,4 @@ fi
 
 echo "Starting waiter..."
 cd ${DIR}/..
-WAITER_AUTH_RUN_AS_USER=$(id -un) lein run config-minimesos.edn
+WAITER_AUTH_RUN_AS_USER=$(id -un) WAITER_LOG_FILE_PREFIX=${WAITER_PORT}- lein run config-minimesos.edn

--- a/waiter/config-minimesos.edn
+++ b/waiter/config-minimesos.edn
@@ -16,6 +16,12 @@
  :authenticator-config {:kind :one-user
                         :one-user {;; The user account used to launch services:
                                    :run-as-user #config/env "WAITER_AUTH_RUN_AS_USER"}}
+ :cors-config {
+               ;; :kind :patterns takes a simple list of regular expressions (see below):
+               :kind :patterns
+               :patterns {
+                          ;; List of regular expressions representing origins to allow:
+                          :allowed-origins [#config/regex "^http://[^\\.]+\\.localhost:\\d+$"]}}
 
  ; ---------- Scheduling ----------
 

--- a/waiter/integration/waiter/async_request_integration_test.clj
+++ b/waiter/integration/waiter/async_request_integration_test.clj
@@ -190,6 +190,7 @@
           (parallelize-requests
             num-threads 1
             (fn []
+              (log/info "making kitchen request")
               (let [async-request-headers
                     (assoc request-headers :x-kitchen-delay-ms (int (* (max 0.5 (double (rand))) request-processing-time-ms))
                                            :x-kitchen-store-async-response-ms 600000)
@@ -198,7 +199,8 @@
                     status-location (get (pc/map-keys str/lower-case headers) "location")]
                 (assert-response-status response 202)
                 (is (not (str/blank? status-location)))
-                status-location)))]
+                status-location))
+            :verbose true)]
 
       (testing "validate-pending-request-counters"
         (Thread/sleep inter-router-metrics-interval-ms) ;; allow routers to sync metrics

--- a/waiter/integration/waiter/autoscaling_test.clj
+++ b/waiter/integration/waiter/autoscaling_test.clj
@@ -217,6 +217,7 @@
                           :x-waiter-name (rand-name "test-minmax-instances")
                           :x-waiter-scale-up-factor 0.99}
           request-fn (fn [& {:keys [cookies] :or {cookies {}}}]
+                       (log/info "making kitchen request")
                        (make-request-with-debug-info
                          custom-headers
                          #(make-kitchen-request waiter-url % :cookies cookies)))

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -50,31 +50,24 @@
           request-headers {:x-waiter-name service-name}
           canary-response (make-request-with-debug-info request-headers #(make-kitchen-request waiter-url % :path "/secrun"))
           all-chars (map char (range 33 127))
-          random-string (fn [n] (reduce str (take n (repeatedly #(rand-nth all-chars)))))]
-      (testing "header-length-2000"
-        (assert-response-status
-          (make-kitchen-request waiter-url (assoc request-headers :x-kitchen-long-string (random-string 2000)))
-          200))
-      (testing "header-length-4000"
-        (assert-response-status
-          (make-kitchen-request waiter-url (assoc request-headers :x-kitchen-long-string (random-string 4000)))
-          200))
-      (testing "header-length-8000"
-        (assert-response-status
-          (make-kitchen-request waiter-url (assoc request-headers :x-kitchen-long-string (random-string 8000)))
-          200))
-      (testing "header-length-16000"
-        (assert-response-status
-          (make-kitchen-request waiter-url (assoc request-headers :x-kitchen-long-string (random-string 16000)))
-          200))
-      (testing "header-length-20000"
-        (assert-response-status
-          (make-kitchen-request waiter-url (assoc request-headers :x-kitchen-long-string (random-string 20000)))
-          200))
-      (testing "header-length-24000"
-        (assert-response-status
-          (make-kitchen-request waiter-url (assoc request-headers :x-kitchen-long-string (random-string 24000)))
-          200))
+          random-string (fn [n] (reduce str (take n (repeatedly #(rand-nth all-chars)))))
+          make-request (fn [header-size]
+                         (log/info "making request with header size" header-size)
+                         (make-kitchen-request waiter-url
+                                               (assoc request-headers :x-kitchen-long-string
+                                                                      (random-string header-size))))]
+      (let [response (make-request 2000)]
+        (assert-response-status response 200))
+      (let [response (make-request 4000)]
+        (assert-response-status response 200))
+      (let [response (make-request 8000)]
+        (assert-response-status response 200))
+      (let [response (make-request 16000)]
+        (assert-response-status response 200))
+      (let [response (make-request 20000)]
+        (assert-response-status response 200))
+      (let [response (make-request 24000)]
+        (assert-response-status response 200))
       (delete-service waiter-url (:service-id canary-response)))))
 
 ; Marked explicit due to:

--- a/waiter/integration/waiter/busy_instance_test.clj
+++ b/waiter/integration/waiter/busy_instance_test.clj
@@ -27,7 +27,8 @@
 
       ;; Make requests to get instances started and avoid shuffling among routers later
       (parallelize-requests 8 10 #(http/get url {:headers (assoc req-headers :x-kitchen-delay-ms 4000)
-                                                 :spnego-auth true}))
+                                                 :spnego-auth true})
+                            :verbose true)
 
       ;; Make a request that returns a 503
       (let [start-millis (System/currentTimeMillis)
@@ -47,7 +48,8 @@
                         #(let [{:keys [headers]} (http/get url {:headers req-headers :spnego-auth true})]
                            (when (-> (System/currentTimeMillis) (- start-millis) (< (- blacklist-time-millis 1000)))
                              (and (= backend-id (get headers "X-Waiter-Backend-Id"))
-                                  (= router-id (get headers "X-Waiter-Router-Id"))))))]
+                                  (= router-id (get headers "X-Waiter-Router-Id")))))
+                        :verbose true)]
           (is (every? #(not %) results))))
 
       (delete-service waiter-url (retrieve-service-id waiter-url req-headers)))))

--- a/waiter/integration/waiter/busy_instance_test.clj
+++ b/waiter/integration/waiter/busy_instance_test.clj
@@ -23,12 +23,14 @@
           req-headers (walk/stringify-keys
                         (merge (kitchen-request-headers)
                                {:x-waiter-name (rand-name "testbusyinstance")
-                                :x-waiter-debug true}))]
+                                :x-waiter-debug true}))
+          make-request (fn []
+                         (log/info "making kitchen request")
+                         (http/get url {:headers (assoc req-headers :x-kitchen-delay-ms 4000)
+                                        :spnego-auth true}))]
 
       ;; Make requests to get instances started and avoid shuffling among routers later
-      (parallelize-requests 8 10 #(http/get url {:headers (assoc req-headers :x-kitchen-delay-ms 4000)
-                                                 :spnego-auth true})
-                            :verbose true)
+      (parallelize-requests 8 10 make-request :verbose true)
 
       ;; Make a request that returns a 503
       (let [start-millis (System/currentTimeMillis)

--- a/waiter/integration/waiter/killed_instance_test.clj
+++ b/waiter/integration/waiter/killed_instance_test.clj
@@ -49,6 +49,7 @@
                          :x-kitchen-delay-ms 5000
                          :x-waiter-name (rand-name "delegate-kill")}
           request-fn (fn []
+                       (log/info "making kitchen request")
                        (make-kitchen-request waiter-url extra-headers))
           _ (log/info "making canary request")
           {:keys [request-headers]} (request-fn)

--- a/waiter/integration/waiter/killed_instance_test.clj
+++ b/waiter/integration/waiter/killed_instance_test.clj
@@ -54,7 +54,7 @@
           {:keys [request-headers]} (request-fn)
           service-id (retrieve-service-id waiter-url request-headers)]
       (time-it (str service-id ":" parallelism "x" requests-per-thread)
-               (parallelize-requests parallelism requests-per-thread #(request-fn)))
+               (parallelize-requests parallelism requests-per-thread #(request-fn) :verbose true))
       (is (< (* 2 (count (routers waiter-url))) (num-instances waiter-url service-id)))
       (wait-for #(= 0 (num-instances waiter-url service-id)) :timeout 180))))
 

--- a/waiter/integration/waiter/streaming_test.clj
+++ b/waiter/integration/waiter/streaming_test.clj
@@ -47,12 +47,12 @@
             (str "response-size-histogram: " response-size-histogram)))
       (delete-service waiter-url service-id))))
 
-(deftest ^:parallel ^:integration-slow test-large-request
+(deftest ^:parallel ^:integration-fast test-large-request
   (testing-using-waiter-url
     (let [request-body (apply str (take 2000000 (repeat "hello")))
          headers {:x-waiter-name (rand-name "test-large-request"), :x-kitchen-echo true}
          {:keys [body status request-headers]} (make-kitchen-request waiter-url headers :body request-body)]
-      (is (= 200 status))
+      (is (= 200 status) body)
       (is (= (count request-body) (count body)))
       (delete-service waiter-url (retrieve-service-id waiter-url request-headers)))))
 

--- a/waiter/integration/waiter/streaming_test.clj
+++ b/waiter/integration/waiter/streaming_test.clj
@@ -51,8 +51,8 @@
   (testing-using-waiter-url
     (let [request-body (apply str (take 2000000 (repeat "hello")))
          headers {:x-waiter-name (rand-name "test-large-request"), :x-kitchen-echo true}
-         {:keys [body status request-headers]} (make-kitchen-request waiter-url headers :body request-body)]
-      (is (= 200 status) body)
+         {:keys [body request-headers] :as response} (make-kitchen-request waiter-url headers :body request-body)]
+      (assert-response-status response 200)
       (is (= (count request-body) (count body)))
       (delete-service waiter-url (retrieve-service-id waiter-url request-headers)))))
 

--- a/waiter/integration/waiter/work_stealing_integration_test.clj
+++ b/waiter/integration/waiter/work_stealing_integration_test.clj
@@ -16,6 +16,7 @@
 (deftest ^:parallel ^:integration-slow test-work-stealing-load-balancing
   (testing-using-waiter-url
     (let [request-fn (fn [router-url waiter-headers & {:keys [cookies] :or {cookies nil}}]
+                       (log/info "making kitchen request")
                        (make-request-with-debug-info
                          waiter-headers
                          #(make-request router-url "/endpoint" :headers % :cookies cookies)))
@@ -36,7 +37,9 @@
 
       ;; set up
       (log/info "service-id:" service-id)
-      (parallelize-requests (+ max-instances 2) 2 #(request-fn waiter-url (assoc extra-headers :x-kitchen-delay-ms 6000)))
+      (parallelize-requests (+ max-instances 2) 2
+                            #(request-fn waiter-url (assoc extra-headers :x-kitchen-delay-ms 6000))
+                            :verbose true)
       (log/info "num instances running" (num-instances waiter-url service-id))
       (print-metrics service-id)
       ;; actual test

--- a/waiter/minimesosFile
+++ b/waiter/minimesosFile
@@ -64,6 +64,64 @@ minimesos {
         }
     }
 
+    agent {
+        imageName = "twosigma/kitchen"
+        imageTag = "latest"
+        loggingLevel = "# INHERIT FROM CLUSTER"
+        portNumber = 5053
+
+        resources {
+            cpu {
+                role = "*"
+                value = 4
+            }
+
+            disk {
+                role = "*"
+                value = 200
+            }
+
+            mem {
+                role = "*"
+                value = 2048
+            }
+
+            ports {
+                role = "*"
+                value = "[31000-32000]"
+            }
+        }
+    }
+
+    agent {
+        imageName = "twosigma/kitchen"
+        imageTag = "latest"
+        loggingLevel = "# INHERIT FROM CLUSTER"
+        portNumber = 5054
+
+        resources {
+            cpu {
+                role = "*"
+                value = 4
+            }
+
+            disk {
+                role = "*"
+                value = 200
+            }
+
+            mem {
+                role = "*"
+                value = 2048
+            }
+
+            ports {
+                role = "*"
+                value = "[31000-32000]"
+            }
+        }
+    }
+
     master {
         aclJson = null
         authenticate = false

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -101,6 +101,7 @@
              "-Dsun.security.krb5.debug=true"
              "-Djavax.security.auth.useSubjectCredsOnly=false"
              "-Dclojure.core.async.pool-size=64"
+             ~(str "-Dwaiter.logFilePrefix=" (System/getenv "WAITER_LOG_FILE_PREFIX"))
              "-XX:+UseG1GC"
              "-XX:MaxGCPauseMillis=50"
              "-XX:PermSize=1g"]

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -120,6 +120,8 @@
                           "-XX:+PrintAdaptiveSizePolicy"
                           "-Xmx512m"
                           "-Xloggc:log/gc.log"]}
+             :test-console {:jvm-opts
+                            ["-Dlog4j.configuration=log4j-console.properties"]}
              :test {:jvm-opts
                     [~(str "-Dwaiter.test.kitchen.cmd=" (or
                                                           (System/getenv "WAITER_TEST_KITCHEN_CMD")

--- a/waiter/resources/log4j-console.properties
+++ b/waiter/resources/log4j-console.properties
@@ -1,0 +1,19 @@
+log4j.rootLogger=DEBUG, stdout, file
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{4} - %m%n
+log4j.appender.stdout.Threshold=INFO
+
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.File=log/waiter-tests.log
+log4j.appender.file.ImmediateFlush=true
+log4j.appender.file.Append=true
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{4} - %m%n
+log4j.appender.file.Threshold=DEBUG
+
+# DEBUG is way too noisy for some categories
+log4j.logger.org.apache.http=INFO
+log4j.logger.org.eclipse.jetty=INFO

--- a/waiter/src/waiter/client_tools.clj
+++ b/waiter/src/waiter/client_tools.clj
@@ -477,6 +477,7 @@
                      (> target-count 300) 6
                      (> target-count 200) 5
                      (> target-count 100) 4
+                     (> target-count 60) 3
                      :else 2)
         checkpoints (set (map #(int (/ (* % target-count) num-groups)) (range 1 num-groups)))
         tasks (map (fn [_]

--- a/waiter/src/waiter/marathon.clj
+++ b/waiter/src/waiter/marathon.clj
@@ -69,10 +69,11 @@
   what the body returns. We wrap this around the calls made to marathonclj
   that call pprint on the request to avoid the unwanted output on stdout"
   [& body]
-  `(let [sw# (new StringWriter)
-         value# (binding [*out* sw#] ~@body)]
-     (.close sw#)
-     value#))
+  `(let [sw# (new StringWriter)]
+     (try
+       (binding [*out* sw#] ~@body)
+       (finally
+         (.close sw#)))))
 
 (defn process-kill-instance-request
   "Processes a kill instance request"


### PR DESCRIPTION
## What's in here?

- a script for running nginx as a proxy for one or more waiters
- the ability to specify a log file prefix at the command line so that multiple waiters can have distinct logs
- more verbosity for several long-running integration tests

## What's not in here?

- this PR doesn't actually make travis run nginx or 2 waiters, because I haven't figured out how to make that not run out of memory and/or lock up

Even though this doesn't get multiple routers running on travis, the nginx configuration and script works and is useful on local dev machines.