### PR TITLE
Fix exception wrapping in WebSocket processing

### DIFF
--- a/waiter/src/waiter/utils.clj
+++ b/waiter/src/waiter/utils.clj
@@ -194,7 +194,7 @@
   "Determines best Content-Type for a response given a request.
   In the case of no Accept header, assume application/json if the
   request Content-Type is application/json."
-  [{{:strs [accept content-type]} :headers}]
+  [{{:strs [accept content-type]} :headers :as request}]
   (cond
     (and accept (str/includes? accept "application/json")) "application/json"
     (and accept (str/includes? accept "text/html")) "text/html"

--- a/waiter/src/waiter/websocket.clj
+++ b/waiter/src/waiter/websocket.clj
@@ -361,7 +361,7 @@
   [track-process-error-metrics-fn {:keys [out] :as request} descriptor exception]
   (log/error exception "error in processing websocket request")
   (track-process-error-metrics-fn descriptor)
-  (let [exception-response (utils/exception->response request exception)]
+  (let [exception-response (utils/exception->response exception request)]
     (async/go
       (async/>! out exception-response)
       (async/close! out))


### PR DESCRIPTION
## Changes proposed in this PR

Fix inverted parameters to the `exception->response` function.

## Why are we making these changes?

We don't like it when the waiter routers crash.