### PR TITLE
avoids reliance on Marathon to provide the protocol for healthcheck requests

### DIFF
--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -300,7 +300,7 @@
                                       (fn assoc-log-url-to-instances [instances]
                                         (when (not-empty instances)
                                           (map #(assoc-log-url prepend-waiter-url %1) instances)))]
-                                  (-> (scheduler/get-instances scheduler service-id)
+                                  (-> (scheduler/get-instances scheduler service-id core-service-description)
                                       (update-in [:active-instances] assoc-log-url-to-instances)
                                       (update-in [:failed-instances] assoc-log-url-to-instances)
                                       (update-in [:killed-instances] assoc-log-url-to-instances)))

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -534,7 +534,7 @@
 (defrecord ShellScheduler [work-directory id->service-agent port->reservation-atom port-grace-period-ms port-range]
   scheduler/ServiceScheduler
 
-  (get-apps->instances [_]
+  (get-apps->instances [_ _]
     (let [id->service @id->service-agent]
       (into {} (map (fn [[_ service-entry]]
                       (service-entry->instances service-entry))
@@ -544,7 +544,7 @@
     (let [id->service @id->service-agent]
       (map (fn [[_ {:keys [service]}]] service) id->service)))
 
-  (get-instances [_ service-id]
+  (get-instances [_ service-id _]
     (let [id->service @id->service-agent
           service-entry (get id->service service-id)]
       (second (service-entry->instances service-entry))))

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -483,7 +483,7 @@
             (is (= "test-service-1" service-id))))))
     (testing "service-handler:valid-response-missing-killed-and-failed"
       (with-redefs [sd/fetch-core (fn [_ service-id & _] {"run-as-user" user, "name" (str service-id "-name")})
-                    scheduler/get-instances (fn [_ service-id]
+                    scheduler/get-instances (fn [_ service-id _]
                                               {:active-instances [{:id (str service-id ".A")
                                                                    :service-id service-id
                                                                    :healthy? true,
@@ -515,7 +515,7 @@
                    {"name" "test-service-1-name", "run-as-user" "waiter-user"}))))))
     (testing "service-handler:valid-response-including-active-killed-and-failed"
       (with-redefs [sd/fetch-core (fn [_ service-id & _] {"run-as-user" user, "name" (str service-id "-name")})
-                    scheduler/get-instances (fn [_ service-id]
+                    scheduler/get-instances (fn [_ service-id _]
                                               {:active-instances [{:id (str service-id ".A"), :service-id service-id}]
                                                :failed-instances [{:id (str service-id ".F"), :service-id service-id}]
                                                :killed-instances [{:id (str service-id ".K"), :service-id service-id}]})]

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -48,7 +48,7 @@
                                               :app {
                                                     :id "test-app-1234",
                                                     :instances 3,
-                                                    :healthChecks [{:path "/health", :portIndex 0, :protocol "HTTPS", :timeoutSeconds 10}],
+                                                    :healthChecks [{:path "/health", :portIndex 0, :protocol "N/A", :timeoutSeconds 10}],
                                                     :lastTaskFailure {
                                                                       :appId "test-app-1234",
                                                                       :host "10.141.141.10",
@@ -138,6 +138,7 @@
                                                                      :log-directory nil,
                                                                      :message "Abnormal executor termination",
                                                                      :port 0,
+                                                                     :protocol "https",
                                                                      :service-id "test-app-1234",
                                                                      :started-at "2014-09-12T232341.711Z"}))
                                               :killed-instances []}},
@@ -146,43 +147,43 @@
                           :marathon-response {
                                               :framework-id "F123445"
                                               :app {
-                                                    :id "test-app-1234",
+                                                    :id "test-app-6789",
                                                     :instances 3,
                                                     :healthChecks [{:path "/health", :portIndex 0, :protocol "HTTP", :timeoutSeconds 10}],
                                                     :tasks [
                                                             {
-                                                             :appId "/test-app-1234",
+                                                             :appId "/test-app-6789",
                                                              :healthCheckResults [{:alive true, :consecutiveFailures 0,
                                                                                    :firstSuccess "2014-09-13T002028.101Z",
                                                                                    :lastFailure nil, :lastSuccess "2014-09-13T002507.506Z",
-                                                                                   :taskId "test-app-1234.A"}],
+                                                                                   :taskId "test-app-6789.A"}],
                                                              :host "10.141.141.11",
-                                                             :id "test-app-1234.A",
+                                                             :id "test-app-6789.A",
                                                              :ports [31045],
                                                              :stagedAt "2014-09-12T232828.594Z",
                                                              :startedAt "2014-09-13T002446.959Z",
                                                              :version "2014-09-12T232821.737Z",
                                                              :slaveId "S234842"},
                                                             {
-                                                             :appId "test-app-1234",
+                                                             :appId "test-app-6789",
                                                              :healthCheckResults [{:alive true, :consecutiveFailures 0,
                                                                                    :firstSuccess "2014-09-13T002028.101Z",
                                                                                    :lastFailure nil, :lastSuccess "2014-09-13T002507.508Z",
-                                                                                   :taskId "test-app-1234.B"}],
+                                                                                   :taskId "test-app-6789.B"}],
                                                              :host "10.141.141.12",
-                                                             :id "test-app-1234.B",
+                                                             :id "test-app-6789.B",
                                                              :ports [31234],
                                                              :stagedAt "2014-09-12T232822.587Z",
                                                              :startedAt "2014-09-13T002446.965Z",
                                                              :version "2014-09-12T232821.737Z"},
                                                             {
-                                                             :appId "/test-app-1234",
+                                                             :appId "/test-app-6789",
                                                              :healthCheckResults [{:alive false, :consecutiveFailures 10,
                                                                                    :firstSuccess "2014-09-13T002028.101Z",
                                                                                    :lastFailure "2014-09-13T002507.508Z", :lastSuccess nil,
-                                                                                   :taskId "/test-app-1234.C"}],
+                                                                                   :taskId "/test-app-6789.C"}],
                                                              :host "10.141.141.13",
-                                                             :id "test-app-1234.C",
+                                                             :id "test-app-6789.C",
                                                              :ports [41234],
                                                              :stagedAt "2014-09-12T232822.587Z",
                                                              :startedAt "2014-09-13T002446.965Z",
@@ -194,34 +195,34 @@
                                                                     {:extra-ports [],
                                                                      :healthy? true,
                                                                      :host "10.141.141.11",
-                                                                     :id "test-app-1234.A",
-                                                                     :log-directory "/slave-dir/S234842/frameworks/F123445/executors/test-app-1234.A/runs/latest",
+                                                                     :id "test-app-6789.A",
+                                                                     :log-directory "/slave-dir/S234842/frameworks/F123445/executors/test-app-6789.A/runs/latest",
                                                                      :message nil,
                                                                      :port 31045,
                                                                      :protocol "http",
-                                                                     :service-id "test-app-1234",
+                                                                     :service-id "test-app-6789",
                                                                      :started-at "2014-09-13T002446.959Z"}),
                                                                   (scheduler/make-ServiceInstance
                                                                     {:extra-ports [],
                                                                      :healthy? true,
                                                                      :host "10.141.141.12",
-                                                                     :id "test-app-1234.B",
+                                                                     :id "test-app-6789.B",
                                                                      :log-directory nil,
                                                                      :message nil,
                                                                      :port 31234,
                                                                      :protocol "http",
-                                                                     :service-id "test-app-1234",
+                                                                     :service-id "test-app-6789",
                                                                      :started-at "2014-09-13T002446.965Z"}),
                                                                   (scheduler/make-ServiceInstance
                                                                     {:extra-ports [],
                                                                      :healthy? false,
                                                                      :host "10.141.141.13",
-                                                                     :id "test-app-1234.C",
-                                                                     :log-directory "/slave-dir/S651616/frameworks/F123445/executors/test-app-1234.C/runs/latest",
+                                                                     :id "test-app-6789.C",
+                                                                     :log-directory "/slave-dir/S651616/frameworks/F123445/executors/test-app-6789.C/runs/latest",
                                                                      :message nil,
                                                                      :port 41234,
                                                                      :protocol "http",
-                                                                     :service-id "test-app-1234",
+                                                                     :service-id "test-app-6789",
                                                                      :started-at "2014-09-13T002446.965Z"}))
                                               :failed-instances []
                                               :killed-instances []}})]
