### PR TITLE
Makes JSON error messages better

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -115,7 +115,16 @@
              :test {:jvm-opts
                     [~(str "-Dwaiter.test.kitchen.cmd=" (or
                                                           (System/getenv "WAITER_TEST_KITCHEN_CMD")
-                                                          (.getCanonicalPath (clojure.java.io/file "../kitchen/bin/run.sh"))))]}
+                                                          (.getCanonicalPath (clojure.java.io/file "../kitchen/bin/run.sh"))))]
+                    ;; Print exception data
+                    :injections [(defmethod clojure.test/report :error [m]
+                                   (clojure.test/with-test-out
+                                     (clojure.test/inc-report-counter :error)
+                                     (println "\nERROR in" (clojure.test/testing-vars-str m))
+                                     (when (seq clojure.test/*testing-contexts*) (println (clojure.test/testing-contexts-str)))
+                                     (when-let [message (:message m)] (println message))
+                                     (println "expected:" (pr-str (:expected m)))
+                                     (print "  actual: " (pr-str (:actual m)))))]}
              :test-console {:jvm-opts
                             ["-Dlog4j.configuration=log4j-console.properties"]}
              :test-log {:jvm-opts

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -115,16 +115,7 @@
              :test {:jvm-opts
                     [~(str "-Dwaiter.test.kitchen.cmd=" (or
                                                           (System/getenv "WAITER_TEST_KITCHEN_CMD")
-                                                          (.getCanonicalPath (clojure.java.io/file "../kitchen/bin/run.sh"))))]
-                    ;; Print exception data
-                    :injections [(defmethod clojure.test/report :error [m]
-                                   (clojure.test/with-test-out
-                                     (clojure.test/inc-report-counter :error)
-                                     (println "\nERROR in" (clojure.test/testing-vars-str m))
-                                     (when (seq clojure.test/*testing-contexts*) (println (clojure.test/testing-contexts-str)))
-                                     (when-let [message (:message m)] (println message))
-                                     (println "expected:" (pr-str (:expected m)))
-                                     (print "  actual: " (pr-str (:actual m)))))]}
+                                                          (.getCanonicalPath (clojure.java.io/file "../kitchen/bin/run.sh"))))]}
              :test-console {:jvm-opts
                             ["-Dlog4j.configuration=log4j-console.properties"]}
              :test-log {:jvm-opts

--- a/waiter/src/waiter/client_tools.clj
+++ b/waiter/src/waiter/client_tools.clj
@@ -51,10 +51,11 @@
 (defn colored-time [time-string] (yellow time-string))
 
 (defn try-parse-json
-  [body]
-  (try (json/read-str body)
-       (catch Exception e
-         (throw (ex-info "Couldn't parse JSON" {:body body} e)))))
+  [s]
+  (try
+    (json/read-str s)
+    (catch Exception e
+      (throw (ex-info "Couldn't parse JSON" {:string s} e)))))
 
 (defn execute-command [& args]
   (let [shell-output (apply shell/sh args)]

--- a/waiter/src/waiter/client_tools.clj
+++ b/waiter/src/waiter/client_tools.clj
@@ -50,6 +50,12 @@
 
 (defn colored-time [time-string] (yellow time-string))
 
+(defn try-parse-json
+  [body]
+  (try (json/read-str body)
+       (catch Exception e
+         (throw (ex-info "Couldn't parse JSON" {:body body} e)))))
+
 (defn execute-command [& args]
   (let [shell-output (apply shell/sh args)]
     (when (not= 0 (:exit shell-output))
@@ -365,7 +371,7 @@
 
 (defn waiter-settings [waiter-url & {:keys [cookies] :or {cookies []}}]
   (let [settings-result (make-request waiter-url "/settings" :verbose true :cookies cookies)
-        settings-json (json/read-str (:body settings-result))]
+        settings-json (try-parse-json (:body settings-result))]
     (walk/keywordize-keys settings-json)))
 
 (defn service-settings [waiter-url service-id & {:keys [keywordize-keys] :or {keywordize-keys true}}]
@@ -373,14 +379,14 @@
         settings-result (make-request waiter-url settings-path)
         settings-body (:body settings-result)
         _ (log/debug "service" service-id ":" settings-body)
-        settings-json (json/read-str settings-body)]
+        settings-json (try-parse-json settings-body)]
     (cond-> settings-json keywordize-keys walk/keywordize-keys)))
 
 (defn service-state [waiter-url service-id & {:keys [cookies] :or {cookies {}}}]
   (let [state-result (make-request waiter-url (str "/state/" service-id) :cookies cookies)
         state-body (:body state-result)
         _ (log/debug "service" service-id "state:" state-body)
-        state-json (json/read-str state-body)]
+        state-json (try-parse-json state-body)]
     (walk/keywordize-keys state-json)))
 
 (defn- retrieve-state-helper
@@ -388,7 +394,7 @@
   [waiter-url endpoint & {:keys [cookies] :or {cookies {}}}]
   (let [state-body (:body (make-request waiter-url endpoint :verbose true :cookies cookies))]
     (log/debug endpoint "body:" state-body)
-    (json/read-str state-body)))
+    (try-parse-json state-body)))
 
 (defn kv-store-state
   "Fetches and returns the kv-store state."
@@ -478,7 +484,7 @@
          (fn []
            (let [app-delete-path (str "/apps/" service-id "?force=true")
                  delete-response (make-request waiter-url app-delete-path :http-method-fn http/delete)
-                 delete-json (json/read-str (:body delete-response))
+                 delete-json (try-parse-json (:body delete-response))
                  delete-success (true? (get delete-json "success"))
                  no-such-service (= "no-such-service-exists" (get delete-json "result"))]
              (log/debug "Delete response for" service-id ":" delete-json)
@@ -744,7 +750,7 @@
   [router-url service-id cookies]
   (let [state-json (:body (make-request router-url (str "/state/" service-id) :cookies cookies))]
     (log/debug "State received from" router-url ":" state-json)
-    (json/read-str state-json)))
+    (try-parse-json state-json)))
 
 (defn service
   "Retrieves the service (from /apps) corresponding to the provided service-id"
@@ -754,7 +760,7 @@
     (fn []
       (let [{:keys [body]} (make-request waiter-url "/apps" :query-params query-params)
             _ (log/debug "Response body:" body)
-            parsed-body (json/read-str body)
+            parsed-body (try-parse-json body)
             service (first (filter #(= service-id (get % "service-id")) parsed-body))]
         (when-not service
           (log/info "Service" service-id "is missing! Response:" body))
@@ -818,7 +824,7 @@
   (let [marathon-url (marathon-url waiter-url)
         app-info-path (str "/v2/apps/" service-id)
         app-info-response (make-request marathon-url app-info-path)
-        app-info-map (walk/keywordize-keys (json/read-str (:body app-info-response)))]
+        app-info-map (walk/keywordize-keys (try-parse-json (:body app-info-response)))]
     (:gracePeriodSeconds (first (:healthChecks (:app app-info-map))))))
 
 (defn using-marathon?


### PR DESCRIPTION
<pre>
ERROR in (test-ex) (core.clj:4617)
Uncaught exception, not in assertion.
expected: nil
  actual:  #error {
 :cause "JSON error (unexpected character): w"
 :via
 [{:type clojure.lang.ExceptionInfo
   :message "Couldn't parse JSON"
   :data {:string "what is this json"}
   :at [clojure.core$ex_info invokeStatic "core.clj" 4617]}
  {:type java.lang.Exception
   :message "JSON error (unexpected character): w"
   :at [clojure.data.json$_read invokeStatic "json.clj" 226]}]
 :trace
 [[clojure.data.json$_read invokeStatic "json.clj" 226]
  [clojure.data.json$_read invoke "json.clj" 177]
...
</pre>

instead of

<pre>
ERROR in (test-ex) (json.clj:226)
Uncaught exception, not in assertion.
expected: nil
  actual: java.lang.Exception: JSON error (unexpected character): w
 at clojure.data.json$_read.invokeStatic (json.clj:226)
    clojure.data.json$_read.invoke (json.clj:177)
...
</pre>