### PR TITLE
Make deployment errors more robust to transient health check exceptions

### DIFF
--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -370,16 +370,19 @@
     (if-not service
       service->service-instances'
       (let [{:strs [health-check-url]} (service-id->service-description-fn (:id service))
-            update-flags (fn [instance error] 
-                           (update-in instance [:flags] 
-                                      (fn [flags]
-                                        (cond-> flags
-                                          (not= error :connect-exception)
-                                          (conj :has-connected)
+            update-unhealthy-instance (fn [instance status error] 
+                                        (-> instance
+                                            (assoc :healthy? false
+                                                   :health-check-status status)
+                                            (update-in [:flags] 
+                                                       (fn [flags]
+                                                         (cond-> flags
+                                                           (not= error :connect-exception)
+                                                           (conj :has-connected)
 
-                                          (and (not= error :connect-exception)
-                                               (not= error :timeout-exception))
-                                          (conj :has-responded)))))
+                                                           (and (not= error :connect-exception)
+                                                                (not= error :timeout-exception))
+                                                           (conj :has-responded))))))
             health-check-refs (map (fn [instance]
                                      (let [chan (async/promise-chan)]
                                        (if (:healthy? instance)
@@ -388,10 +391,7 @@
                                            1 chan (map (fn [{:keys [healthy? status error]}]
                                                          (if healthy?
                                                            (assoc instance :healthy? true)
-                                                           (-> instance
-                                                               (assoc :healthy? false)
-                                                               (assoc :health-check-status status)
-                                                               (update-flags error)))))
+                                                           (update-unhealthy-instance instance status error))))
                                            (available? instance health-check-url)))
                                        chan))
                                    active-instances)]

--- a/waiter/src/waiter/state.clj
+++ b/waiter/src/waiter/state.clj
@@ -1018,9 +1018,10 @@
           has-unhealthy-instances? (not-empty unhealthy-instances) 
           first-unhealthy-status (-> unhealthy-instances first :health-check-status)
           first-exit-code (-> failed-instances first :exit-code)
