### PR TITLE
Safer way of calculating memory usage

### DIFF
--- a/waiter/integration/waiter/deployment_errors_test.clj
+++ b/waiter/integration/waiter/deployment_errors_test.clj
@@ -9,11 +9,21 @@
 ;;       actual or intended publication of such source code.
 ;;
 (ns waiter.deployment-errors-test
-  (:require [clojure.string :as str]
+  (:require [clojure.pprint :as pprint]
+            [clojure.string :as str]
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
+            [plumbing.core :as pc]
             [waiter.client-tools :refer :all]
             [waiter.settings :as settings]))
+
+(defn get-router->service-state
+  [waiter-url service-id]
+  (let [{:keys [cookies]} (make-request waiter-url "/waiter-auth")]
+    (->> (routers waiter-url)
+         (map (fn [[_ router-url]]
+                (service-state router-url service-id :cookies cookies)))
+         (pc/map-from-keys :router-id))))
 
 (deftest ^:parallel ^:integration-slow test-invalid-health-check-response
   (testing-using-waiter-url
@@ -23,10 +33,18 @@
                    :x-waiter-queue-timeout 600000}
           {:keys [headers body] :as response} (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))
           service-id (get headers "x-waiter-service-id")]
-      (is (not (nil? service-id)))
-      (assert-response-status response 503)
-      (is (str/includes? body (str "Deployment error: " (-> (waiter-settings waiter-url) :messages :invalid-health-check-response))))
-      (delete-service waiter-url service-id))))
+      (try
+        (assert-response-status response 503)
+        (is service-id)
+        (is (get-router->service-state waiter-url service-id))
+        (is (str/includes? body (str "Deployment error: " (-> (waiter-settings waiter-url)
+                                                              :messages
+                                                              :invalid-health-check-response)))
+            (str "router->service-state:\n" (with-out-str
+                                              (pprint/pprint
+                                                (get-router->service-state waiter-url service-id)))))
+        (finally
+          (delete-service waiter-url service-id))))))
 
 (deftest ^:parallel ^:integration-slow test-cannot-connect
   (testing-using-waiter-url
@@ -36,10 +54,18 @@
                    :x-waiter-queue-timeout 600000}
           {:keys [headers body] :as response} (make-request-with-debug-info headers #(make-shell-request waiter-url %))
           service-id (get headers "x-waiter-service-id")]
-      (is (not (nil? service-id)))
-      (assert-response-status response 503)
-      (is (str/includes? body (str "Deployment error: " (-> (waiter-settings waiter-url) :messages :cannot-connect))))
-      (delete-service waiter-url service-id))))
+      (try
+        (assert-response-status response 503)
+        (is service-id)
+        (is (get-router->service-state waiter-url service-id))
+        (is (str/includes? body (str "Deployment error: " (-> (waiter-settings waiter-url)
+                                                              :messages
+                                                              :cannot-connect)))
+            (str "router->service-state:\n" (with-out-str
+                                              (pprint/pprint
+                                                (get-router->service-state waiter-url service-id)))))
+        (finally
+          (delete-service waiter-url service-id))))))
 
 (deftest ^:parallel ^:integration-slow test-health-check-timed-out
   (testing-using-waiter-url
@@ -49,10 +75,18 @@
                    :x-waiter-queue-timeout 600000}
           {:keys [headers body] :as response} (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))
           service-id (get headers "x-waiter-service-id")]
-      (is (not (nil? service-id)))
-      (assert-response-status response 503)
-      (is (str/includes? body (str "Deployment error: " (-> (waiter-settings waiter-url) :messages :health-check-timed-out))))
-      (delete-service waiter-url service-id))))
+      (try
+        (assert-response-status response 503)
+        (is service-id)
+        (is (get-router->service-state waiter-url service-id))
+        (is (str/includes? body (str "Deployment error: " (-> (waiter-settings waiter-url)
+                                                              :messages
+                                                              :health-check-timed-out)))
+            (str "router->service-state:\n" (with-out-str
+                                              (pprint/pprint
+                                                (get-router->service-state waiter-url service-id)))))
+        (finally
+          (delete-service waiter-url service-id))))))
 
 (deftest ^:parallel ^:integration-fast test-health-check-requires-authentication
   (testing-using-waiter-url
@@ -60,10 +94,19 @@
                    :x-waiter-health-check-url "/bad-status?status=401"}
           {:keys [headers body] :as response} (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))
           service-id (get headers "x-waiter-service-id")]