@@ -229,12 +230,15 @@
       (testing (str "Test " name)
         (let [framework-id (:framework-id marathon-response)
               service-id->failed-instances-transient-store (atom {})
+              service-id->service-description {"test-app-1234" {"backend-proto" "https"}
+                                               "test-app-6789" {"backend-proto" "http"}}
               actual-response (response-data->service-instances
                                 marathon-response
                                 [:app]
                                 (fn [] framework-id)
                                 {:slave-directory "/slave-dir"}
-                                service-id->failed-instances-transient-store)]
+                                service-id->failed-instances-transient-store
+                                service-id->service-description)]
           (is (= expected-response actual-response) (str name))
           (scheduler/preserve-only-killed-instances-for-services! [])
           (preserve-only-failed-instances-for-services! service-id->failed-instances-transient-store []))))))
@@ -376,12 +380,15 @@
                          :healthy? false
                          :host "10.141.141.10"
                          :port 0
+                         :protocol "http"
                          :started-at "2014-09-12T232341.711Z"
                          :message "Abnormal executor termination"}))
                     :killed-instances []})
         service-id->failed-instances-transient-store (atom {})
-        actual (response-data->service->service-instances input (fn [] nil) nil
-                                                          service-id->failed-instances-transient-store)]
+        service-id->service-description {"test-app-1234" {"backend-proto" "https"}
+                                         "test-app-6789" {"backend-proto" "http"}}
+        actual (response-data->service->service-instances
+                 input (fn [] nil) nil service-id->failed-instances-transient-store service-id->service-description)]
     (is (= expected actual))
     (scheduler/preserve-only-killed-instances-for-services! [])
     (preserve-only-failed-instances-for-services! service-id->failed-instances-transient-store [])))

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -29,19 +29,22 @@
                           :marathon-response nil
                           :expected-response {:active-instances []
                                               :failed-instances []
-                                              :killed-instances []}},
+                                              :killed-instances []}
+                          :service-id->service-description {}},
                          {
                           :name "response-data->service-instances empty response"
                           :marathon-response {}
                           :expected-response {:active-instances []
                                               :failed-instances []
-                                              :killed-instances []}},
+                                              :killed-instances []}
+                          :service-id->service-description {}},
                          {
                           :name "response-data->service-instances empty-app response"
                           :marathon-response {:app {}}
                           :expected-response {:active-instances []
                                               :failed-instances []
-                                              :killed-instances []}},
+                                              :killed-instances []}
+                          :service-id->service-description {}},
                          {
                           :name "response-data->service-instances valid response with task failure"
                           :marathon-response {
@@ -141,49 +144,50 @@
                                                                      :protocol "https",
                                                                      :service-id "test-app-1234",
                                                                      :started-at "2014-09-12T232341.711Z"}))
