### PR TITLE
Parse cookies directly.  Don't use cookie store.

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -559,7 +559,7 @@
                                                 "service-id" service-id})]
                   (reset! cookies-atom cookies)
                   (is (= "Added cookie x-waiter-consent" body))
-                  (is (every? (fn [h] (some #(= h (:name %1)) cookies)) ["x-waiter-auth" "x-waiter-consent"]))
+                  (is (= (set (map :name cookies)) #{"x-waiter-auth" "x-waiter-consent"}))
                   (assert-response-status response 200)))
 
               (testing "auto run-as-user population on expected service-id"
@@ -573,7 +573,8 @@
                           {:keys [run-as-user permitted-user]} service-description]
                       (reset! service-id-atom service-id)
                       (is (= "Hello World" body))
-                      (is (every? (fn [h] (some #(= h (:name %1)) cookies)) ["x-waiter-auth" "x-waiter-consent"]))
+                      ; x-waiter-consent should not be re-emitted Waiter
+                      (is (= (set (map :name cookies)) #{"x-waiter-auth"}))
                       (is (= expected-service-id service-id))
                       (is (not (str/blank? permitted-user)))
                       (is (= run-as-user permitted-user))
@@ -608,7 +609,7 @@
                   (is (not= @cookies-atom cookies))
                   (reset! cookies-atom cookies)
                   (is (= "Added cookie x-waiter-consent" body))
-                  (is (every? (fn [h] (some #(= h (:name %1)) cookies)) ["x-waiter-auth" "x-waiter-consent"]))
+                  (is (= (set (map :name cookies)) #{"x-waiter-auth" "x-waiter-consent"}))
                   (assert-response-status response 200)))
 
               (testing "auto run-as-user population on approved token"
@@ -620,7 +621,8 @@
                                                         #(make-request waiter-url "/hello-world" :cookies @cookies-atom :headers %1))]
                       (reset! service-id-atom service-id)
                       (is (= "Hello World" body))
-                      (is (every? (fn [h] (some #(= h (:name %1)) cookies)) ["x-waiter-auth" "x-waiter-consent"]))
+                      ; x-waiter-consent should not be re-emitted Waiter
+                      (is (= (set (map :name cookies)) #{"x-waiter-auth"}))
                       (is (not= previous-service-id service-id))
                       (assert-response-status response 200))
                     (finally

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -559,7 +559,8 @@
                                                 "service-id" service-id})]
                   (reset! cookies-atom cookies)
                   (is (= "Added cookie x-waiter-consent" body))
-                  (is (= (set (map :name cookies)) #{"x-waiter-auth" "x-waiter-consent"}))
+                  ; x-waiter-consent should be emitted Waiter
+                  (is (contains? (set (map :name cookies)) "x-waiter-consent"))
                   (assert-response-status response 200)))
 
               (testing "auto run-as-user population on expected service-id"
@@ -574,7 +575,7 @@
                       (reset! service-id-atom service-id)
                       (is (= "Hello World" body))
                       ; x-waiter-consent should not be re-emitted Waiter
-                      (is (= (set (map :name cookies)) #{"x-waiter-auth"}))
+                      (is (not (contains? (set (map :name cookies)) "x-waiter-consent")))
                       (is (= expected-service-id service-id))
                       (is (not (str/blank? permitted-user)))
                       (is (= run-as-user permitted-user))
@@ -606,10 +607,10 @@
                                               "x-requested-with" "XMLHttpRequest"}
                                     :http-method-fn http/post
                                     :multipart {"mode" "token"})]
-                  (is (not= @cookies-atom cookies))
                   (reset! cookies-atom cookies)
                   (is (= "Added cookie x-waiter-consent" body))
-                  (is (= (set (map :name cookies)) #{"x-waiter-auth" "x-waiter-consent"}))
+                  ; x-waiter-consent should be emitted Waiter
+                  (is (contains? (set (map :name cookies)) "x-waiter-consent"))
                   (assert-response-status response 200)))
 
               (testing "auto run-as-user population on approved token"
@@ -622,7 +623,7 @@
                       (reset! service-id-atom service-id)
                       (is (= "Hello World" body))
                       ; x-waiter-consent should not be re-emitted Waiter
-                      (is (= (set (map :name cookies)) #{"x-waiter-auth"}))
+                      (is (not (contains? (set (map :name cookies)) "x-waiter-consent")))
                       (is (not= previous-service-id service-id))
                       (assert-response-status response 200))
                     (finally

--- a/waiter/src/waiter/client_tools.clj
+++ b/waiter/src/waiter/client_tools.clj
@@ -20,14 +20,13 @@
             [marathonclj.common :as mc]
             [marathonclj.rest.apps :as apps]
             [plumbing.core :as pc]
-            [qbits.jet.client.cookies :as cookies]
             [qbits.jet.client.http :as http]
             [waiter.auth.authentication :as authentication]
             [waiter.auth.spnego :as spnego]
             [waiter.correlation-id :as cid]
             [waiter.statsd :as statsd]
             [waiter.utils :as utils])
-  (:import (java.net URI)
+  (:import (java.net HttpCookie URI)
            (java.util.concurrent Callable Future Executors)
            (marathonclj.common Connection)
            (org.apache.http.client CookieStore)
@@ -197,10 +196,10 @@
 
 (defn parse-set-cookie-string
   "Parse the value of a single Set-Cookie header."
-  [string-value]
-  (when string-value
-    (let [cookie-list (java.net.HttpCookie/parse string-value)]
-      (map (fn [^java.net.HttpCookie cookie]
+  [^String value]
+  (when value
+    (let [cookie-list (HttpCookie/parse value)]
+      (map (fn [^HttpCookie cookie]
              {:name (.getName cookie)
               :value (.getValue cookie)}) cookie-list))))
 

--- a/waiter/src/waiter/client_tools.clj
+++ b/waiter/src/waiter/client_tools.clj
@@ -140,7 +140,7 @@
      (time-it ~name ~@body)))
 
 (defn make-http-client
-  "Instantiates and returns a new HttpClient with a cookie store"
+  "Instantiates and returns a new HttpClient without a cookie store"
   []
   (let [client (http/client)]
     (.setCookieStore client (HttpCookieStore$Empty.))

--- a/waiter/src/waiter/client_tools.clj
+++ b/waiter/src/waiter/client_tools.clj
@@ -32,7 +32,7 @@
            (marathonclj.common Connection)
            (org.apache.http.client CookieStore)
            (org.eclipse.jetty.client HttpClient)
-           (org.eclipse.jetty.util HttpCookieStore)
+           (org.eclipse.jetty.util HttpCookieStore HttpCookieStore$Empty)
            (org.joda.time Period)
            (org.joda.time.format PeriodFormatterBuilder)))
 
@@ -143,9 +143,8 @@
 (defn make-http-client
   "Instantiates and returns a new HttpClient with a cookie store"
   []
-  (let [client (http/client)
-        cookie-store (HttpCookieStore.)
-        _ (.setCookieStore ^HttpClient client cookie-store)]
+  (let [client (http/client)]
+    (.setCookieStore client (HttpCookieStore$Empty.))
     client))
 
 (defmacro testing-using-waiter-url
@@ -191,16 +190,26 @@
             (log/warn (RuntimeException.))))
         (assoc request-headers "x-cid" new-cid)))))
 
-(defn- add-cookies
-  [waiter-url cookies ^CookieStore cs]
-  {:pre [(not (str/blank? waiter-url))]}
-  (doseq [cookie cookies]
-    (cookies/add-cookie! cs (str HTTP-SCHEME waiter-url) cookie)))
-
 (defn strip-trailing-slash
   "If s ends with /, returns s with the / stripped"
   [s]
   (cond-> s (str/ends-with? s "/") (subs 0 (- (count s) 1))))
+
+(defn parse-set-cookie-string
+  "Parse the value of a single Set-Cookie header."
+  [string-value]
+  (when string-value
+    (let [cookie-list (java.net.HttpCookie/parse string-value)]
+      (map (fn [^java.net.HttpCookie cookie]
+             {:name (.getName cookie)
+              :value (.getValue cookie)}) cookie-list))))
+
+(defn parse-cookies
+  "Create a list of cookies from response headers."
+  [set-cookie-header-value]
+  (when set-cookie-header-value
+    (vec (cond (coll? set-cookie-header-value) (mapcat parse-set-cookie-string set-cookie-header-value)
+               (string? set-cookie-header-value) (parse-set-cookie-string set-cookie-header-value)))))
 
 (defn make-request
   ([waiter-url path &
@@ -240,7 +249,7 @@
          (when verbose
            (log/info (get request-headers "x-cid") "response size:" (count (str response-body))))
          {:request-headers request-headers
-          :cookies (cookies/get-cookies (.getCookieStore client))
+          :cookies (parse-cookies (get headers "set-cookie"))
           :status status
           :headers headers
           :body response-body})

--- a/waiter/test/waiter/client_tools_test.clj
+++ b/waiter/test/waiter/client_tools_test.clj
@@ -1,0 +1,22 @@
+;;
+;;       Copyright (c) 2017 Two Sigma Investments, LP.
+;;       All Rights Reserved
+;;
+;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
+;;       Two Sigma Investments, LP.
+;;
+;;       The copyright notice above does not evidence any
+;;       actual or intended publication of such source code.
+;;
+(ns waiter.client-tools-test
+  (:require [clojure.test :refer :all]
+            [waiter.client-tools :refer :all]))
+
+(deftest test-parse-set-cookie-string
+  (is (= (list {:name "name" :value "value"}) (parse-set-cookie-string "name=value")))
+  (is (= (list {:name "name" :value "value"}) (parse-set-cookie-string "name=value;Path=/")))
+  (is (= nil (parse-set-cookie-string nil))))
+
+(deftest test-parse-cookies
+  (is (= [{:name "name" :value "value"}] (parse-cookies "name=value")))
+  (is (= [{:name "name" :value "value"} {:name "name2" :value "value2"}] (parse-cookies ["name=value" "name2=value2"]))))


### PR DESCRIPTION
Our current method utilized a method of retrieving cookies that used `CookieStore` and wasn't thread-safe.  This change parses cookies directly from the response and doesn't utilize `CookieStore`.