### PR TITLE
Work-stealing fixes

### DIFF
--- a/waiter/src/waiter/metrics.clj
+++ b/waiter/src/waiter/metrics.clj
@@ -153,7 +153,7 @@
   "Retrieves the core set of metrics used by the routers to make decisions based on aggregate metrics.
    The returned data has the format service-id->core-metrics-map
    The core-metrics-map is a flat map that has the following string keys:
-     slots-offered (via work-stealing), slots-assigned, slots-available, slots-in-use, outstanding and total.
+     slots-received (via work-stealing), slots-assigned, slots-available, slots-in-use, outstanding and total.
    The numeric values in each entry of the map come from corresponding codahale metrics."
   []
   (let [services-string "services"
@@ -177,7 +177,7 @@
                          (assoc-if ["counters" "instance-counts" "slots-in-use"] "slots-in-use")
                          (assoc-if ["counters" "request-counts" "outstanding"] "outstanding")
                          (assoc-if ["counters" "request-counts" "total"] "total")
-                         (assoc-if ["counters" "work-stealing" "received-from" "in-flight"] "slots-offered")
+                         (assoc-if ["counters" "work-stealing" "received-from" "in-flight"] "slots-received")
                          (persistent!))))
                  service-id->metrics)))
 

--- a/waiter/src/waiter/state.clj
+++ b/waiter/src/waiter/state.clj
@@ -300,7 +300,7 @@
      :response-chan resp-chan
      :response deployment-error}
     (if-let [{:keys [instance router-id] :as work-stealer-data} (first work-stealing-queue)]
-      ; using instance offered via work-stealing
+      ; using instance received via work-stealing
       (let [instance-id (:id instance)]
         (cid/cdebug (str cid "|" (:cid work-stealer-data)) "using work-stealing instance" instance-id)
         (counters/inc! (metrics/service-counter service-id "work-stealing" "received-from" router-id "accepts"))
@@ -355,7 +355,7 @@
               (cond-> (-> current-state
                           (update-in [:instance-id->request-id->use-reason-map] #(utils/dissoc-in % [instance-id request-id]))
                           (update-in [:instance-id->state instance-id] sanitize-instance-state))
-                ; instance offered from work-stealing, do not change slot state
+                ; instance received from work-stealing, do not change slot state
                 (nil? work-stealing-data) (update-slot-state-fn instance-id #(cond-> %2 (not= :kill-instance reason) (-> (dec) (max 0))))
                 ; mark instance as no longer locked.
                 (nil? work-stealing-data) (update-in [:instance-id->state instance-id] update-status-tag-fn #(disj % :locked))

--- a/waiter/src/waiter/utils.clj
+++ b/waiter/src/waiter/utils.clj
@@ -389,7 +389,7 @@
   ([slots-in-use slots-available slots-offered outstanding]
    (- outstanding (+ slots-in-use slots-available slots-offered))))
 
-(defn requires-help?
+(defn help-required?
   "Determines whether a given router needs help based on the values of:
      outstanding: the number of outstanding requests at the router;
      slots-available: the number of slots available (where available = not in use and not blacklisted) from those assigned
@@ -400,7 +400,7 @@
    It returns true if there are no slots available and `compute-help-required` returns a positive value."
   ([{:strs [outstanding slots-available slots-in-use slots-offered]
      :or {outstanding 0, slots-available 0, slots-in-use 0, slots-offered 0}}]
-   (requires-help? slots-in-use slots-available slots-offered outstanding))
+   (help-required? slots-in-use slots-available slots-offered outstanding))
   ([slots-in-use slots-available slots-offered outstanding]
    (and (zero? slots-available)
         (pos? (compute-help-required slots-in-use slots-available slots-offered outstanding)))))

--- a/waiter/src/waiter/utils.clj
+++ b/waiter/src/waiter/utils.clj
@@ -377,17 +377,17 @@
                       to the router by the distribution algorithm;
      slots-in-use: the number of slots used by the router from those that were assigned to it by the distribution
                    algorithm at some point in time, it may include slots from instances that the router no longer owns; and
-     slots-offered: the number of slots offered as help to the router from other routers via work-stealing.
+     slots-received: the number of slots received as help from other routers via work-stealing.
    The slots-in-use allows us to account for instances being used by a router that it no longer owns.
    If the function returns positive, say +x, it means the router needs x slots of help to service requests.
    If the function returns zero, it means the router does not need help.
    If the function returns negative, say -x, then the router needs no help and has x extra unused slots that were
    either assigned to it by the distribution algorithm or received from work-stealing offers."
-  ([{:strs [outstanding slots-available slots-in-use slots-offered]
-     :or {outstanding 0, slots-available 0, slots-in-use 0, slots-offered 0}}]
-   (compute-help-required slots-in-use slots-available slots-offered outstanding))
-  ([slots-in-use slots-available slots-offered outstanding]
-   (- outstanding (+ slots-in-use slots-available slots-offered))))
+  ([{:strs [outstanding slots-available slots-in-use slots-received]
+     :or {outstanding 0, slots-available 0, slots-in-use 0, slots-received 0}}]
+   (compute-help-required slots-in-use slots-available slots-received outstanding))
+  ([slots-in-use slots-available slots-received outstanding]
+   (- outstanding (+ slots-in-use slots-available slots-received))))
 
 (defn help-required?
   "Determines whether a given router needs help based on the values of:
@@ -396,14 +396,14 @@
                       to the router by the distribution algorithm;
      slots-in-use: the number of slots used by the router from those that were assigned to it by the distribution
                    algorithm at some point in time, it may include slots from instances that the router no longer owns; and
-     slots-offered: the number of slots offered as help to the router from other routers via work-stealing.
+     slots-received: the number of slots received as help from other routers via work-stealing.
    It returns true if there are no slots available and `compute-help-required` returns a positive value."
-  ([{:strs [outstanding slots-available slots-in-use slots-offered]
-     :or {outstanding 0, slots-available 0, slots-in-use 0, slots-offered 0}}]
-   (help-required? slots-in-use slots-available slots-offered outstanding))
-  ([slots-in-use slots-available slots-offered outstanding]
+  ([{:strs [outstanding slots-available slots-in-use slots-received]
+     :or {outstanding 0, slots-available 0, slots-in-use 0, slots-received 0}}]
+   (help-required? slots-in-use slots-available slots-received outstanding))
+  ([slots-in-use slots-available slots-received outstanding]
    (and (zero? slots-available)
-        (pos? (compute-help-required slots-in-use slots-available slots-offered outstanding)))))
+        (pos? (compute-help-required slots-in-use slots-available slots-received outstanding)))))
 
 (let [messages (atom {})]
   (defn message

--- a/waiter/src/waiter/utils.clj
+++ b/waiter/src/waiter/utils.clj
@@ -374,7 +374,7 @@
   "Computes the number of slots (requests that can be made to instances) of help required at a router given the values for:
      outstanding: the number of outstanding requests at the router;
      slots-available: the number of slots available (where available = not in use and not blacklisted) from those assigned
-                      to the router by the distrbution algorithm;
+                      to the router by the distribution algorithm;
      slots-in-use: the number of slots used by the router from those that were assigned to it by the distribution
                    algorithm at some point in time, it may include slots from instances that the router no longer owns; and
      slots-offered: the number of slots offered as help to the router from other routers via work-stealing.
@@ -388,6 +388,22 @@
    (compute-help-required slots-in-use slots-available slots-offered outstanding))
   ([slots-in-use slots-available slots-offered outstanding]
    (- outstanding (+ slots-in-use slots-available slots-offered))))
+
+(defn requires-help?
+  "Determines whether a given router needs help based on the values of:
+     outstanding: the number of outstanding requests at the router;
+     slots-available: the number of slots available (where available = not in use and not blacklisted) from those assigned
+                      to the router by the distribution algorithm;
+     slots-in-use: the number of slots used by the router from those that were assigned to it by the distribution
+                   algorithm at some point in time, it may include slots from instances that the router no longer owns; and
+     slots-offered: the number of slots offered as help to the router from other routers via work-stealing.
+   It returns true if there are no slots available and `compute-help-required` returns a positive value."
+  ([{:strs [outstanding slots-available slots-in-use slots-offered]
+     :or {outstanding 0, slots-available 0, slots-in-use 0, slots-offered 0}}]
+   (requires-help? slots-in-use slots-available slots-offered outstanding))
+  ([slots-in-use slots-available slots-offered outstanding]
+   (and (zero? slots-available)
+        (pos? (compute-help-required slots-in-use slots-available slots-offered outstanding)))))
 
 (let [messages (atom {})]
   (defn message

--- a/waiter/src/waiter/utils.clj
+++ b/waiter/src/waiter/utils.clj
@@ -370,41 +370,6 @@
   (let [data-bytes (data->byte-array byte-buffer)]
     (nippy/thaw data-bytes {:password decryption-key, :compressor compression/lzma2-compressor})))
 
-(defn compute-help-required
-  "Computes the number of slots (requests that can be made to instances) of help required at a router given the values for:
-     outstanding: the number of outstanding requests at the router;
-     slots-available: the number of slots available (where available = not in use and not blacklisted) from those assigned
-                      to the router by the distribution algorithm;
-     slots-in-use: the number of slots used by the router from those that were assigned to it by the distribution
-                   algorithm at some point in time, it may include slots from instances that the router no longer owns; and
-     slots-received: the number of slots received as help from other routers via work-stealing.
-   The slots-in-use allows us to account for instances being used by a router that it no longer owns.
-   If the function returns positive, say +x, it means the router needs x slots of help to service requests.
-   If the function returns zero, it means the router does not need help.
-   If the function returns negative, say -x, then the router needs no help and has x extra unused slots that were
-   either assigned to it by the distribution algorithm or received from work-stealing offers."
-  ([{:strs [outstanding slots-available slots-in-use slots-received]
-     :or {outstanding 0, slots-available 0, slots-in-use 0, slots-received 0}}]
-   (compute-help-required slots-in-use slots-available slots-received outstanding))
-  ([slots-in-use slots-available slots-received outstanding]
-   (- outstanding (+ slots-in-use slots-available slots-received))))
-
-(defn help-required?
-  "Determines whether a given router needs help based on the values of:
-     outstanding: the number of outstanding requests at the router;
-     slots-available: the number of slots available (where available = not in use and not blacklisted) from those assigned
-                      to the router by the distribution algorithm;
-     slots-in-use: the number of slots used by the router from those that were assigned to it by the distribution
-                   algorithm at some point in time, it may include slots from instances that the router no longer owns; and
-     slots-received: the number of slots received as help from other routers via work-stealing.
-   It returns true if there are no slots available and `compute-help-required` returns a positive value."
-  ([{:strs [outstanding slots-available slots-in-use slots-received]
-     :or {outstanding 0, slots-available 0, slots-in-use 0, slots-received 0}}]
-   (help-required? slots-in-use slots-available slots-received outstanding))
-  ([slots-in-use slots-available slots-received outstanding]
-   (and (zero? slots-available)
-        (pos? (compute-help-required slots-in-use slots-available slots-received outstanding)))))
-
 (let [messages (atom {})]
   (defn message
     "Returns the message corresponding to the provided key"

--- a/waiter/src/waiter/work_stealing.clj
+++ b/waiter/src/waiter/work_stealing.clj
@@ -131,7 +131,6 @@
                                  offerable-slots (-> (router-id->metrics router-id)
                                                      (utils/compute-help-required)
                                                      (unchecked-negate))
-                                 offered-slots (count request-id->work-stealer)
                                  router-id->help-required (-> router-id->metrics
                                                               (dissoc router-id)
                                                               (router-id->metrics->router-id->help-required))]
@@ -146,7 +145,7 @@
                                      (log/debug label "no work-stealing offers this iteration"
                                                 {:metrics (router-id->metrics router-id)
                                                  :slots {:offerable offerable-slots
-                                                         :offered offered-slots}})
+                                                         :offered (count request-id->work-stealer)}})
                                      current-state))
                                  (assoc :timeout-chan (timeout-chan-factory)))))
 