-                                              :killed-instances []}},
+                                              :killed-instances []}
+                          :service-id->service-description {"test-app-1234" {"backend-proto" "https"}}},
                          {
                           :name "response-data->service-instances valid response without task failure"
                           :marathon-response {
                                               :framework-id "F123445"
                                               :app {
-                                                    :id "test-app-6789",
+                                                    :id "test-app-1234",
                                                     :instances 3,
                                                     :healthChecks [{:path "/health", :portIndex 0, :protocol "HTTP", :timeoutSeconds 10}],
                                                     :tasks [
                                                             {
-                                                             :appId "/test-app-6789",
+                                                             :appId "/test-app-1234",
                                                              :healthCheckResults [{:alive true, :consecutiveFailures 0,
                                                                                    :firstSuccess "2014-09-13T002028.101Z",
                                                                                    :lastFailure nil, :lastSuccess "2014-09-13T002507.506Z",
-                                                                                   :taskId "test-app-6789.A"}],
+                                                                                   :taskId "test-app-1234.A"}],
                                                              :host "10.141.141.11",
-                                                             :id "test-app-6789.A",
+                                                             :id "test-app-1234.A",
                                                              :ports [31045],
                                                              :stagedAt "2014-09-12T232828.594Z",
                                                              :startedAt "2014-09-13T002446.959Z",
                                                              :version "2014-09-12T232821.737Z",
                                                              :slaveId "S234842"},
                                                             {
-                                                             :appId "test-app-6789",
+                                                             :appId "test-app-1234",
                                                              :healthCheckResults [{:alive true, :consecutiveFailures 0,
                                                                                    :firstSuccess "2014-09-13T002028.101Z",
                                                                                    :lastFailure nil, :lastSuccess "2014-09-13T002507.508Z",
-                                                                                   :taskId "test-app-6789.B"}],
+                                                                                   :taskId "test-app-1234.B"}],
                                                              :host "10.141.141.12",
-                                                             :id "test-app-6789.B",
+                                                             :id "test-app-1234.B",
                                                              :ports [31234],
                                                              :stagedAt "2014-09-12T232822.587Z",
                                                              :startedAt "2014-09-13T002446.965Z",
                                                              :version "2014-09-12T232821.737Z"},
                                                             {
-                                                             :appId "/test-app-6789",
+                                                             :appId "/test-app-1234",
                                                              :healthCheckResults [{:alive false, :consecutiveFailures 10,
                                                                                    :firstSuccess "2014-09-13T002028.101Z",
                                                                                    :lastFailure "2014-09-13T002507.508Z", :lastSuccess nil,
-                                                                                   :taskId "/test-app-6789.C"}],
+                                                                                   :taskId "/test-app-1234.C"}],
                                                              :host "10.141.141.13",
