### PR TITLE
waiter: support for numeric maximum value limits on service description parameters

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -357,10 +357,10 @@
                                 "scale-factor" 1
                                 "scale-up-factor" 0.1}
 
- ;; Service description parameters with numeric values, e.g. cpus, can be configured to have
- ;; maximum value limits. When not configured, these defaults will be used:
- :service-description-resource-limits {"cpus" 100
-                                       "mem" 1048576}
+ ;; Service description parameters with numeric values, e.g. cpus, can be configured
+ ;; to have maximum value limits.
+ :service-description-upper-limits {"cpus" 40
+                                    "mem" 32768} ;; mem is in megabytes
 
  ; ---------- Timeouts ----------
 

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -320,6 +320,11 @@
                                                 ;; waiter.service-description.ServiceDescriptionBuilder:
                                                 :factory-fn waiter.service-description/->DefaultServiceDescriptionBuilder}}
 
+ ;; Additional configurable constraints on description parameters.
+ ;; Only max is supported currently.
+ :service-description-constraints {"cpus" {:max 40}
+                                   "mem" {:max 32768}} ;; mem is in megabytes
+
  ;; The following service description parameters are required and
  ;; therefore don't have default values:
  ;;
@@ -356,11 +361,6 @@
                                 "scale-down-factor" 0.001
                                 "scale-factor" 1
                                 "scale-up-factor" 0.1}
-
- ;; Service description parameters with numeric values, e.g. cpus, can be configured
- ;; to have maximum value limits.
- :service-description-upper-limits {"cpus" 40
-                                    "mem" 32768} ;; mem is in megabytes
 
  ; ---------- Timeouts ----------
 

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -357,6 +357,11 @@
                                 "scale-factor" 1
                                 "scale-up-factor" 0.1}
 
+ ;; Service description parameters with numeric values, e.g. cpus, can be configured to have
+ ;; maximum value limits. When not configured, these defaults will be used:
+ :service-description-resource-limits {"cpus" 100
+                                       "mem" 1048576}
+
  ; ---------- Timeouts ----------
 
  ; Waiter maintains a list of recently "killed" and "erroneous" (e.g. an error occurred while streaming the response)

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -179,7 +179,7 @@
       (is (= 400 status))
       (is (str/includes? body "Command type fakecommand is not supported")))))
 