@@ -154,7 +153,6 @@
                          ([data]
                            (let [{:keys [response-chan]} data
                                  router-id->metrics (service-id->router-id->metrics service-id)
-                                 offered-slots (count request-id->work-stealer)
                                  offerable-slots (-> (router-id->metrics router-id)
                                                      (utils/compute-help-required)
                                                      (unchecked-negate))
@@ -167,7 +165,7 @@
                                                            (assoc :router-id->help-required router-id->help-required
                                                                   :router-id->metrics router-id->metrics
                                                                   :slots {:offerable offerable-slots
-                                                                          :offered offered-slots})))
+                                                                          :offered (count request-id->work-stealer)})))
                              current-state))
 
                          :priority true)]

--- a/waiter/src/waiter/work_stealing.clj
+++ b/waiter/src/waiter/work_stealing.clj
@@ -27,7 +27,7 @@
   [router->metrics]
   (->> router->metrics
        (pc/map-vals (fn [metrics]
-                      (when (utils/requires-help? metrics)
+                      (when (utils/help-required? metrics)
                         (utils/compute-help-required metrics))))
        (utils/filterm (fn [[_ help-required]]
                         (and help-required (pos? help-required))))))
@@ -35,14 +35,14 @@
 (defn- make-work-stealing-offers
   "Makes work-stealing offers to victim routers when the current router has idle slots.
    Routers which are more heavily loaded preferentially receive help offers."
-  [label offer-help-fn reserve-instance-fn {:keys [iteration] :as current-state} stealable-slots
+  [label offer-help-fn reserve-instance-fn {:keys [iteration] :as current-state} offerable-slots
    router-id->help-required cleanup-chan router-id service-id]
   (async/go
     (loop [counter 0
            iteration-state current-state
            router-id->help-required router-id->help-required]
       (let [iter-label (str label ".iter" iteration)]
-        (if (and (< counter stealable-slots) (seq router-id->help-required))
+        (if (and (< counter offerable-slots) (seq router-id->help-required))
           (let [request-id (str service-id "." router-id ".ws" iteration ".offer" counter)
                 reservation-parameters {:cid request-id, :request-id request-id}
                 response-chan (async/promise-chan)
@@ -69,11 +69,11 @@
                          (update-in router-id->help-required [target-router-id] dec))))
               (do
                 (when (pos? counter)
-                  (log/info iter-label "no more instances to offer, offered" counter "of" stealable-slots "slots"))
+                  (log/info iter-label "no more instances to offer, offered" counter "of" offerable-slots "slots"))
                 iteration-state)))
           (do
             (if (pos? counter)
-              (log/info iter-label "exhausted help offers, offered" counter "of" stealable-slots "slots"))
+              (log/info iter-label "exhausted help offers, offered" counter "of" offerable-slots "slots"))
             iteration-state))))))
 
 (defn work-stealing-balancer
@@ -128,25 +128,24 @@
                          ([_]
                            (let [router-id->metrics (service-id->router-id->metrics service-id)
                                  _ (log/trace label "received metrics from" (count router-id->metrics) "routers")
-                                 extra-slots (-> (router-id->metrics router-id)
-                                                 (utils/compute-help-required)
-                                                 (unchecked-negate))
+                                 offerable-slots (-> (router-id->metrics router-id)
+                                                     (utils/compute-help-required)
+                                                     (unchecked-negate))
                                  offered-slots (count request-id->work-stealer)
-                                 stealable-slots (- extra-slots offered-slots)
                                  router-id->help-required (-> router-id->metrics
                                                               (dissoc router-id)
                                                               (router-id->metrics->router-id->help-required))]
-                             (log/trace label "can make up to" stealable-slots "work-stealing offers this iteration")
-                             (-> (if (and (pos? stealable-slots)
+                             (log/trace label "can make up to" offerable-slots "work-stealing offers this iteration")
+                             (-> (if (and (pos? offerable-slots)
                                           (seq router-id->help-required))
                                    (async/<!
                                      (make-work-stealing-offers
-                                       label offer-help-fn reserve-instance-fn current-state stealable-slots
+                                       label offer-help-fn reserve-instance-fn current-state offerable-slots
                                        router-id->help-required cleanup-chan router-id service-id))
                                    (do
                                      (log/debug label "no work-stealing offers this iteration"
                                                 {:metrics (router-id->metrics router-id)
-                                                 :slots {:extra extra-slots
+                                                 :slots {:offerable offerable-slots
                                                          :offered offered-slots}})
                                      current-state))
                                  (assoc :timeout-chan (timeout-chan-factory)))))
@@ -156,9 +155,9 @@
                            (let [{:keys [response-chan]} data
                                  router-id->metrics (service-id->router-id->metrics service-id)
                                  offered-slots (count request-id->work-stealer)
-                                 extra-slots (-> (router-id->metrics router-id)
-                                                 (utils/compute-help-required)
-                                                 (unchecked-negate))
+                                 offerable-slots (-> (router-id->metrics router-id)
+                                                     (utils/compute-help-required)
+                                                     (unchecked-negate))
                                  router-id->help-required (-> router-id->metrics
                                                               (dissoc router-id)
                                                               (router-id->metrics->router-id->help-required))]
@@ -167,7 +166,7 @@
                                                            (dissoc :timeout-chan)
                                                            (assoc :router-id->help-required router-id->help-required
                                                                   :router-id->metrics router-id->metrics
-                                                                  :slots {:extra extra-slots
+                                                                  :slots {:offerable offerable-slots
                                                                           :offered offered-slots})))
                              current-state))
 

--- a/waiter/test/waiter/utils_test.clj
+++ b/waiter/test/waiter/utils_test.clj
@@ -431,22 +431,6 @@
       (is (thrown-with-msg? Exception #"Thaw failed"
                             (compress-and-decompress {"a" :b, :c :d, :e [:f "g" "h"]}))))))
 
