### PR TITLE
Distinguish service-parameters and token-metadata in token data in kv-store

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -166,7 +166,8 @@
               (log/info (str "Created configuration using token " token))
               (let [token-response (get-token waiter-url token)
                     response-body (json/read-str (:body token-response))]
-                (is (= {"health-check-url" "/custom-endpoint", "name" service-id-prefix, "owner" (retrieve-username)}
+                (is (= {"health-check-url" "/custom-endpoint", "name" service-id-prefix,
+                        "token-metadata" {"owner" (retrieve-username)}}
                        response-body)))
               (log/info (str "Asserted retrieval of configuration for token " token)))
 
@@ -474,7 +475,8 @@
           (let [token-response (get-token waiter-url token)
                 response-body (-> token-response (:body) (json/read-str) (pc/keywordize-map))]
             (is (nil? (get response-body :run-as-user)))
-            (is (= (assoc service-description :owner (retrieve-username)) response-body))))
+            (is (= (assoc service-description :token-metadata {:owner (retrieve-username)})
+                   response-body))))
 
         (testing "expecting redirect"
           (let [{:keys [body headers] :as response} (make-request waiter-url "/hello-world" :headers {"host" host-header})]
@@ -594,7 +596,8 @@
         (testing "token retrieval"
           (let [token-response (get-token waiter-url token)
                 response-body (-> token-response (:body) (json/read-str) (pc/keywordize-map))]
-            (is (= (assoc service-description :authentication "disabled" :owner current-user) response-body))))
+            (is (= (assoc service-description :authentication "disabled" :token-metadata {:owner current-user})
+                   response-body))))
 
         (testing "successful request"
           (let [{:keys [body] :as response} (make-request waiter-url "/hello-world" :headers request-headers :spnego-auth false)]

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -166,8 +166,7 @@
               (log/info (str "Created configuration using token " token))
               (let [token-response (get-token waiter-url token)
                     response-body (json/read-str (:body token-response))]
-                (is (= {"health-check-url" "/custom-endpoint", "name" service-id-prefix,
-                        "token-metadata" {"owner" (retrieve-username)}}
+                (is (= {"health-check-url" "/custom-endpoint", "name" service-id-prefix, "owner" (retrieve-username)}
                        response-body)))
               (log/info (str "Asserted retrieval of configuration for token " token)))
 
@@ -475,7 +474,7 @@
           (let [token-response (get-token waiter-url token)
                 response-body (-> token-response (:body) (json/read-str) (pc/keywordize-map))]
             (is (nil? (get response-body :run-as-user)))
-            (is (= (assoc service-description :token-metadata {:owner (retrieve-username)})
+            (is (= (assoc service-description :owner (retrieve-username))
                    response-body))))
 
         (testing "expecting redirect"
@@ -596,7 +595,7 @@
         (testing "token retrieval"
           (let [token-response (get-token waiter-url token)
                 response-body (-> token-response (:body) (json/read-str) (pc/keywordize-map))]
-            (is (= (assoc service-description :authentication "disabled" :token-metadata {:owner current-user})
+            (is (= (assoc service-description :authentication "disabled" :owner current-user)
                    response-body))))
 
         (testing "successful request"

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -545,7 +545,7 @@
 (defn acknowledge-consent-handler
   "Processes the acknowledgment to launch a service as the auth-user.
    It triggers storing of the x-waiter-consent cookie on the client."
-  [token->service-description-template service-description->service-id consent-cookie-value add-encoded-cookie
+  [token->token-description service-description->service-id consent-cookie-value add-encoded-cookie
    consent-expiry-days {:keys [request-method] :as request}]
   (try
     (when-not (= :post request-method)
@@ -567,7 +567,7 @@
         (when-not service-id
           (throw (ex-info "Missing service-id!" params))))
       (let [token (utils/authority->host host)
-            service-description-template (token->service-description-template token)]
+            {:keys [service-description-template token-metadata]} (token->token-description token)]
         (when-not (seq service-description-template)
           (throw (ex-info "Unable to load description for token!" {:token token})))
         (when (= "service" mode)
@@ -579,7 +579,7 @@
               (log/error "computed" computed-service-id ", but user[" auth-user "] provided" service-id "for" token)
               (throw (ex-info "Invalid service-id for specified token" params)))))
         (let [cookie-name "x-waiter-consent"
-              cookie-value (consent-cookie-value mode service-id token service-description-template)]
+              cookie-value (consent-cookie-value mode service-id token token-metadata)]
           (counters/inc! (metrics/waiter-counter "auto-run-as-requester" "approve-success"))
           (meters/mark! (metrics/waiter-meter "auto-run-as-requester" "approve-success"))
           (-> {:body (str "Added cookie " cookie-name), :headers {}, :status 200}

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -105,8 +105,11 @@
 ; keys allowed in a service description for on-the-fly requests
 (def ^:const on-the-fly-service-description-keys (set/union service-description-keys #{"token"}))
 
-; keys allowed in a service description templates for tokens
-(def ^:const token-service-description-template-keys (set/union service-description-keys #{"owner"}))
+; keys allowed in metadata for tokens, these need to be distinct from service description keys
+(def ^:const token-metadata-keys #{"owner"})
+
+; keys allowed in a token description
+(def ^:const token-description-keys (set/union service-description-keys token-metadata-keys))
 
 (defn map-validation-helper [issue key]
   (when-let [error (get issue key)]
@@ -345,16 +348,29 @@
   [service-description]
   (or (get service-description "health-check-url") default-health-check-path))
 
+(defn- token->kv-data
+  "Retrieves the data stored against the token in the kv-store."
+  [kv-store ^String token error-on-missing]
+  (let [{:strs [run-as-user] :as data} (when token (kv/fetch kv-store token))
+        data (when data ; populate token owner for backwards compatibility
+               (update-in data ["owner"] (fn [current-owner] (or current-owner run-as-user))))]
+    (when (and error-on-missing (not data))
+      (throw (ex-info (str "No service description template available for token " token) {})))
+    (log/debug "Extracted data for" token "is" data)
+    data))
+
+(defn token->token-description
+  "Retrieves the token description for the given token."
+  [kv-store ^String token]
+  (let [config (token->kv-data kv-store token false)]
+    {:service-description-template (select-keys config service-description-keys)
+     :token-metadata (select-keys config token-metadata-keys)}))
+
 (defn token->service-description-template
   "Retrieves the service description template for the given token."
   [kv-store ^String token & {:keys [error-on-missing] :or {error-on-missing true}}]
-  (let [config (when token (kv/fetch kv-store token))
-        config (when config ; populate token owner for backwards compatibility
-                 (update-in config ["owner"] (fn [current-owner] (or current-owner (get config "run-as-user")))))]
-    (when (and error-on-missing (not config))
-      (throw (ex-info (str "No service description template available for token " token) {})))
-    (log/debug "Extracted config for" token "is" config)
-    (or config {})))
+  (let [config (token->kv-data kv-store token error-on-missing)]
+    (select-keys config service-description-keys)))
 
 (defn retrieve-token-from-service-description-or-hostname
   "Retrieve the token name from the service description map using the x-waiter-token key.

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -243,9 +243,8 @@
   (let [{:strs [name]} service-description
         prefix (cond-> service-id-prefix
                        name (str (str/replace (str/lower-case name) #"[^a-z0-9]" "") "-"))
-        sorted-service-desc (->> service-description
-                                 (filter (fn [k] (service-description-keys (key k))))
-                                 sort)
+        sorted-service-desc (-> (select-keys service-description service-description-keys)
+                                sort)
         service-id (loop [[[k v] & kvs] sorted-service-desc
                           acc (transient [])]
                      (if k

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -197,7 +197,7 @@
                  ;;NB do not ever return the password to the user
                  (do
                    (log/info "successfully retrieved token " token)
-                   (utils/map->json-response (assoc service-description-template "token-metadata" token-metadata)))
+                   (utils/map->json-response (merge service-description-template token-metadata)))
                  (do
                    (log/info "token not found " token)
                    (utils/map->json-response {:message (str "couldn't find token " token)} :status 404)))))

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -44,12 +44,13 @@
 
   (defn store-service-description-for-token
     "Store the token mapping of the service description template in the key-value store."
-    [synchronize-fn kv-store ^String token service-description-template]
+    [synchronize-fn kv-store ^String token service-description-template token-metadata]
     (synchronize-fn
       token-lock
       (fn inner-store-service-description-for-token []
         (log/info "Storing service description for token:" token)
-        (let [{:strs [owner] :as filtered-service-desc} (sd/sanitize-service-description service-description-template sd/token-service-description-template-keys)
+        (let [token-description (merge service-description-template (select-keys token-metadata sd/token-metadata-keys))
+              {:strs [owner] :as filtered-service-desc} (sd/sanitize-service-description token-description sd/token-description-keys)
               previous-owner (get (kv/fetch kv-store token :refresh true) "owner")
               owner->owner-key (kv/fetch kv-store token-owners-key)]
           ; Store the service description
@@ -168,9 +169,9 @@
                     {:keys [token]} (sd/retrieve-token-from-service-description-or-hostname req-headers req-headers waiter-hostname)
                     current-user (get req :authorization/user)]
                 (if token
-                  (let [service-description-template (sd/token->service-description-template kv-store token :error-on-missing false)]
+                  (let [{:keys [service-description-template token-metadata]} (sd/token->token-description kv-store token)]
                     (if (and service-description-template (not-empty service-description-template))
-                      (let [token-owner (get service-description-template "owner")]
+                      (let [token-owner (get token-metadata "owner")]
                         (when-not (can-run-as? current-user token-owner)
                           (throw (ex-info "User not allowed to delete token"
                                           {:existing-owner token-owner
@@ -191,12 +192,12 @@
     :get (try
            (let [req-headers (:headers req)
                  {:keys [token]} (sd/retrieve-token-from-service-description-or-hostname req-headers req-headers waiter-hostname)]
-             (let [service-description-template (sd/token->service-description-template kv-store token :error-on-missing false)]
+             (let [{:keys [service-description-template token-metadata]} (sd/token->token-description kv-store token)]
                (if (and service-description-template (not-empty service-description-template))
                  ;;NB do not ever return the password to the user
                  (do
                    (log/info "successfully retrieved token " token)
-                   (utils/map->json-response service-description-template))
+                   (utils/map->json-response (assoc service-description-template "token-metadata" token-metadata)))
                  (do
                    (log/info "token not found " token)
                    (utils/map->json-response {:message (str "couldn't find token " token)} :status 404)))))
@@ -205,34 +206,35 @@
              (utils/exception->json-response e)))
     :post (try
             (let [authenticated-user (get req :authorization/user)
-                  {:strs [token run-as-user] :as service-description-template} (json/read-str (slurp (:body req)))
-                  existing-service-description-template (sd/token->service-description-template kv-store token :error-on-missing false)
-                  owner (or (get service-description-template "owner")
-                            (get existing-service-description-template "owner")
+                  {:strs [token run-as-user] :as new-token-description} (json/read-str (slurp (:body req)))
+                  {existing-token-metadata :token-metadata} (sd/token->token-description kv-store token)
+                  owner (or (get new-token-description "owner")
+                            (get existing-token-metadata "owner")
                             authenticated-user)
-                  {:strs [authentication permitted-user] :as service-description-template} (dissoc service-description-template "token")]
+                  {:strs [authentication permitted-user] :as new-token-description} (dissoc new-token-description "token")]
               (when (str/blank? token)
                 (throw (ex-info "Must provide the token" {})))
               (when (= waiter-hostname token)
                 (throw (ex-info "Token name is reserved" {:token token})))
               (when-not (re-matches valid-token-re token)
                 (throw (ex-info "Token must match pattern." {:token token :pattern (str valid-token-re)})))
-              (validate-service-description-fn service-description-template)
-              (let [unknown-keys (set/difference (set (keys service-description-template)) (set sd/token-service-description-template-keys))]
+              (validate-service-description-fn new-token-description)
+              (let [unknown-keys (set/difference (-> new-token-description keys set) (set sd/token-description-keys))]
                 (when (not-empty unknown-keys)
                   (throw (ex-info (str "Unsupported key(s) in token: " (str (vec unknown-keys))) {:token token}))))
               (when (= authentication "disabled")
                 (when (not= permitted-user "*")
                   (throw (ex-info (str "Tokens with authentication disabled must specify permitted-user as *, instead provided " permitted-user) {:token token})))
                 ;; partial tokens not supported when authentication is disabled
-                (when-not (sd/required-keys-present? service-description-template)
+                (when-not (sd/required-keys-present? new-token-description)
                   (throw (ex-info "Tokens with authentication disabled must specify all required parameters"
-                                  {:missing-parameters (->> sd/service-required-keys (remove #(contains? service-description-template %1)) seq)
-                                   :service-description service-description-template}))))
+                                  {:missing-parameters (->> sd/service-required-keys
+                                                            (remove #(contains? new-token-description %1)) seq)
+                                   :service-description new-token-description}))))
               (when (and run-as-user (not= "*" run-as-user))
                 (when-not (can-run-as? authenticated-user run-as-user)
                   (throw (ex-info "Cannot run as user" {:authenticated-user authenticated-user :run-as-user run-as-user}))))
-              (let [existing-service-description-owner (get existing-service-description-template "owner")]
+              (let [existing-service-description-owner (get existing-token-metadata "owner")]
                 (if-not (str/blank? existing-service-description-owner)
                   (when-not (can-run-as? authenticated-user existing-service-description-owner)
                     (throw (ex-info "Cannot change owner of token"
@@ -241,14 +243,14 @@
                   (when-not (can-run-as? authenticated-user owner)
                     (throw (ex-info "Cannot create token as user" {:authenticated-user authenticated-user :owner owner})))))
               ; Store the token
-              (store-service-description-for-token synchronize-fn kv-store token (assoc service-description-template "owner" owner))
+              (store-service-description-for-token synchronize-fn kv-store token new-token-description {"owner" owner})
               ; notify peers of token update
               (make-peer-requests-fn "tokens/refresh"
                                      :method :post
                                      :body (json/write-str {:token token
                                                             :owner owner}))
               (utils/map->json-response {:message (str "Successfully created " token)
-                                         :service-description service-description-template}))
+                                         :service-description new-token-description}))
             (catch Exception e
               (log/error e "Token post failed")
               (utils/exception->json-response e)))))


### PR DESCRIPTION
This PR is in preparation for adding additional metadata keys that will be required in the token syncing changes.
It introduces a new function `token->token-description` which returns a map containing the keys `:service-description-template` and `:token-metadata`.  
It **does not** change what is stored in the underlying `kv-store`.

