### PR TITLE
OAuth support

### DIFF
--- a/waiter/config-shell-oauth.edn
+++ b/waiter/config-shell-oauth.edn
@@ -1,0 +1,36 @@
+{
+ ; ---------- Cluster ----------
+
+ :zookeeper {
+             ;; Use an in-process ZK (not for production use):
+             :connect-string :in-process}
+
+ ; ---------- Network ----------
+
+ ;; Set the bind address to a specific IP:
+ :host "localhost"
+
+ ;; Set the port:
+ :port #config/env-int "WAITER_PORT"
+
+ ; ---------- Security ----------
+
+ :authenticator-config {:kind :oauth
+                        :oauth {:factory-fn waiter.auth.oauth/oauth-authenticator
+                                :providers {:kinds [:github :google]
+                                            :github {:factory-fn waiter.auth.oauth/map->GitHubOAuthProvider
+                                                     :client-id #config/env "GITHUB_OAUTH_CLIENT_ID"
+                                                     :client-secret #config/env "GITHUB_OAUTH_CLIENT_SECRET"}
+                                            :google {:factory-fn waiter.auth.oauth/map->GoogleOAuthProvider
+                                                     :client-id #config/env "GOOGLE_OAUTH_CLIENT_ID"
+                                                     :client-secret #config/env "GOOGLE_OAUTH_CLIENT_SECRET"}}
+                                :run-as-user #config/env "WAITER_AUTH_RUN_AS_USER"}}
+
+ ; ---------- Scheduling ----------
+
+ :scheduler-config {
+                    ;; :kind :shell simply schedules instances on your local machine (for testing purposes only):
+                    :kind :shell}
+
+ ; ---------- CORS ----------
+ :cors-config {:kind :allow-all}}

--- a/waiter/config-shell-oauth.edn
+++ b/waiter/config-shell-oauth.edn
@@ -18,10 +18,10 @@
  :authenticator-config {:kind :oauth
                         :oauth {:factory-fn waiter.auth.oauth/oauth-authenticator
                                 :providers {:kinds [:github :google]
-                                            :github {:factory-fn waiter.auth.oauth/map->GitHubOAuthProvider
+                                            :github {:factory-fn waiter.auth.oauth.github/map->GitHubOAuthProvider
                                                      :client-id #config/env "GITHUB_OAUTH_CLIENT_ID"
                                                      :client-secret #config/env "GITHUB_OAUTH_CLIENT_SECRET"}
-                                            :google {:factory-fn waiter.auth.oauth/map->GoogleOAuthProvider
+                                            :google {:factory-fn waiter.auth.oauth.google/map->GoogleOAuthProvider
                                                      :client-id #config/env "GOOGLE_OAUTH_CLIENT_ID"
                                                      :client-secret #config/env "GOOGLE_OAUTH_CLIENT_SECRET"}}
                                 :run-as-user #config/env "WAITER_AUTH_RUN_AS_USER"}}

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -349,13 +349,18 @@
   (testing-using-waiter-url
     (log/info "Basic waiter-auth test")
     (let [{:keys [status body headers]} (make-request waiter-url "/waiter-auth")
-          set-cookie (get headers "set-cookie")]
+          set-cookie (get headers "set-cookie")
+          parsed-json (-> (try (json/read-str body)
+                               (catch Exception _
+                                 (is false (str "Unable to parse JSON\n:" body))))
+                          (walk/keywordize-keys))]
       (is (= 200 status))
       (is (str/includes? set-cookie "x-waiter-auth="))
       (is (str/includes? set-cookie "Max-Age="))
       (is (str/includes? set-cookie "Path=/"))
       (is (str/includes? set-cookie "HttpOnly=true"))
-      (is (= (System/getProperty "user.name") (str body))))))
+      (is (= {:user (System/getProperty "user.name")
+              :principal (System/getProperty "user.name")} parsed-json)))))
 
 ; Marked explicit due to:
 ;   FAIL in (test-killed-instances)

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -351,7 +351,7 @@
     (let [{:keys [status body headers]} (make-request waiter-url "/waiter-auth")
           set-cookie (get headers "set-cookie")
           parsed-json (-> (try-parse-json body)
-                          (walk/keywordize-keys))]
+                          walk/keywordize-keys)]
       (is (= 200 status))
       (is (str/includes? set-cookie "x-waiter-auth="))
       (is (str/includes? set-cookie "Max-Age="))

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -357,8 +357,8 @@
       (is (str/includes? set-cookie "Max-Age="))
       (is (str/includes? set-cookie "Path=/"))
       (is (str/includes? set-cookie "HttpOnly=true"))
-      (is (= {:user (System/getProperty "user.name")
-              :principal (System/getProperty "user.name")} parsed-json)))))
+      (is (= (System/getProperty "user.name") (:user parsed-json)))
+      (is (:principal parsed-json)))))
 
 ; Marked explicit due to:
 ;   FAIL in (test-killed-instances)

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -115,7 +115,16 @@
              :test {:jvm-opts
                     [~(str "-Dwaiter.test.kitchen.cmd=" (or
                                                           (System/getenv "WAITER_TEST_KITCHEN_CMD")
-                                                          (.getCanonicalPath (clojure.java.io/file "../kitchen/bin/run.sh"))))]}
+                                                          (.getCanonicalPath (clojure.java.io/file "../kitchen/bin/run.sh"))))]
+                    ;; Print exception data
+                    :injections [(defmethod clojure.test/report :error [m]
+                                   (clojure.test/with-test-out
+                                     (clojure.test/inc-report-counter :error)
+                                     (println "\nERROR in" (clojure.test/testing-vars-str m))
+                                     (when (seq clojure.test/*testing-contexts*) (println (clojure.test/testing-contexts-str)))
+                                     (when-let [message (:message m)] (println message))
+                                     (println "expected:" (pr-str (:expected m)))
+                                     (print "  actual: " (pr-str (:actual m)))))]}
              :test-console {:jvm-opts
                             ["-Dlog4j.configuration=log4j-console.properties"]}
              :test-log {:jvm-opts

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -115,16 +115,7 @@
              :test {:jvm-opts
                     [~(str "-Dwaiter.test.kitchen.cmd=" (or
                                                           (System/getenv "WAITER_TEST_KITCHEN_CMD")
-                                                          (.getCanonicalPath (clojure.java.io/file "../kitchen/bin/run.sh"))))]
-                    ;; Print exception data
-                    :injections [(defmethod clojure.test/report :error [m]
-                                   (clojure.test/with-test-out
-                                     (clojure.test/inc-report-counter :error)
-                                     (println "\nERROR in" (clojure.test/testing-vars-str m))
-                                     (when (seq clojure.test/*testing-contexts*) (println (clojure.test/testing-contexts-str)))
-                                     (when-let [message (:message m)] (println message))
-                                     (println "expected:" (pr-str (:expected m)))
-                                     (print "  actual: " (pr-str (:actual m)))))]}
+                                                          (.getCanonicalPath (clojure.java.io/file "../kitchen/bin/run.sh"))))]}
              :test-console {:jvm-opts
                             ["-Dlog4j.configuration=log4j-console.properties"]}
              :test-log {:jvm-opts

--- a/waiter/resources/web/error.html
+++ b/waiter/resources/web/error.html
@@ -128,7 +128,7 @@
   <div class="divider"></div>
   <div>
 	<h3>Additional Info</h3>
-	<pre id="details" class="code"><%= details %></pre>
+	<pre id="details" class="code"><%= (escape-html details) %></pre>
   </div>
 </div>
 

--- a/waiter/resources/web/oauth.html
+++ b/waiter/resources/web/oauth.html
@@ -31,10 +31,25 @@
     <div>
         <p>Choose a provider:</p>
         <% (doseq [[provider-key provider] providers] %>
-            <li><a href="/waiter-auth/oauth/<%= (name provider-key) %>/redirect/<%= path %><% (when query-string %><%= (str \? query-string) %><% ) %>"><%= (display-name provider) %></a></li>
+            <li><a class="redirect" href="/waiter-auth/oauth/<%= (name provider-key) %>/redirect/<%= path %><% (when query-string %><%= (str \? query-string) %><% ) %>"><%= (display-name provider) %></a></li>
         <% ) %>
     </div>
 </div>
+
+<script>
+if (location.hash) {
+    var redirectLinks = document.getElementsByClassName('redirect');
+    for (var i = 0; i < redirectLinks.length; i++) {
+        <% (when query-string %>
+            redirectLinks[i].href += "&_waiter_hash=" + encodeURIComponent(location.hash);
+        <% ) %>
+        <% (when-not query-string %>
+            redirectLinks[i].href += "?_waiter_hash=" + encodeURIComponent(location.hash);
+        <% ) %>
+
+    }
+}
+</script>
 
 </body>
 </html>

--- a/waiter/resources/web/oauth.html
+++ b/waiter/resources/web/oauth.html
@@ -41,10 +41,10 @@ if (location.hash) {
     var redirectLinks = document.getElementsByClassName('redirect');
     for (var i = 0; i < redirectLinks.length; i++) {
         <% (when query-string %>
-            redirectLinks[i].href += "&_waiter_hash=" + encodeURIComponent(location.hash);
+            redirectLinks[i].href += "&_<%= hash-query-param-name %>=" + encodeURIComponent(location.hash);
         <% ) %>
         <% (when-not query-string %>
-            redirectLinks[i].href += "?_waiter_hash=" + encodeURIComponent(location.hash);
+            redirectLinks[i].href += "?_<%= hash-query-param-name %>=" + encodeURIComponent(location.hash);
         <% ) %>
 
     }

--- a/waiter/resources/web/oauth.html
+++ b/waiter/resources/web/oauth.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+<head>
+    <title>Login - Waiter</title>
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <style type="text/css">
+   html {
+     font-family: 'Lato', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+     color: rgba(0,0,0,.87);
+   }
+
+   .main-content {
+     margin: auto;
+     margin-top: 4em;
+     width: 800px;
+   }
+
+   .main-note {
+     color: #0e566c;
+     text-align: center;
+   }
+
+    </style>
+</head>
+<body>
+
+<div class="main-content">
+    <h2 class="main-note">
+        Login to Waiter
+    </h2>
+    <div>
+        <p>Choose a provider:</p>
+        <% (doseq [[provider-key provider] providers] %>
+            <li><a href="/waiter-auth/oauth/<%= (name provider-key) %>/redirect/<%= path %><% (when query-string %><%= (str \? query-string) %><% ) %>"><%= (display-name provider) %></a></li>
+        <% ) %>
+    </div>
+</div>
+
+</body>
+</html>

--- a/waiter/resources/web/oauth.html
+++ b/waiter/resources/web/oauth.html
@@ -40,13 +40,7 @@
 if (location.hash) {
     var redirectLinks = document.getElementsByClassName('redirect');
     for (var i = 0; i < redirectLinks.length; i++) {
-        <% (when query-string %>
-            redirectLinks[i].href += "&_<%= hash-query-param-name %>=" + encodeURIComponent(location.hash);
-        <% ) %>
-        <% (when-not query-string %>
-            redirectLinks[i].href += "?_<%= hash-query-param-name %>=" + encodeURIComponent(location.hash);
-        <% ) %>
-
+        redirectLinks[i].href += "<%= (if query-string \& \?) %>_<%= hash-query-param-name %>=" + encodeURIComponent(location.hash);
     }
 }
 </script>

--- a/waiter/src/waiter/auth/authentication.clj
+++ b/waiter/src/waiter/auth/authentication.clj
@@ -30,9 +30,9 @@
      - either issue a 401 challenge asking the client to authenticate itself,
      - or upon successful authentication populate the request with :authorization/user and :authenticated-principal"))
 
-(defn- add-cached-auth
+(defn add-cached-auth
   [response password principal]
-  (cookie-support/add-encoded-cookie response password AUTH-COOKIE-NAME [principal (System/currentTimeMillis)] 1))
+  (cookie-support/add-encoded-cookie response password AUTH-COOKIE-NAME [principal (System/currentTimeMillis)] (-> 1 t/days t/in-seconds)))
 
 (defn handle-request-auth
   "Invokes the given request-handler on the given request, adding the necessary

--- a/waiter/src/waiter/auth/oauth.clj
+++ b/waiter/src/waiter/auth/oauth.clj
@@ -135,9 +135,9 @@
               (-> request
                   (auth/assoc-auth-in-request auth-principal)
                   handler-fn)
-              {:status 307
-               :headers {"location" (cond-> (str "/waiter-auth/oauth/providers" uri)
-                                      (not (str/blank? query-string)) (str \? query-string))}}))))
+              {:headers {"location" (cond-> (str "/waiter-auth/oauth/providers" uri)
+                                      (not (str/blank? query-string)) (str \? query-string))}
+               :status 307}))))
       (catch Exception ex
         (utils/exception->response ex request)))))
 

--- a/waiter/src/waiter/auth/oauth.clj
+++ b/waiter/src/waiter/auth/oauth.clj
@@ -157,8 +157,9 @@
                                                           (str (utils/request->scheme request) "://"
                                                                host "/waiter-auth/oauth/" (name kind) "/authenticate"))]
                                 (utils/create-component (assoc providers :kind kind)
-                                                        :context {:http-client http-client
-                                                                  :authenticate-uri-fn authenticate-uri-fn})))
+                                                        :context {:authenticate-uri-fn authenticate-uri-fn
+                                                                  :http-client http-client
+                                                                  :password password})))
                             kinds)]
     (map->OAuthAuthenticator {:password password
                               :providers enabled-providers

--- a/waiter/src/waiter/auth/oauth.clj
+++ b/waiter/src/waiter/auth/oauth.clj
@@ -31,7 +31,7 @@
 (def OAUTH-COOKIE-NAME "x-waiter-oauth")
 (def HASH-QUERY-PARAM-NAME "_waiter_hash")
 
-(defn make-http-client
+(defn- make-http-client
   "Instantiates and returns a new HttpClient without a cookie store"
   []
   (let [client (http/client {:connect-timeout 5000

--- a/waiter/src/waiter/auth/oauth.clj
+++ b/waiter/src/waiter/auth/oauth.clj
@@ -148,6 +148,7 @@
 (defn oauth-authenticator
   "Factory function for creating OAuthAuthenticator"
   [{:keys [password providers run-as-user]}]
+  {:pre [password providers run-as-user]}
   (let [http-client (make-http-client) {:keys [kinds]} providers
         enabled-providers (pc/map-from-keys
                             (fn [kind]

--- a/waiter/src/waiter/auth/oauth.clj
+++ b/waiter/src/waiter/auth/oauth.clj
@@ -16,11 +16,13 @@
             [clojure.tools.logging :as log]
             [comb.template :as template]
             [digest]
+            [metrics.counters :as counters]
             [plumbing.core :as pc]
             [plumbing.graph :as graph]
             [qbits.jet.client.http :as http]
             [waiter.auth.authentication :as auth]
             [waiter.cookie-support :as cookie-support]
+            [waiter.metrics :as metrics]
             [waiter.utils :as utils])
   (:import java.security.SecureRandom
            org.eclipse.jetty.util.HttpCookieStore$Empty
@@ -120,6 +122,8 @@
       (let [{:keys [handler route-params] :as match} (match-oauth-route uri)
             request' (assoc request :route-params route-params)
             provider-fn (fn [] (-> route-params :provider keyword providers))]
+        (when handler
+          (counters/inc! (metrics/waiter-counter "requests" "oauth" (name handler))))
         (case handler
           :provider-list (provider-list-handler providers request')
           :redirect (redirect (provider-fn) request')

--- a/waiter/src/waiter/auth/oauth.clj
+++ b/waiter/src/waiter/auth/oauth.clj
@@ -153,7 +153,7 @@
 (defn oauth-authenticator
   "Factory function for creating OAuthAuthenticator"
   [{:keys [password providers run-as-user]}]
-  {:pre [password providers run-as-user]}
+  {:pre [password (seq providers) run-as-user]}
   (let [http-client (make-http-client) {:keys [kinds]} providers
         enabled-providers (pc/map-from-keys
                             (fn [kind]

--- a/waiter/src/waiter/auth/oauth.clj
+++ b/waiter/src/waiter/auth/oauth.clj
@@ -34,7 +34,8 @@
 (defn make-http-client
   "Instantiates and returns a new HttpClient without a cookie store"
   []
-  (let [client (http/client)]
+  (let [client (http/client {:connect-timeout 5000
+                             :idle-timeout 5000})]
     (.setCookieStore client (HttpCookieStore$Empty.))
     client))
 

--- a/waiter/src/waiter/auth/oauth.clj
+++ b/waiter/src/waiter/auth/oauth.clj
@@ -63,7 +63,8 @@
     "Handles the response from the OAuth provider.  Returns an async response."))
 
 (defn make-uri
-  "Takes a URI and adds a formatted query-string from query parameters in a map."
+  "Takes a URI and adds a formatted query-string from query parameters in a map.
+  Repeated parameters are not supported."
   [uri query-params]
   (str uri "?"
        (->> query-params

--- a/waiter/src/waiter/auth/oauth.clj
+++ b/waiter/src/waiter/auth/oauth.clj
@@ -97,7 +97,8 @@
                                 :display-name (fn [provider] (display-name provider))
                                 :hash-query-param-name HASH-QUERY-PARAM-NAME
                                 :path path
-                                :query-string query-string})}
+                                :query-string query-string})
+          :headers {"content-type" "text/html"}}
     (throw (ex-info "Invalid request method"
                     {:request-method request-method
                      :status 405}))))

--- a/waiter/src/waiter/auth/oauth.clj
+++ b/waiter/src/waiter/auth/oauth.clj
@@ -68,11 +68,11 @@
   "Takes a URI and adds a formatted query-string from query parameters in a map.
   Repeated parameters are not supported."
   [uri query-params]
-  (str uri "?"
+  (str uri \?
        (->> query-params
             (map (fn [[name value]]
-                   (str name "=" (UrlEncoded/encodeString value))))
-            (str/join "&"))))
+                   (str name \= (UrlEncoded/encodeString value))))
+            (str/join \&))))
 
 (defn make-location
   "Given a path and query-string, return the value for the Location header

--- a/waiter/src/waiter/auth/oauth.clj
+++ b/waiter/src/waiter/auth/oauth.clj
@@ -1,0 +1,277 @@
+;;
+;;       Copyright (c) 2017 Two Sigma Investments, LP.
+;;       All Rights Reserved
+;;
+;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
+;;       Two Sigma Investments, LP.
+;;
+;;       The copyright notice above does not evidence any
+;;       actual or intended publication of such source code.
+;;
+(ns waiter.auth.oauth
+  (:require [bidi.bidi :as bidi]
+            [clj-time.core :as t]
+            [clojure.core.async :as async]
+            [clojure.data.codec.base64 :as b64]
+            [clojure.data.json :as json]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.tools.logging :as log]
+            [comb.template :as template]
+            [digest]
+            [full.async :as fa]
+            [plumbing.core :as pc]
+            [plumbing.graph :as graph]
+            [qbits.jet.client.http :as http]
+            [ring.middleware.params :as ring-params]
+            [ring.util.codec :as ring-codec]
+            [waiter.auth.authentication :as auth]
+            [waiter.cookie-support :as cookie-support]
+            [waiter.utils :as utils])
+  (:import java.security.SecureRandom
+           org.eclipse.jetty.util.HttpCookieStore$Empty
+           org.eclipse.jetty.util.UrlEncoded))
+
+(def secure-random (SecureRandom.))
+
+(def OAUTH-COOKIE-NAME "x-waiter-oauth")
+
+(defn make-http-client
+  "Instantiates and returns a new HttpClient without a cookie store"
+  []
+  (let [client (http/client)]
+    (.setCookieStore client (HttpCookieStore$Empty.))
+    client))
+
+(defn random-str
+  "Generates a random string."
+  []
+  (let [bytes (byte-array 1024)
+        _ (.nextBytes secure-random bytes)]
+        (digest/sha1 bytes)))
+
+(defn verify-oauth-cookie
+  [{:keys [headers]} expected-cookie-value password]
+  (let [cookie-value (cookie-support/cookie-value (get headers "cookie") OAUTH-COOKIE-NAME)
+        decoded-cookie-value (cookie-support/decode-cookie cookie-value password)]
+    (when-not (= expected-cookie-value decoded-cookie-value)
+      (throw (ex-info "Invalid OAuth cookie" {:status 403})))
+    (log/info "state cookie matched")))
+
+(defprotocol OAuthProvider
+  "An OAuth provider"
+  (display-name [this]
+    "Gets a display name for the provider.")
+  (redirect [this request]
+    "Handles a redirect to the OAuth provider.  Returns an async response.")
+  (authenticate [this request]
+    "Handles the response from the OAuth provider.  Returns an async response."))
+
+(defn google-discovery-document
+  "Gets Google's discovery document."
+  [http-client]
+  (fa/go-try
+    (let [discovery-uri "https://accounts.google.com/.well-known/openid-configuration"
+          {:keys [body]} (async/<! (http/get http-client discovery-uri {:headers {"accept" "application/json"}}))]
+      (try
+        (json/read-str (async/<! body))
+        (catch Exception e
+          (throw (ex-info "Couldn't retrieve Google discovery document" {:status 403})))))))
+
+(defn make-uri
+  [uri query-params]
+  (str uri "?"
+       (->> query-params
+           (map (fn [[name value]]
+                  (str name "=" (UrlEncoded/encodeString value))))
+            (str/join "&"))))
+
+; See https://developers.google.com/identity/protocols/OpenIDConnect#authenticatingtheuser
+(defrecord GoogleOAuthProvider [authenticate-uri client-id client-secret http-client password]
+  OAuthProvider
+  (display-name [_] "Google")
+  (redirect [_ {:keys [query-string] {:keys [path]} :route-params}]
+    (fa/go-try
+      (let [token (random-str)
+            state (-> {:path (str \/ path)
+                       :token token
+                       :query-string query-string}
+                      json/write-str)
+            {:strs [authorization_endpoint]} (fa/<? (google-discovery-document http-client))
+            _ (when-not authorization_endpoint
+                (throw (ex-info "Couldn't get Google authorization endpoint" {:status 403})))
+            location (make-uri authorization_endpoint
+                               {"client_id" client-id
+                                "nonce" (random-str)
+                                "response_type" "code"
+                                "redirect_uri" authenticate-uri
+                                "scope" "openid email"
+                                "state" state})]
+        (-> {:status 307
+             :headers {"location" location}}
+            (cookie-support/add-encoded-cookie password OAUTH-COOKIE-NAME token (-> 15 t/minutes t/in-seconds))))))
+  (authenticate [_ request]
+    (fa/go-try
+      (let [{:strs [code state]} (:params (ring-params/params-request request))
+            {:strs [path query-string token]} (try (-> state
+                                                       json/read-str)
+                                                   (catch Exception e
+                                                     (throw (ex-info "Couldn't parse state from Google" {:status 403}))))
+            _ (verify-oauth-cookie request token password)
+            {:strs [token_endpoint]} (fa/<? (google-discovery-document http-client))
+            _ (when-not token_endpoint
+                (throw (ex-info "Couldn't get Google token endpoint" {:status 403})))
+            {:keys [body status]} (async/<! (http/post http-client token_endpoint
+                                                       {:form-params {"client_id" client-id
+                                                                      "client_secret" client-secret
+                                                                      "code" code
+                                                                      "grant_type" "authorization_code"
+                                                                      "redirect_uri" authenticate-uri}}))
+            _  (when-not (= status 200)
+                 (throw (ex-info "Invalid token response from Google" {:status 403})))
+            {:strs [id_token] :as response} (try
+                                     (json/read-str (async/<! body))
+                                     (catch Exception e
+                                       (throw (ex-info "Couldn't parse JSON from Google" {:status 403}))))
+            _ (log/info "google response" response)
+            _  (when-not id_token
+                 (throw (ex-info "Missing id token from Google" {:status 403})))
+            {:strs [email email_verified]} (try
+                                             (-> id_token
+                                                 (str/split #"\.")
+                                                 second
+                                                 .getBytes
+                                                 b64/decode
+                                                 String.
+                                                 json/read-str)
+                                             (catch Exception e
+                                               (throw (ex-info "Coudln't parse id token from Google"
+                                                               {:status 403}))))
+            _ (when-not (and (not (str/blank? email)) email_verified)
+                (throw (ex-info "Can't get email from Google" {:status 403})))]
+        (-> {:status 307
+             :headers {"location" (cond-> path
+                                    (not (str/blank? query-string)) (str \? query-string))}}
+            (auth/add-cached-auth password email))))))
+
+; See https://developer.github.com/apps/building-integrations/setting-up-and-registering-github-apps/identifying-users-for-github-apps/
+(defrecord GitHubOAuthProvider [authenticate-uri client-id client-secret http-client password]
+  OAuthProvider
+  (display-name [_] "GitHub")
+  (redirect [_ _]
+    (fa/go-try
+      (let [state (random-str)
+            location (make-uri "https://github.com/login/oauth/authorize"
+                               {"client_id" client-id
+                                "scope" "user:email"
+                                "redirect_uri" authenticate-uri
+                                "state" state})]
+        (-> {:status 307
+             :headers {"location" location}}
+            (cookie-support/add-encoded-cookie password OAUTH-COOKIE-NAME state (-> 15 t/minutes t/in-seconds))))))
+
+  (authenticate [_ request]
+    (fa/go-try
+      (let [{:strs [code state]} (:params (ring-params/params-request request))
+            _ (verify-oauth-cookie request state password)
+            {:keys [body status]} (async/<! (http/post http-client "https://github.com/login/oauth/access_token"
+                                                       {:form-params {"client_id" client-id
+                                                                      "client_secret" client-secret
+                                                                      "code" code
+                                                                      "state" state}}))
+            _  (when-not (= status 200)
+                 (throw (ex-info "Invalid access token response from GitHub" {:status 403})))
+            access-token-body (async/<! body)
+            {:strs [access_token]} (-> access-token-body
+                                       (ring-codec/form-decode))
+            _  (when (str/blank? access_token)
+                 (throw (ex-info "Invalid access token from GitHub" {:status 403})))
+            {:keys [body status]} (async/<! (http/get http-client "https://api.github.com/user/emails"
+                                                      {:headers {"authorization" (str "token " access_token)}}))
+            _ (when-not (= status 200)
+                (throw (ex-info "Invalid user API response from GitHub" {:status 403})))
+            response-body (async/<! body)
+            emails (try (json/read-str response-body)
+                        (catch Exception e
+                          (throw (ex-info "Invalid JSON from GitHub" {:status 403}))))
+            email (->> emails
+                       (keep (fn [{:strs [email primary verified]}]
+                               (when (and primary verified)
+                                 email)))
+                       first)
+            _ (when-not email
+                (throw (ex-info "Can't get email from GitHub" {:status 403})))]
+        (-> {:status 307
+             :headers {"location" "finalredirect"}}
+            (auth/add-cached-auth password email))))))
+
+(defn provider-list-handler
+  "Responds with a login page listing available OAuth providers."
+  [providers {:keys [query-string request-method] {:keys [path]} :route-params}]
+  (case request-method
+    :get {:body (template/eval (slurp (io/resource "web/oauth.html"))
+                               {:providers providers
+                                :display-name (fn [provider] (display-name provider))
+                                :path path
+                                :query-string query-string})}
+    (throw (ex-info "Invalid request method"
+                    {:request-method request-method
+                     :status 405}))))
+
+(defn match-oauth-route
+  "Match an OAuth route based upon a uri."
+  [uri]
+  (let [route-map ["/waiter-auth/oauth" {["/providers/" [#".*" :path]] :provider-list
+                                         "/" {[:provider "/redirect/" [#".*" :path]] :redirect
+                                              [:provider "/authenticate"] :authenticate} }]]
+    (bidi/match-route route-map uri)))
+
+(defn wrap-oauth
+  "Middleware for handling OAuth."
+  [handler-fn run-as-user password providers]
+  (fn [{:keys [headers query-string uri] :as request}]
+    (try
+      (let [{:keys [handler route-params] :as match} (match-oauth-route uri)
+            request' (assoc request :route-params route-params)
+            provider-fn (fn [] (-> route-params :provider keyword providers))]
+        (case handler
+          :provider-list (provider-list-handler providers request')
+          :redirect (redirect (provider-fn) request')
+          :authenticate (authenticate (provider-fn) request')
+          ; else
+          (let [waiter-cookie (auth/get-auth-cookie-value (get headers "cookie"))
+                [auth-principal _ :as decoded-auth-cookie] (auth/decode-auth-cookie waiter-cookie password)]
+            (if (auth/decoded-auth-valid? decoded-auth-cookie)
+              (-> request
+                  (auth/assoc-auth-in-request auth-principal)
+                  handler-fn)
+              {:status 307
+               :headers {"location" (cond-> (str "/waiter-auth/oauth/providers" uri)
+                                      (not (str/blank? query-string)) (str \? query-string))}}))))
+      (catch Exception ex
+        (utils/exception->response ex request)))))
+
+(defrecord OAuthAuthenticator [password providers run-as-user]
+  auth/Authenticator
+  (auth-type [_]
+    :oauth)
+  (check-user [_ user _]
+    user)
+  (wrap-auth-handler [_ handler]
+    (wrap-oauth handler run-as-user password providers)))
+
+(defn oauth-authenticator
+  "Factory function for creating OAuthAuthenticator"
+  [{:keys [host password port providers run-as-user]}]
+  (let [http-client (make-http-client) {:keys [kinds]} providers
+        enabled-providers (pc/map-from-keys
+                            (fn [kind]
+                              (let [base-uri (str "http://" host ":" port "/waiter-auth/oauth/" (name kind))
+                                    authenticate-uri (str base-uri "/authenticate")]
+                                (utils/create-component (assoc providers :kind kind)
+                                                        :context {:http-client http-client
+                                                                  :authenticate-uri authenticate-uri})))
+                            kinds)]
+    (map->OAuthAuthenticator {:password password
+                              :providers enabled-providers
+                              :run-as-user run-as-user})))

--- a/waiter/src/waiter/auth/oauth/github.clj
+++ b/waiter/src/waiter/auth/oauth/github.clj
@@ -1,0 +1,84 @@
+;;
+;;       Copyright (c) 2017 Two Sigma Investments, LP.
+;;       All Rights Reserved
+;;
+;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
+;;       Two Sigma Investments, LP.
+;;
+;;       The copyright notice above does not evidence any
+;;       actual or intended publication of such source code.
+;;
+(ns waiter.auth.oauth.github
+  (:require [clj-time.core :as t]
+            [clojure.core.async :as async]
+            [clojure.data.json :as json]
+            [clojure.string :as str]
+            [full.async :as fa]
+            [qbits.jet.client.http :as http]
+            [ring.middleware.params :as ring-params]
+            [ring.util.codec :as ring-codec]
+            [waiter.auth.authentication :as auth]
+            [waiter.auth.oauth :as oauth]
+            [waiter.cookie-support :as cookie-support]))
+
+; See https://developer.github.com/apps/building-integrations/setting-up-and-registering-github-apps/identifying-users-for-github-apps/
+(defrecord GitHubOAuthProvider [authenticate-uri-fn client-id client-secret http-client password]
+  oauth/OAuthProvider
+  (display-name [_] "GitHub")
+  (redirect [_ {:keys [query-string] {:keys [path]} :route-params :as request}]
+    (fa/go-try
+      (let [token (oauth/random-str)
+            state (-> {:location (oauth/make-location {:path path
+                                                       :query-string query-string})
+                       :token token}
+                      json/write-str)
+            location (oauth/make-uri "https://github.com/login/oauth/authorize"
+                                     {"client_id" client-id
+                                      "scope" "user:email"
+                                      "redirect_uri" (authenticate-uri-fn request)
+                                      "state" state})]
+        (-> {:status 307
+             :headers {"location" location}}
+            (cookie-support/add-encoded-cookie password oauth/OAUTH-COOKIE-NAME token (-> 15 t/minutes t/in-seconds))))))
+  (authenticate [_ request]
+    (fa/go-try
+      (let [{:strs [code state]} (:params (ring-params/params-request request))
+            {:strs [location token]} (try (-> state
+                                              json/read-str)
+                                          (catch Exception e
+                                            (throw (ex-info "Couldn't parse state from GitHub" {:status 403} e))))
+            _ (oauth/verify-oauth-cookie request token password)
+            {:keys [body error status]} (async/<! (http/post http-client "https://github.com/login/oauth/access_token"
+                                                             {:form-params {"client_id" client-id
+                                                                            "client_secret" client-secret
+                                                                            "code" code
+                                                                            "state" state}}))
+            _ (when error
+                (throw (ex-info "Error while communicating with GitHub" {:status 403} error)))
+            _  (when-not (= status 200)
+                 (throw (ex-info "Invalid access token response from GitHub" {:status 403})))
+            access-token-body (async/<! body)
+            {:strs [access_token]} (-> access-token-body
+                                       (ring-codec/form-decode))
+            _  (when (str/blank? access_token)
+                 (throw (ex-info "Invalid access token from GitHub" {:status 403})))
+            {:keys [body status error]} (async/<! (http/get http-client "https://api.github.com/user/emails"
+                                                      {:headers {"authorization" (str "token " access_token)}}))
+            _ (when error
+                (throw (ex-info "Error while communicating with GitHub" {:status 403} error)))
+            _ (when-not (= status 200)
+                (throw (ex-info "Invalid user API response from GitHub" {:status 403})))
+            response-body (async/<! body)
+            emails (try (json/read-str response-body)
+                        (catch Exception e
+                          (throw (ex-info "Invalid JSON from GitHub" {:status 403} e))))
+            email (->> emails
+                       (keep (fn [{:strs [email primary verified]}]
+                               (when (and primary verified)
+                                 email)))
+                       first)
+            _ (when-not email
+                (throw (ex-info "Can't get email from GitHub" {:status 403})))]
+        (-> {:status 307
+             :headers {"location" location}}
+            (auth/add-cached-auth password email))))))

--- a/waiter/src/waiter/auth/oauth/github.clj
+++ b/waiter/src/waiter/auth/oauth/github.clj
@@ -37,8 +37,8 @@
                                       "scope" "user:email"
                                       "redirect_uri" (authenticate-uri-fn request)
                                       "state" state})]
-        (-> {:status 307
-             :headers {"location" location}}
+        (-> {:headers {"location" location}
+             :status 307}
             ;; We should store this cookie only long enough to provide a reasonable amount of time
             ;; for the client to authenticate.
             (cookie-support/add-encoded-cookie password oauth/OAUTH-COOKIE-NAME token (-> 15 t/minutes t/in-seconds))))))
@@ -46,8 +46,7 @@
     (fa/go-try
       (let [{:strs [code state] :as params} (:params (ring-params/params-request request))
             _ (when-not (and code state)
-                (throw (ex-info "Malformed request" {:status 400
-                                                     :params params})))
+                (throw (ex-info "Malformed request" {:params params :status 400})))
             {:strs [location token]} (try (-> state
                                               json/read-str)
                                           (catch Exception e

--- a/waiter/src/waiter/auth/oauth/github.clj
+++ b/waiter/src/waiter/auth/oauth/github.clj
@@ -45,6 +45,8 @@
   (authenticate [_ request]
     (fa/go-try
       (let [{:strs [code state]} (:params (ring-params/params-request request))
+            _ (when-not (and code state)
+                (throw (ex-info "Malformed request" {:status 400})))
             {:strs [location token]} (try (-> state
                                               json/read-str)
                                           (catch Exception e

--- a/waiter/src/waiter/auth/oauth/github.clj
+++ b/waiter/src/waiter/auth/oauth/github.clj
@@ -44,9 +44,10 @@
             (cookie-support/add-encoded-cookie password oauth/OAUTH-COOKIE-NAME token (-> 15 t/minutes t/in-seconds))))))
   (authenticate [_ request]
     (fa/go-try
-      (let [{:strs [code state]} (:params (ring-params/params-request request))
+      (let [{:strs [code state] :as params} (:params (ring-params/params-request request))
             _ (when-not (and code state)
-                (throw (ex-info "Malformed request" {:status 400})))
+                (throw (ex-info "Malformed request" {:status 400
+                                                     :params params})))
             {:strs [location token]} (try (-> state
                                               json/read-str)
                                           (catch Exception e

--- a/waiter/src/waiter/auth/oauth/github.clj
+++ b/waiter/src/waiter/auth/oauth/github.clj
@@ -39,6 +39,8 @@
                                       "state" state})]
         (-> {:status 307
              :headers {"location" location}}
+            ;; We should store this cookie only long enough to provide a reasonable amount of time
+            ;; for the client to authenticate.
             (cookie-support/add-encoded-cookie password oauth/OAUTH-COOKIE-NAME token (-> 15 t/minutes t/in-seconds))))))
   (authenticate [_ request]
     (fa/go-try

--- a/waiter/src/waiter/auth/oauth/github.clj
+++ b/waiter/src/waiter/auth/oauth/github.clj
@@ -59,8 +59,8 @@
                                                                             "state" state}}))
             _ (when error
                 (throw (ex-info "Error while communicating with GitHub" {:status 403} error)))
-            _  (when-not (= status 200)
-                 (throw (ex-info "Invalid access token response from GitHub" {:status 403})))
+            _ (when-not (= status 200)
+                (throw (ex-info "Invalid access token response from GitHub" {:status 403})))
             access-token-body (async/<! body)
             {:strs [access_token]} (-> access-token-body
                                        (ring-codec/form-decode))

--- a/waiter/src/waiter/auth/oauth/google.clj
+++ b/waiter/src/waiter/auth/oauth/google.clj
@@ -65,6 +65,8 @@
   (authenticate [_ request]
     (fa/go-try
       (let [{:strs [code state]} (:params (ring-params/params-request request))
+            _ (when-not (and code state)
+                (throw (ex-info "Malformed request" {:status 400})))
             {:strs [location token]} (try (-> state
                                               json/read-str)
                                           (catch Exception e

--- a/waiter/src/waiter/auth/oauth/google.clj
+++ b/waiter/src/waiter/auth/oauth/google.clj
@@ -59,6 +59,8 @@
                                       "state" state})]
         (-> {:status 307
              :headers {"location" location}}
+            ;; We should store this cookie only long enough to provide a reasonable amount of time
+            ;; for the client to authenticate.
             (cookie-support/add-encoded-cookie password oauth/OAUTH-COOKIE-NAME token (-> 15 t/minutes t/in-seconds))))))
   (authenticate [_ request]
     (fa/go-try

--- a/waiter/src/waiter/auth/oauth/google.clj
+++ b/waiter/src/waiter/auth/oauth/google.clj
@@ -64,9 +64,10 @@
             (cookie-support/add-encoded-cookie password oauth/OAUTH-COOKIE-NAME token (-> 15 t/minutes t/in-seconds))))))
   (authenticate [_ request]
     (fa/go-try
-      (let [{:strs [code state]} (:params (ring-params/params-request request))
+      (let [{:strs [code state] :as params} (:params (ring-params/params-request request))
             _ (when-not (and code state)
-                (throw (ex-info "Malformed request" {:status 400})))
+                (throw (ex-info "Malformed request" {:status 400
+                                                     :params params})))
             {:strs [location token]} (try (-> state
                                               json/read-str)
                                           (catch Exception e

--- a/waiter/src/waiter/auth/oauth/google.clj
+++ b/waiter/src/waiter/auth/oauth/google.clj
@@ -57,8 +57,8 @@
                                       "redirect_uri" (authenticate-uri-fn request)
                                       "scope" "openid email"
                                       "state" state})]
-        (-> {:status 307
-             :headers {"location" location}}
+        (-> {:headers {"location" location}
+             :status 307}
             ;; We should store this cookie only long enough to provide a reasonable amount of time
             ;; for the client to authenticate.
             (cookie-support/add-encoded-cookie password oauth/OAUTH-COOKIE-NAME token (-> 15 t/minutes t/in-seconds))))))
@@ -66,8 +66,7 @@
     (fa/go-try
       (let [{:strs [code state] :as params} (:params (ring-params/params-request request))
             _ (when-not (and code state)
-                (throw (ex-info "Malformed request" {:status 400
-                                                     :params params})))
+                (throw (ex-info "Malformed request" {:params params :status 400})))
             {:strs [location token]} (try (-> state
                                               json/read-str)
                                           (catch Exception e

--- a/waiter/src/waiter/auth/oauth/google.clj
+++ b/waiter/src/waiter/auth/oauth/google.clj
@@ -1,0 +1,105 @@
+;;
+;;       Copyright (c) 2017 Two Sigma Investments, LP.
+;;       All Rights Reserved
+;;
+;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
+;;       Two Sigma Investments, LP.
+;;
+;;       The copyright notice above does not evidence any
+;;       actual or intended publication of such source code.
+;;
+(ns waiter.auth.oauth.google
+  (:require [clj-time.core :as t]
+            [clojure.core.async :as async]
+            [clojure.data.codec.base64 :as b64]
+            [clojure.data.json :as json]
+            [clojure.string :as str]
+            [full.async :as fa]
+            [qbits.jet.client.http :as http]
+            [ring.middleware.params :as ring-params]
+            [waiter.auth.authentication :as auth]
+            [waiter.auth.oauth :as oauth]
+            [waiter.cookie-support :as cookie-support]))
+
+(defn google-discovery-document
+  "Gets Google's discovery document."
+  [http-client]
+  (fa/go-try
+    (let [discovery-uri "https://accounts.google.com/.well-known/openid-configuration"
+          {:keys [body error status]} (async/<! (http/get http-client discovery-uri {:headers {"accept" "application/json"}}))]
+      (when error
+        (throw (ex-info "Error while communicating with Google" {:status 403} error)))
+      (when-not (= 200 status)
+        (throw (ex-info "Invalid response from Google" {:status 403} error)))
+      (try
+        (json/read-str (async/<! body))
+        (catch Exception e
+          (throw (ex-info "Couldn't retrieve Google discovery document" {:status 403})))))))
+
+; See https://developers.google.com/identity/protocols/OpenIDConnect#authenticatingtheuser
+(defrecord GoogleOAuthProvider [authenticate-uri-fn client-id client-secret http-client password]
+  oauth/OAuthProvider
+  (display-name [_] "Google")
+  (redirect [_ {:keys [query-string] {:keys [path]} :route-params :as request}]
+    (fa/go-try
+      (let [token (oauth/random-str)
+            state (-> {:location (oauth/make-location {:path path
+                                                       :query-string query-string})
+                       :token token}
+                      json/write-str)
+            {:strs [authorization_endpoint]} (fa/<? (google-discovery-document http-client))
+            _ (when-not authorization_endpoint
+                (throw (ex-info "Couldn't get Google authorization endpoint" {:status 403})))
+            location (oauth/make-uri authorization_endpoint
+                                     {"client_id" client-id
+                                      "nonce" (oauth/random-str)
+                                      "response_type" "code"
+                                      "redirect_uri" (authenticate-uri-fn request)
+                                      "scope" "openid email"
+                                      "state" state})]
+        (-> {:status 307
+             :headers {"location" location}}
+            (cookie-support/add-encoded-cookie password oauth/OAUTH-COOKIE-NAME token (-> 15 t/minutes t/in-seconds))))))
+  (authenticate [_ request]
+    (fa/go-try
+      (let [{:strs [code state]} (:params (ring-params/params-request request))
+            {:strs [location token]} (try (-> state
+                                              json/read-str)
+                                          (catch Exception e
+                                            (throw (ex-info "Couldn't parse state from Google" {:status 403} e))))
+            _ (oauth/verify-oauth-cookie request token password)
+            {:strs [token_endpoint]} (fa/<? (google-discovery-document http-client))
+            _ (when-not token_endpoint
+                (throw (ex-info "Couldn't get Google token endpoint" {:status 403})))
+            {:keys [body error status]} (async/<! (http/post http-client token_endpoint
+                                                             {:form-params {"client_id" client-id
+                                                                            "client_secret" client-secret
+                                                                            "code" code
+                                                                            "grant_type" "authorization_code"
+                                                                            "redirect_uri" (authenticate-uri-fn request)}}))
+            _ (when error
+                (throw (ex-info "Error while communicating with Google" {:status 403} error)))
+            _  (when-not (= status 200)
+                 (throw (ex-info "Invalid token response from Google" {:status 403})))
+            {:strs [id_token] :as response} (try
+                                              (json/read-str (async/<! body))
+                                              (catch Exception e
+                                                (throw (ex-info "Couldn't parse JSON from Google" {:status 403} e))))
+            _  (when-not id_token
+                 (throw (ex-info "Missing id token from Google" {:status 403})))
+            {:strs [email email_verified]} (try
+                                             (-> id_token
+                                                 (str/split #"\.")
+                                                 second
+                                                 .getBytes
+                                                 b64/decode
+                                                 String.
+                                                 json/read-str)
+                                             (catch Exception e
+                                               (throw (ex-info "Coudln't parse id token from Google"
+                                                               {:status 403} e))))
+            _ (when-not (and (not (str/blank? email)) email_verified)
+                (throw (ex-info "Can't get email from Google" {:status 403})))]
+        (-> {:status 307
+             :headers {"location" location}}
+            (auth/add-cached-auth password email))))))

--- a/waiter/src/waiter/auth/oauth/google.clj
+++ b/waiter/src/waiter/auth/oauth/google.clj
@@ -30,7 +30,7 @@
       (when error
         (throw (ex-info "Error while communicating with Google" {:status 403} error)))
       (when-not (= 200 status)
-        (throw (ex-info "Invalid response from Google" {:status 403} error)))
+        (throw (ex-info "Invalid response from Google" {:status 403})))
       (try
         (json/read-str (async/<! body))
         (catch Exception e

--- a/waiter/src/waiter/cookie_support.clj
+++ b/waiter/src/waiter/cookie_support.clj
@@ -55,11 +55,10 @@
 
 (defn add-encoded-cookie
   "Inserts the provided name-value pair as a Set-Cookie header in the response"
-  [response password name value age-in-days]
+  [response password name value max-age]
   (letfn [(add-cookie-into-response [response]
             (let [encoded-cookie (-> (encode-cookie value password)
                                      UrlEncoded/encodeString)
-                  max-age (-> age-in-days t/days t/in-seconds)
                   path "/"
                   set-cookie-header (str name "=" encoded-cookie ";Max-Age=" max-age ";Path=" path ";HttpOnly=true")
                   existing-header (get-in response [:headers "set-cookie"])

--- a/waiter/src/waiter/cookie_support.clj
+++ b/waiter/src/waiter/cookie_support.clj
@@ -55,12 +55,12 @@
 
 (defn add-encoded-cookie
   "Inserts the provided name-value pair as a Set-Cookie header in the response"
-  [response password name value max-age]
+  [response password name value max-age-in-seconds]
   (letfn [(add-cookie-into-response [response]
             (let [encoded-cookie (-> (encode-cookie value password)
                                      UrlEncoded/encodeString)
                   path "/"
-                  set-cookie-header (str name "=" encoded-cookie ";Max-Age=" max-age ";Path=" path ";HttpOnly=true")
+                  set-cookie-header (str name "=" encoded-cookie ";Max-Age=" max-age-in-seconds ";Path=" path ";HttpOnly=true")
                   existing-header (get-in response [:headers "set-cookie"])
                   new-header (cond
                                (nil? existing-header) set-cookie-header

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1250,10 +1250,9 @@
                              (fn waiter-auth-handler-fn [request]
                                (handle-secure-request-fn
                                  (fn inner-waiter-auth-handler-fn [request]
-                                   {:content-type "application/json"
-                                    :body (json/write-str {:user (:authorization/user request)
-                                                           :principal (:authenticated-principal request)})
-                                    :status 200})
+                                   (utils/map->json-response
+                                     {:user (:authorization/user request)
+                                      :principal (:authenticated-principal request)}))
                                  request)))
    :waiter-acknowledge-consent-handler-fn (pc/fnk [[:routines service-description->service-id token->token-description]
                                                    [:settings consent-expiry-days]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -443,11 +443,9 @@
 ;; PRIVATE API
 (def state
   {:async-request-store-atom (pc/fnk [] (atom {}))
-   :authenticator (pc/fnk [[:settings authenticator-config host port]
+   :authenticator (pc/fnk [[:settings authenticator-config]
                            passwords]
-                    (utils/create-component authenticator-config :context {:password (first passwords)
-                                                                           :host host
-                                                                           :port port}))
+                    (utils/create-component authenticator-config :context {:password (first passwords)}))
    :clock (pc/fnk [] t/now)
    :cors-validator (pc/fnk [[:settings cors-config]]
                      (utils/create-component cors-config))

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -710,7 +710,7 @@
                                :consent-expiry-days consent-expiry-days
                                :service-description-template service-description-template
                                :service-id service-id
-                               :target-url (str (name (utils/request->scheme request)) "://" host-header "/" path
+                               :target-url (str (utils/request->scheme request) "://" host-header "/" path
                                                 (when (not (str/blank? query-string)) (str "?" query-string)))
                                :token token})
          :headers {"content-type" "text/html"}

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -642,18 +642,18 @@
           {:strs [mode service-id] :as params} params]
       (when-not (str/blank? origin)
         (when-not (utils/same-origin request)
-          (throw (ex-info "Origin is not the same as the host" 
+          (throw (ex-info "Origin is not the same as the host"
                           {:host host
                            :origin origin
                            :status 400}))))
       (when (and (not (str/blank? origin)) (not (str/blank? referer)))
         (when-not (str/starts-with? referer origin)
-          (throw (ex-info "Referer does not start with origin" 
+          (throw (ex-info "Referer does not start with origin"
                           {:origin origin
                            :referer referer
                            :status 400}))))
       (when-not (= x-requested-with "XMLHttpRequest")
-        (throw (ex-info "Header x-requested-with does not match expected value" 
+        (throw (ex-info "Header x-requested-with does not match expected value"
                         {:actual x-requested-with
                          :expected "XMLHttpRequest"
                          :status 400})))
@@ -679,7 +679,7 @@
           (counters/inc! (metrics/waiter-counter "auto-run-as-requester" "approve-success"))
           (meters/mark! (metrics/waiter-meter "auto-run-as-requester" "approve-success"))
           (-> {:body (str "Added cookie " cookie-name), :headers {}, :status 200}
-              (add-encoded-cookie cookie-name cookie-value (-> consent-expiry-days t/days t/in-secs))))))
+              (add-encoded-cookie cookie-name cookie-value (-> consent-expiry-days t/days t/in-seconds))))))
     (catch Exception ex
       (counters/inc! (metrics/waiter-counter "auto-run-as-requester" "approve-error"))
       (meters/mark! (metrics/waiter-meter "auto-run-as-requester" "approve-error"))

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -679,7 +679,7 @@
           (counters/inc! (metrics/waiter-counter "auto-run-as-requester" "approve-success"))
           (meters/mark! (metrics/waiter-meter "auto-run-as-requester" "approve-success"))
           (-> {:body (str "Added cookie " cookie-name), :headers {}, :status 200}
-              (add-encoded-cookie cookie-name cookie-value consent-expiry-days)))))
+              (add-encoded-cookie cookie-name cookie-value (-> consent-expiry-days t/days t/in-secs))))))
     (catch Exception ex
       (counters/inc! (metrics/waiter-counter "auto-run-as-requester" "approve-error"))
       (meters/mark! (metrics/waiter-meter "auto-run-as-requester" "approve-error"))

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -517,7 +517,7 @@
                         (fn [nanos] (statsd/histo! metric-group "process" nanos))
                         (let [instance-request-properties (prepare-request-properties instance-request-properties waiter-headers)
                               start-new-service-fn (fn start-new-service-in-process [] (start-new-service-fn descriptor))
-                              request-id (str (utils/unique-identifier) "-" (-> request utils/request->scheme name))
+                              request-id (str (utils/unique-identifier) "-" (-> request utils/request->scheme))
                               priority (determine-priority-fn waiter-headers)
                               reason-map (cond-> {:reason :serve-request
                                                   :state {:initial (metrics/retrieve-local-stats-for-service service-id)}

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -176,7 +176,8 @@
 
 (def settings-defaults
   {:authenticator-config {:kind :one-user
-                          :one-user {:factory-fn 'waiter.auth.authentication/one-user-authenticator}}
+                          :one-user {:factory-fn 'waiter.auth.authentication/one-user-authenticator}
+                          :oauth {:factory-fn 'waiter.auth.oauth/oauth-authenticator}}
    :cors-config {:kind :patterns
                  :patterns {:factory-fn 'waiter.cors/pattern-based-validator
                             :allowed-origins []}

--- a/waiter/src/waiter/utils.clj
+++ b/waiter/src/waiter/utils.clj
@@ -13,7 +13,6 @@
             [clj-time.core :as t]
             [clj-time.format :as f]
             [clojure.core.cache :as cache]
-            [clojure.data.codec.base64 :as b64]
             [clojure.data.json :as json]
             [clojure.java.io :as io]
             [clojure.pprint :as pprint]

--- a/waiter/src/waiter/utils.clj
+++ b/waiter/src/waiter/utils.clj
@@ -13,6 +13,7 @@
             [clj-time.core :as t]
             [clj-time.format :as f]
             [clojure.core.cache :as cache]
+            [clojure.data.codec.base64 :as b64]
             [clojure.data.json :as json]
             [clojure.java.io :as io]
             [clojure.pprint :as pprint]

--- a/waiter/src/waiter/utils.clj
+++ b/waiter/src/waiter/utils.clj
@@ -408,7 +408,7 @@
   "Extracts the scheme from the request."
   [{:keys [headers scheme]}]
   (let [{:strs [x-forwarded-proto]} headers]
-    (or x-forwarded-proto scheme)))
+    (or x-forwarded-proto (when scheme (name scheme)))))
 
 (defn same-origin
   "Returns true if the host and origin are non-nil and are equivalent."
@@ -416,7 +416,7 @@
   (let [{:strs [host origin]} headers
         scheme (request->scheme request)]
     (when (and host origin scheme)
-      (= origin (str (name scheme) "://" host)))))
+      (= origin (str scheme "://" host)))))
 
 (defn create-component
   "Creates a component based on the specified :kind"

--- a/waiter/test/waiter/auth/oauth_test.clj
+++ b/waiter/test/waiter/auth/oauth_test.clj
@@ -111,11 +111,11 @@
         (is (= body "handler"))))))
 
 (deftest test-github-provider
-  (let [authenticate-uri "http://authenticate"
+  (let [authenticate-uri-fn (constantly "http://authenticate")
         client-id "client-id"
         client-secret "client-secret"
         password [:cached "password"]
-        provider (map->GitHubOAuthProvider {:authenticate-uri authenticate-uri
+        provider (map->GitHubOAuthProvider {:authenticate-uri-fn authenticate-uri-fn
                                             :client-id client-id
                                             :client-secret client-secret
                                             :password password})
@@ -168,11 +168,11 @@
                                          :query-string "a=1&_waiter_hash=%23b%3D2"}))))
 
 (deftest test-google-provider
-  (let [authenticate-uri "http://authenticate"
+  (let [authenticate-uri-fn (constantly "http://authenticate")
         client-id "client-id"
         client-secret "client-secret"
         password [:cached "password"]
-        provider (map->GoogleOAuthProvider {:authenticate-uri authenticate-uri
+        provider (map->GoogleOAuthProvider {:authenticate-uri-fn authenticate-uri-fn
                                             :client-id client-id
                                             :client-secret client-secret
                                             :password password})

--- a/waiter/test/waiter/auth/oauth_test.clj
+++ b/waiter/test/waiter/auth/oauth_test.clj
@@ -49,7 +49,8 @@
                                      :client-secret ""}}
                 :run-as-user "user"
                 :host "host"
-                :port 8080}
+                :port 8080
+                :password [:cached "password"]}
         authenticator (oauth-authenticator config)]
     (is authenticator)
     (is (= 2 (-> authenticator :providers count)))))

--- a/waiter/test/waiter/auth/oauth_test.clj
+++ b/waiter/test/waiter/auth/oauth_test.clj
@@ -18,6 +18,8 @@
             [qbits.jet.client.http :as http]
             [waiter.auth.authentication :as auth]
             [waiter.auth.oauth :refer :all]
+            [waiter.auth.oauth.github :refer :all]
+            [waiter.auth.oauth.google :refer :all]
             [waiter.cookie-support :as cs]
             [waiter.utils :as utils])
   (:import (clojure.lang ExceptionInfo)
@@ -39,10 +41,10 @@
 (deftest test-oauth-authenticator
   (let [config {:factory-fn waiter.auth.oauth/oauth-authenticator
                 :providers {:kinds [:github :google]
-                            :github {:factory-fn 'waiter.auth.oauth/map->GitHubOAuthProvider
+                            :github {:factory-fn 'waiter.auth.oauth.github/map->GitHubOAuthProvider
                                      :client-id ""
                                      :client-secret ""}
-                            :google {:factory-fn 'waiter.auth.oauth/map->GoogleOAuthProvider
+                            :google {:factory-fn 'waiter.auth.oauth.google/map->GoogleOAuthProvider
                                      :client-id ""
                                      :client-secret ""}}
                 :run-as-user "user"

--- a/waiter/test/waiter/auth/oauth_test.clj
+++ b/waiter/test/waiter/auth/oauth_test.clj
@@ -1,0 +1,197 @@
+;;
+;;       Copyright (c) 2017 Two Sigma Investments, LP.
+;;       All Rights Reserved
+;;
+;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
+;;       Two Sigma Investments, LP.
+;;
+;;       The copyright notice above does not evidence any
+;;       actual or intended publication of such source code.
+;;
+(ns waiter.auth.oauth-test
+  (:require [clojure.core.async :as async]
+            [clojure.data.codec.base64 :as b64]
+            [clojure.data.json :as json]
+            [clojure.string :as str]
+            [clojure.test :refer :all]
+            [full.async :as fa]
+            [qbits.jet.client.http :as http]
+            [waiter.auth.authentication :as auth]
+            [waiter.auth.oauth :refer :all]
+            [waiter.cookie-support :as cs]
+            [waiter.utils :as utils])
+  (:import (clojure.lang ExceptionInfo)
+           org.eclipse.jetty.util.UrlEncoded))
+
+(deftest test-random-str
+  (is (random-str)))
+
+(deftest test-provider-list-handler
+  (testing "get"
+    (let [{:keys [body headers]} (provider-list-handler
+                                   {:github (map->GitHubOAuthProvider {})
+                                    :google (map->GoogleOAuthProvider {})}
+                                   {:request-method :get})]
+      (is body)
+      (is (str/includes? body "GitHub"))
+      (is (str/includes? body "Google")))))
+
+(deftest test-oauth-authenticator
+  (let [config {:factory-fn waiter.auth.oauth/oauth-authenticator
+                :providers {:kinds [:github :google]
+                            :github {:factory-fn 'waiter.auth.oauth/map->GitHubOAuthProvider
+                                     :client-id ""
+                                     :client-secret ""}
+                            :google {:factory-fn 'waiter.auth.oauth/map->GoogleOAuthProvider
+                                     :client-id ""
+                                     :client-secret ""}}
+                :run-as-user "user"
+                :host "host"
+                :port 8080}
+        authenticator (oauth-authenticator config)]
+    (is authenticator)
+    (is (= 2 (-> authenticator :providers count)))))
+
+(deftest test-match-oauth-route
+  (is (= {:handler :provider-list :route-params {:path ""}}
+         (match-oauth-route "/waiter-auth/oauth/providers/")))
+  (is (= {:handler :provider-list :route-params {:path "path"}}
+         (match-oauth-route "/waiter-auth/oauth/providers/path")))
+  (is (= {:handler :redirect :route-params {:provider "github" :path ""}}
+         (match-oauth-route "/waiter-auth/oauth/github/redirect/")))
+  (is (= {:handler :redirect :route-params {:provider "github" :path "path"}}
+         (match-oauth-route "/waiter-auth/oauth/github/redirect/path")))
+  (is (= {:handler :authenticate :route-params {:provider "google"}}
+         (match-oauth-route "/waiter-auth/oauth/google/authenticate")))
+  (is (= nil (match-oauth-route "/no-match"))))
+
+(deftest test-wrap-oauth
+  (let [providers {:dummy (reify OAuthProvider
+                            (display-name [_] "Dummy")
+                            (redirect [_ _]
+                              {:headers {"location" "http://preauth"}
+                               :status 307})
+                            (authenticate [_ _]
+                              {:headers {"location" "http://postauth"}
+                               :status 307}))}
+        handler (fn [_] {:status 200
+                         :body "handler"})
+        run-as-user "testuser"
+        principal "testuser@example.com"
+        now (System/currentTimeMillis)
+        password [:cached "password"]
+        wrapped-handler (wrap-oauth handler run-as-user password providers)]
+    (testing "list providers"
+      (let [{:keys [body]} (wrapped-handler {:request-method :get
+                                             :uri "/waiter-auth/oauth/providers/"})]
+        (is body)
+        (is (str/includes? body "Dummy"))))
+    (testing "redirect"
+      (let [{{:strs [location]} :headers :keys [status]}
+            (wrapped-handler {:uri "/waiter-auth/oauth/dummy/redirect/"})]
+        (is (= "http://preauth" location))
+        (is (= 307 status))))
+    (testing "authenticate"
+      (let [{{:strs [location]} :headers :keys [status]}
+            (wrapped-handler {:uri "/waiter-auth/oauth/dummy/authenticate"})]
+        (is (= "http://postauth" location))
+        (is (= 307 status))))
+    (testing "unauthenticated"
+      (let [{{:strs [location]} :headers :keys [status]}
+            (wrapped-handler {:uri "/requires-auth"})]
+        (is (= "/waiter-auth/oauth/providers/requires-auth" location))
+        (is (= 307 status))))
+    (testing "already authenticated"
+      (let [cookie (str auth/AUTH-COOKIE-NAME "=" (-> (cs/encode-cookie [principal now] password)
+                                                      UrlEncoded/encodeString))
+            {{:strs [location]} :headers :keys [body status]}
+            (wrapped-handler {:uri "/requires-auth"
+                              :headers {"cookie" cookie}})]
+        (is (= 200 status))
+        (is (= body "handler"))))))
+
+
+(deftest test-github-provider
+  (let [authenticate-uri "http://authenticate"
+        client-id "client-id"
+        client-secret "client-secret"
+        password [:cached "password"]
+        provider (map->GitHubOAuthProvider {:authenticate-uri authenticate-uri
+                                            :client-id client-id
+                                            :client-secret client-secret
+                                            :password password})
+        state "state"
+        cookie (str OAUTH-COOKIE-NAME "=" (-> (cs/encode-cookie state password)
+                                              UrlEncoded/encodeString))]
+    (testing "redirect"
+      (let [{{:strs [set-cookie location]} :headers :keys [status]} (fa/<?? (redirect provider {}))]
+        (is location)
+        (is (= status 307))
+        (is set-cookie)))
+    (testing "authenticate"
+      (with-redefs [random-str (fn [] state)
+                    http/post (fn [_ _ _]
+                                (async/go {:body (async/go "access_token=accesstoken&token_type=bearer")
+                                           :status 200}))
+                    http/get (fn [_ _ _]
+                               (async/go
+                                 {:body (async/go
+                                          (json/write-str [{:email "user@example.com"
+                                                            :primary true
+                                                            :verified true}]))
+                                  :status 200}))]
+        (let [{{:strs [location]} :headers :keys [status] :as response}
+              (fa/<?? (authenticate provider {:headers {"cookie" cookie}
+                                              :query-string "code=code&state=state"}))]
+          (is location)
+          (is (= status 307)))))))
+
+(deftest test-make-uri
+  (is (= "http://test?a=1" (make-uri "http://test" {"a" "1"})))
+  (is (= "http://test?a=1&b=2" (make-uri "http://test" {"a" "1"
+                                                        "b" "2"})))
+  (is (= "http://test?message=hello+world" (make-uri "http://test" {"message" "hello world"}))))
+
+(deftest test-google-provider
+  (let [authenticate-uri "http://authenticate"
+        client-id "client-id"
+        client-secret "client-secret"
+        password [:cached "password"]
+        provider (map->GoogleOAuthProvider {:authenticate-uri authenticate-uri
+                                            :client-id client-id
+                                            :client-secret client-secret
+                                            :password password})
+        token "abc123"
+        state {:path "/path"
+               :query-string "a=1"
+               :token token}
+        cookie (str OAUTH-COOKIE-NAME "=" (-> (cs/encode-cookie token password)
+                                              UrlEncoded/encodeString))]
+    (testing "redirect"
+      (with-redefs [google-discovery-document (fn [_] (async/go
+                                                        {"authorization_endpoint" "http://endpoint"}))]
+        (let [{{:strs [set-cookie location]} :headers :keys [status]} (fa/<?? (redirect provider {}))]
+        (is location)
+        (is (= status 307))
+        (is set-cookie))))
+    (testing "authenticate"
+      (let [jwt (str "headernotused." (-> (json/write-str {:email "user@example.com"
+                                                           :email_verified true})
+                                          (.getBytes "utf8")
+                                          b64/encode
+                                          (String.)))]
+        (with-redefs [random-str (fn [] "abc123")
+                      google-discovery-document (fn [_] (async/go
+                                                          {"token_endpoint" "http://endpoint"}))
+                      http/post (fn [_ _ _]
+                                  (async/go {:body (async/go
+                                                     (json/write-str {:id_token jwt}))
+                                             :status 200}))]
+          (let [{{:strs [location]} :headers :keys [status] :as response}
+                (fa/<?? (authenticate provider {:headers {"cookie" cookie}
+                                                :query-string (str "code=code&state="
+                                                                   (-> state
+                                                                       json/write-str
+                                                                       UrlEncoded/encodeString))}))]
+            (is location)
+            (is (= status 307))))))))

--- a/waiter/test/waiter/auth/oauth_test.clj
+++ b/waiter/test/waiter/auth/oauth_test.clj
@@ -30,13 +30,15 @@
 
 (deftest test-provider-list-handler
   (testing "get"
-    (let [{:keys [body headers]} (provider-list-handler
-                                   {:github (map->GitHubOAuthProvider {})
-                                    :google (map->GoogleOAuthProvider {})}
+    (let [github-provider (map->GitHubOAuthProvider {})
+          google-provider (map->GoogleOAuthProvider {})
+          {:keys [body headers]} (provider-list-handler
+                                   {:github github-provider
+                                    :google google-provider}
                                    {:request-method :get})]
       (is body)
-      (is (str/includes? body "GitHub"))
-      (is (str/includes? body "Google")))))
+      (is (str/includes? body (display-name github-provider)))
+      (is (str/includes? body (display-name google-provider))))))
 
 (deftest test-oauth-authenticator
   (let [config {:factory-fn waiter.auth.oauth/oauth-authenticator

--- a/waiter/test/waiter/auth/oauth_test.clj
+++ b/waiter/test/waiter/auth/oauth_test.clj
@@ -55,7 +55,21 @@
                 :password [:cached "password"]}
         authenticator (oauth-authenticator config)]
     (is authenticator)
-    (is (= 2 (-> authenticator :providers count)))))
+    (let [{:keys [github google]} (-> authenticator :providers)]
+      (is github)
+      (is (satisfies? OAuthProvider github))
+      (is (instance? waiter.auth.oauth.github.GitHubOAuthProvider github))
+      (let [{:keys [authenticate-uri-fn http-client password]} github]
+        (is password)
+        (is http-client)
+        (is authenticate-uri-fn))
+      (is google)
+      (is (satisfies? OAuthProvider google))
+      (is (instance? waiter.auth.oauth.google.GoogleOAuthProvider google))
+      (let [{:keys [authenticate-uri-fn http-client password]} google]
+        (is password)
+        (is http-client)
+        (is authenticate-uri-fn)))))
 
 (deftest test-match-oauth-route
   (is (= {:handler :provider-list :route-params {:path ""}}

--- a/waiter/test/waiter/cookie_support_test.clj
+++ b/waiter/test/waiter/cookie_support_test.clj
@@ -41,20 +41,20 @@
   (is (= "a=b; c=d" (remove-cookie "a=b; x-waiter-auth=auth; c=d" "x-waiter-auth"))))
 
 (deftest test-add-encoded-cookie
-  (let [cookie-attrs ";Max-Age=864000;Path=/;HttpOnly=true"
+  (let [cookie-attrs ";Max-Age=86400;Path=/;HttpOnly=true"
         user-cookie (str "user=" (UrlEncoded/encodeString "data:john") cookie-attrs)]
     (with-redefs [b64/encode (fn [^String data-string] (.getBytes data-string))
                   nippy/freeze (fn [input _] (str "data:" input))]
       (is (= {:headers {"set-cookie" user-cookie}}
-             (add-encoded-cookie {} [:cached "password"] "user" "john" 10)))
+             (add-encoded-cookie {} [:cached "password"] "user" "john" 86400)))
       (is (= {:headers {"set-cookie" ["foo=bar" user-cookie]}}
-             (add-encoded-cookie {:headers {"set-cookie" "foo=bar"}} [:cached "password"] "user" "john" 10)))
+             (add-encoded-cookie {:headers {"set-cookie" "foo=bar"}} [:cached "password"] "user" "john" 86400)))
       (is (= {:headers {"set-cookie" ["foo=bar" "baz=quux" user-cookie]}}
-             (add-encoded-cookie {:headers {"set-cookie" ["foo=bar" "baz=quux"]}} [:cached "password"] "user" "john" 10)))
+             (add-encoded-cookie {:headers {"set-cookie" ["foo=bar" "baz=quux"]}} [:cached "password"] "user" "john" 86400)))
       (let [response-chan (async/promise-chan)]
         (async/>!! response-chan {})
         (is (= {:headers {"set-cookie" user-cookie}}
-               (async/<!! (add-encoded-cookie response-chan [:cached "password"] "user" "john" 10))))))))
+               (async/<!! (add-encoded-cookie response-chan [:cached "password"] "user" "john" 86400))))))))
 
 (deftest test-decode-cookie
   (with-redefs [b64/decode (fn [value-bytes] (String. ^bytes value-bytes "utf-8"))

--- a/waiter/test/waiter/utils_test.clj
+++ b/waiter/test/waiter/utils_test.clj
@@ -574,3 +574,12 @@
   (is (= "https" (request->scheme {:scheme :http :headers {"x-forwarded-proto" "https"}})))
   (is (= "http" (request->scheme {:scheme :https :headers {"x-forwarded-proto" "http"}})))
   (is (= "https" (request->scheme {:scheme :https :headers {"x-forwarded-proto" "https"}}))))
+
+(deftest test-escape-html
+  (is (= "&amp;" (escape-html "&")))
+  (is (= "&lt;" (escape-html "<")))
+  (is (= "&gt;" (escape-html ">")))
+  (is (= "&quot;" (escape-html "\"")))
+  (is (= "&#x27;" (escape-html "'")))
+  (is (= "&#x2F;" (escape-html "/")))
+  (is (= "&lt;script&gt;alert(&#x27;xss&#x27;);&lt;&#x2F;script&gt;" (escape-html "<script>alert('xss');</script>"))))

--- a/waiter/test/waiter/utils_test.clj
+++ b/waiter/test/waiter/utils_test.clj
@@ -566,3 +566,11 @@
     (is (= "text/plain" (request->content-type {:headers {"accept" "*/*"}})))
     (is (= "text/plain" (request->content-type {:headers {"accept" ""}})))
     (is (= "text/plain" (request->content-type {})))))
+
+(deftest test-request->scheme
+  (is (= "http" (request->scheme {:scheme :http})))
+  (is (= "https" (request->scheme {:scheme :https})))
+  (is (= "http" (request->scheme {:scheme :http :headers {"x-forwarded-proto" "http"}})))
+  (is (= "https" (request->scheme {:scheme :http :headers {"x-forwarded-proto" "https"}})))
+  (is (= "http" (request->scheme {:scheme :https :headers {"x-forwarded-proto" "http"}})))
+  (is (= "https" (request->scheme {:scheme :https :headers {"x-forwarded-proto" "https"}}))))


### PR DESCRIPTION
# Overview 

Add OAuth support for public-facing use cases.

The OAuth flow:
1. Unauthenticated requests are redirected to a page with a list of providers.
1. Client selects one provider from the list of configured providers (Google and GitHub are implemented.)
1. Client is redirected to the provider to approve Waiter's access to the client's credentials.
1. Provider redirects user back to Waiter with a token that can be used by Waiter to verify the user.
1. After authentication, client is redirected to original location, with path, query-string, and hash preserved.

OAuth requires an application to be registered with the provider.  Upon registering an application, the provider provides a client-id and a client-secret.  These values are configured via settings, where loading these values via environment variables is preferred for security.

Providers also require the URI redirecting back to the application to be specified when registering.  Some providers allow multiple callback URIs (e.g. Google), while others only one (e.g. GitHub).  Providers that allow multiple redirect URIs to be specified are preferred, since Waiter will likely be hosting multiple applications with different hostnames.  Each hostname hosted by Waiter will need to be registered.  Using a provider that supports only one redirect URI limits usage of the OAuth support to one hostname.

OAuth is, at its core, not a method of authenticating users, but it can be used for authentication if the provider has a way to look up a user's verified email address using the access_token provided.  Open ID Connect is a standardized flow for this, but while Google supports Open ID Connect, GitHub does not.

The user's email address is used as the principal for Waiter.  This implementation still expects a single `run-as-user` to be configured since we can't reliably map a principal to a username that makes sense to the scheduler.

If per-user instances are desired, a `ServiceDescriptionBuilder` can be used to add principal metadata to the service description, ensuring unique services per user.

Integration tests for OAuth would be difficult, given that interactive authorization by a user is required.

# Demo

After trying to visit `localhost:9091/settings`, the browser is redirected:

![choose-provider](https://user-images.githubusercontent.com/6118583/31856289-d3aae966-b682-11e7-860f-9ffc8e809a80.PNG)

After choosing Google as the provider:

![google-login](https://user-images.githubusercontent.com/6118583/31856292-ed3a7c48-b682-11e7-9aa1-f89b3108ca51.PNG)

GitHub has its own login page.

After successfully logging in, browser is redirected back to `localhost:9091/settings`.