-          all-instances-flagged-with? (fn [flag] (every? (fn [{:keys [flags]}] (contains? flags flag)) failed-instances))
-          no-instances-flagged-with? (fn [flag] (every? (fn [{:keys [flags]}] (not (contains? flags flag))) failed-instances))
-          all-instances-exited-similarly? (and first-exit-code (every? (fn [{:keys [exit-code]}] (= exit-code first-exit-code)) failed-instances))]
+          failed-instance-flags (map :flags failed-instances)
+          all-instances-flagged-with? (fn [flag] (every? #(contains? % flag) failed-instance-flags))
+          no-instances-flagged-with? (fn [flag] (every? #(not (contains? % flag)) failed-instance-flags))
+          all-instances-exited-similarly? (and first-exit-code (every? #(= first-exit-code %) (map :exit-code failed-instances)))]
       (cond
         (and has-failed-instances? all-instances-exited-similarly?) :bad-startup-command
         (and has-failed-instances? (all-instances-flagged-with? :memory-limit-exceeded)) :not-enough-memory

--- a/waiter/src/waiter/state.clj
+++ b/waiter/src/waiter/state.clj
@@ -1013,21 +1013,21 @@
   [healthy-instances unhealthy-instances failed-instances {:keys [min-failed-instances min-hosts]}]
   (when (empty? healthy-instances)
     (let [failed-instance-hosts (set (map :host failed-instances))
-          has-failed-instances (and (>= (count failed-instances) min-failed-instances)
-                                    (>= (count failed-instance-hosts) min-hosts)
-                                    (apply = (map :flags failed-instances))
-                                    (apply = (map :exit-code failed-instances)))
-          failed-instance-flags (-> failed-instances first :flags)
-          has-unhealthy-instances (and (not-empty unhealthy-instances)
-                                       (apply = (map :health-check-status unhealthy-instances)))
-          unhealthy-status (-> unhealthy-instances first :health-check-status)]
+          has-failed-instances? (and (>= (count failed-instances) min-failed-instances)
+                                     (>= (count failed-instance-hosts) min-hosts))
+          has-unhealthy-instances? (not-empty unhealthy-instances) 
+          first-unhealthy-status (-> unhealthy-instances first :health-check-status)
+          first-exit-code (-> failed-instances first :exit-code)
+          all-instances-flagged-with? (fn [flag] (every? (fn [{:keys [flags]}] (contains? flags flag)) failed-instances))
+          no-instances-flagged-with? (fn [flag] (every? (fn [{:keys [flags]}] (not (contains? flags flag))) failed-instances))
+          all-instances-exited-similarly? (and first-exit-code (every? (fn [{:keys [exit-code]}] (= exit-code first-exit-code)) failed-instances))]
       (cond
-        (and has-failed-instances (:memory-limit-exceeded failed-instance-flags)) :not-enough-memory
-        (and has-failed-instances (:timeout-exception failed-instance-flags)) :health-check-timed-out
-        (and has-failed-instances (:connect-exception failed-instance-flags)) :cannot-connect
-        (and has-failed-instances (:never-passed-health-checks failed-instance-flags)) :invalid-health-check-response
-        (and has-failed-instances (-> failed-instances first :exit-code)) :bad-startup-command
-        (and has-unhealthy-instances (= unhealthy-status 401)) :health-check-requires-authentication))))
+        (and has-failed-instances? all-instances-exited-similarly?) :bad-startup-command
+        (and has-failed-instances? (all-instances-flagged-with? :memory-limit-exceeded)) :not-enough-memory
+        (and has-failed-instances? (no-instances-flagged-with? :has-connected)) :cannot-connect
+        (and has-failed-instances? (no-instances-flagged-with? :has-responded)) :health-check-timed-out
+        (and has-failed-instances? (all-instances-flagged-with? :never-passed-health-checks)) :invalid-health-check-response
+        (and has-unhealthy-instances? (= first-unhealthy-status 401)) :health-check-requires-authentication))))
 
 (defn start-router-state-maintainer
   "Start the instance state maintainer.

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -248,7 +248,10 @@
       (is (= (list "1") (:available-apps update-apps)))
       (is (= :update-app-instances update-instances-msg))
       (is (= [(assoc instance1 :healthy? true) instance2] (:healthy-instances update-instances)))
-      (is (= [(assoc instance3 :healthy? false :health-check-status 400)] (:unhealthy-instances update-instances)))
+      (is (= [(assoc instance3 
+                     :healthy? false 
+                     :health-check-status 400
+                     :flags #{:has-responded :has-connected})] (:unhealthy-instances update-instances)))
       (is (= "1" (:service-id update-instances))))
     ;; Retrieves scheduler state without service-id
     (let [response-chan (async/promise-chan)

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -251,7 +251,7 @@
       (is (= [(assoc instance3 
                      :healthy? false 
                      :health-check-status 400
-                     :flags #{:has-responded :has-connected})] (:unhealthy-instances update-instances)))
+                     :flags #{:has-connected :has-responded})] (:unhealthy-instances update-instances)))
       (is (= "1" (:service-id update-instances))))
     ;; Retrieves scheduler state without service-id
     (let [response-chan (async/promise-chan)

--- a/waiter/test/waiter/state_test.clj
+++ b/waiter/test/waiter/state_test.clj
@@ -862,23 +862,23 @@
                           :failed-instances [], :expected nil}
                          {:name "multiple-different-failed-instances", :healthy-instances [], :unhealthy-instances [],
                           :failed-instances [{:message "Command exited with status" :exit-code 1}
-                                             {:message "Memory limit exceeded:" :flags #{:memory-limit-exceeded}}],
+                                             {:message "Memory limit exceeded:" :flags #{:memory-limit-exceeded :has-connected :has-responded}}],
                           :expected nil}
                          {:name "not-enough-memory", :healthy-instances [], :unhealthy-instances [],
                           :failed-instances [{:message "Memory limit exceeded:" :flags #{:memory-limit-exceeded}}
                                              {:message "Memory limit exceeded:" :flags #{:memory-limit-exceeded}}],
                           :expected :not-enough-memory}
                          {:name "invalid-health-check-response", :healthy-instances [], :unhealthy-instances [],
-                          :failed-instances [{:message "Task was killed" :flags #{:never-passed-health-checks}}
-                                             {:message nil :flags #{:never-passed-health-checks}}],
+                          :failed-instances [{:message "Task was killed" :flags #{:never-passed-health-checks :has-connected :has-responded}}
+                                             {:message nil :flags #{:never-passed-health-checks :has-connected :has-responded}}],
                           :expected :invalid-health-check-response}
                          {:name "health-check-timed-out", :healthy-instances [], :unhealthy-instances [],
-                          :failed-instances [{:message "Task was killed" :flags #{:timeout-exception :never-passed-health-checks}}
-                                             {:message nil :flags #{:never-passed-health-checks :timeout-exception}}],
+                          :failed-instances [{:message "Task was killed" :flags #{:never-passed-health-checks :has-connected}}
+                                             {:message nil :flags #{:never-passed-health-checks :has-connected}}],
                           :expected :health-check-timed-out}
                          {:name "cannot-connect", :healthy-instances [], :unhealthy-instances [],
-                          :failed-instances [{:message "Task was killed" :flags #{:connect-exception :never-passed-health-checks}}
-                                             {:message nil :flags #{:connect-exception :never-passed-health-checks}}],
+                          :failed-instances [{:message "Task was killed" :flags #{:never-passed-health-checks}}
+                                             {:message nil :flags #{:never-passed-health-checks}}],
                           :expected :cannot-connect}
                          {:name "bad-startup-command", :healthy-instances [], :unhealthy-instances [],
                           :failed-instances [{:message "Command exited with status" :exit-code 1}

--- a/waiter/test/waiter/state_test.clj
+++ b/waiter/test/waiter/state_test.clj
@@ -862,19 +862,19 @@
                           :failed-instances [], :expected nil}
                          {:name "multiple-different-failed-instances", :healthy-instances [], :unhealthy-instances [],
                           :failed-instances [{:message "Command exited with status" :exit-code 1}
-                                             {:message "Memory limit exceeded:" :flags #{:memory-limit-exceeded :has-connected :has-responded}}],
+                                             {:message "Memory limit exceeded:" :flags #{:has-connected :has-responded :memory-limit-exceeded}}],
                           :expected nil}
                          {:name "not-enough-memory", :healthy-instances [], :unhealthy-instances [],
                           :failed-instances [{:message "Memory limit exceeded:" :flags #{:memory-limit-exceeded}}
                                              {:message "Memory limit exceeded:" :flags #{:memory-limit-exceeded}}],
                           :expected :not-enough-memory}
                          {:name "invalid-health-check-response", :healthy-instances [], :unhealthy-instances [],
-                          :failed-instances [{:message "Task was killed" :flags #{:never-passed-health-checks :has-connected :has-responded}}
-                                             {:message nil :flags #{:never-passed-health-checks :has-connected :has-responded}}],
+                          :failed-instances [{:message "Task was killed" :flags #{:has-connected :has-responded :never-passed-health-checks}}
+                                             {:message nil :flags #{:has-connected :has-responded :never-passed-health-checks}}],
                           :expected :invalid-health-check-response}
                          {:name "health-check-timed-out", :healthy-instances [], :unhealthy-instances [],
-                          :failed-instances [{:message "Task was killed" :flags #{:never-passed-health-checks :has-connected}}
-                                             {:message nil :flags #{:never-passed-health-checks :has-connected}}],
+                          :failed-instances [{:message "Task was killed" :flags #{:has-connected :never-passed-health-checks}}
+                                             {:message nil :flags #{:has-connected :never-passed-health-checks}}],
                           :expected :health-check-timed-out}
                          {:name "cannot-connect", :healthy-instances [], :unhealthy-instances [],
                           :failed-instances [{:message "Task was killed" :flags #{:never-passed-health-checks}}


### PR DESCRIPTION
The current deployment error code is vulnerable to timing of health checks and the resulting minor inconsistencies between the flags of failed instances. 

In order to test if a service has deployment error `:cannot-connect`, meaning we haven't been able to connect to the instances, we now check whether we've *ever* been able to connect, instead of relying on the last health check to *not* report a connection error.

In order to test if a service has deployment error `:health-check-timed-out`, meaning all health checks are timing out, we now record whether we've ever *not* had a timeout, instead of relying on the last health check to timeout.
