### PR TITLE
Fix exception->response bug caused by shadowing ex-data

### DIFF
--- a/waiter/src/waiter/utils.clj
+++ b/waiter/src/waiter/utils.clj
@@ -275,13 +275,13 @@
   "Converts an exception into a ring response."
   [^Exception ex {:keys [] :as request}]
   (let [wrapped-ex (wrap-unhandled-exception ex)
-        {:keys [friendly-error-message message status] :as ex-data} (ex-data wrapped-ex)
+        {:keys [friendly-error-message message status] :as data} (ex-data wrapped-ex)
         message (or friendly-error-message message (.getMessage wrapped-ex))
         {:keys [headers suppress-logging]} (ex-data wrapped-ex)
         processed-headers (into {} (for [[k v] headers] [(name k) (str v)]))]
     (when-not suppress-logging
       (log/error wrapped-ex))
-    (-> {:details ex-data, :headers processed-headers, :message message, :status status}
+    (-> {:details data, :headers processed-headers, :message message, :status status}
         (data->error-response request))))
 
 (defmacro log-and-suppress-when-exception-thrown

--- a/waiter/src/waiter/utils.clj
+++ b/waiter/src/waiter/utils.clj
@@ -275,13 +275,12 @@
   "Converts an exception into a ring response."
   [^Exception ex {:keys [] :as request}]
   (let [wrapped-ex (wrap-unhandled-exception ex)
-        {:keys [friendly-error-message message status] :as data} (ex-data wrapped-ex)
-        message (or friendly-error-message message (.getMessage wrapped-ex))
-        {:keys [headers suppress-logging]} (ex-data wrapped-ex)
+        {:keys [friendly-error-message headers message status suppress-logging] :as data} (ex-data wrapped-ex)
+        response-msg (or friendly-error-message message (.getMessage wrapped-ex))
         processed-headers (into {} (for [[k v] headers] [(name k) (str v)]))]
     (when-not suppress-logging
       (log/error wrapped-ex))
-    (-> {:details data, :headers processed-headers, :message message, :status status}
+    (-> {:details data, :headers processed-headers, :message response-msg, :status status}
         (data->error-response request))))
 
 (defmacro log-and-suppress-when-exception-thrown

--- a/waiter/test/waiter/utils_test.clj
+++ b/waiter/test/waiter/utils_test.clj
@@ -166,6 +166,8 @@
                                json-response->str
                                json/read-str)))))
 
+(defrecord TestResponse [status friendly-error-message])
+
 (deftest test-exception->response
   (let [request {:request-method :get
                  :uri "/path"
@@ -173,7 +175,7 @@
     (testing "html response"
       (let [{:keys [body headers status]}
             (exception->response
-              (ex-info "TestCase Exception" {:status 400})
+              (ex-info "TestCase Exception" (map->TestResponse {:status 400}))
               (assoc-in request [:headers "accept"] "text/html"))]
         (is (= 400 status))
         (is (= {"content-type" "text/html"} headers))
@@ -181,8 +183,8 @@
     (testing "html response with links"
       (let [{:keys [body headers status]}
             (exception->response
-              (ex-info "TestCase Exception" {:status 400
-                                             :friendly-error-message "See http://localhost/path"})
+              (ex-info "TestCase Exception" (map->TestResponse {:status 400
+                                                                :friendly-error-message "See http://localhost/path"}))
               (assoc-in request [:headers "accept"] "text/html"))]
         (is (= 400 status))
         (is (= {"content-type" "text/html"} headers))
@@ -190,7 +192,7 @@
     (testing "plaintext response"
       (let [{:keys [body headers status]}
             (exception->response
-              (ex-info "TestCase Exception" {:status 400})
+              (ex-info "TestCase Exception" (map->TestResponse {:status 400}))
               (assoc-in request [:headers "accept"] "text/plain"))]
         (is (= 400 status))
         (is (= {"content-type" "text/plain"} headers))
@@ -198,7 +200,7 @@
     (testing "json response"
       (let [{:keys [body headers status]}
             (exception->response
-              (ex-info "TestCase Exception" {:status 500})
+              (ex-info "TestCase Exception" (map->TestResponse {:status 500}))
               (assoc-in request [:headers "accept"] "application/json"))]
         (is (= 500 status))
         (is (= {"content-type" "application/json"} headers))


### PR DESCRIPTION
## Changes proposed in this PR

Fix `exception->response` bug caused by shadowing the `ex-data` function in a local `let` binding.

## Why are we making these changes?

We were using `ex-data` to reference two unique things (one a local data structure, and one a core clojure function) in the `exception->response` utility function, which obviously doesn't work. Choosing a different name for the local binding for the response data structure fixes the problem.