-      (is (not (nil? service-id)))
-      (assert-response-status response 503)
-      (is (str/includes? body (str "Deployment error: " (-> (waiter-settings waiter-url) :messages :health-check-requires-authentication))))
-      (delete-service waiter-url service-id))))
+      (try
+        (assert-response-status response 503)
+        (is service-id)
+        (is (get-router->service-state waiter-url service-id))
+        (is (str/includes? body (str "Deployment error: " (-> (waiter-settings waiter-url)
+                                                         :messages
+                                                         :health-check-requires-authentication)))
+            (str "router->service-state:\n" (with-out-str
+                                              (pprint/pprint
+                                                (get-router->service-state waiter-url service-id)))))
+
+        (finally
+          (delete-service waiter-url service-id))))))
 
 ; Marked explicit because not all servers use cgroups to limit memory (this error is not reproducible on testing platforms)
 (deftest ^:parallel ^:integration-fast ^:explicit test-not-enough-memory
@@ -72,10 +115,18 @@
                    :x-waiter-mem 1}
           {:keys [headers body] :as response} (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))
           service-id (get headers "x-waiter-service-id")]
-      (is (not (nil? service-id)))
-      (assert-response-status response 503)
-      (is (str/includes? body (str "Deployment error: " (-> (waiter-settings waiter-url) :messages :not-enough-memory))))
-      (delete-service waiter-url service-id))))
+      (try
+        (assert-response-status response 503)
+        (is service-id)
+        (is (get-router->service-state waiter-url service-id))
+        (is (str/includes? body (str "Deployment error: " (-> (waiter-settings waiter-url)
+                                                              :messages
+                                                              :not-enough-memory)))
+            (str "router->service-state:\n" (with-out-str
+                                              (pprint/pprint
+                                                (get-router->service-state waiter-url service-id)))))
+        (finally
+          (delete-service waiter-url service-id))))))
 
 (deftest ^:parallel ^:integration-fast test-bad-startup-command
   (testing-using-waiter-url
@@ -84,8 +135,16 @@
                    :x-waiter-cmd (str "asdf" (kitchen-cmd "-p $PORT0"))}
           {:keys [headers body] :as response} (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))
           service-id (get headers "x-waiter-service-id")]
-      (is (not (nil? service-id)))
-      (assert-response-status response 503)
-      (is (str/includes? body (str "Deployment error: " (-> (waiter-settings waiter-url) :messages :bad-startup-command))))
-      (delete-service waiter-url service-id))))
+      (try
+        (is service-id)
+        (is (get-router->service-state waiter-url service-id))
+        (assert-response-status response 503)
+        (is (str/includes? body (str "Deployment error: " (-> (waiter-settings waiter-url)
+                                                              :messages
+                                                              :bad-startup-command)))
+            (str "router->service-state:\n" (with-out-str
+                                              (pprint/pprint
+                                                (get-router->service-state waiter-url service-id)))))
+        (finally
+          (delete-service waiter-url service-id))))))
 