-(deftest test-compute-help-required
-  (is (= -6 (compute-help-required {"outstanding" 6, "slots-available" 2, "slots-in-use" 10, "slots-received" 0})))
-  (is (= -10 (compute-help-required {"outstanding" 6, "slots-available" 2, "slots-in-use" 14, "slots-received" 0})))
-  (is (= 0 (compute-help-required {"outstanding" 10, "slots-available" 10, "slots-in-use" 0, "slots-received" 0})))
-  (is (= 0 (compute-help-required {"outstanding" 14, "slots-available" 10, "slots-in-use" 4, "slots-received" 0})))
-
-  (is (= 13 (compute-help-required {"outstanding" 25, "slots-available" 2, "slots-in-use" 10, "slots-received" 0})))
-  (is (= 9 (compute-help-required {"outstanding" 25, "slots-available" 2, "slots-in-use" 14, "slots-received" 0})))
-  (is (= 15 (compute-help-required {"outstanding" 25, "slots-available" 10, "slots-in-use" 0, "slots-received" 0})))
-  (is (= 11 (compute-help-required {"outstanding" 25, "slots-available" 10, "slots-in-use" 4, "slots-received" 0})))
-
-  (is (= 1 (compute-help-required {"outstanding" 25, "slots-available" 2, "slots-in-use" 10, "slots-received" 12})))
-  (is (= -3 (compute-help-required {"outstanding" 25, "slots-available" 2, "slots-in-use" 14, "slots-received" 12})))
-  (is (= 3 (compute-help-required {"outstanding" 25, "slots-available" 10, "slots-in-use" 0, "slots-received" 12})))
-  (is (= -1 (compute-help-required {"outstanding" 25, "slots-available" 10, "slots-in-use" 4, "slots-received" 12}))))
-
 (deftest test-request-flag
   (is (not (request-flag {} "foo")))
   (is (not (request-flag {"bar" 1} "foo")))

--- a/waiter/test/waiter/utils_test.clj
+++ b/waiter/test/waiter/utils_test.clj
@@ -432,20 +432,20 @@
                             (compress-and-decompress {"a" :b, :c :d, :e [:f "g" "h"]}))))))
 
 (deftest test-compute-help-required
-  (is (= -6 (compute-help-required {"outstanding" 6, "slots-available" 2, "slots-in-use" 10, "slots-offered" 0})))
-  (is (= -10 (compute-help-required {"outstanding" 6, "slots-available" 2, "slots-in-use" 14, "slots-offered" 0})))
-  (is (= 0 (compute-help-required {"outstanding" 10, "slots-available" 10, "slots-in-use" 0, "slots-offered" 0})))
-  (is (= 0 (compute-help-required {"outstanding" 14, "slots-available" 10, "slots-in-use" 4, "slots-offered" 0})))
+  (is (= -6 (compute-help-required {"outstanding" 6, "slots-available" 2, "slots-in-use" 10, "slots-received" 0})))
+  (is (= -10 (compute-help-required {"outstanding" 6, "slots-available" 2, "slots-in-use" 14, "slots-received" 0})))
+  (is (= 0 (compute-help-required {"outstanding" 10, "slots-available" 10, "slots-in-use" 0, "slots-received" 0})))
+  (is (= 0 (compute-help-required {"outstanding" 14, "slots-available" 10, "slots-in-use" 4, "slots-received" 0})))
 
-  (is (= 13 (compute-help-required {"outstanding" 25, "slots-available" 2, "slots-in-use" 10, "slots-offered" 0})))
-  (is (= 9 (compute-help-required {"outstanding" 25, "slots-available" 2, "slots-in-use" 14, "slots-offered" 0})))
-  (is (= 15 (compute-help-required {"outstanding" 25, "slots-available" 10, "slots-in-use" 0, "slots-offered" 0})))
-  (is (= 11 (compute-help-required {"outstanding" 25, "slots-available" 10, "slots-in-use" 4, "slots-offered" 0})))
+  (is (= 13 (compute-help-required {"outstanding" 25, "slots-available" 2, "slots-in-use" 10, "slots-received" 0})))
+  (is (= 9 (compute-help-required {"outstanding" 25, "slots-available" 2, "slots-in-use" 14, "slots-received" 0})))
+  (is (= 15 (compute-help-required {"outstanding" 25, "slots-available" 10, "slots-in-use" 0, "slots-received" 0})))
+  (is (= 11 (compute-help-required {"outstanding" 25, "slots-available" 10, "slots-in-use" 4, "slots-received" 0})))
 
-  (is (= 1 (compute-help-required {"outstanding" 25, "slots-available" 2, "slots-in-use" 10, "slots-offered" 12})))
-  (is (= -3 (compute-help-required {"outstanding" 25, "slots-available" 2, "slots-in-use" 14, "slots-offered" 12})))
-  (is (= 3 (compute-help-required {"outstanding" 25, "slots-available" 10, "slots-in-use" 0, "slots-offered" 12})))
-  (is (= -1 (compute-help-required {"outstanding" 25, "slots-available" 10, "slots-in-use" 4, "slots-offered" 12}))))
+  (is (= 1 (compute-help-required {"outstanding" 25, "slots-available" 2, "slots-in-use" 10, "slots-received" 12})))
+  (is (= -3 (compute-help-required {"outstanding" 25, "slots-available" 2, "slots-in-use" 14, "slots-received" 12})))
+  (is (= 3 (compute-help-required {"outstanding" 25, "slots-available" 10, "slots-in-use" 0, "slots-received" 12})))
+  (is (= -1 (compute-help-required {"outstanding" 25, "slots-available" 10, "slots-in-use" 4, "slots-received" 12}))))
 
 (deftest test-request-flag
   (is (not (request-flag {} "foo")))

--- a/waiter/test/waiter/work_stealing_test.clj
+++ b/waiter/test/waiter/work_stealing_test.clj
@@ -25,6 +25,38 @@
    "slots-in-use" slots-in-use
    "slots-received" slots-received})
 
