### PR TITLE
adds the github PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Changes proposed in this PR
+
+-
+
+## Why are we making these changes?
+
+


### PR DESCRIPTION
## Changes proposed in this PR

- Adds a PR template file under `.github/` that has the same shape as this description
- For more info on PR templates, see https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/

## Why are we making these changes?

This will encourage us to include the reason(s) for a PR.
