### PR TITLE
Share http-client across health checks

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -48,7 +48,6 @@
             [waiter.service :as service]
             [waiter.service-description :as sd]
             [waiter.settings :as settings]
-            [waiter.shell-scheduler :as shell-scheduler]
             [waiter.simulator :as simulator]
             [waiter.state :as state]
             [waiter.statsd :as statsd]

--- a/waiter/test/waiter/shell_scheduler_test.clj
+++ b/waiter/test/waiter/shell_scheduler_test.clj
@@ -54,7 +54,7 @@
       :task-stats))
 
 (defn- ensure-agent-finished
-  "Sends the agent to a function that delivers a promise, letting us know that previous functions applied to agent have finished execution"
+  "Awaits the scheduler's agent"
   [{:keys [id->service-agent]}]
   (await id->service-agent))
 


### PR DESCRIPTION
Without this, we have an unbounded number of `start`ed `HttpClient`s that eventually fill up memory.