### PR TITLE
Add log when scheduler reports fewer than min instances instances

### DIFF
--- a/waiter/src/waiter/scaling.clj
+++ b/waiter/src/waiter/scaling.clj
@@ -373,7 +373,7 @@
                             {:scheduler-state scheduler-state, :service-id service-id})
                   {:scale-to-instances instances :target-instances target-instances :scale-amount 0}))]
           (when (< instances (service-description "min-instances"))
-            (log/warn "Scheduler reported service had fewer instances than min-instances" {:service-id service-id
+            (log/warn "scheduler reported service had fewer instances than min-instances" {:service-id service-id
                                                                                            :instances instances
                                                                                            :min-instances (service-description "min-instances")}))
           (when-not (zero? scale-amount)

--- a/waiter/src/waiter/scaling.clj
+++ b/waiter/src/waiter/scaling.clj
@@ -373,9 +373,8 @@
                             {:scheduler-state scheduler-state, :service-id service-id})
                   {:scale-to-instances instances :target-instances target-instances :scale-amount 0}))]
           (when (< instances (service-description "min-instances"))
-            (log/warn "scheduler reported service had fewer instances than min-instances" {:service-id service-id
-                                                                                           :instances instances
-                                                                                           :min-instances (service-description "min-instances")}))
+            (log/warn "scheduler reported service had fewer instances than min-instances"
+                      {:service-id service-id :instances instances :min-instances (service-description "min-instances")}))
           (when-not (zero? scale-amount)
             (apply-scaling-fn service-id
                               {:outstanding-requests outstanding-requests

--- a/waiter/src/waiter/scaling.clj
+++ b/waiter/src/waiter/scaling.clj
@@ -359,10 +359,10 @@
               {:keys [instances task-count] :as scheduler-state} (service-id->scheduler-state service-id)
               ; if we don't have a target instance count, default to the number of tasks
               target-instances (get-in service-id->scale-state [service-id :target-instances] task-count)
+              service-description (get service-id->service-description service-id)
               {:keys [target-instances scale-to-instances scale-amount]}
               (if (and target-instances scale-ticks)
-                (scale-app-fn (assoc (get service-id->service-description service-id)
-                                "scale-ticks" scale-ticks)
+                (scale-app-fn (assoc service-description "scale-ticks" scale-ticks)
                               {:healthy-instances healthy-instances
                                :expired-instances expired-instances
                                :outstanding-requests outstanding-requests
@@ -372,6 +372,10 @@
                   (log/info "no target instances available for service"
                             {:scheduler-state scheduler-state, :service-id service-id})
                   {:scale-to-instances instances :target-instances target-instances :scale-amount 0}))]
+          (when (< instances (service-description "min-instances"))
+            (log/warn "Scheduler reported service had fewer instances than min-instances" {:service-id service-id
+                                                                                           :instances instances
+                                                                                           :min-instances (service-description "min-instances")}))
           (when-not (zero? scale-amount)
             (apply-scaling-fn service-id
                               {:outstanding-requests outstanding-requests

--- a/waiter/test/waiter/scaling_test.clj
+++ b/waiter/test/waiter/scaling_test.clj
@@ -680,7 +680,8 @@
 
 (let [leader?-fn (constantly true)
       instance-killer-multiplexer-fn (fn [_])
-      service-id->service-description (fn [id] {:service-id id})
+      service-id->service-description (fn [id] {:service-id id
+                                                "min-instances" 1})
       timeout-interval-ms 10000
       scale-app-fn (fn [_ state]
                      (case (int (:total-instances state))


### PR DESCRIPTION
## Changes proposed in this PR
- Adds a log message when the scheduler reports fewer than min-instances instances.

## Why are we making these changes?
We believe that there's a bug where the marathon scheduler occasionally returns 0 instances even though it is attempting to scale to 1 instance. We'd like to verify this with a log message and then implement a fix for the bug.