### PR TITLE
Lower number of concurrent requests in perf test

### DIFF
--- a/waiter/integration/waiter/latency_test.clj
+++ b/waiter/integration/waiter/latency_test.clj
@@ -71,7 +71,7 @@
   (testing-using-waiter-url
     (let [max-instances (Integer/parseInt (or (System/getenv "WAITER_TEST_REQUEST_LATENCY_MAX_INSTANCES") "50"))
           _ (log/info "using max-instances =" max-instances)
-          client-concurrency-level 800
+          client-concurrency-level 300
           waiter-concurrency-level 4
           total-requests 100000
           name (rand-name)


### PR DESCRIPTION
## Changes proposed in this PR
- Lower number of concurrent connections in perf test from 800 to 300

## Why are we making these changes?
This falls under our internal concurrent connection limit.