### PR TITLE
Increase timeout to avoid race in unit test

### DIFF
--- a/waiter/test/waiter/service_test.clj
+++ b/waiter/test/waiter/service_test.clj
@@ -249,7 +249,7 @@
         (.get ^Future start-app-result)
         (is @start-called-atom)))
     (testing "app-already-starting"
-      (let [cache-atom (make-cache-fn 100 20)
+      (let [cache-atom (make-cache-fn 100 1000)
             start-called-atom (atom false)
             start-fn (fn [] (reset! start-called-atom (not @start-called-atom)))]
         (let [start-app-result-1 (start-new-service scheduler service-id->password-fn descriptor cache-atom start-app-threadpool :start-fn start-fn)]


### PR DESCRIPTION
This unit test failed because there is a race on against cache eviction.  Increased the TTL of the cache to hopefully avoid test failure.