-(deftest ^:parallel ^:integration-fast test-basic-parameters-exceed-limits
+(deftest ^:parallel ^:integration-fast test-basic-parameters-violates-upper-limit-constraints
   (testing-using-waiter-url
     (let [constraints (setting waiter-url [:service-description-constraints])
           upper-limits (->> constraints

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -188,6 +188,7 @@
       (is (seq upper-limits))
       (doseq [[parameter upper-limit] (rest upper-limits)]
         (let [headers {:x-waiter-cmd "false"
+                       :x-waiter-cmd-type "shell"
                        :x-waiter-name (rand-name)
                        :x-waiter-version "1"
                        (keyword (str "x-waiter-" (name parameter))) (inc upper-limit)}

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -178,6 +178,23 @@
       (is (= 400 status))
       (is (str/includes? body "Command type fakecommand is not supported")))))
 
+(deftest ^:parallel ^:integration-fast test-basic-parameters-exceed-limits
+  (testing-using-waiter-url
+    (let [upper-limits (get (waiter-settings waiter-url) :service-description-upper-limits)]
+      (is (seq upper-limits))
+      (doseq [[parameter upper-limit] (rest upper-limits)]
+        (let [headers {:x-waiter-cmd "false"
+                       :x-waiter-name (rand-name)
+                       :x-waiter-version "1"
+                       (keyword (str "x-waiter-" (name parameter))) (inc upper-limit)}
+              {:keys [body status]} (make-light-request waiter-url headers)]
+          (is (= 400 status))
+          (is (not (str/includes? body "clojure")) body)
+          (is (every? #(str/includes? body %)
+                      ["The following fields exceed their allowed limits"
+                       (str (name parameter) " is " (inc upper-limit) " but the max allowed is " upper-limit)])
+              body))))))
+
 (deftest ^:parallel ^:integration-fast test-header-metadata
   (testing-using-waiter-url
     (let [headers {:x-waiter-name (rand-name)

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -17,6 +17,7 @@
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [clojure.walk :as walk]
+            [plumbing.core :as pc]
             [qbits.jet.client.http :as http]
             [waiter.client-tools :refer :all]
             [waiter.service-description :as sd]
@@ -180,7 +181,10 @@
 
 (deftest ^:parallel ^:integration-fast test-basic-parameters-exceed-limits
   (testing-using-waiter-url
-    (let [upper-limits (get (waiter-settings waiter-url) :service-description-upper-limits)]
+    (let [constraints (setting waiter-url [:service-description-constraints])
+          upper-limits (->> constraints
+                            (filter (fn [[_ constraint]] (contains? constraint :max)))
+                            (pc/map-vals :max))]
       (is (seq upper-limits))
       (doseq [[parameter upper-limit] (rest upper-limits)]
         (let [headers {:x-waiter-cmd "false"

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -17,7 +17,6 @@
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [clojure.walk :as walk]
-            [plumbing.core :as pc]
             [qbits.jet.client.http :as http]
             [waiter.client-tools :refer :all]
             [waiter.service-description :as sd]
@@ -179,25 +178,23 @@
       (is (= 400 status))
       (is (str/includes? body "Command type fakecommand is not supported")))))
 
-(deftest ^:parallel ^:integration-fast test-basic-parameters-violates-upper-limit-constraints
+(deftest ^:parallel ^:integration-fast test-basic-parameters-violates-max-constraint
   (testing-using-waiter-url
     (let [constraints (setting waiter-url [:service-description-constraints])
-          upper-limits (->> constraints
-                            (filter (fn [[_ constraint]] (contains? constraint :max)))
-                            (pc/map-vals :max))]
-      (is (seq upper-limits))
-      (doseq [[parameter upper-limit] (rest upper-limits)]
+          max-constraints (sd/extract-max-constraints constraints)]
+      (is (seq max-constraints))
+      (doseq [[parameter max-constraint] (rest max-constraints)]
         (let [headers {:x-waiter-cmd "false"
                        :x-waiter-cmd-type "shell"
                        :x-waiter-name (rand-name)
                        :x-waiter-version "1"
-                       (keyword (str "x-waiter-" (name parameter))) (inc upper-limit)}
+                       (keyword (str "x-waiter-" (name parameter))) (inc max-constraint)}
               {:keys [body status]} (make-light-request waiter-url headers)]
           (is (= 400 status))
           (is (not (str/includes? body "clojure")) body)
           (is (every? #(str/includes? body %)
                       ["The following fields exceed their allowed limits"
-                       (str (name parameter) " is " (inc upper-limit) " but the max allowed is " upper-limit)])
+                       (str (name parameter) " is " (inc max-constraint) " but the max allowed is " max-constraint)])
               body))))))
 
 (deftest ^:parallel ^:integration-fast test-header-metadata

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -665,17 +665,17 @@
 (deftest ^:parallel ^:integration-fast test-token-parameters-exceed-limits
   (testing-using-waiter-url
     (let [constraints (setting waiter-url [:service-description-constraints])
-          upper-limits (->> constraints
-                            (filter (fn [[_ constraint]] (contains? constraint :max)))
-                            (pc/map-vals :max))]
-      (is (seq upper-limits))
-      (doseq [[parameter upper-limit] upper-limits]
-        (let [{:keys [body status]} (post-token waiter-url {parameter (inc upper-limit) :token (rand-name)})]
+          max-constraints (->> constraints
+                               (filter (fn [[_ constraint]] (contains? constraint :max)))
+                               (pc/map-vals :max))]
+      (is (seq max-constraints))
+      (doseq [[parameter max-constraint] max-constraints]
+        (let [{:keys [body status]} (post-token waiter-url {parameter (inc max-constraint) :token (rand-name)})]
           (is (= 400 status))
           (is (not (str/includes? body "clojure")) body)
           (is (every? #(str/includes? body %)
                       ["The following fields exceed their allowed limits"
-                       (str (name parameter) " is " (inc upper-limit) " but the max allowed is " upper-limit)])
+                       (str (name parameter) " is " (inc max-constraint) " but the max allowed is " max-constraint)])
               body))))))
 
 (deftest ^:parallel ^:integration-fast test-auto-run-as-requester-support

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -17,6 +17,7 @@
             [plumbing.core :as pc]
             [qbits.jet.client.http :as http]
             [waiter.client-tools :refer :all]
+            [waiter.service-description :as sd]
             [waiter.utils :as utils])
   (:import (java.net URL)
            (org.joda.time DateTime)))
@@ -665,9 +666,7 @@
 (deftest ^:parallel ^:integration-fast test-token-parameters-exceed-limits
   (testing-using-waiter-url
     (let [constraints (setting waiter-url [:service-description-constraints])
-          max-constraints (->> constraints
-                               (filter (fn [[_ constraint]] (contains? constraint :max)))
-                               (pc/map-vals :max))]
+          max-constraints (sd/extract-max-constraints constraints)]
       (is (seq max-constraints))
       (doseq [[parameter max-constraint] max-constraints]
         (let [{:keys [body status]} (post-token waiter-url {parameter (inc max-constraint) :token (rand-name)})]

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -664,7 +664,10 @@
 
 (deftest ^:parallel ^:integration-fast test-token-parameters-exceed-limits
   (testing-using-waiter-url
-    (let [upper-limits (get (waiter-settings waiter-url) :service-description-upper-limits)]
+    (let [constraints (setting waiter-url [:service-description-constraints])
+          upper-limits (->> constraints
+                            (filter (fn [[_ constraint]] (contains? constraint :max)))
+                            (pc/map-vals :max))]
       (is (seq upper-limits))
       (doseq [[parameter upper-limit] upper-limits]
         (let [{:keys [body status]} (post-token waiter-url {parameter (inc upper-limit) :token (rand-name)})]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -475,8 +475,9 @@
                         (str/starts-with? service-id service-id-prefix))]
                   (utils/create-component scheduler-config :context {:is-waiter-app?-fn is-waiter-app?-fn})))
    :scheduler-state-chan (pc/fnk [] (au/latest-chan))
-   :service-description-builder (pc/fnk [[:settings service-description-builder-config]]
-                                  (utils/create-component service-description-builder-config))
+   :service-description-builder (pc/fnk [[:settings service-description-builder-config service-description-resource-limits]]
+                                  (utils/create-component
+                                    service-description-builder-config :context {:resource-limits service-description-resource-limits}))
    :service-id-prefix (pc/fnk [[:settings [:cluster-config service-prefix]]] service-prefix)
    :start-app-cache-atom (pc/fnk []
                            (-> {}

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -476,6 +476,14 @@
                   (utils/create-component scheduler-config :context {:is-waiter-app?-fn is-waiter-app?-fn})))
    :scheduler-state-chan (pc/fnk [] (au/latest-chan))
    :service-description-builder (pc/fnk [[:settings service-description-builder-config service-description-constraints]]
+                                  (when-let [unknown-keys (-> service-description-constraints
+                                                              keys
+                                                              set
+                                                              (set/difference sd/service-description-keys)
+                                                              seq)]
+                                    (throw (ex-info "Unsupported keys present in the service description constraints"
+                                                    {:service-description-constraints service-description-constraints
+                                                     :unsupported-keys (-> unknown-keys vec sort)})))
                                   (utils/create-component
                                     service-description-builder-config :context {:constraints service-description-constraints}))
    :service-id-prefix (pc/fnk [[:settings [:cluster-config service-prefix]]] service-prefix)

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -475,9 +475,9 @@
                         (str/starts-with? service-id service-id-prefix))]
                   (utils/create-component scheduler-config :context {:is-waiter-app?-fn is-waiter-app?-fn})))
    :scheduler-state-chan (pc/fnk [] (au/latest-chan))
-   :service-description-builder (pc/fnk [[:settings service-description-builder-config service-description-upper-limits]]
+   :service-description-builder (pc/fnk [[:settings service-description-builder-config service-description-constraints]]
                                   (utils/create-component
-                                    service-description-builder-config :context {:upper-limits service-description-upper-limits}))
+                                    service-description-builder-config :context {:constraints service-description-constraints}))
    :service-id-prefix (pc/fnk [[:settings [:cluster-config service-prefix]]] service-prefix)
    :start-app-cache-atom (pc/fnk []
                            (-> {}

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -475,9 +475,9 @@
                         (str/starts-with? service-id service-id-prefix))]
                   (utils/create-component scheduler-config :context {:is-waiter-app?-fn is-waiter-app?-fn})))
    :scheduler-state-chan (pc/fnk [] (au/latest-chan))
-   :service-description-builder (pc/fnk [[:settings service-description-builder-config service-description-resource-limits]]
+   :service-description-builder (pc/fnk [[:settings service-description-builder-config service-description-upper-limits]]
                                   (utils/create-component
-                                    service-description-builder-config :context {:resource-limits service-description-resource-limits}))
+                                    service-description-builder-config :context {:upper-limits service-description-upper-limits}))
    :service-id-prefix (pc/fnk [[:settings [:cluster-config service-prefix]]] service-prefix)
    :start-app-cache-atom (pc/fnk []
                            (-> {}

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -290,17 +290,16 @@
       (s/validate upper-limits-schema service-description-to-use)
       (catch Exception e
         (let [issue (s/check upper-limits-schema service-description-to-use)
+              issue->param->limit (fn [issue param]
+                                    (-> issue (get param) .schema .pred-name (str/replace "limit-" "")))
               param->message (fn [param]
-                               (str param
-                                    " is "
-                                    (get service-description-to-use param)
-                                    " but allowed max is "
-                                    (-> issue (get param) .schema .pred-name (str/replace "limit-" ""))))
-              friendly-error-message (str "The following fields exceed their allowed limits: "
-                                          (str/join ", " (->> issue
-                                                              keys
-                                                              sort
-                                                              (map param->message))))]
+                               (str "- " param " is " (get service-description-to-use param) " but the max allowed is "
+                                    (issue->param->limit issue param)))
+              friendly-error-message (str "The following fields exceed their allowed limits: " \newline
+                                          (str/join \newline (->> issue
+                                                                  keys
+                                                                  sort
+                                                                  (map param->message))))]
           (throw-error e issue friendly-error-message))))
 
     ; Validate max-instances >= min-instances

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -91,6 +91,7 @@
                                                           {:kind s/Keyword
                                                            s/Keyword schema/require-symbol-factory-fn}
                                                           schema/contains-kind-sub-map?)
+   (s/required-key :service-description-constraints) {s/Str {(s/required-key :max) schema/positive-num}}
    ; service-description-defaults should never contain default values for required fields, e.g. version, cmd, run-as-user, etc.
    (s/required-key :service-description-defaults) {(s/required-key "authentication") schema/valid-authentication
                                                    (s/required-key "backend-proto") schema/valid-backend-proto
@@ -116,7 +117,6 @@
                                                    (s/required-key "scale-factor") schema/positive-fraction-less-than-or-equal-to-1
                                                    (s/required-key "scale-up-factor") schema/positive-fraction-less-than-1
                                                    (s/required-key "scale-down-factor") schema/positive-fraction-less-than-1}
-   (s/required-key :service-description-upper-limits) {s/Str schema/positive-num}
    (s/required-key :statsd) (s/either (s/eq :disabled)
                                       {(s/required-key :cluster) schema/non-empty-string
                                        (s/required-key :environment) schema/non-empty-string
@@ -266,6 +266,8 @@
    :scheduler-syncer-interval-secs 5
    :service-description-builder-config {:kind :default
                                         :default {:factory-fn 'waiter.service-description/create-default-service-description-builder}}
+   :service-description-constraints {"cpus" {:max 32}
+                                     "mem" {:max (* 128 1024)}}
    :service-description-defaults {"authentication" "standard"
                                   "backend-proto" "http"
                                   "blacklist-on-503" true
@@ -290,8 +292,6 @@
                                   "scale-down-factor" 0.001
                                   "scale-factor" 1
                                   "scale-up-factor" 0.1}
-   :service-description-upper-limits {"cpus" 32
-                                      "mem" (* 128 1024)}
    :statsd :disabled
    :support-info [{:label "Waiter on GitHub"
                    :link {:type :url

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -116,8 +116,7 @@
                                                    (s/required-key "scale-factor") schema/positive-fraction-less-than-or-equal-to-1
                                                    (s/required-key "scale-up-factor") schema/positive-fraction-less-than-1
                                                    (s/required-key "scale-down-factor") schema/positive-fraction-less-than-1}
-   (s/required-key :service-description-resource-limits) {(s/required-key "cpus") schema/positive-int
-                                                          (s/required-key "mem") schema/positive-int}
+   (s/required-key :service-description-upper-limits) {s/Str schema/positive-num}
    (s/required-key :statsd) (s/either (s/eq :disabled)
                                       {(s/required-key :cluster) schema/non-empty-string
                                        (s/required-key :environment) schema/non-empty-string
@@ -291,8 +290,8 @@
                                   "scale-down-factor" 0.001
                                   "scale-factor" 1
                                   "scale-up-factor" 0.1}
-   :service-description-resource-limits {"cpus" 100
-                                         "mem" (* 1024 1024)}
+   :service-description-upper-limits {"cpus" 32
+                                      "mem" (* 128 1024)}
    :statsd :disabled
    :support-info [{:label "Waiter on GitHub"
                    :link {:type :url

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -116,6 +116,8 @@
                                                    (s/required-key "scale-factor") schema/positive-fraction-less-than-or-equal-to-1
                                                    (s/required-key "scale-up-factor") schema/positive-fraction-less-than-1
                                                    (s/required-key "scale-down-factor") schema/positive-fraction-less-than-1}
+   (s/required-key :service-description-resource-limits) {(s/required-key "cpus") schema/positive-int
+                                                          (s/required-key "mem") schema/positive-int}
    (s/required-key :statsd) (s/either (s/eq :disabled)
                                       {(s/required-key :cluster) schema/non-empty-string
                                        (s/required-key :environment) schema/non-empty-string
@@ -264,8 +266,7 @@
                          :scheduler-gc-interval-ms 60000}
    :scheduler-syncer-interval-secs 5
    :service-description-builder-config {:kind :default
-                                        :default {:factory-fn
-                                                  'waiter.service-description/->DefaultServiceDescriptionBuilder}}
+                                        :default {:factory-fn 'waiter.service-description/create-default-service-description-builder}}
    :service-description-defaults {"authentication" "standard"
                                   "backend-proto" "http"
                                   "blacklist-on-503" true
@@ -290,11 +291,13 @@
                                   "scale-down-factor" 0.001
                                   "scale-factor" 1
                                   "scale-up-factor" 0.1}
+   :service-description-resource-limits {"cpus" 100
+                                         "mem" (* 1024 1024)}
    :statsd :disabled
    :support-info [{:label "Waiter on GitHub"
                    :link {:type :url
                           :value "http://github.com/twosigma/waiter"}}]
-   :websocket-config {:ws-max-binary-message-size  (* 1024 1024 40)
+   :websocket-config {:ws-max-binary-message-size (* 1024 1024 40)
                       :ws-max-text-message-size (* 1024 1024 40)}
    :work-stealing {:offer-help-interval-ms 100
                    :reserve-timeout-ms 1000}

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -426,7 +426,7 @@
         can-run-as? #(= %1 %2)
         waiter-hostname "waiter-hostname.app.example.com"
         assoc-run-as-user-approved? (fn [_ _] false)
-        service-builder (sd/->DefaultServiceDescriptionBuilder nil)]
+        service-builder (sd/create-default-service-description-builder {})]
     (testing "missing user in request"
       (with-redefs [sd/request->descriptor (fn [& _] {:service-description {}
                                                       :service-preauthorized false})]

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -1419,8 +1419,8 @@
       "We found common elements in service-description-keys and token-metadata-keys!"))
 
 (deftest test-default-service-description-builder-validate
-  (let [resource-limits {"cpus" 100, "mem" (* 1024 1024)}
-        builder (create-default-service-description-builder {:resource-limits resource-limits})
+  (let [upper-limits {"cpus" 100, "mem" (* 32 1024)}
+        builder (create-default-service-description-builder {:upper-limits upper-limits})
         basic-service-description {"cpus" 1, "mem" 1, "cmd" "foo", "version" "bar", "run-as-user" "*"}
         validation-settings {:allow-missing-required-fields? false}]
 
@@ -1448,12 +1448,12 @@
                    (select-keys (ex-data ex) [:friendly-error-message :status :type])))))))
 
     (testing "validate-service-description-cpus-and-mem-outside-limits"
-      (let [service-description (assoc basic-service-description "cpus" 200 "mem" (* 3 1024 1024))]
+      (let [service-description (assoc basic-service-description "cpus" 200 "mem" (* 40 1024))]
         (try
           (validate builder service-description validation-settings)
           (is false)
           (catch ExceptionInfo ex
             (is (= {:friendly-error-message (str "The following fields exceed their allowed limits: "
-                                                 "cpus is 200 but allowed max is 100, mem is 3145728 but allowed max is 1048576")
+                                                 "cpus is 200 but allowed max is 100, mem is 40960 but allowed max is 32768")
                     :status 400, :type :service-description-error}
                    (select-keys (ex-data ex) [:friendly-error-message :status :type])))))))))

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -1419,8 +1419,9 @@
       "We found common elements in service-description-keys and token-metadata-keys!"))
 
 (deftest test-default-service-description-builder-validate
-  (let [upper-limits {"cpus" 100, "mem" (* 32 1024)}
-        builder (create-default-service-description-builder {:upper-limits upper-limits})
+  (let [constraints {"cpus" {:max 100}
+                     "mem" {:max (* 32 1024)}}
+        builder (create-default-service-description-builder {:constraints constraints})
         basic-service-description {"cpus" 1, "mem" 1, "cmd" "foo", "version" "bar", "run-as-user" "*"}
         validation-settings {:allow-missing-required-fields? false}]
 
@@ -1443,8 +1444,7 @@
           (is false)
           (catch ExceptionInfo ex
             (is (= {:friendly-error-message (str "The following fields exceed their allowed limits: "
-                                                 \newline
-                                                 "- cpus is 200 but the max allowed is 100")
+                                                 "cpus is 200 but the max allowed is 100")
                     :status 400, :type :service-description-error}
                    (select-keys (ex-data ex) [:friendly-error-message :status :type])))))))
 
@@ -1455,9 +1455,7 @@
           (is false)
           (catch ExceptionInfo ex
             (is (= {:friendly-error-message (str "The following fields exceed their allowed limits: "
-                                                 \newline
-                                                 "- cpus is 200 but the max allowed is 100"
-                                                 \newline
-                                                 "- mem is 40960 but the max allowed is 32768")
+                                                 "cpus is 200 but the max allowed is 100, "
+                                                 "mem is 40960 but the max allowed is 32768")
                     :status 400, :type :service-description-error}
                    (select-keys (ex-data ex) [:friendly-error-message :status :type])))))))))

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -1443,7 +1443,8 @@
           (is false)
           (catch ExceptionInfo ex
             (is (= {:friendly-error-message (str "The following fields exceed their allowed limits: "
-                                                 "cpus is 200 but allowed max is 100")
+                                                 \newline
+                                                 "- cpus is 200 but the max allowed is 100")
                     :status 400, :type :service-description-error}
                    (select-keys (ex-data ex) [:friendly-error-message :status :type])))))))
 
@@ -1454,6 +1455,9 @@
           (is false)
           (catch ExceptionInfo ex
             (is (= {:friendly-error-message (str "The following fields exceed their allowed limits: "
-                                                 "cpus is 200 but allowed max is 100, mem is 40960 but allowed max is 32768")
+                                                 \newline
+                                                 "- cpus is 200 but the max allowed is 100"
+                                                 \newline
+                                                 "- mem is 40960 but the max allowed is 32768")
                     :status 400, :type :service-description-error}
                    (select-keys (ex-data ex) [:friendly-error-message :status :type])))))))))

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -14,6 +14,7 @@
             [clojure.string :as str]
             [clojure.test :refer :all]
             [clojure.walk :as walk]