--- a/waiter/integration/waiter/deployment_errors_test.clj
+++ b/waiter/integration/waiter/deployment_errors_test.clj
@@ -18,12 +18,38 @@
             [waiter.settings :as settings]))
 
 (defn get-router->service-state
+  "Retrieves service state for a service."
   [waiter-url service-id]
   (let [{:keys [cookies]} (make-request waiter-url "/waiter-auth")]
     (->> (routers waiter-url)
          (map (fn [[_ router-url]]
                 (service-state router-url service-id :cookies cookies)))
-         (pc/map-from-keys :router-id))))
+         (pc/map-from-vals :router-id))))
+
+(defn formatted-service-state
+  "Generates a formatted representation of service state."
+  [waiter-url service-id]
+  (str "router->service-state:\n" (with-out-str
+                                    (pprint/pprint
+                                      (get-router->service-state waiter-url service-id)))))
+
+(defn deployment-error->str
+  "Converts a deployment error keyword to the associated error message."
+  [waiter-url deployment-error]
+  (str "Deployment error: " (-> (waiter-settings waiter-url)
+                                :messages
+                                deployment-error)))
+
+(defmacro assert-deployment-error
+  "Asserts that the given response has a status of 503 and body with the error message
+  associated with the deployment error."
+  [response deployment-error]
+  `(let [response# ~response
+         body# (:body response#)
+         service-id# (response->service-id response#)]
+     (assert-response-status response# 503)
+     (is (str/includes? body# (deployment-error->str ~'waiter-url ~deployment-error))
+         (formatted-service-state ~'waiter-url service-id#))))
 
 (deftest ^:parallel ^:integration-slow test-invalid-health-check-response
   (testing-using-waiter-url
@@ -31,20 +57,9 @@
                    ; health check endpoint always returns status 402
                    :x-waiter-health-check-url "/bad-status?status=402"
                    :x-waiter-queue-timeout 600000}
-          {:keys [headers body] :as response} (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))
-          service-id (get headers "x-waiter-service-id")]
-      (try
-        (assert-response-status response 503)
-        (is service-id)
-        (is (get-router->service-state waiter-url service-id))
-        (is (str/includes? body (str "Deployment error: " (-> (waiter-settings waiter-url)
-                                                              :messages
-                                                              :invalid-health-check-response)))
-            (str "router->service-state:\n" (with-out-str
-                                              (pprint/pprint
-                                                (get-router->service-state waiter-url service-id)))))
-        (finally
-          (delete-service waiter-url service-id))))))
+          response (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))]
+      (with-service-cleanup (response->service-id response)
+        (assert-deployment-error response :invalid-health-check-response)))))
 
 (deftest ^:parallel ^:integration-slow test-cannot-connect
   (testing-using-waiter-url
@@ -52,20 +67,9 @@
                    ; nothing to connect to
                    :x-waiter-cmd "sleep 3600"
                    :x-waiter-queue-timeout 600000}
-          {:keys [headers body] :as response} (make-request-with-debug-info headers #(make-shell-request waiter-url %))
-          service-id (get headers "x-waiter-service-id")]
-      (try
-        (assert-response-status response 503)
-        (is service-id)
-        (is (get-router->service-state waiter-url service-id))
-        (is (str/includes? body (str "Deployment error: " (-> (waiter-settings waiter-url)
-                                                              :messages
-                                                              :cannot-connect)))
-            (str "router->service-state:\n" (with-out-str
-                                              (pprint/pprint
-                                                (get-router->service-state waiter-url service-id)))))
-        (finally
-          (delete-service waiter-url service-id))))))
+          response (make-request-with-debug-info headers #(make-shell-request waiter-url %))]
+      (with-service-cleanup (response->service-id response)
+        (assert-deployment-error response :cannot-connect)))))
 
 (deftest ^:parallel ^:integration-slow test-health-check-timed-out
   (testing-using-waiter-url
@@ -73,78 +77,32 @@
                    ; health check endpoint sleeps for 300000 ms (= 5 minutes)
                    :x-waiter-health-check-url "/sleep?sleep-ms=300000&status=400"
                    :x-waiter-queue-timeout 600000}
-          {:keys [headers body] :as response} (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))
-          service-id (get headers "x-waiter-service-id")]
-      (try
-        (assert-response-status response 503)
-        (is service-id)
-        (is (get-router->service-state waiter-url service-id))
-        (is (str/includes? body (str "Deployment error: " (-> (waiter-settings waiter-url)
-                                                              :messages
-                                                              :health-check-timed-out)))
-            (str "router->service-state:\n" (with-out-str
-                                              (pprint/pprint
-                                                (get-router->service-state waiter-url service-id)))))
-        (finally
-          (delete-service waiter-url service-id))))))
+          response (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))]
+      (with-service-cleanup (response->service-id response)
+        (assert-deployment-error response :health-check-timed-out)))))
 
 (deftest ^:parallel ^:integration-fast test-health-check-requires-authentication
   (testing-using-waiter-url
     (let [headers {:x-waiter-name (rand-name)
                    :x-waiter-health-check-url "/bad-status?status=401"}
-          {:keys [headers body] :as response} (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))
-          service-id (get headers "x-waiter-service-id")]
-      (try
-        (assert-response-status response 503)
-        (is service-id)
-        (is (get-router->service-state waiter-url service-id))
-        (is (str/includes? body (str "Deployment error: " (-> (waiter-settings waiter-url)
-                                                         :messages
-                                                         :health-check-requires-authentication)))
-            (str "router->service-state:\n" (with-out-str
-                                              (pprint/pprint
-                                                (get-router->service-state waiter-url service-id)))))
-
-        (finally
-          (delete-service waiter-url service-id))))))
+          response (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))]
+      (with-service-cleanup (response->service-id response)
+        (assert-deployment-error response :health-check-requires-authentication)))))
 
 ; Marked explicit because not all servers use cgroups to limit memory (this error is not reproducible on testing platforms)
 (deftest ^:parallel ^:integration-fast ^:explicit test-not-enough-memory
   (testing-using-waiter-url
     (let [headers {:x-waiter-name (rand-name)
                    :x-waiter-mem 1}
-          {:keys [headers body] :as response} (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))
-          service-id (get headers "x-waiter-service-id")]
-      (try
-        (assert-response-status response 503)
-        (is service-id)
-        (is (get-router->service-state waiter-url service-id))
-        (is (str/includes? body (str "Deployment error: " (-> (waiter-settings waiter-url)
-                                                              :messages
-                                                              :not-enough-memory)))
-            (str "router->service-state:\n" (with-out-str
-                                              (pprint/pprint
-                                                (get-router->service-state waiter-url service-id)))))
-        (finally
-          (delete-service waiter-url service-id))))))
+          response (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))]
+      (with-service-cleanup (response->service-id response)
+        (assert-deployment-error response :not-enough-memory)))))
 
 (deftest ^:parallel ^:integration-fast test-bad-startup-command
   (testing-using-waiter-url
     (let [headers {:x-waiter-name (rand-name)
                    ; misspelled command (invalid prefix asdf)
                    :x-waiter-cmd (str "asdf" (kitchen-cmd "-p $PORT0"))}
-          {:keys [headers body] :as response} (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))
-          service-id (get headers "x-waiter-service-id")]
-      (try
-        (is service-id)
-        (is (get-router->service-state waiter-url service-id))
-        (assert-response-status response 503)
-        (is (str/includes? body (str "Deployment error: " (-> (waiter-settings waiter-url)
-                                                              :messages
-                                                              :bad-startup-command)))
-            (str "router->service-state:\n" (with-out-str
-                                              (pprint/pprint
-                                                (get-router->service-state waiter-url service-id)))))
-        (finally
-          (delete-service waiter-url service-id))))))
-
+          response (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))]
+      (with-service-cleanup (response->service-id response)
+        (assert-deployment-error response :bad-startup-command)))))

--- a/waiter/src/waiter/client_tools.clj
+++ b/waiter/src/waiter/client_tools.clj
@@ -818,3 +818,16 @@
                                      :query-params query-params)]
     (log/debug "retrieved token" token ":" (:body token-response))
     token-response))
+
+(defmacro with-service-cleanup
+  "Ensures a service is cleaned up."
+  [service-id & body]
+  `(try
+     ~@body
+     (finally
+       (delete-service ~'waiter-url ~service-id))))
+
+(defn response->service-id
+  "Gets the service-id from a response."
+  [{:keys [headers]}]
+  (get headers "x-waiter-service-id"))

--- a/waiter/src/waiter/shell_scheduler.clj
+++ b/waiter/src/waiter/shell_scheduler.clj
@@ -345,7 +345,7 @@
   [{:keys [:shell-scheduler/process :shell-scheduler/pid] :as instance} mem pid->memory port->reservation-atom port-grace-period-ms]
   (if (and (active? instance) (.isAlive process))
     (let [memory-allocated (* mem 1000)
-          memory-used (get pid->memory pid)]
+          memory-used (pid->memory pid)]
       (if (and memory-used (> memory-used memory-allocated))
         (do (log/info "instance exceeds memory limit, killing instance" {:instance instance :memory-limit memory-allocated :memory-used memory-used})
             (kill-process! instance port->reservation-atom port-grace-period-ms)
@@ -358,42 +358,62 @@
     instance))
 
 (defn- get-pid->memory
-  "Issues and parses the results of a ps shell command and returns a new pid->memory map"
+  "Issues and parses the results of a ps shell command and returns a pid->memory fn."
   []
   (try
-    (let [ps-output (-> (sh/sh "ps" "-eo" "pid,pgid,rss") :out (str/split #"\n") rest)
-          pid->pgid (map #(-> % str/trim (str/split #"\s+") butlast
-                              ((fn [[a b]] [(Integer/parseInt a) (Integer/parseInt b)])))
-                         ps-output)
-          pgid->rss (apply merge-with +
-                           (map #(-> % str/trim (str/split #"\s+") rest
-                                     ((fn [[a b]] {(Integer/parseInt a) (Integer/parseInt b)})))
-                                ps-output))]
-      (into {} (for [[pid pgid] pid->pgid] [pid (get pgid->rss pgid)])))
+    (let [cols->entry (fn [[pid ppid rss]] {:pid (Integer/parseInt pid)
+                                            :ppid (Integer/parseInt ppid)
+                                            :rss (Integer/parseInt rss)})
+          line->entry (fn [line] (-> line
+                                    str/trim
+                                    (str/split #"\s+")
+                                    cols->entry))
+          ps-entries (->> (sh/sh "ps" "-eo" "pid,ppid,rss")
+                          :out
+                          str/split-lines
+                          rest
+                          (map line->entry))
+          pid->entry (pc/map-from-vals :pid ps-entries)
+          ppid->children (group-by :ppid ps-entries)]
+      (fn pid->memory [pid]
+        (let [root-entry (pid->entry pid)]
+          (when root-entry
+            (loop [memory 0
+                   entries [root-entry]]
+              (if (seq entries)
+                (recur (+ memory (reduce + (map :rss entries)))
+                       (->> (map :pid entries)
+                            (map ppid->children)
+                            (reduce concat)))
+                memory))))))
     (catch Throwable e
-      (log/error e "error attempting to issue ps command")
+      (log/error e "error creating pid->memory")
       {})))
 
 (defn update-service-health
   "Runs health checks against all active instances of service and returns the updated service-entry"
   [id->service port->reservation-atom port-grace-period-ms http-client]
-  (timers/start-stop-time!
-    (metrics/waiter-timer "shell-scheduler" "update-health")
-    (let [pid->memory (get-pid->memory)
-          exit-codes-check #(associate-exit-codes % port->reservation-atom port-grace-period-ms)]
-      (loop [remaining-service-entries (vals id->service)
-             id->service' {}]
-        (if-let [{:keys [service id->instance] :as service-entry} (first remaining-service-entries)]
-          (let [{:strs [health-check-url grace-period-secs]} (:service-description service)
-                health-check #(update-instance-health % health-check-url http-client)
-                limits-check #(enforce-instance-limits % (:shell-scheduler/mem service) pid->memory port->reservation-atom port-grace-period-ms)
-                grace-period-check #(enforce-grace-period % grace-period-secs port->reservation-atom port-grace-period-ms)
-                id->instance' (pc/map-vals (comp grace-period-check health-check limits-check exit-codes-check) id->instance)
-                service-entry' (-> service-entry
-                                   (assoc :id->instance id->instance')
-                                   update-task-stats)]
-            (recur (rest remaining-service-entries) (assoc id->service' (:id service) service-entry')))
-          id->service')))))
+  (try
+    (timers/start-stop-time!
+      (metrics/waiter-timer "shell-scheduler" "update-health")
+      (let [pid->memory (get-pid->memory)
+            exit-codes-check #(associate-exit-codes % port->reservation-atom port-grace-period-ms)]
+        (loop [remaining-service-entries (vals id->service)
+               id->service' {}]
+          (if-let [{:keys [service id->instance] :as service-entry} (first remaining-service-entries)]
+            (let [{:strs [health-check-url grace-period-secs]} (:service-description service)
+                  health-check #(update-instance-health % health-check-url http-client)
+                  limits-check #(enforce-instance-limits % (:shell-scheduler/mem service) pid->memory port->reservation-atom port-grace-period-ms)
+                  grace-period-check #(enforce-grace-period % grace-period-secs port->reservation-atom port-grace-period-ms)
+                  id->instance' (pc/map-vals (comp grace-period-check health-check limits-check exit-codes-check) id->instance)
+                  service-entry' (-> service-entry
+                                     (assoc :id->instance id->instance')
+                                     update-task-stats)]
+              (recur (rest remaining-service-entries) (assoc id->service' (:id service) service-entry')))
+            id->service'))))
+    (catch Throwable e
+      (log/error e "error while updating service health")
+      id->service)))
 
 (defn- start-updating-health
   "Runs health checks against all active instances of all services in a loop"

--- a/waiter/src/waiter/shell_scheduler.clj
+++ b/waiter/src/waiter/shell_scheduler.clj
@@ -344,7 +344,7 @@
   "Kills processes that exceed allocated memory usage"
   [{:keys [:shell-scheduler/process :shell-scheduler/pid] :as instance} mem pid->memory port->reservation-atom port-grace-period-ms]
   (if (and (active? instance) (.isAlive process))
-    (let [memory-allocated (* mem 1000)
+    (let [memory-allocated (* mem 1024)
           memory-used (pid->memory pid)]
       (if (and memory-used (> memory-used memory-allocated))
         (do (log/info "instance exceeds memory limit, killing instance" {:instance instance :memory-limit memory-allocated :memory-used memory-used})
@@ -357,17 +357,17 @@
         instance))
     instance))
 
-(defn- get-pid->memory
-  "Issues and parses the results of a ps shell command and returns a pid->memory fn."
+(defn get-pid->memory
+  "Issues and parses the results of a ps shell command and returns a pid->memory fn.  Memory is measured in KB."
   []
   (try
     (let [cols->entry (fn [[pid ppid rss]] {:pid (Integer/parseInt pid)
                                             :ppid (Integer/parseInt ppid)
                                             :rss (Integer/parseInt rss)})
           line->entry (fn [line] (-> line
-                                    str/trim
-                                    (str/split #"\s+")
-                                    cols->entry))
+                                     str/trim
+                                     (str/split #"\s+")
+                                     cols->entry))
           ps-entries (->> (sh/sh "ps" "-eo" "pid,ppid,rss")
                           :out
                           str/split-lines
@@ -384,7 +384,7 @@
                 (recur (+ memory (reduce + (map :rss entries)))
                        (->> (map :pid entries)
                             (map ppid->children)
-                            (reduce concat)))
+                            (apply concat)))
                 memory))))))
     (catch Throwable e
       (log/error e "error creating pid->memory")
@@ -398,9 +398,8 @@
       (metrics/waiter-timer "shell-scheduler" "update-health")
       (let [pid->memory (get-pid->memory)
             exit-codes-check #(associate-exit-codes % port->reservation-atom port-grace-period-ms)]
-        (loop [remaining-service-entries (vals id->service)
-               id->service' {}]
-          (if-let [{:keys [service id->instance] :as service-entry} (first remaining-service-entries)]
+        (reduce
+          (fn [id->service' {:keys [service id->instance] :as service-entry}]
             (let [{:strs [health-check-url grace-period-secs]} (:service-description service)
                   health-check #(update-instance-health % health-check-url http-client)
                   limits-check #(enforce-instance-limits % (:shell-scheduler/mem service) pid->memory port->reservation-atom port-grace-period-ms)
@@ -409,8 +408,9 @@
                   service-entry' (-> service-entry
                                      (assoc :id->instance id->instance')
                                      update-task-stats)]
-              (recur (rest remaining-service-entries) (assoc id->service' (:id service) service-entry')))
-            id->service'))))
+              (assoc id->service' (:id service) service-entry')))
+          {}
+          (vals id->service))))
     (catch Throwable e
       (log/error e "error while updating service health")
       id->service)))


### PR DESCRIPTION
This PR avoids race that causes shell scheduler's unit tests to fail.

### Previous approach
Calculate the memory usage by summing usage of all processes in the subprocess' process group.

The race:
1. Start process (`setsid bash ...`)
2. Check memory usage of `pgid`
3. `setsid` hasn't changed the process group yet.

Since the process hasn't changed groups, the memory calculation includes all ancestor processes sharing the process group.  And since that number is much larger, the processes are killed due to using too much memory, and test assertions fail.

### New approach

Build a tree of processes, and when calculating memory, include strictly only the subprocess and its children.