-                                                             :id "test-app-6789.C",
+                                                             :id "test-app-1234.C",
                                                              :ports [41234],
                                                              :stagedAt "2014-09-12T232822.587Z",
                                                              :startedAt "2014-09-13T002446.965Z",
@@ -195,43 +199,42 @@
                                                                     {:extra-ports [],
                                                                      :healthy? true,
                                                                      :host "10.141.141.11",
-                                                                     :id "test-app-6789.A",
-                                                                     :log-directory "/slave-dir/S234842/frameworks/F123445/executors/test-app-6789.A/runs/latest",
+                                                                     :id "test-app-1234.A",
+                                                                     :log-directory "/slave-dir/S234842/frameworks/F123445/executors/test-app-1234.A/runs/latest",
                                                                      :message nil,
                                                                      :port 31045,
                                                                      :protocol "http",
-                                                                     :service-id "test-app-6789",
+                                                                     :service-id "test-app-1234",
                                                                      :started-at "2014-09-13T002446.959Z"}),
                                                                   (scheduler/make-ServiceInstance
                                                                     {:extra-ports [],
                                                                      :healthy? true,
                                                                      :host "10.141.141.12",
-                                                                     :id "test-app-6789.B",
+                                                                     :id "test-app-1234.B",
                                                                      :log-directory nil,
                                                                      :message nil,
                                                                      :port 31234,
                                                                      :protocol "http",
-                                                                     :service-id "test-app-6789",
+                                                                     :service-id "test-app-1234",
                                                                      :started-at "2014-09-13T002446.965Z"}),
                                                                   (scheduler/make-ServiceInstance
                                                                     {:extra-ports [],
                                                                      :healthy? false,
                                                                      :host "10.141.141.13",
-                                                                     :id "test-app-6789.C",
-                                                                     :log-directory "/slave-dir/S651616/frameworks/F123445/executors/test-app-6789.C/runs/latest",
+                                                                     :id "test-app-1234.C",
+                                                                     :log-directory "/slave-dir/S651616/frameworks/F123445/executors/test-app-1234.C/runs/latest",
                                                                      :message nil,
                                                                      :port 41234,
                                                                      :protocol "http",
-                                                                     :service-id "test-app-6789",
+                                                                     :service-id "test-app-1234",
                                                                      :started-at "2014-09-13T002446.965Z"}))
                                               :failed-instances []
-                                              :killed-instances []}})]
-    (doseq [{:keys [expected-response marathon-response name]} test-cases]
+                                              :killed-instances []}
+                          :service-id->service-description {"test-app-1234" {"backend-proto" "http"}}})]
+    (doseq [{:keys [expected-response marathon-response name service-id->service-description]} test-cases]
       (testing (str "Test " name)
         (let [framework-id (:framework-id marathon-response)
               service-id->failed-instances-transient-store (atom {})
-              service-id->service-description {"test-app-1234" {"backend-proto" "https"}
-                                               "test-app-6789" {"backend-proto" "http"}}
               actual-response (response-data->service-instances
                                 marathon-response
                                 [:app]

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -231,7 +231,7 @@
         instance2 (->ServiceInstance "s1.i2" "s1" started-at true nil #{} nil "host" 123 [] "proto" "/log" "test")
         instance3 (->ServiceInstance "s1.i3" "s1" started-at nil nil #{} nil "host" 123 [] "proto" "/log" "test")
         scheduler (reify ServiceScheduler
-                    (get-apps->instances [_]
+                    (get-apps->instances [_ _]
                       {(->Service "s1" {} {} {}) {:active-instances [instance1 instance2 instance3]
                                                   :failed-instances []}})
                     (service-id->state [_ _]


### PR DESCRIPTION

## Changes proposed in this PR

- retrieve the instance protocol from the service description (guaranteed to have the backend-proto) instead of Marathon (as it can be missing sometimes)

## Why are we making these changes?

- Ensure the healthchecks from Waiter can execute despite missing protocol reported from Marathon
