### PR TITLE
Add welcome page and 404s

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Welcome to Two Sigma's Waiter project!
 
-Waiter is a web service platform that runs, manages and automatically scales services without requiring human intervention.
+Waiter is a web service platform that runs, manages, and automatically scales services without requiring human intervention.
 
 [Waiter Design](waiter/docs/waiter-design-docs.md) is a good place to start to learn more.
 

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -479,6 +479,7 @@
             :invalid-service-description "Service description using waiter headers/token improperly configured"
             :metadata-error-info "Error in metadata"
             :not-enough-memory "Not enough memory allocated"
+            :not-found "Not found"
             :prestashed-tickets-not-available "Prestashed jobsystem tickets not available"}
 
  ;; Support information used to provide user guidance in error messages

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -545,4 +545,8 @@
                              (is false ("Not json:\n" body))))]
         (is (= 200 status))
         (is (= "application/json" (get headers "content-type")))
-        (is (= "Welcome to Waiter" (get json-data "message")))))))
+        (is (= "Welcome to Waiter" (get json-data "message")))))
+    (testing "only GET"
+      (let [{:keys [body status]} (make-request waiter-url "/" :http-method-fn http/post)]
+        (is (= 405 status))
+        (is (str/includes? body "Only GET supported"))))))

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -468,56 +468,81 @@
 (deftest ^:parallel ^:integration-fast test-error-handling
   (testing-using-waiter-url
     (testing "text/plain default"
-      (let [{:keys [body headers status]} (make-request waiter-url "/")]
-        (is (= 400 status))
+      (let [{:keys [body headers status]} (make-request waiter-url "/404")]
+        (is (= 404 status))
         (is (= "text/plain" (get headers "content-type")))
-        (is (str/includes? body "Waiter Error 400"))
+        (is (str/includes? body "Waiter Error 404"))
         (is (str/includes? body "================"))))
     (testing "text/plain explicit"
-      (let [{:keys [body headers status]} (make-request waiter-url "/" :headers {"accept" "text/plain"})]
-        (is (= 400 status))
+      (let [{:keys [body headers status]} (make-request waiter-url "/404" :headers {"accept" "text/plain"})]
+        (is (= 404 status))
         (is (= "text/plain" (get headers "content-type")))
-        (is (str/includes? body "Waiter Error 400"))
+        (is (str/includes? body "Waiter Error 404"))
         (is (str/includes? body "================"))))
     (testing "text/html"
-      (let [{:keys [body headers status]} (make-request waiter-url "/" :headers {"accept" "text/html"})]
-        (is (= 400 status))
+      (let [{:keys [body headers status]} (make-request waiter-url "/404" :headers {"accept" "text/html"})]
+        (is (= 404 status))
         (is (= "text/html" (get headers "content-type")))
-        (is (str/includes? body "Waiter Error 400"))
+        (is (str/includes? body "Waiter Error 404"))
         (is (str/includes? body "<html>"))))
     (testing "application/json explicit"
-      (let [{:keys [body headers status]} (make-request waiter-url "/" :headers {"accept" "application/json"})
+      (let [{:keys [body headers status]} (make-request waiter-url "/404" :headers {"accept" "application/json"})
             {:strs [waiter-error]} (try (json/read-str body)
                                         (catch Throwable e
                                           (is false (str "Could not parse body that is supposed to be JSON:\n" body))))]
-        (is (= 400 status))
+        (is (= 404 status))
         (is (= "application/json" (get headers "content-type")))
         (is waiter-error (str "Could not find waiter-error element in body " body))
         (let [{:strs [status]} waiter-error]
-          (is (= 400 status)))))
+          (is (= 404 status)))))
     (testing "application/json implied by content-type"
-      (let [{:keys [body headers status]} (make-request waiter-url "/" :headers {"content-type" "application/json"})
+      (let [{:keys [body headers status]} (make-request waiter-url "/404" :headers {"content-type" "application/json"})
             {:strs [waiter-error]} (try (json/read-str body)
                                         (catch Throwable e
                                           (is false (str "Could not parse body that is supposed to be JSON:\n" body))))]
-        (is (= 400 status))
+        (is (= 404 status))
         (is (= "application/json" (get headers "content-type")))
         (is waiter-error (str "Could not find waiter-error element in body " body))
         (let [{:strs [status]} waiter-error]
-          (is (= 400 status)))))
+          (is (= 404 status)))))
     (testing "support information included"
-      (let [{:keys [body headers status]} (make-request waiter-url "/" :headers {"accept" "application/json"})
-            {:keys [support-info]} (waiter-settings waiter-url)
+      (let [{:keys [body headers status]} (make-request waiter-url "/404" :headers {"accept" "application/json"})
+            {:keys [messages support-info]} (waiter-settings waiter-url)
             {:strs [waiter-error]} (try (json/read-str body)
                                         (catch Throwable e
                                           (is false (str "Could not parse body that is supposed to be JSON:\n" body))))]
 
-        (is (= 400 status))
+        (is (= 404 status))
         (is (= "application/json" (get headers "content-type")))
+        (is (= (:not-found messages) (get waiter-error "message")))
         (is waiter-error (str "Could not find waiter-error element in body " body))
         (let [{:strs [status]} waiter-error]
-          (is (= 400 status))
+          (is (= 404 status))
           (is (= support-info (-> (get waiter-error "support-info")
                                   (walk/keywordize-keys)))))))))
 
-
+(deftest ^:parallel ^:integration-fast test-welcome-page
+  (testing-using-waiter-url
+    (testing "default text/plain"
+      (let [{:keys [body headers status]} (make-request waiter-url "/")]
+        (is (= 200 status))
+        (is (= "text/plain" (get headers "content-type")))
+        (is (str/includes? body "Welcome to Waiter"))))
+    (testing "accept text/plain"
+      (let [{:keys [body headers status]} (make-request waiter-url "/" :headers {"accept" "text/plain"})]
+        (is (= 200 status))
+        (is (= "text/plain" (get headers "content-type")))
+        (is (str/includes? body "Welcome to Waiter"))))
+    (testing "accept text/html"
+      (let [{:keys [body headers status]} (make-request waiter-url "/" :headers {"accept" "text/html"})]
+        (is (= 200 status))
+        (is (= "text/html" (get headers "content-type")))
+        (is (str/includes? body "Welcome to Waiter"))))
+    (testing "accept application/json"
+      (let [{:keys [body headers status]} (make-request waiter-url "/" :headers {"accept" "application/json"})
+            json-data (try (json/read-str body)
+                           (catch Exception _
+                             (is false ("Not json:\n" body))))]
+        (is (= 200 status))
+        (is (= "application/json" (get headers "content-type")))
+        (is (= "Welcome to Waiter" (get json-data "message")))))))

--- a/waiter/resources/web/consent.html
+++ b/waiter/resources/web/consent.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-    <title>Waiter - Run Web App?</title>
+    <title>Run Web App? - Waiter</title>
     <meta http-equiv="x-ua-compatible" content="IE=edge" />
     <style type="text/css">
    html {

--- a/waiter/resources/web/error.html
+++ b/waiter/resources/web/error.html
@@ -132,6 +132,7 @@
   </div>
 </div>
 
+<% (when (seq support-info) %>
 <div class="additional-info">
   <div class="divider"></div>
   <div>
@@ -146,6 +147,7 @@
       <% ) %>
     </ul>
 </div>
+<% ) %>
 
 </body>
 

--- a/waiter/resources/web/error.txt
+++ b/waiter/resources/web/error.txt
@@ -19,7 +19,7 @@ Additional Info
 ===============
 
   <%= details %>
-<% ) %><% (when support-info %>Getting Help
+<% ) %><% (when (seq support-info) %>Getting Help
 ============
 <% (doseq [{label :label {:keys [value]} :link} support-info] %>
   <%= label %>: <%= value %> <% ) %>

--- a/waiter/resources/web/welcome.html
+++ b/waiter/resources/web/welcome.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-  <title>Error <%= status %> - Waiter</title>
+  <title>Welcome - Waiter</title>
   <meta http-equiv="x-ua-compatible" content="IE=edge" />
   <style type="text/css">
    html {
@@ -43,6 +43,10 @@
      margin-top: 2em;
    }
 
+   .additional-info p {
+     margin-left: 1em;
+   }
+
    .additional-info h3 {
      margin-top: 2em;
    }
@@ -72,6 +76,7 @@
      font-weight: bold;
      text-align: right;
      vertical-align: baseline;
+     width: 70px;
    }
 
    .additional-info td.code {
@@ -82,18 +87,44 @@
      margin-left: 1em;
      border-collapse: collapse;
    }
-
     </style>
 </head>
 <body>
 
 <div class="main-content">
   <h1>
-    Waiter Error <%= status %>
+    Welcome to Waiter
   </h1>
   <p>
-  <%= message %>
+    Waiter is a high-level platform for running and managing web services and applications.
   </p>
+  <p>
+    See <a href="#gettinghelp">Getting Help</a> for more info, or if you feel you've reached this page in error.
+  </p>
+</div>
+
+<div class="additional-info">
+  <div class="divider"></div>
+  <div>
+    <h3>Server Info</h3>
+    <table>
+      <tr>
+        <td class="field">Host</td>
+        <td class="code"><%= hostname %></td>
+      </tr>
+      <tr>
+        <td class="field">Interface</td>
+        <td class="code"><%= host %></td>
+      </tr>
+      <tr>
+        <td class="field">Port</td>
+        <td class="code"><%= port %></td>
+      </tr>
+    </table>
+    <p>
+      <a href="/settings">More Settings</a>
+    </p>
+  </div>
 </div>
 
 <div class="additional-info">
@@ -101,38 +132,20 @@
   <div>
     <h3>Request Info</h3>
     <table>
-      <% (when host %>
       <tr>
-        <td class="field">Host</td><td class="code"><%= host %></td>
-      </tr>
-      <% ) %>
-      <tr>
-        <td class="field">Path</td><td class="code"><%= uri %></td>
-      </tr>
-      <% (when query-string %>
-      <tr>
-        <td class="field">Query String</td><td class="code"><%= query-string %></td>
-      </tr>
-      <% ) %>
-      <tr>
-        <td class="field">CID</td><td class="code"><%= cid %></td>
+        <td class="field">CID</td>
+        <td class="code"><%= cid %></td>
       </tr>
       <tr>
-        <td class="field">Time</td><td class="code"><%= timestamp %></td>
+        <td class="field">Time</td>
+        <td class="code"><%= timestamp %></td>
       </tr>
     </table>
   </div>
 </div>
 
-<div class="additional-info">
-  <div class="divider"></div>
-  <div>
-	<h3>Additional Info</h3>
-	<pre id="details" class="code"><%= details %></pre>
-  </div>
-</div>
 
-<div class="additional-info">
+<div class="additional-info" id="gettinghelp">
   <div class="divider"></div>
   <div>
     <h3>Getting Help</h3>

--- a/waiter/resources/web/welcome.html
+++ b/waiter/resources/web/welcome.html
@@ -98,9 +98,11 @@
   <p>
     Waiter is a platform for running and managing web services and applications.
   </p>
+<% (when (seq support-info) %>
   <p>
     See <a href="#gettinghelp">Getting Help</a> for more information.
   </p>
+<% ) %>
 </div>
 
 <div class="additional-info">
@@ -144,7 +146,8 @@
   </div>
 </div>
 
-
+<% (when (seq support-info) %>
+Getting Help
 <div class="additional-info" id="gettinghelp">
   <div class="divider"></div>
   <div>
@@ -159,6 +162,7 @@
       <% ) %>
     </ul>
 </div>
+<% ) %>
 
 </body>
 

--- a/waiter/resources/web/welcome.html
+++ b/waiter/resources/web/welcome.html
@@ -96,10 +96,10 @@
     Welcome to Waiter
   </h1>
   <p>
-    Waiter is a high-level platform for running and managing web services and applications.
+    Waiter is a platform for running and managing web services and applications.
   </p>
   <p>
-    See <a href="#gettinghelp">Getting Help</a> for more info, or if you feel you've reached this page in error.
+    See <a href="#gettinghelp">Getting Help</a> for more information.
   </p>
 </div>
 

--- a/waiter/resources/web/welcome.txt
+++ b/waiter/resources/web/welcome.txt
@@ -1,0 +1,25 @@
+
+Welcome to Waiter
+=================
+
+  Waiter is a high-level platform for running and managing web services and applications.
+  See `Getting Help' for more info, or if you feel you've reached this page in error.
+
+Server Info
+===========
+
+       Host: <%= hostname %>
+  Interface: <%= host %>
+       Port: <%= port %>
+
+Request Info
+============
+
+        CID: <%= cid %>
+       Time: <%= timestamp %>
+
+<% (when support-info %>Getting Help
+============
+<% (doseq [{label :label {:keys [value]} :link} support-info] %>
+  <%= label %>: <%= value %> <% ) %>
+<% ) %>

--- a/waiter/resources/web/welcome.txt
+++ b/waiter/resources/web/welcome.txt
@@ -2,8 +2,8 @@
 Welcome to Waiter
 =================
 
-  Waiter is a platform for running and managing web services and applications.
-  See `Getting Help' for more information.
+  Waiter is a platform for running and managing web services and applications.<% (when (seq support-info) %>
+  See `Getting Help' for more information.<% ) %>
 
 Server Info
 ===========
@@ -18,7 +18,7 @@ Request Info
         CID: <%= cid %>
        Time: <%= timestamp %>
 
-<% (when support-info %>Getting Help
+<% (when (seq support-info) %>Getting Help
 ============
 <% (doseq [{label :label {:keys [value]} :link} support-info] %>
   <%= label %>: <%= value %> <% ) %>

--- a/waiter/resources/web/welcome.txt
+++ b/waiter/resources/web/welcome.txt
@@ -2,8 +2,8 @@
 Welcome to Waiter
 =================
 
-  Waiter is a high-level platform for running and managing web services and applications.
-  See `Getting Help' for more info, or if you feel you've reached this page in error.
+  Waiter is a platform for running and managing web services and applications.
+  See `Getting Help' for more information.
 
 Server Info
 ===========

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -90,10 +90,10 @@
                      "state" {"" :display-state-handler-fn
                               ["/" :service-id] :service-state-handler-fn}
                      "status" :status-handler-fn
-                     "token" :token-handler-fn   
-                     "tokens" { "" :token-list-handler-fn   
+                     "token" :token-handler-fn
+                     "tokens" { "" :token-list-handler-fn
                                "/owners" :token-owners-handler-fn
-                               "/refresh":token-refresh-handler-fn 
+                               "/refresh":token-refresh-handler-fn
                                "/reindex" :token-reindex-handler-fn}
                      "waiter-async" {["/complete/" :request-id "/" :service-id] :async-complete-handler-fn
                                      ["/result/" :request-id "/" :router-id "/" :service-id "/" :host "/" :port "/" [#".+" :location]]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -71,7 +71,8 @@
   "Returns a map containing a keyword handler and the parsed route-params based on the request uri."
   ;; Please include/update a corresponding unit test anytime the routes data structure is modified
   [{:keys [uri]}]
-  (let [routes ["/" {"app-name" :app-name-handler-fn
+  (let [routes ["/" {"" :welcome-handler-fn
+                     "app-name" :app-name-handler-fn
                      "apps" {"" :service-list-handler-fn
                              ["/" :service-id] :service-handler-fn
                              ["/" :service-id "/logs"] :service-view-logs-handler-fn
@@ -106,7 +107,7 @@
                      "waiter-kill-instance" {["/" :service-id] :kill-instance-handler-fn}
                      "work-stealing" :work-stealing-handler-fn}]]
     (or (bidi/match-route routes uri)
-        {:handler :process-request-fn})))
+        {:handler :not-found-handler-fn})))
 
 (defn ring-handler-factory
   "Creates the handler for processing http requests."
@@ -1002,6 +1003,7 @@
    :metrics-request-handler-fn (pc/fnk []
                                  (fn metrics-request-handler-fn [request]
                                    (handler/metrics-request-handler request)))
+   :not-found-handler-fn (pc/fnk [] handler/not-found-handler)
    :process-request-fn (pc/fnk [[:routines determine-priority-fn make-basic-auth-fn post-process-async-request-response-fn
                                  prepend-waiter-url request->descriptor-fn service-id->password-fn start-new-service-fn]
                                 [:settings instance-request-properties]
@@ -1189,6 +1191,8 @@
                                                 token->service-description-template service-description->service-id
                                                 consent-expiry-days request))
                                             request)))
+   :welcome-handler-fn (pc/fnk [handle-secure-request-fn settings]
+                               (partial handler/welcome-handler settings))
    :work-stealing-handler-fn (pc/fnk [[:state instance-rpc-chan]
                                       handle-inter-router-request-fn]
                                (fn work-stealing-handler-fn [request]

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -221,6 +221,7 @@
               :invalid-health-check-response "Health check returned an invalid response"
               :invalid-service-description "Service description using waiter headers/token improperly configured"
               :not-enough-memory "Not enough memory allocated"
+              :not-found "Not found"
               :prestashed-tickets-not-available "Prestashed jobsystem tickets not available"}
    :metric-group-mappings []
    :metrics-config {:inter-router-metrics-idle-timeout-ms 2000

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -809,6 +809,8 @@
 
 (deftest test-routes-mapper
   (let [exec-routes-mapper (fn [uri] (routes-mapper {:uri uri}))]
+    (is (= {:handler :welcome-handler-fn}
+           (exec-routes-mapper "/")))
     (is (= {:handler :app-name-handler-fn}
            (exec-routes-mapper "/app-name")))
     (is (= {:handler :service-list-handler-fn}
@@ -831,12 +833,10 @@
            (exec-routes-mapper "/blacklist/test-service")))
     (is (= {:handler :favicon-handler-fn}
            (exec-routes-mapper "/favicon.ico")))
-    (is (= {:handler :process-request-fn} ;; outdated mapping
-           (exec-routes-mapper "/kill-instance")))
     (is (= {:handler :metrics-request-handler-fn}
            (exec-routes-mapper "/metrics")))
-    (is (= {:handler :process-request-fn}
-           (exec-routes-mapper "/secrun")))
+    (is (= {:handler :not-found-handler-fn}
+           (exec-routes-mapper "/not-found"))) ; any path that isn't mapped
     (is (= {:handler :service-id-handler-fn}
            (exec-routes-mapper "/service-id")))
     (is (= {:handler :display-settings-handler-fn}
@@ -847,8 +847,6 @@
            (exec-routes-mapper "/state")))
     (is (= {:handler :service-state-handler-fn, :route-params {:service-id "test-service"}}
            (exec-routes-mapper "/state/test-service")))
-    (is (= {:handler :process-request-fn}
-           (exec-routes-mapper "/stats")))
     (is (= {:handler :status-handler-fn}
            (exec-routes-mapper "/status")))
     (is (= {:handler :token-handler-fn}
@@ -861,8 +859,6 @@
            (exec-routes-mapper "/tokens/refresh")))
     (is (= {:handler :token-reindex-handler-fn}
            (exec-routes-mapper "/tokens/reindex")))
-    (is (= {:handler :process-request-fn}
-           (exec-routes-mapper "/through-to-backend")))
     (is (= {:handler :async-complete-handler-fn, :route-params {:request-id "test-request-id", :service-id "test-service-id"}}
            (exec-routes-mapper "/waiter-async/complete/test-request-id/test-service-id")))
     (is (= {:handler :async-result-handler-fn

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -948,19 +948,19 @@
                        :scheme :http}
               {:keys [body headers status]} (request-consent-handler-fn request)]
           (is (= 200 status))
-          (is (= {} headers))
+          (is (= {"content-type" "text/html"} headers))
           (is (= body "template:some-content")))))
 
     (with-redefs [io/resource io-resource-fn
                   template/eval (template-eval-factory "https")]
-      (testing "token without service description - http scheme"
+      (testing "token without service description - https scheme"
         (let [request {:authorization/user "test-user"
                        :headers {"host" "www.example.com:6789"}
                        :route-params {:path "some-path"}
                        :scheme :https}
               {:keys [body headers status]} (request-consent-handler-fn request)]
           (is (= 200 status))
-          (is (= {} headers))
+          (is (= {"content-type" "text/html"} headers))
           (is (= body "template:some-content")))))
 
     (with-redefs [io/resource io-resource-fn
@@ -972,7 +972,7 @@
                        :scheme :http}
               {:keys [body headers status]} (request-consent-handler-fn request)]
           (is (= 200 status))
-          (is (= {} headers))
+          (is (= {"content-type" "text/html"} headers))
           (is (= body "template:some-content")))))))
 
 (deftest test-blacklist-instance-cannot-find-channel


### PR DESCRIPTION
- Adds a content-negotiated welcome page for `/`
- Changes behavior for `waiter-request?`s to return a 404 error instead of falling through to `process-request-fn` if it doesn't match a path.

Welcome page (text/html)
<img width="860" alt="screen shot 2017-09-26 at 2 03 17 am" src="https://user-images.githubusercontent.com/6118583/30844867-f05fa160-a25e-11e7-9fae-a7a418c1d19e.png">

Welcome page (text/plain)
<pre>
Welcome to Waiter
=================

  Waiter is a high-level platform for running and managing web services and applications.
  See `Getting Help' for more info, or if you feel you've reached this page in error.

Server Info
===========

       Host: localhost
  Interface: 127.0.0.1
       Port: 9091

Request Info
============

        CID: 5c928a72ad29-6612ef5e48d54bac
       Time: 2017-09-26 02:04:31.643

Getting Help
============

  Waiter on GitHub: http://github.com/twosigma/waiter 
</pre>

Welcome page (application/json)
<pre>{
  "cid": "5c9a9388d000-de5e52e5a6a8ec6",
  "host": "127.0.0.1",
  "hostname": "localhost",
  "message": "Welcome to Waiter",
  "port": 9091,
  "support-info": [
    {
      "label": "Waiter on GitHub",
      "link": {
        "type": "url",
        "value": "http://github.com/twosigma/waiter"
      }
    }
  ],
  "timestamp": "2017-09-26 02:05:06.157"
}</pre>
