### PR TITLE
Enables HttpOnly on Waiter cookies

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -350,8 +350,13 @@
 (deftest ^:parallel ^:integration-fast basic-waiter-auth-test
   (testing-using-waiter-url
     (log/info "Basic waiter-auth test")
-    (let [{:keys [status body]} (make-request waiter-url "/waiter-auth")]
+    (let [{:keys [status body headers]} (make-request waiter-url "/waiter-auth")
+          set-cookie (get headers "set-cookie")]
       (is (= 200 status))
+      (is (str/includes? set-cookie "x-waiter-auth="))
+      (is (str/includes? set-cookie "Max-Age="))
+      (is (str/includes? set-cookie "Path=/"))
+      (is (str/includes? set-cookie "HttpOnly=true"))
       (is (= (System/getProperty "user.name") (str body))))))
 
 ; Marked explicit due to:

--- a/waiter/src/waiter/cookie_support.clj
+++ b/waiter/src/waiter/cookie_support.clj
@@ -62,7 +62,7 @@
                                      UrlEncoded/encodeString)
                   max-age (-> age-in-days t/days t/in-seconds)
                   path "/"
-                  set-cookie-header (str name "=" encoded-cookie ";Max-Age=" max-age ";Path=" path)
+                  set-cookie-header (str name "=" encoded-cookie ";Max-Age=" max-age ";Path=" path ";HttpOnly=true")
                   existing-header (get-in response [:headers "set-cookie"])
                   new-header (cond
                                (nil? existing-header) set-cookie-header

--- a/waiter/test/waiter/cookie_support_test.clj
+++ b/waiter/test/waiter/cookie_support_test.clj
@@ -41,7 +41,7 @@
   (is (= "a=b; c=d" (remove-cookie "a=b; x-waiter-auth=auth; c=d" "x-waiter-auth"))))
 
 (deftest test-add-encoded-cookie
-  (let [cookie-attrs ";Max-Age=864000;Path=/"
+  (let [cookie-attrs ";Max-Age=864000;Path=/;HttpOnly=true"
         user-cookie (str "user=" (UrlEncoded/encodeString "data:john") cookie-attrs)]
     (with-redefs [b64/encode (fn [^String data-string] (.getBytes data-string))
                   nippy/freeze (fn [input _] (str "data:" input))]


### PR DESCRIPTION
This prevents browsers from allowing JS access to these cookies via document.cookie.