### PR TITLE
waiter: provides the resources in the service description as env variables to the instances

### DIFF
--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -607,10 +607,12 @@
 
 (defn environment
   "Returns a new environment variable map with some basic variables added in"
-  [service-id {:strs [env run-as-user]} service-id->password-fn home-path]
+  [service-id {:strs [cpus env mem run-as-user]} service-id->password-fn home-path]
   (merge env
-         {"WAITER_USERNAME" "waiter"
-          "WAITER_PASSWORD" (service-id->password-fn service-id)
-          "HOME" home-path
+         {"HOME" home-path
           "LOGNAME" run-as-user
-          "USER" run-as-user}))
+          "USER" run-as-user
+          "WAITER_CPUS" (-> cpus str)
+          "WAITER_MEM_MB" (-> mem str)
+          "WAITER_PASSWORD" (service-id->password-fn service-id)
+          "WAITER_USERNAME" "waiter"}))

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -537,13 +537,15 @@
       (let [expected {:id "test-service-1"
                       :labels {:source "waiter"
                                :user "test-user"}
-                      :env {"WAITER_USERNAME" "waiter"
-                            "WAITER_PASSWORD" "test-service-1-password"
+                      :env {"BAZ" "quux"
+                            "FOO" "bar"
                             "HOME" "/home/path/test-user"
                             "LOGNAME" "test-user"
                             "USER" "test-user"
-                            "FOO" "bar"
-                            "BAZ" "quux"}
+                            "WAITER_CPUS" "1"
+                            "WAITER_MEM_MB" "1536"
+                            "WAITER_PASSWORD" "test-service-1-password"
+                            "WAITER_USERNAME" "waiter"}
                       :cmd "test-command"
                       :cpus 1
                       :disk nil

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -36,6 +36,7 @@
   ([scheduler service-id custom-service-description]
    (let [descriptor {:service-description (merge {"backend-proto" "http"
                                                   "cmd" "ls"
+                                                  "cpus" 2
                                                   "grace-period-secs" 10
                                                   "mem" 32
                                                   "ports" 1}
@@ -134,6 +135,8 @@
 (deftest test-directory-content
   (let [service-description {"backend-proto" "http"
                              "cmd" "echo Hello, World!"
+                             "cpus" 4
+                             "mem" 256
                              "ports" 1}
         id->service (create-service {} "foo" service-description (constantly "password")
                                     (work-dir) (atom {}) [0 0] (promise))
@@ -383,13 +386,16 @@
                   :instances 1
                   :task-count 1
                   :task-stats {:running 1, :healthy 0, :unhealthy 1, :staged 0}
-                  :environment {"WAITER_USERNAME" "waiter"
-                                "WAITER_PASSWORD" "password"
-                                "HOME" (work-dir)
+                  :environment {"HOME" (work-dir)
                                 "LOGNAME" nil
-                                "USER" nil}
+                                "USER" nil
+                                "WAITER_CPUS" "2"
+                                "WAITER_MEM_MB" "32"
+                                "WAITER_PASSWORD" "password"
+                                "WAITER_USERNAME" "waiter"}
                   :service-description {"backend-proto" "http"
                                         "cmd" "sleep 10000"
+                                        "cpus" 2
                                         "grace-period-secs" 10
                                         "mem" 32
                                         "ports" 1}
@@ -398,13 +404,16 @@
                   :instances 1
                   :task-count 1
                   :task-stats {:running 1, :healthy 0, :unhealthy 1, :staged 0}
-                  :environment {"WAITER_USERNAME" "waiter"
-                                "WAITER_PASSWORD" "password"
-                                "HOME" (work-dir)
+                  :environment {"HOME" (work-dir)
                                 "LOGNAME" nil
-                                "USER" nil}
+                                "USER" nil
+                                "WAITER_CPUS" "2"
+                                "WAITER_MEM_MB" "32"
+                                "WAITER_PASSWORD" "password"
+                                "WAITER_USERNAME" "waiter"}
                   :service-description {"backend-proto" "http"
                                         "cmd" "sleep 10000"
+                                        "cpus" 2
                                         "grace-period-secs" 10
                                         "mem" 32
                                         "ports" 1}
@@ -413,13 +422,16 @@
                   :instances 1
                   :task-count 1
                   :task-stats {:running 1, :healthy 0, :unhealthy 1, :staged 0}
-                  :environment {"WAITER_USERNAME" "waiter"
-                                "WAITER_PASSWORD" "password"
-                                "HOME" (work-dir)
+                  :environment {"HOME" (work-dir)
                                 "LOGNAME" nil
-                                "USER" nil}
+                                "USER" nil
+                                "WAITER_CPUS" "2"
+                                "WAITER_MEM_MB" "32"
+                                "WAITER_PASSWORD" "password"
+                                "WAITER_USERNAME" "waiter"}
                   :service-description {"backend-proto" "http"
                                         "cmd" "sleep 10000"
+                                        "cpus" 2
                                         "grace-period-secs" 10
                                         "mem" 32
                                         "ports" 1}
@@ -449,13 +461,16 @@
                                     :instances 1
                                     :task-count 1
                                     :task-stats {:running 1, :healthy 0, :unhealthy 1, :staged 0}
-                                    :environment {"WAITER_USERNAME" "waiter"
-                                                  "WAITER_PASSWORD" "password"
-                                                  "HOME" (work-dir)
+                                    :environment {"HOME" (work-dir)
                                                   "LOGNAME" nil
-                                                  "USER" nil}
+                                                  "USER" nil
+                                                  "WAITER_CPUS" "2"
+                                                  "WAITER_MEM_MB" "32"
+                                                  "WAITER_PASSWORD" "password"
+                                                  "WAITER_USERNAME" "waiter"}
                                     :service-description {"backend-proto" "http"
                                                           "cmd" "ls"
+                                                          "cpus" 2
                                                           "grace-period-secs" 10
                                                           "mem" 32
                                                           "ports" 1}


### PR DESCRIPTION


## Changes proposed in this PR

- adds `WAITER_CPUS` and `WAITER_MEM_MB` environment variables

## Why are we making these changes?

Given these environment variables, tasks can decide how much memory and threads they can allocate at runtime.

