### PR TITLE
Upgrades the lein voom version to work with lein 2.8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ branches:
 env:
   global:
     - DEPS_CMD='lein with-profiles +test voom build-deps'
-    - LEIN_GET='wget https://raw.githubusercontent.com/technomancy/leiningen/2.6.1/bin/lein'
+    - LEIN_GET='wget https://raw.githubusercontent.com/technomancy/leiningen/2.8.1/bin/lein'
     - LEIN_CHMOD='chmod +x ./lein'
     - _JAVA_OPTIONS='' # Avoid unwanted _JAVA_OPTIONS set by Travis CI
   matrix:

--- a/kitchen/project.clj
+++ b/kitchen/project.clj
@@ -10,7 +10,7 @@
 ;;
 (defproject kitchen "0.1.0-SNAPSHOT"
   :dependencies [^{:voom {:repo "https://github.com/twosigma/jet.git" :branch "waiter-patch"}}
-                 [cc.qbits/jet "0.7.10-20170801_153701-gf517b70"]
+                 [cc.qbits/jet "0.7.10-20180124_192153-gf3270ee"]
                  [log4j/log4j "1.2.17" :exclusions [javax.mail/mail
                                                     javax.jms/jms
                                                     com.sun.jmdk/jmxtools
@@ -22,7 +22,7 @@
                  [prismatic/plumbing "0.5.3"]
                  [ring/ring-core "1.4.0"]
                  [ring-basic-authentication "1.0.5"]]
-  :plugins [[lein-voom "0.1.0-20150115_230705-gd96d771"]]
+  :plugins [[lein-voom "0.1.0-20171225_233657-g7962d1d"]]
   :main ^:skip-aot kitchen.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -26,9 +26,9 @@
   :dependencies [[bidi "2.0.16"
                   :exclusions [prismatic/schema ring/ring-core]]
                  ^{:voom {:repo "https://github.com/twosigma/jet.git" :branch "waiter-patch"}}
-                 [cc.qbits/jet "0.7.10-20170801_153701-gf517b70"]
+                 [cc.qbits/jet "0.7.10-20180124_192153-gf3270ee"]
                  ^{:voom {:repo "https://github.com/twosigma/clj-http.git" :branch "waiter-patch"}}
-                 [clj-http "1.0.2-20170524_085846-g161c42f"
+                 [clj-http "1.0.2-20180124_192038-g917314d"
                   :exclusions [commons-io org.clojure/tools.reader potemkin slingshot]]
                  [clj-time "0.12.0"
                   :exclusions
@@ -47,7 +47,7 @@
                    org.clojure/core.async]]
                  [joda-time "2.9.4"]
                  ^{:voom {:repo "https://github.com/twosigma/metrics-clojure.git" :branch "waiter-patch"}}
-                 [metrics-clojure "2.6.0-20170531_164957-gd0d2c2c"
+                 [metrics-clojure "2.6.0-20180124_192727-g36960dc"
                   :exclusions [org.clojure/clojure io.netty/netty org.slf4j/slf4j-api]]
                  [metrics-clojure-jvm "2.6.0"
                   :exclusions [io.dropwizard.metrics/metrics-core
@@ -88,7 +88,7 @@
 
   :resource-paths ["resources"]
   :main waiter.main
-  :plugins [[lein-voom "0.1.0-20150115_230705-gd96d771"
+  :plugins [[lein-voom "0.1.0-20171225_233657-g7962d1d"
              :exclusions [org.clojure/clojure]]
             [test2junit "1.2.2"]
             [com.holychao/parallel-test "0.3.1"]]


### PR DESCRIPTION
## Changes proposed in this PR

- Upgrade lein-voom to 0.1.0-20171225_233657-g7962d1d

## Why are we making these changes?

- Allows us to use the latest version of `lein` in our build scripts.
It prevents errors such as the following:
```clojure.lang.Compiler$CompilerException: java.lang.ClassNotFoundException: org.sonatype.aether.util.version.GenericVersionScheme, compiling:(leiningen/voom.clj:1:1)
 at clojure.lang.Compiler.load (Compiler.java:7391)                 
    clojure.lang.RT.loadResourceScript (RT.java:372)                       
    clojure.lang.RT.loadResourceScript (RT.java:363)
```

## Related PRs:

- These PRs need to be merged before we can merge this PR.

`clj-http`: https://github.com/twosigma/clj-http/pull/1
`jet`: https://github.com/twosigma/jet/pull/6
`metrics-clojure`: https://github.com/twosigma/metrics-clojure/pull/1