+            [schema.core :as s]
             [waiter.authorization :as authz]
             [waiter.kv :as kv]
             [waiter.service-description :as sd]
@@ -547,7 +548,8 @@
   (with-redefs [sd/service-description->service-id (fn [prefix sd] (str prefix (hash (select-keys sd sd/service-description-keys))))]
     (let [entitlement-manager (authz/->SimpleEntitlementManager nil)
           make-peer-requests-fn (fn [endpoint _ _] (and (str/starts-with? endpoint "token/") (str/ends-with? endpoint "/refresh")) {})
-          validate-service-description-fn (fn validate-service-description-fn [service-description] (sd/validate-schema service-description nil))
+          validate-service-description-fn (fn validate-service-description-fn [service-description]
+                                            (sd/validate-schema service-description {s/Str s/Any} nil))
           token "test-token"
           token-root "test-token-root"
           waiter-hostname "waiter-hostname.app.example.com"

--- a/waiter/test/waiter/utils_test.clj
+++ b/waiter/test/waiter/utils_test.clj
@@ -509,12 +509,12 @@
                                         :patterns {:factory-fn 'waiter.cors/pattern-based-validator
                                                    :allowed-origins []}})))
       (let [constraints {"cpus" {:max 100}
-                          "mem" {:max (* 32 1024)}}
+                         "mem" {:max (* 32 1024)}}
             builder (create-component {:kind :default
                                        :default {:factory-fn 'waiter.service-description/create-default-service-description-builder}}
                                       :context {:constraints constraints})]
         (is (instance? DefaultServiceDescriptionBuilder builder))
-        (is (:upper-limits-schema builder))
+        (is (:max-constraints-schema builder))
         (waiter.service-description/validate builder {} {})))
 
     (testing "should throw when config sub-map is missing"

--- a/waiter/test/waiter/utils_test.clj
+++ b/waiter/test/waiter/utils_test.clj
@@ -508,11 +508,11 @@
                      (create-component {:kind :patterns
                                         :patterns {:factory-fn 'waiter.cors/pattern-based-validator
                                                    :allowed-origins []}})))
