### PR TITLE
Refactor for set idioms

### DIFF
--- a/waiter/integration/waiter/cookie_support_integration_test.clj
+++ b/waiter/integration/waiter/cookie_support_integration_test.clj
@@ -50,5 +50,5 @@
               {:keys [body]} (make-request-with-debug-info headers #(make-kitchen-request waiter-url % :path "/request-info"
                                                                                           :cookies cookies))
               {:strings [headers]} (json/read-str (str body))]
-          (is (not (contains? (set (keys headers)) "cookie")))
+          (is (not (contains? headers "cookie")))
           (delete-service waiter-url service-id))))))

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -612,7 +612,8 @@
                                   (dissoc :run-as-user))
           waiter-port (.getPort (URL. (str "http://" waiter-url)))
           waiter-port (if (neg? waiter-port) 80 waiter-port)
-          host-header (str token ":" waiter-port)]
+          host-header (str token ":" waiter-port)
+          has-x-waiter-consent? (partial some #(= (:name %) "x-waiter-consent"))]
       (try
         (testing "token creation"
           (let [token-description (assoc service-description :token token)
@@ -657,7 +658,7 @@
                   (reset! cookies-atom cookies)
                   (is (= "Added cookie x-waiter-consent" body))
                   ; x-waiter-consent should be emitted Waiter
-                  (is (contains? (set (map :name cookies)) "x-waiter-consent"))
+                  (is (has-x-waiter-consent? cookies))
                   (assert-response-status response 200)))
 
               (testing "auto run-as-user population on expected service-id"
@@ -672,7 +673,7 @@
                       (reset! service-id-atom service-id)
                       (is (= "Hello World" body))
                       ; x-waiter-consent should not be re-emitted Waiter
-                      (is (not (contains? (set (map :name cookies)) "x-waiter-consent")))
+                      (is (not (has-x-waiter-consent? cookies)))
                       (is (= expected-service-id service-id))
                       (is (not (str/blank? permitted-user)))
                       (is (= run-as-user permitted-user))
@@ -707,7 +708,7 @@
                   (reset! cookies-atom cookies)
                   (is (= "Added cookie x-waiter-consent" body))
                   ; x-waiter-consent should be emitted Waiter
-                  (is (contains? (set (map :name cookies)) "x-waiter-consent"))
+                  (is (has-x-waiter-consent? cookies))
                   (assert-response-status response 200)))
 
               (testing "auto run-as-user population on approved token"
@@ -720,7 +721,7 @@
                       (reset! service-id-atom service-id)
                       (is (= "Hello World" body))
                       ; x-waiter-consent should not be re-emitted Waiter
-                      (is (not (contains? (set (map :name cookies)) "x-waiter-consent")))
+                      (is (not (has-x-waiter-consent? cookies)))
                       (is (not= previous-service-id service-id))
                       (assert-response-status response 200))
                     (finally

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -337,7 +337,7 @@
                                                                (catch Exception e
                                                                  (log/error e (str "error in deleting: " service)))))
                                                            apps-to-gc)