+(deftest test-compute-help-required
+  (is (= -6 (compute-help-required {"outstanding" 6, "slots-available" 2, "slots-in-use" 10, "slots-received" 0})))
+  (is (= -10 (compute-help-required {"outstanding" 6, "slots-available" 2, "slots-in-use" 14, "slots-received" 0})))
+  (is (= 0 (compute-help-required {"outstanding" 10, "slots-available" 10, "slots-in-use" 0, "slots-received" 0})))
+  (is (= 0 (compute-help-required {"outstanding" 14, "slots-available" 10, "slots-in-use" 4, "slots-received" 0})))
+
+  (is (= 13 (compute-help-required {"outstanding" 25, "slots-available" 2, "slots-in-use" 10, "slots-received" 0})))
+  (is (= 9 (compute-help-required {"outstanding" 25, "slots-available" 2, "slots-in-use" 14, "slots-received" 0})))
+  (is (= 15 (compute-help-required {"outstanding" 25, "slots-available" 10, "slots-in-use" 0, "slots-received" 0})))
+  (is (= 11 (compute-help-required {"outstanding" 25, "slots-available" 10, "slots-in-use" 4, "slots-received" 0})))
+
+  (is (= 1 (compute-help-required {"outstanding" 25, "slots-available" 2, "slots-in-use" 10, "slots-received" 12})))
+  (is (= -3 (compute-help-required {"outstanding" 25, "slots-available" 2, "slots-in-use" 14, "slots-received" 12})))
+  (is (= 3 (compute-help-required {"outstanding" 25, "slots-available" 10, "slots-in-use" 0, "slots-received" 12})))
+  (is (= -1 (compute-help-required {"outstanding" 25, "slots-available" 10, "slots-in-use" 4, "slots-received" 12}))))
+
+(deftest test-help-required?
+  (is (false? (help-required? {"outstanding" 6, "slots-available" 2, "slots-in-use" 10, "slots-received" 0})))
+  (is (false? (help-required? {"outstanding" 6, "slots-available" 2, "slots-in-use" 14, "slots-received" 0})))
+  (is (false? (help-required? {"outstanding" 10, "slots-available" 10, "slots-in-use" 0, "slots-received" 0})))
+  (is (false? (help-required? {"outstanding" 14, "slots-available" 10, "slots-in-use" 4, "slots-received" 0})))
+
+  (is (false? (help-required? {"outstanding" 25, "slots-available" 1, "slots-in-use" 10, "slots-received" 0})))
+  (is (true? (help-required? {"outstanding" 25, "slots-available" 0, "slots-in-use" 14, "slots-received" 0})))
+  (is (false? (help-required? {"outstanding" 25, "slots-available" 10, "slots-in-use" 0, "slots-received" 0})))
+  (is (true? (help-required? {"outstanding" 25, "slots-available" 0, "slots-in-use" 4, "slots-received" 0})))
+
+  (is (false? (help-required? {"outstanding" 25, "slots-available" 2, "slots-in-use" 10, "slots-received" 12})))
+  (is (false? (help-required? {"outstanding" 25, "slots-available" 2, "slots-in-use" 14, "slots-received" 12})))
+  (is (false? (help-required? {"outstanding" 25, "slots-available" 10, "slots-in-use" 0, "slots-received" 12})))
+  (is (false? (help-required? {"outstanding" 25, "slots-available" 10, "slots-in-use" 4, "slots-received" 12}))))
+
 (deftest test-router-id->metrics->router-id->help-required
   (testing "nil-input"
     (is (= {}

--- a/waiter/test/waiter/work_stealing_test.clj
+++ b/waiter/test/waiter/work_stealing_test.clj
@@ -18,12 +18,12 @@
             [waiter.work-stealing :refer :all]))
 
 (defn- make-metrics
-  [{:keys [outstanding slots-available slots-in-use slots-offered]
-    :or {outstanding 0, slots-available 0, slots-in-use 0, slots-offered 0}}]
+  [{:keys [outstanding slots-available slots-in-use slots-received]
+    :or {outstanding 0, slots-available 0, slots-in-use 0, slots-received 0}}]
   {"outstanding" outstanding
    "slots-available" slots-available
    "slots-in-use" slots-in-use
-   "slots-offered" slots-offered})
+   "slots-received" slots-received})
 
 (deftest test-router-id->metrics->router-id->help-required
   (testing "nil-input"
@@ -54,10 +54,10 @@
               "router-2B" (make-metrics {:outstanding 5, :slots-available 2})
               "router-3" (make-metrics {:outstanding 2, :slots-available 5})
               "router-4" (make-metrics {})
-              "router-5" (make-metrics {:outstanding 10, :slots-available 20, :slots-offered 15})
-              "router-6" (make-metrics {:outstanding 20, :slots-available 10, :slots-offered 15})
-              "router-7A" (make-metrics {:outstanding 20, :slots-available 0, :slots-offered 15})
-              "router-7B" (make-metrics {:outstanding 40, :slots-available 20, :slots-offered 15})})))))
+              "router-5" (make-metrics {:outstanding 10, :slots-available 20, :slots-received 15})
+              "router-6" (make-metrics {:outstanding 20, :slots-available 10, :slots-received 15})
+              "router-7A" (make-metrics {:outstanding 20, :slots-available 0, :slots-received 15})
+              "router-7B" (make-metrics {:outstanding 40, :slots-available 20, :slots-received 15})})))))
 
 (defmacro check-work-stealing-balancer-query-state [query-chan expected-result]
   `(let [response-chan# (async/chan 1)


### PR DESCRIPTION
 - fix bug in computation of extra-slots, renamed to offerable-slots
 - do not offer help until the target router has exhausted all its slots
 - do not accept work-stealing offers if a router has unused slots
 - renamed `slots-offered` to `slots-received`