-      (let [upper-limits {"cpus" 100
-                          "mem" (* 32 1024)}
+      (let [constraints {"cpus" {:max 100}
+                          "mem" {:max (* 32 1024)}}
             builder (create-component {:kind :default
                                        :default {:factory-fn 'waiter.service-description/create-default-service-description-builder}}
-                                      :context {:upper-limits upper-limits})]
+                                      :context {:constraints constraints})]
         (is (instance? DefaultServiceDescriptionBuilder builder))
         (is (:upper-limits-schema builder))
         (waiter.service-description/validate builder {} {})))

--- a/waiter/test/waiter/utils_test.clj
+++ b/waiter/test/waiter/utils_test.clj
@@ -171,16 +171,16 @@
                  :uri "/path"
                  :host "localhost"}]
     (testing "html response"
-      (let [{:keys [body headers status]} 
-            (exception->response 
+      (let [{:keys [body headers status]}
+            (exception->response
               (ex-info "TestCase Exception" {:status 400})
               (assoc-in request [:headers "accept"] "text/html"))]
         (is (= 400 status))
         (is (= {"content-type" "text/html"} headers))
         (is (str/includes? body "TestCase Exception"))))
     (testing "html response with links"
-      (let [{:keys [body headers status]} 
-            (exception->response 
+      (let [{:keys [body headers status]}
+            (exception->response
               (ex-info "TestCase Exception" {:status 400
                                              :friendly-error-message "See http://localhost/path"})
               (assoc-in request [:headers "accept"] "text/html"))]
@@ -197,7 +197,7 @@
         (is (str/includes? body "TestCase Exception"))))
     (testing "json response"
       (let [{:keys [body headers status]}
-            (exception->response 
+            (exception->response
               (ex-info "TestCase Exception" {:status 500})
               (assoc-in request [:headers "accept"] "application/json"))]
         (is (= 500 status))
@@ -508,10 +508,14 @@
                      (create-component {:kind :patterns
                                         :patterns {:factory-fn 'waiter.cors/pattern-based-validator
                                                    :allowed-origins []}})))
-      (is (instance? DefaultServiceDescriptionBuilder
-                     (create-component {:kind :default
-                                        :default {:factory-fn
-                                                  'waiter.service-description/->DefaultServiceDescriptionBuilder}}))))
+      (let [resource-limits {"cpus" 100
+                             "mem" (* 1024 1024)}
+            builder (create-component {:kind :default
+                                       :default {:factory-fn 'waiter.service-description/create-default-service-description-builder}}
+                                      :context {:resource-limits resource-limits})]
+        (is (instance? DefaultServiceDescriptionBuilder builder))
+        (is (:resource-limits-schema builder))
+        (waiter.service-description/validate builder {} {})))
 
     (testing "should throw when config sub-map is missing"
       (is (thrown-with-msg? ExceptionInfo

--- a/waiter/test/waiter/utils_test.clj
+++ b/waiter/test/waiter/utils_test.clj
@@ -508,13 +508,13 @@
                      (create-component {:kind :patterns
                                         :patterns {:factory-fn 'waiter.cors/pattern-based-validator
                                                    :allowed-origins []}})))
-      (let [resource-limits {"cpus" 100
-                             "mem" (* 1024 1024)}
+      (let [upper-limits {"cpus" 100
+                          "mem" (* 32 1024)}
             builder (create-component {:kind :default
                                        :default {:factory-fn 'waiter.service-description/create-default-service-description-builder}}
-                                      :context {:resource-limits resource-limits})]
+                                      :context {:upper-limits upper-limits})]
         (is (instance? DefaultServiceDescriptionBuilder builder))
-        (is (:resource-limits-schema builder))
+        (is (:upper-limits-schema builder))
         (waiter.service-description/validate builder {} {})))
 
     (testing "should throw when config sub-map is missing"


### PR DESCRIPTION
## Changes proposed in this PR

- Adds generic support for maximum value restrictions on service parameters.

## Why are we making these changes?

Introducing limits allows us to fail requests early if the cluster cannot support the requested resources for an instance.

An example error response is shown below:
<img width="1069" alt="screen shot 2018-02-06 at 10 25 05 am" src="https://user-images.githubusercontent.com/6611249/35870746-0c8cc5ac-0b28-11e8-8dbf-9af7ce30399b.png">



