### PR TITLE
WIP: Creates a request log

### DIFF
--- a/waiter/resources/log4j.properties
+++ b/waiter/resources/log4j.properties
@@ -18,3 +18,13 @@ log4j.appender.ErrorAppender.DatePattern='.'yyyy-MM-dd
 log4j.appender.ErrorAppender.layout=org.apache.log4j.PatternLayout
 # CID will be replaced by the custom pattern layout configured in waiter.correlation-id/replace-pattern-layout-in-log4j-appenders
 log4j.appender.ErrorAppender.layout.ConversionPattern=%d{ISO8601} %-5p %c [%t] - [CID] %m%n
+
+log4j.category.waiter.request-log=INFO, requestlog
+log4j.additivity.waiter.request-log=false
+
+log4j.appender.requestlog=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.requestlog.Threshold=INFO
+log4j.appender.requestlog.File=log/${waiter.logFilePrefix}request.log
+log4j.appender.requestlog.DatePattern='.'yyyy-MM-dd
+log4j.appender.requestlog.layout=org.apache.log4j.PatternLayout
+log4j.appender.requestlog.layout.ConversionPattern=%d{ISO8601} %-5p %c [%t] - %m%n

--- a/waiter/resources/log4j.properties
+++ b/waiter/resources/log4j.properties
@@ -27,4 +27,4 @@ log4j.appender.requestlog.Threshold=INFO
 log4j.appender.requestlog.File=log/${waiter.logFilePrefix}request.log
 log4j.appender.requestlog.DatePattern='.'yyyy-MM-dd
 log4j.appender.requestlog.layout=org.apache.log4j.PatternLayout
-log4j.appender.requestlog.layout.ConversionPattern=%d{ISO8601} %-5p %c [%t] - %m%n
+log4j.appender.requestlog.layout.ConversionPattern=%m%n

--- a/waiter/src/waiter/async_request.clj
+++ b/waiter/src/waiter/async_request.clj
@@ -139,8 +139,8 @@
    The function assumes location begins with a slash.
    This method wires up the completion and status check callbacks for the monitoring system.
    It also modifies the status check endpoint in the response header."