-                            apps-failed-to-delete (set/difference (set apps-to-gc) (set apps-successfully-gced))
+                            apps-failed-to-delete (apply disj (set apps-to-gc) apps-successfully-gced)
                             service->state'' (apply dissoc service->state' apps-successfully-gced)]
                         (when (or (not= (set (keys service->state'')) (set (keys service->raw-data)))
                                   (not= (set (keys service->state'')) (set (keys service->state))))
@@ -408,7 +408,7 @@
   "Creates a function that determines for a given request whether or not
   the request is intended for Waiter itself or a service of Waiter."
   [valid-waiter-hostnames]
-  (let [valid-waiter-hostnames (set/union (set valid-waiter-hostnames) #{"localhost" "127.0.0.1"})]
+  (let [valid-waiter-hostnames (set/union valid-waiter-hostnames #{"localhost" "127.0.0.1"})]
     (fn waiter-request? [{:keys [uri headers]}]
       (let [{:strs [host]} headers]
         (or (#{"/app-name" "/service-id" "/token"} uri) ; special urls that are always for Waiter (FIXME)
@@ -737,8 +737,7 @@
                          (let [local-router (InetAddress/getLocalHost)
                                waiter-router-hostname (.getCanonicalHostName local-router)
                                waiter-router-ip (.getHostAddress local-router)
-                               ;; use (set [...]) instead of #{...} below as there may be duplicate values
-                               hostnames (set/union waiter-hostnames (set [waiter-router-hostname waiter-router-ip]))]
+                               hostnames (conj waiter-hostnames waiter-router-hostname waiter-router-ip)]
                            (waiter-request?-factory hostnames)))
    :websocket-request-auth-cookie-attacher (pc/fnk [[:state passwords router-id]]
                                              (fn websocket-request-auth-cookie-attacher [request]

--- a/waiter/src/waiter/scaling.clj
+++ b/waiter/src/waiter/scaling.clj
@@ -428,9 +428,9 @@
                         (assoc current-state :continue-looping false :timeout-chan nil)
                         state-chan
                         (let [{:keys [service-id->healthy-instances service-id->unhealthy-instances service-id->expired-instances]} args
-                              existing-service-ids-set (set (keys service-id->router-state))
-                              service-ids-set (set/union (-> service-id->healthy-instances (keys) (set))
-                                                         (-> service-id->unhealthy-instances (keys) (set)))
+                              existing-service-ids-set (-> service-id->router-state keys set)
+                              service-ids-set (into (-> service-id->healthy-instances keys set)
+                                                    (-> service-id->unhealthy-instances keys))
                               deleted-service-ids (set/difference existing-service-ids-set service-ids-set)
                               new-service-ids (set/difference service-ids-set existing-service-ids-set)
                               service-id->router-state' (pc/map-from-keys

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -362,12 +362,11 @@
   "Queries the scheduler and builds a list of healthy and unhealthy instances for the specified service-id."
   [service-id service-instances]
   (when service-instances
-    (let [healthy-instances (vec (filter :healthy? service-instances))
-          unhealthy-instances (vec (clojure.set/difference (set service-instances) (set healthy-instances)))]
+    (let [{healthy-instances true, unhealthy-instances false} (group-by (comp boolean :healthy?) service-instances)]
       (log/trace "request-instances-for-app" service-id "has" (count healthy-instances) "healthy instance(s)"
                  "and" (count unhealthy-instances) " unhealthy instance(s).")
-      {:healthy-instances healthy-instances
-       :unhealthy-instances unhealthy-instances})))
+      {:healthy-instances (vec healthy-instances)
+       :unhealthy-instances (vec unhealthy-instances)})))
 
 (defn start-health-checks
   "Takes a map from service -> service instances and replaces each active instance with a ref which performs a

--- a/waiter/src/waiter/state.clj
+++ b/waiter/src/waiter/state.clj
@@ -1121,7 +1121,7 @@
                                        filter-fn (fn [[service-id _]] (contains? available-apps-set service-id))
                                        service-id->healthy-instances' (utils/filterm filter-fn service-id->healthy-instances)
                                        service-id->unhealthy-instances' (utils/filterm filter-fn service-id->unhealthy-instances)
-                                       services-without-instances (set/difference available-apps-set (set (keys service-id->my-instance->slots)))
+                                       services-without-instances (apply disj available-apps-set (keys service-id->my-instance->slots))
                                        service-id->expired-instances' (utils/filterm filter-fn service-id->expired-instances)
                                        service-id->starting-instances' (utils/filterm filter-fn service-id->starting-instances)
                                        service-id->failed-instances' (utils/filterm filter-fn service-id->failed-instances)
@@ -1163,8 +1163,8 @@
                                              (not= (get service-id->unhealthy-instances service-id) unhealthy-instances))
                                      (let [curr-instance-ids (set (map :id healthy-instances))
                                            prev-instance-ids (set (map :id (get service-id->healthy-instances service-id)))
-                                           new-instance-ids (vec (set/difference curr-instance-ids prev-instance-ids))
-                                           rem-instance-ids (vec (set/difference prev-instance-ids curr-instance-ids))
+                                           new-instance-ids (filterv (complement prev-instance-ids) curr-instance-ids)
+                                           rem-instance-ids (filterv (complement curr-instance-ids) prev-instance-ids)
                                            unhealthy-instance-ids (mapv :id (get service-id->unhealthy-instances' service-id))]
                                        (log/info "update-healthy-instances:" service-id "has"
                                                  (count healthy-instances) "healthy instance(s) and"

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -268,9 +268,8 @@
       (throw (ex-info "Token must match pattern"
                       {:status 400 :token token :pattern (str valid-token-re)})))
     (validate-service-description-fn new-service-description-template)
-    (let [unknown-keys (set/difference (-> new-token-description keys set)
-                                       (set sd/token-description-keys)
-                                       #{"token"})]
+    (let [unknown-keys (apply disj (-> new-token-description keys set)
+                              "token" sd/token-description-keys)]
       (when (not-empty unknown-keys)
         (throw (ex-info (str "Unsupported key(s) in token: " (str (vec unknown-keys)))
                         {:status 400 :token token}))))
@@ -369,7 +368,7 @@
     (case request-method
       :get (let [request-params (:params (ring-params/params-request req))
                  owner (get request-params "owner")
-                 owners (if owner (set [owner]) (list-token-owners kv-store))]
+                 owners (if owner #{owner} (list-token-owners kv-store))]
              (->> owners
                   (map (fn [owner] (->> (list-tokens-for-owner kv-store owner)
                                         (map (fn [v] {:token v, :owner owner})))))

--- a/waiter/test/waiter/metrics_sync_test.clj
+++ b/waiter/test/waiter/metrics_sync_test.clj
@@ -241,10 +241,10 @@
           (is (= new-router-ids (keyset (get-in out-router-metrics-state [:metrics :routers]))))
           (is (= (set/intersection (keyset (:router-id->incoming-ws out-router-metrics-state)) new-router-ids)
                  (keyset (get-in out-router-metrics-state [:router-id->incoming-ws]))))
-          (is (= (set/difference new-router-ids #{my-router-id "router-1"})
+          (is (= (disj new-router-ids my-router-id "router-1")
                  (keyset (get-in out-router-metrics-state [:router-id->outgoing-ws]))))
           (let [old-outgoing-router-ids (keyset (get-in in-router-metrics-state [:router-id->outgoing-ws]))
-                new-outgoing-router-ids (set/difference new-router-ids (set/union old-outgoing-router-ids #{my-router-id}))]
+                new-outgoing-router-ids (set/difference new-router-ids old-outgoing-router-ids #{my-router-id})]
             (doseq [[router-id ws-request] (-> out-router-metrics-state :router-id->outgoing-ws seq)]
               (if (contains? new-outgoing-router-ids router-id)
                 (do
@@ -305,10 +305,10 @@
         (is (= new-router-ids (keyset (get-in out-router-metrics-state [:metrics :routers]))))
         (is (= (set/intersection (keyset (:router-id->incoming-ws out-router-metrics-state)) new-router-ids)
                (keyset (get-in out-router-metrics-state [:router-id->incoming-ws]))))
-        (is (= (set/difference new-router-ids #{my-router-id})
+        (is (= (disj new-router-ids my-router-id)
                (keyset (get-in out-router-metrics-state [:router-id->outgoing-ws]))))
         (let [old-outgoing-router-ids (keyset (get-in in-router-metrics-state [:router-id->outgoing-ws]))
-              new-outgoing-router-ids (set/difference new-router-ids (set/union old-outgoing-router-ids #{my-router-id}))]
+              new-outgoing-router-ids (set/difference new-router-ids old-outgoing-router-ids #{my-router-id})]
           (doseq [[router-id ws-request] (-> out-router-metrics-state :router-id->outgoing-ws seq)]
             (if (contains? new-outgoing-router-ids router-id)
               (do

--- a/waiter/test/waiter/state_test.clj
+++ b/waiter/test/waiter/state_test.clj
@@ -301,7 +301,9 @@
               (is (empty? actual))
               (do
                 (is (every? (fn [[instance-id _]] (some #(= instance-id (:id %)) instances)) actual))
-                (is (every? (fn [[_ router-hash-list]] (= (set routers) (reduce #(conj %1 (first %2)) #{} router-hash-list))) actual))))))))))
+                (is (every? true?
+                            (for [[_ router-hash-list] actual]
+                              (= (set routers) (set (map first router-hash-list))))))))))))))
 
 ;; These tests are enumerated to document the minimum number of cases considered
 (deftest test-allocate-from-available-slots


### PR DESCRIPTION
Refactoring several set expressions to:

1. Avoid building extra intermediate sets (or other data structures)
2. Use more efficient functions to perform the same operations

In most cases, I think the updated versions are faster, and at least as readable as the original versions. This also addresses my comment in #158.