-  [router-id async-request-store-atom make-http-request-fn instance-rpc-chan service-id metric-group {:keys [host port] :as instance}
-   {:keys [request-id] :as reason-map} request-properties location response-headers]
+  [router-id async-request-store-atom make-http-request-fn instance-rpc-chan response service-id metric-group {:keys [host port] :as instance}
+   {:keys [request-id] :as reason-map} request-properties location]
   (let [correlation-id (cid/get-correlation-id)
         status-endpoint (scheduler/end-point-url instance location)
         _ (log/info "status endpoint for async request is" status-endpoint)
@@ -172,4 +172,4 @@
     (let [param-map {:host host, :location location, :port port, :request-id request-id, :router-id router-id, :service-id service-id}
           status-location (route-params->uri "/waiter-async/status/" param-map)]
       (log/info "updating status location to" status-location "from" location)
-      (swap! response-headers assoc "location" status-location))))
+      (assoc-in response [:headers "location"] status-location))))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -120,35 +120,37 @@
   "Creates the handler for processing http requests."
   [waiter-request?-fn {:keys [cors-preflight-handler-fn process-request-fn] :as handlers}]
   (fn http-handler [{:keys [uri] :as request}]
-    (cond
-      (cors/preflight-request? request)
-      (do
-        (counters/inc! (metrics/waiter-counter "requests" "cors-preflight"))
-        (cors-preflight-handler-fn request))
+    (let [request (utils/mark-request-time request :received)]
+      (cond
+        (cors/preflight-request? request)
+        (do
+          (counters/inc! (metrics/waiter-counter "requests" "cors-preflight"))
+          (cors-preflight-handler-fn request))
 
-      (not (waiter-request?-fn request))
-      (do
-        (counters/inc! (metrics/waiter-counter "requests" "service-request"))
-        (process-request-fn request))
+        (not (waiter-request?-fn request))
+        (do
+          (counters/inc! (metrics/waiter-counter "requests" "service-request"))
+          (process-request-fn request))
 
-      :else
-      (let [{:keys [handler route-params]} (routes-mapper request)
-            request (assoc request :route-params (or route-params {}))
-            handler-fn (get handlers handler process-request-fn)]
-        (when (and (not= handler :process-request-fn) (= handler-fn process-request-fn))
-          (log/warn "using default handler as no mapping found for" handler "at uri" uri))
-        (when handler
-          (counters/inc! (metrics/waiter-counter "requests" (name handler))))
-        (handler-fn request)))))
+        :else
+        (let [{:keys [handler route-params]} (routes-mapper request)
+              request (assoc request :route-params (or route-params {}))
+              handler-fn (get handlers handler process-request-fn)]
+          (when (and (not= handler :process-request-fn) (= handler-fn process-request-fn))
+            (log/warn "using default handler as no mapping found for" handler "at uri" uri))
+          (when handler
+            (counters/inc! (metrics/waiter-counter "requests" (name handler))))
+          (handler-fn request))))))
 
 (defn websocket-handler-factory
   "Creates the handler for processing websocket requests.
    Websockets are currently used for inter-router metrics syncing."
   [{:keys [default-websocket-handler-fn router-metrics-handler-fn]}]
   (fn websocket-handler [{:keys [uri] :as request}]
-    (case uri
-      "/waiter-router-metrics" (router-metrics-handler-fn request)
-      (default-websocket-handler-fn request))))
+    (let [request (utils/mark-request-time request :received)]
+      (case uri
+        "/waiter-router-metrics" (router-metrics-handler-fn request)
+        (default-websocket-handler-fn request)))))
 
 (defn correlation-id-middleware
   "Attaches an x-cid header to the request and response if one is not already provided."

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -665,10 +665,10 @@
    :post-process-async-request-response-fn (pc/fnk [[:state async-request-store-atom instance-rpc-chan router-id]
                                                     make-http-request-fn]
                                              (fn post-process-async-request-response-wrapper
-                                               [service-id metric-group instance _ reason-map request-properties location response-headers]
+                                               [response service-id metric-group instance _ reason-map request-properties location]
                                                (async-req/post-process-async-request-response
-                                                 router-id async-request-store-atom make-http-request-fn instance-rpc-chan service-id metric-group
-                                                 instance reason-map request-properties location response-headers)))
+                                                 router-id async-request-store-atom make-http-request-fn instance-rpc-chan response service-id metric-group
+                                                 instance reason-map request-properties location)))
    :prepend-waiter-url (pc/fnk [[:settings port hostname]]
                          (let [hostname (if (sequential? hostname) (first hostname) hostname)]
                            (fn [endpoint-url]

--- a/waiter/src/waiter/metrics.clj
+++ b/waiter/src/waiter/metrics.clj
@@ -449,6 +449,16 @@
      (~handle-elapsed-nanos-fn elapsed#)
      out#))
 
+(defmacro with-timer
+  "Times the operation specified by body using the provided
+  timer and calls handle-elapsed-nanos-fn with the epased
+  time in nanoseconds. Returns [value of body, nanos]."
+  [timer & body]
+  `(let [^Timer$Context start# (metrics.timers/start ~timer)
+         out# (do ~@body)
+         elapsed# (metrics.timers/stop start#)]
+     [out# elapsed#]))
+
 (defn stream-metric-map
   "Returns a map containing metrics used for reporting streaming metrics for a given service."
   [service-id]

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -390,10 +390,10 @@
                     (if-not more-bytes-possibly-available?
                       (let [request (-> request
                                         (utils/mark-request-time :closed))]
-                        (rlog/log (merge (rlog/request->context request)
-                                       {:bytes-streamed bytes-streamed
-                                        :status (:status response)
-                                        :termination-state :success})))
+                        (rlog/log (assoc (rlog/request->context request)
+                                         :bytes-streamed bytes-streamed
+                                         :status (:status response)
+                                         :termination-state :success)))
                       (recur bytes-streamed' bytes-reported-to-statsd'))))))))
         (catch Exception e
           (meters/mark! stream-exception-meter)
@@ -409,10 +409,10 @@
           (let [{:keys [bytes-streamed]} (ex-data e)
                 request (-> request
                             (utils/mark-request-time :closed))]
-            (rlog/log (merge (rlog/request->context request)
-                             {:bytes-streamed bytes-streamed
-                              :status (:status response)
-                              :termination-state :stream-error}))))
+            (rlog/log (assoc (rlog/request->context request)
+                             :bytes-streamed bytes-streamed
+                             :status (:status response)
+                             :termination-state :stream-error))))
         (finally
           (async/close! resp-chan)
           (async/close! body)
@@ -621,9 +621,9 @@
                                                                     (merge @response-headers headers))))
                                     request (-> request
                                                 (utils/mark-request-time :closed))]
-                                (rlog/log (merge (rlog/request->context request)
-                                                 {:status (:status response)
-                                                  :termination-state :backend-error}))
+                                (rlog/log (assoc (rlog/request->context request)
+                                                 :status (:status response)
+                                                 :termination-state :backend-error))
                                 response))))))
                     (catch Exception e
                       (let [{:keys [descriptor]} (ex-data e)
@@ -632,9 +632,9 @@
                                                             (merge @response-headers headers))))
                             request (-> request
                                         (utils/mark-request-time :closed))]
-                        (rlog/log (merge (rlog/request->context request)
-                                         {:status (:status response)
-                                          :termination-state :instance-reservation-error}))
+                        (rlog/log (assoc (rlog/request->context request)
+                                         :status (:status response)
+                                         :termination-state :instance-reservation-error))
                         response))))))
             (catch Exception e
               (let [{:keys [descriptor]} (ex-data e)
@@ -643,9 +643,9 @@
                                                     (merge @response-headers headers))))
                     request (-> request
                                 (utils/mark-request-time :closed))]
-                (rlog/log (merge (rlog/request->context request)
-                                 {:status (:status response)
-                                  :termination-state :service-discovery-error}))
+                (rlog/log (assoc (rlog/request->context request)
+                                 :status (:status response)
+                                 :termination-state :service-discovery-error))
                 response))))))))
 
 (defn handle-suspended-service

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -605,8 +605,7 @@
                                                         (-> (t/interval instance-requested instance-reserved)
                                                             t/in-millis
                                                             (* 1000000)
-                                                            str
-                                                            )))]
+                                                            str)))]
                           (try
                             (log/info "suggested instance:" id host port)
                             (confirm-live-connection-without-abort)

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -508,9 +508,9 @@
                                           (update :headers (fn [headers]
                                                              (merge response-headers headers))))
         request (utils/mark-request-time request :closed)]
-    (rlog/log (assoc (rlog/request->context request)
-                     :status status
-                     :termination-state termination-status))
+    (rlog/log-request request
+                      :status status
+                      :termination-state termination-status)
     response))
 
 (let [process-timer (metrics/waiter-timer "core" "process")]

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -526,7 +526,8 @@
           confirm-live-connection-factory #(confirm-live-connection-factory control-mult reservation-status-promise %1)
           confirm-live-connection-without-abort (confirm-live-connection-factory nil)
           waiter-debug-enabled? (utils/request->debug-enabled? request)
-          response-headers (when waiter-debug-enabled? {"x-waiter-router-id" router-id})]
+          response-headers (when waiter-debug-enabled? {"x-waiter-router-id" router-id
+                                                        "x-waiter-request-date" (utils/date-to-str received utils/formatter-rfc822)})]
       (async/go
         (if waiter-debug-enabled?
           (log/info "process request to" (get-in request [:headers "host"]) "at path" request)
@@ -544,10 +545,7 @@
                                      :service-version (get service-description "version"))
                               (utils/mark-request-time :service-discovered))
                   response-headers (when waiter-debug-enabled?
-                                     (-> response-headers
-                                         (assoc "x-waiter-request-date"
-                                                (utils/date-to-str received utils/formatter-rfc822))
-                                         (assoc "x-waiter-service-id" service-id)))]
+                                     (assoc response-headers "x-waiter-service-id" service-id))]
               (send local-usage-agent metrics/update-last-request-time-usage-metric service-id received)
               (loop [[handler & remaining-handlers] handlers]
                 (if handler

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -623,11 +623,10 @@
                                                 (utils/mark-request-time :closed))]
                                 (rlog/log (assoc (rlog/request->context request)
                                                  :status (:status response)
-                                                 :termination-state :backend-error))
+                                                 :termination-state :gateway-error))
                                 response))))))
                     (catch Exception e
-                      (let [{:keys [descriptor]} (ex-data e)
-                            {:keys [status] :as response} (-> (process-exception-fn track-process-error-metrics request e)
+                      (let [{:keys [status] :as response} (-> (process-exception-fn track-process-error-metrics request e)
                                                               (update :headers (fn [headers]
                                                                                  (merge @response-headers headers))))
                             request (utils/mark-request-time request :closed)]
@@ -636,8 +635,7 @@
                                           :termination-state :instance-reservation-error)
                         response))))))
             (catch Exception e
-              (let [{:keys [descriptor]} (ex-data e)
-                    {:keys [status] :as response} (-> (process-exception-fn track-process-error-metrics request e)
+              (let [{:keys [status] :as response} (-> (process-exception-fn track-process-error-metrics request e)
                                                       (update :headers (fn [headers]
                                                                          (merge @response-headers headers))))
                     request (utils/mark-request-time request :closed)]

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -534,10 +534,13 @@
           (try
             (confirm-live-connection-without-abort)
             (let [{:keys [service-id service-description] :as descriptor} (request->descriptor-fn request)
-                  request (-> request
-                              (assoc :service-id service-id)
-                              (utils/mark-request-time :service-discovered))
                   {:strs [metric-group]} service-description
+                  request (-> request
+                              (assoc :metric-group metric-group
+                                     :service-id service-id
+                                     :service-name (get service-description "name")
+                                     :service-version (get service-description "version"))
+                              (utils/mark-request-time :service-discovered))
                   ^DateTime request-time (t/now)]
               (->> (utils/date-to-str request-time utils/formatter-rfc822)
                    (add-debug-header-into-response! "x-waiter-request-date"))

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -601,7 +601,7 @@
                                                  :instance-port port
                                                  :instance-proto protocol))]
                           (try
-                            (log/info "suggested instance:" (:id instance) (:host instance) (:port instance))
+                            (log/info "suggested instance:" id host port)
                             (when waiter-debug-enabled?
                               (swap! response-headers merge (instance->debug-headers instance prepend-waiter-url)))
                             (confirm-live-connection-without-abort)

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -526,12 +526,13 @@
           confirm-live-connection-factory #(confirm-live-connection-factory control-mult reservation-status-promise %1)
           confirm-live-connection-without-abort (confirm-live-connection-factory nil)
           waiter-debug-enabled? (utils/request->debug-enabled? request)
-          response-headers (when waiter-debug-enabled? {"x-waiter-router-id" router-id
-                                                        "x-waiter-request-date" (utils/date-to-str received utils/formatter-rfc822)})]
+          response-headers (when waiter-debug-enabled?
+                             {"x-waiter-router-id" router-id
+                              "x-waiter-request-date" (utils/date-to-str received utils/formatter-rfc822)})]
       (async/go
         (if waiter-debug-enabled?
-          (log/info "process request to" (get-in request [:headers "host"]) "at path" request)
-          (log/debug "process request to" (get-in request [:headers "host"]) "at path" request))
+          (log/info "process request to" (get-in request [:headers "host"]) "at path" uri)
+          (log/debug "process request to" (get-in request [:headers "host"]) "at path" uri))
         (timers/start-stop-time!
           process-timer
           (try

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -648,6 +648,7 @@
       (log/info "Service has been suspended" response-map)
       (track-response-status-metrics request 503)
       (meters/mark! (metrics/service-meter service-id "response-rate" "error" "suspended"))
+      (rlog/log-request request :status 503 :termination-state :service-suspended)
       (-> {:details (str response-map), :message "Service has been suspended", :status 503}
           (utils/data->error-response request)))))
 
@@ -665,6 +666,7 @@
         (log/info "Max queue length exceeded" response-map)
         (track-response-status-metrics request 503)
         (meters/mark! (metrics/service-meter service-id "response-rate" "error" "queue-length"))
+        (rlog/log-request request :status 503 :termination-state :max-queue-length-exceeded)
         (-> {:details (str response-map), :message "Max queue length exceeded", :status 503}
             (utils/data->error-response request))))))
 

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -594,7 +594,7 @@
                               _ (statsd/histo! metric-group "get_instance" get-available-instance-nanos)
                               request (-> request
                                           (utils/mark-request-time :instance-reserved)
-                                          (assoc :instance-id (subs id (inc (count service-id)))
+                                          (assoc :instance-id id
                                                  :instance-host host
                                                  :instance-port port
                                                  :instance-proto protocol))

--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -50,3 +50,8 @@
       (and instance-reserved received) (assoc :instance-latency (- instance-reserved received))
       (and sent-to-backend received) (assoc :overhead-latency (- sent-to-backend received))
       (and closed received) (assoc :total-latency (- closed received)))))
+
+(defn log-request
+  "Logs a request and any additional context."
+  [request & {:as additional-context}]
+  (log (merge (request->context request) additional-context)))

--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -23,7 +23,8 @@
 (defn request->context
   "Convert a request into a context suitable for logging."
   [{:keys [authenticated-principal headers instance-id instance-host instance-port
-           instance-proto query-string request-method service-id timing uri] :as request}]
+           instance-proto metric-group query-string request-method service-id service-name
+           service-version timing uri] :as request}]
   (let [{:keys [received service-discovered instance-reserved sent-to-backend closed]} timing
         {:strs [host x-cid]} headers]
     (cond-> {:cid x-cid
@@ -36,8 +37,11 @@
       instance-id (assoc :instance-id instance-id)
       instance-port (assoc :instance-port instance-port)
       instance-proto (assoc :instance-proto instance-proto)
+      metric-group (assoc :metric-group metric-group)
       query-string (assoc :query-string query-string)
       service-id (assoc :service-id service-id)
+      service-name (assoc :service-name service-name)
+      service-version (assoc :service-version service-version)
       received (assoc :timestamp (-> received
                                      (coerce/from-long)
                                      (utils/date-to-str)))

--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -30,10 +30,10 @@
         {:strs [host x-cid]} headers]
     (cond-> {:cid x-cid
              :host host
-             :method (-> request-method name str/upper-case)
              :path uri
              :principal authenticated-principal
              :scheme (utils/request->scheme request)}
+      request-method (assoc :method (-> request-method name str/upper-case))
       instance-host (assoc :instance-host instance-host)
       instance-id (assoc :instance-id instance-id)
       instance-port (assoc :instance-port instance-port)

--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -1,0 +1,48 @@
+;;
+;;       Copyright (c) 2018 Two Sigma Investments, LP.
+;;       All Rights Reserved
+;;
+;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
+;;       Two Sigma Investments, LP.
+;;
+;;       The copyright notice above does not evidence any
+;;       actual or intended publication of such source code.
+;;
+(ns waiter.request-log
+  (:require [clj-time.coerce :as coerce]
+            [clojure.string :as str]
+            [waiter.utils :as utils]))
+
+(def ^:dynamic *request-log-file* "log/request.log")
+
+(defn log
+  "Log a request context."
+  [context]
+  (spit *request-log-file* (str context \newline) :append true))
+
+(defn request->context
+  "Convert a request into a context suitable for logging."
+  [{:keys [authenticated-principal headers instance-id instance-host instance-port
+           instance-proto query-string request-method service-id timing uri] :as request}]
+  (let [{:keys [received service-discovered instance-reserved sent-to-backend closed]} timing
+        {:strs [host x-cid]} headers]
+    (cond-> {:cid x-cid
+             :host host
+             :method (-> request-method name str/upper-case)
+             :path uri
+             :principal authenticated-principal
+             :scheme (utils/request->scheme request)}
+      instance-host (assoc :instance-host instance-host)
+      instance-id (assoc :instance-id instance-id)
+      instance-port (assoc :instance-port instance-port)
+      instance-proto (assoc :instance-proto instance-proto)
+      query-string (assoc :query-string query-string)
+      service-id (assoc :service-id service-id)
+      received (assoc :timestamp (-> received
+                                     (coerce/from-long)
+                                     (utils/date-to-str)))
+      (and closed sent-to-backend) (assoc :backend-latency (- closed sent-to-backend))
+      (and service-discovered received) (assoc :discovery-latency (- service-discovered received))
+      (and instance-reserved received) (assoc :instance-latency (- instance-reserved received))
+      (and sent-to-backend received) (assoc :overhead-latency (- sent-to-backend received))
+      (and closed received) (assoc :total-latency (- closed received)))))

--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -11,14 +11,13 @@
 (ns waiter.request-log
   (:require [clj-time.core :as t]
             [clojure.string :as str]
+            [clojure.tools.logging :as log]
             [waiter.utils :as utils]))
-
-(def ^:dynamic *request-log-file* "log/request.log")
 
 (defn log
   "Log a request context."
   [context]
-  (spit *request-log-file* (str context \newline) :append true))
+  (log/info context))
 
 (defn request->context
   "Convert a request into a context suitable for logging."

--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -10,7 +10,6 @@
 ;;
 (ns waiter.request-log
   (:require [clj-time.core :as t]
-            [clj-time.coerce :as coerce]
             [clojure.string :as str]
             [waiter.utils :as utils]))
 
@@ -43,9 +42,7 @@
       service-id (assoc :service-id service-id)
       service-name (assoc :service-name service-name)
       service-version (assoc :service-version service-version)
-      received (assoc :timestamp (-> received
-                                     (coerce/from-long)
-                                     (utils/date-to-str)))
+      received (assoc :timestamp (utils/date-to-str received))
       (and sent-to-backend closed) (assoc :backend-latency (t/in-millis (t/interval sent-to-backend closed)))
       (and received service-discovered) (assoc :discovery-latency (t/in-millis (t/interval received service-discovered)))
       (and received instance-reserved) (assoc :instance-latency (t/in-millis (t/interval received instance-reserved)))

--- a/waiter/src/waiter/service.clj
+++ b/waiter/src/waiter/service.clj
@@ -227,55 +227,51 @@
     (cid/with-correlation-id
       (:cid reason-map)
       (try
-        (metrics/with-timer!
-          (metrics/service-timer service-id "get-available-instance")
-          (fn [nanos]
-            (statsd/histo! metric-group "get_instance" nanos))
-          (counters/inc! (metrics/service-counter service-id "request-counts" "waiting-for-available-instance"))
-          (statsd/gauge-delta! metric-group "request_waiting_for_instance" +1)
-          (let [expiry-time (t/plus (t/now) (t/millis queue-timeout-ms))]
-            (loop [iterations 1]
-              (let [instance (get-rand-inst instance-rpc-chan service-id reason-map #{} queue-timeout-ms)]
-                (if-not (nil? (:id instance)) ; instance is nil or :no-matching-instance-found
-                  (do
-                    (histograms/update!
-                      (metrics/service-histogram service-id "iterations-to-find-available-instance")
-                      iterations)
-                    instance)
-                  (if (and instance (not= instance :no-matching-instance-found))
-                    ; instance is a deployment error if it (1) does not have an :id tag, (2) is not nil, and (3) does not equal :no-matching-instance-found
-                    (ex-info (str "Deployment error: " (utils/message instance)) {:service-id service-id :status 503})
-                    (if-not (t/before? (t/now) expiry-time) 
-                      (do
-                        ;; No instances were started in a reasonable amount of time
-                        (meters/mark! (metrics/service-meter service-id "no-available-instance-timeout"))
-                        (statsd/inc! metric-group "no_instance_timeout")
-                        (let [outstanding-requests (counters/value (metrics/service-counter service-id "request-counts" "outstanding"))
-                              requests-waiting-to-stream (counters/value (metrics/service-counter service-id "request-counts" "waiting-to-stream"))
-                              waiting-for-available-instance (counters/value (metrics/service-counter service-id "request-counts" "waiting-for-available-instance"))
-                              healthy-instances (counters/value (metrics/service-counter service-id "instance-counts" "healthy")) 
-                              unhealthy-instances (counters/value (metrics/service-counter service-id "instance-counts" "unhealthy"))
-                              failed-instances (counters/value (metrics/service-counter service-id "instance-counts" "failed"))]
-                          (ex-info (str "After " (t/in-seconds (t/millis queue-timeout-ms))
-                                        " seconds, no instance available to handle request."
-                                        (when (and (zero? healthy-instances) (or (pos? unhealthy-instances) (pos? failed-instances)))
-                                          " Check that your service is able to start properly!")
-                                        (when (and (pos? outstanding-requests) (pos? healthy-instances))
-                                          " Check that your service is able to scale properly!"))
-                                   {:service-id service-id
-                                    :outstanding-requests outstanding-requests
-                                    :requests-waiting-to-stream requests-waiting-to-stream
-                                    :waiting-for-available-instance waiting-for-available-instance
-                                    :slots-assigned (counters/value (metrics/service-counter service-id "instance-counts" "slots-assigned"))
-                                    :slots-available (counters/value (metrics/service-counter service-id "instance-counts" "slots-available"))
-                                    :slots-in-use (counters/value (metrics/service-counter service-id "instance-counts" "slots-in-use"))
-                                    :work-stealing-offers-received (counters/value (metrics/service-counter service-id "work-stealing" "received-from" "in-flight"))
-                                    :work-stealing-offers-sent (counters/value (metrics/service-counter service-id "work-stealing" "sent-to" "in-flight"))
-                                    :status 503})))
-                      (do
-                        (app-not-found-fn)
-                        (async/<! (async/timeout 1500))
-                        (recur (inc iterations))))))))))
+        (counters/inc! (metrics/service-counter service-id "request-counts" "waiting-for-available-instance"))
+        (statsd/gauge-delta! metric-group "request_waiting_for_instance" +1)
+        (let [expiry-time (t/plus (t/now) (t/millis queue-timeout-ms))]
+          (loop [iterations 1]
+            (let [instance (get-rand-inst instance-rpc-chan service-id reason-map #{} queue-timeout-ms)]
+              (if-not (nil? (:id instance)) ; instance is nil or :no-matching-instance-found
+                (do
+                  (histograms/update!
+                    (metrics/service-histogram service-id "iterations-to-find-available-instance")
+                    iterations)
+                  instance)
+                (if (and instance (not= instance :no-matching-instance-found))
+                  ; instance is a deployment error if it (1) does not have an :id tag, (2) is not nil, and (3) does not equal :no-matching-instance-found
+                  (ex-info (str "Deployment error: " (utils/message instance)) {:service-id service-id :status 503})
+                  (if-not (t/before? (t/now) expiry-time)
+                    (do
+                      ;; No instances were started in a reasonable amount of time
+                      (meters/mark! (metrics/service-meter service-id "no-available-instance-timeout"))
+                      (statsd/inc! metric-group "no_instance_timeout")
+                      (let [outstanding-requests (counters/value (metrics/service-counter service-id "request-counts" "outstanding"))
+                            requests-waiting-to-stream (counters/value (metrics/service-counter service-id "request-counts" "waiting-to-stream"))
+                            waiting-for-available-instance (counters/value (metrics/service-counter service-id "request-counts" "waiting-for-available-instance"))
+                            healthy-instances (counters/value (metrics/service-counter service-id "instance-counts" "healthy")) 
+                            unhealthy-instances (counters/value (metrics/service-counter service-id "instance-counts" "unhealthy"))
+                            failed-instances (counters/value (metrics/service-counter service-id "instance-counts" "failed"))]
+                        (ex-info (str "After " (t/in-seconds (t/millis queue-timeout-ms))
+                                      " seconds, no instance available to handle request."
+                                      (when (and (zero? healthy-instances) (or (pos? unhealthy-instances) (pos? failed-instances)))
+                                        " Check that your service is able to start properly!")
+                                      (when (and (pos? outstanding-requests) (pos? healthy-instances))
+                                        " Check that your service is able to scale properly!"))
+                                 {:service-id service-id
+                                  :outstanding-requests outstanding-requests
+                                  :requests-waiting-to-stream requests-waiting-to-stream
+                                  :waiting-for-available-instance waiting-for-available-instance
+                                  :slots-assigned (counters/value (metrics/service-counter service-id "instance-counts" "slots-assigned"))
+                                  :slots-available (counters/value (metrics/service-counter service-id "instance-counts" "slots-available"))
+                                  :slots-in-use (counters/value (metrics/service-counter service-id "instance-counts" "slots-in-use"))
+                                  :work-stealing-offers-received (counters/value (metrics/service-counter service-id "work-stealing" "received-from" "in-flight"))
+                                  :work-stealing-offers-sent (counters/value (metrics/service-counter service-id "work-stealing" "sent-to" "in-flight"))
+                                  :status 503})))
+                    (do
+                      (app-not-found-fn)
+                      (async/<! (async/timeout 1500))
+                      (recur (inc iterations)))))))))
         (catch Exception e
           (log/error e "Error in get-available-instance")
           e)

--- a/waiter/src/waiter/service.clj
+++ b/waiter/src/waiter/service.clj
@@ -222,7 +222,7 @@
   "Starts a `clojure.core.async/go` block to query the router state to get an
    available instance to send a request. It will continue to query the state until
    an instance is available."
-  [instance-rpc-chan service-id reason-map app-not-found-fn queue-timeout-ms metric-group add-debug-header-into-response!]
+  [instance-rpc-chan service-id reason-map app-not-found-fn queue-timeout-ms metric-group]
   (async/go
     (cid/with-correlation-id
       (:cid reason-map)
@@ -230,7 +230,6 @@
         (metrics/with-timer!
           (metrics/service-timer service-id "get-available-instance")
           (fn [nanos]
-            (add-debug-header-into-response! "X-Waiter-Get-Available-Instance-ns" nanos)
             (statsd/histo! metric-group "get_instance" nanos))
           (counters/inc! (metrics/service-counter service-id "request-counts" "waiting-for-available-instance"))
           (statsd/gauge-delta! metric-group "request_waiting_for_instance" +1)

--- a/waiter/src/waiter/utils.clj
+++ b/waiter/src/waiter/utils.clj
@@ -531,3 +531,9 @@
                (str (digest/digest "MD5" (str/join "" (persistent! acc))))))]
     (log/debug "got ID" id "for" sorted-parameters)
     id))
+
+(defn mark-request-time
+  "Mark the completion of a timing event with the current time in the request timing map."
+  [request k]
+  (assoc-in request [:timing k] (System/currentTimeMillis)))
+

--- a/waiter/src/waiter/utils.clj
+++ b/waiter/src/waiter/utils.clj
@@ -536,4 +536,3 @@
   "Mark the completion of a timing event with the current time in the request timing map."
   [request k]
   (assoc-in request [:timing k] (System/currentTimeMillis)))
-

--- a/waiter/src/waiter/utils.clj
+++ b/waiter/src/waiter/utils.clj
@@ -535,4 +535,4 @@
 (defn mark-request-time
   "Mark the completion of a timing event with the current time in the request timing map."
   [request k]
-  (assoc-in request [:timing k] (System/currentTimeMillis)))
+  (assoc-in request [:timing k] (t/now)))

--- a/waiter/src/waiter/websocket.clj
+++ b/waiter/src/waiter/websocket.clj
@@ -358,9 +358,9 @@
 
 (defn process-exception-in-request
   "Processes exceptions thrown while processing a websocket request."
-  [track-process-error-metrics-fn {:keys [out] :as request} descriptor exception]
+  [track-process-error-metrics-fn {:keys [out] :as request} exception]
   (log/error exception "error in processing websocket request")
-  (track-process-error-metrics-fn descriptor)
+  (track-process-error-metrics-fn request)
   (let [exception-response (utils/exception->response exception request)]
     (async/go
       (async/>! out exception-response)

--- a/waiter/src/waiter/websocket.clj
+++ b/waiter/src/waiter/websocket.clj
@@ -25,6 +25,7 @@
             [waiter.correlation-id :as cid]
             [waiter.headers :as headers]
             [waiter.metrics :as metrics]
+            [waiter.request-log :as rlog]
             [waiter.scheduler :as scheduler]
             [waiter.statsd :as statsd]
             [waiter.utils :as utils])
@@ -296,6 +297,9 @@
         request-close-promise-chan (async/promise-chan)
         {:keys [requests-streaming stream stream-complete-rate stream-request-rate] :as metrics-map}
         (metrics/stream-metric-map service-id)]
+
+    ; log the request immediately; don't wait for streaming to finish
+    (rlog/log-request request)
 
     ;; go-block that handles cleanup by closing all channels related to the websocket request
     (async/go

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -276,10 +276,10 @@
             (let [reservation-status-promise (promise)
                   post-process-data (atom {})
                   post-process-async-request-response-fn
-                  (fn [_ _ _ auth-user _ _ location _]
+                  (fn [_ _ _ _ auth-user _ _ location]
                     (reset! post-process-data {:auth-user (:username auth-user), :location location}))]
               (inspect-for-202-async-request-response
-                post-process-async-request-response-fn {} "service-id" "metric-group" {}
+                {} post-process-async-request-response-fn {} "service-id" "metric-group" {}
                 endpoint request {} response (atom {}) reservation-status-promise)
               (deliver reservation-status-promise :not-async)
               (assoc @post-process-data :result @reservation-status-promise)))]

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -243,7 +243,7 @@
               (recur (+ bytes-streamed bytes-to-stream)))))
         (stream-http-response response confirm-live-connection request-abort-callback resp-chan instance-request-properties
                               reservation-status-promise request-state-chan metric-group
-                              waiter-debug-enabled? (metrics/stream-metric-map service-id))
+                              waiter-debug-enabled? (metrics/stream-metric-map service-id) {})
         (loop []
           (let [message (async/<!! resp-chan)]
             (when message
@@ -621,7 +621,7 @@
         response-chan (process "router-id" nil nil request->descriptor-fn nil {} [] nil nil nil
                                process-exception-in-http-request request-abort-callback-factory
                                local-usage-agent request)
-        {:keys [body headers status]} (cond-> response-chan (au/chan? response-chan) (async/<!!))]
+        {:keys [body headers status] :as response} (cond-> response-chan (au/chan? response-chan) (async/<!!))]
     (is (= 404 status))
     (is (= "text/plain" (get headers "content-type")))
     (is (str/includes? (str body) "Error message for user"))))

--- a/waiter/test/waiter/websocket_test.clj
+++ b/waiter/test/waiter/websocket_test.clj
@@ -348,8 +348,7 @@
   (let [out (async/chan 1)
         request {:out out :headers {"accept" "application/json"}}
         ex (Exception.)
-        desc "error descriptor"
-        _ (process-exception-in-request identity request desc ex)
+        _ (process-exception-in-request identity request ex)
         ex-msg (-> out async/<!! :body json/read-str (get-in ["waiter-error" "message"]))]
     ;; response should indicate an internal server error
     (is (= "Internal error" ex-msg))


### PR DESCRIPTION
## Changes proposed in this PR

Create a request log.  In scope:

- Log proxied requests
- One request per line
- Structured log format suitable for indexing

## Why are we making these changes?

A request log is a more compact, structured form of logging than what we do currently.  

## TODO
- Plug into logging framework
- Handle WS requests
- Decide on structured output format
- Tests

## Sample log
`{:termination-state :success, :path "/sleep", :service-id "waiter-service-exampleservice-73e3607e7980ff4b57cb2c455cd0af89", :service-name "example-service", :backend-latency 83, :instance-port 10005, :method "GET", :cid "262a9d71848d2d-37f288159dba2c2a", :total-latency 6427, :bytes-streamed 15, :discovery-latency 49, :instance-id "262a9dbad2d076-16de7b48e62c412c", :overhead-latency 6344, :instance-latency 6343, :host "example.com", :status 400, :instance-proto "http", :principal "sradack", :query-string "sleep-ms=50", :timestamp "2018-02-22T09:03:50.929-06:00", :scheme :http, :instance-host "127.0.0.5", :service-version "2", :metric-group "example-metric-group"}`

`{:termination-state :success, :path "/sleep", :service-id "waiter-service-exampleservice-73e3607e7980ff4b57cb2c455cd0af89", :service-name "example-service", :backend-latency 56, :instance-port 10005, :method "GET", :cid "262aa0383a53e9-56136a954ba05930", :total-latency 59, :bytes-streamed 15, :discovery-latency 1, :instance-id "262a9dbad2d076-16de7b48e62c412c", :overhead-latency 3, :instance-latency 2, :host "example.com", :status 400, :instance-proto "http", :principal "sradack", :query-string "sleep-ms=50", :timestamp "2018-02-22T09:04:02.852-06:00", :scheme :http, :instance-host "127.0.0.5", :service-version "2", :metric-group "example-metric-group"}`

`{:termination-state :backend-error, :path "/die", :service-id "waiter-service-exampleservice-73e3607e7980ff4b57cb2c455cd0af89", :service-name "example-service", :instance-port 10005, :method "GET", :cid "262aa11d38d4c3-4b96fc8e9c07101", :total-latency 360, :discovery-latency 2, :instance-id "262a9dbad2d076-16de7b48e62c412c", :instance-latency 3, :host "example.com", :status 502, :instance-proto "http", :principal "sradack", :timestamp "2018-02-22T09:04:06.693-06:00", :scheme :http, :instance-host "127.0.0.5", :service-version "2", :metric-group "example-metric-group"}`

`{:termination-state :success, :path "/hello", :service-id "waiter-service-exampleservice-b933688e1e6069bbfddb4a4cca03036b", :service-name "example-service", :backend-latency 7, :instance-port 10007, :method "GET", :cid "262abdb4df5cd6-246211cc3f4119", :total-latency 3019, :bytes-streamed 11, :discovery-latency 10, :instance-id "262abdb67cfb94-53d3497ab0b9bce8", :overhead-latency 3012, :instance-latency 3011, :host "example.com", :status 200, :instance-proto "http", :principal "sradack", :timestamp "2018-02-22T09:06:09.497-06:00", :scheme :http, :instance-host "127.0.0.5", :service-version "3", :metric-group "example-metric-group"}`
