### PR TITLE
ts: adds support for manual backup of tokens to file

### DIFF
--- a/token-syncer/src/token_syncer/main.clj
+++ b/token-syncer/src/token_syncer/main.clj
@@ -13,6 +13,7 @@
             [clojure.tools.logging :as log]
             [qbits.jet.client.http :as http]
             [token-syncer.cli :as cli]
+            [token-syncer.commands.backup :as backup]
             [token-syncer.commands.syncer :as syncer]
             [token-syncer.waiter :as waiter])
   (:import (org.eclipse.jetty.client HttpClient))
@@ -102,7 +103,8 @@
   (try
     (log/info "command-line arguments:" (vec args))
     (let [token-syncer-command-config (assoc base-command-config :command-name "token-syncer")
-          context {:sub-command->config {"sync-clusters" syncer/sync-clusters-config}}
+          context {:sub-command->config {"backup-tokens" backup/backup-tokens-config
+                                         "sync-clusters" syncer/sync-clusters-config}}
           {:keys [exit-code message]} (cli/process-command token-syncer-command-config context args)]
       (exit exit-code message))
     (catch Exception e

--- a/token-syncer/test/token_syncer/commands/backup_test.clj
+++ b/token-syncer/test/token_syncer/commands/backup_test.clj
@@ -1,0 +1,134 @@
+;;
+;;       Copyright (c) 2018 Two Sigma Investments, LP.
+;;       All Rights Reserved
+;;
+;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
+;;       Two Sigma Investments, LP.
+;;
+;;       The copyright notice above does not evidence any
+;;       actual or intended publication of such source code.
+;;
+(ns token-syncer.commands.backup-test
+  (:require [clojure.test :refer :all]
+            [token-syncer.cli :as cli]
+            [token-syncer.commands.backup :refer :all])
+  (:import (java.io File)))
+
+(defn- create-temp-file
+  "Creates a temporary file."
+  []
+  (File/createTempFile "temp-" ".json"))
+
+(defn- file->path
+  "Returns the absolute path of the file."
+  [^File file]
+  (.getAbsolutePath file))
+
+(defmacro with-temp-file
+  "Uses a temporary file for some content and deletes it immediately after running the body."
+  [bindings & body]
+  (cond
+    (and (= (count bindings) 2) (symbol? (bindings 0)))
+    `(let ~bindings
+       (try
+         ~@body
+         (finally
+           (.delete ~(bindings 0)))))
+    :else (throw (IllegalArgumentException.
+                   "with-temp-file requires a single Symbol in bindings"))))
+
+(deftest test-read-from-and-write-to-file
+  (with-temp-file
+    [my-temp-file (create-temp-file)]
+    (let [my-temp-file-path (file->path my-temp-file)
+          initial-content {"token-1" {"foo1" "bar", "hello" "world1"}
+                           "token-3" {"foo3" "bar", "hello" "world3"}
+                           "token-5" {"foo5" "bar", "hello" "world5"}}]
+      (write-to-file my-temp-file-path initial-content)
+      (is (= initial-content (read-from-file my-temp-file-path))))))
+
+(deftest test-backup
+  (let [test-cluster-url "http://www.test-cluster.com"
+        waiter-api {:load-token (fn [cluster-url token]
+                                  (is (= test-cluster-url cluster-url))
+                                  {:description {"cpus" 1, "mem" 1024, "name" token, "owner" "test-user"}
+                                   :token-etag (str "etag-" token)})
+                    :load-token-list (fn [cluster-url]
+                                       (is (= test-cluster-url cluster-url))
+                                       [{"token" "token-1"}
+                                        {"token" "token-2"}
+                                        {"token" "token-3"}])}
+        file-operations-api {:read-from-file read-from-file
+                             :write-to-file write-to-file}]
+
+    (testing "backup in accrete mode"
+      (with-temp-file
+        [my-temp-file (create-temp-file)]
+        (let [my-temp-file-path (file->path my-temp-file)
+              initial-content {"token-1" {"foo1" "bar", "hello" "world1"}
+                               "token-3" {"foo3" "bar", "hello" "world3"}
+                               "token-5" {"foo5" "bar", "hello" "world5"}
+                               "token-7" {"foo7" "bar", "hello" "world7"}}]
+          (write-to-file my-temp-file-path initial-content)
+
+          (backup-tokens waiter-api file-operations-api test-cluster-url my-temp-file-path true)
+
+          (is (= {"token-1" {"description" {"cpus" 1, "mem" 1024, "name" "token-1", "owner" "test-user"}
+                             "token-etag" "etag-token-1"}
+                  "token-2" {"description" {"cpus" 1, "mem" 1024, "name" "token-2", "owner" "test-user"}
+                             "token-etag" "etag-token-2"}
+                  "token-3" {"description" {"cpus" 1, "mem" 1024, "name" "token-3", "owner" "test-user"}
+                             "token-etag" "etag-token-3"}
+                  "token-5" {"foo5" "bar", "hello" "world5"}
+                  "token-7" {"foo7" "bar", "hello" "world7"}}
+                 (read-from-file my-temp-file-path))))))
+
+    (testing "backup without accrete mode"
+      (with-temp-file
+        [my-temp-file (create-temp-file)]
+        (let [my-temp-file-path (file->path my-temp-file)
+              initial-content {"token-1" {"foo1" "bar", "hello" "world1"}
+                               "token-3" {"foo3" "bar", "hello" "world3"}
+                               "token-5" {"foo5" "bar", "hello" "world5"}
+                               "token-7" {"foo7" "bar", "hello" "world7"}}]
+          (write-to-file my-temp-file-path initial-content)
+
+          (backup-tokens waiter-api file-operations-api test-cluster-url my-temp-file-path false)
+
+          (is (= {"token-1" {"description" {"cpus" 1, "mem" 1024, "name" "token-1", "owner" "test-user"}
+                             "token-etag" "etag-token-1"}
+                  "token-2" {"description" {"cpus" 1, "mem" 1024, "name" "token-2", "owner" "test-user"}
+                             "token-etag" "etag-token-2"}
+                  "token-3" {"description" {"cpus" 1, "mem" 1024, "name" "token-3", "owner" "test-user"}
+                             "token-etag" "etag-token-3"}}
+                 (read-from-file my-temp-file-path))))))))
+
+(deftest test-backup-tokens-config
+  (let [test-command-config (assoc backup-tokens-config :command-name "test-command")
+        waiter-api {:load-token (constantly {})
+                    :load-token-list (constantly {})}
+        context {:waiter-api waiter-api}
+        file-operations-api {:read-from-file (constantly {})
+                             :write-to-file (constantly {})}]
+    (with-redefs [init-file-operations-api (constantly file-operations-api)]
+      (let [args []]
+        (is (= {:exit-code 1
+                :message "test-command: expected 2 arguments FILE URL, provided 0: []"}
+               (cli/process-command test-command-config context args))))
+      (with-out-str
+        (let [args ["-h"]]
+          (is (= {:exit-code 0
+                  :message "test-command: displayed documentation"}
+                 (cli/process-command test-command-config context args)))))
+      (let [args ["some-file.txt" "http://cluster-1.com" "http://cluster-2.com"]]
+        (is (= {:exit-code 1
+                :message "test-command: expected 2 arguments FILE URL, provided 3: [\"some-file.txt\" \"http://cluster-1.com\" \"http://cluster-2.com\"]"}
+               (cli/process-command test-command-config context args))))
+      (let [args ["some-file.txt" "http://cluster-1.com"]]
+        (with-redefs [backup-tokens (fn [in-waiter-api in-file-operations-api cluster-url file accrete]
+                                      (is (= waiter-api in-waiter-api))
+                                      (is (= file-operations-api in-file-operations-api))
+                                      (println "backup-tokens:" cluster-url file accrete))]
+          (is (= {:exit-code 0
+                  :message "test-command: exiting with code 0"}
+                 (cli/process-command test-command-config context args))))))))

--- a/token-syncer/test/token_syncer/main_test.clj
+++ b/token-syncer/test/token_syncer/main_test.clj
@@ -37,8 +37,9 @@
 
 (deftest test-base-command-config
   (let [test-sub-command-config {:execute-command (fn execute-base-command
-                                                    [_ {:keys [options]} arguments]
+                                                    [context {:keys [options]} arguments]
                                                     {:arguments arguments
+                                                     :context context
                                                      :options options
                                                      :exit-code 0})
                                  :option-specs [["-a" "--activate" "For test only, activate"]]
@@ -51,9 +52,11 @@
         (is (= {:exit-code 0
                 :message "test-command: test-sub-command: displayed documentation"}
                (cli/process-command test-command-config context args)))))
-    (let [args ["-d" "test-sub-command" "-a"]]
+    (let [args ["-d" "test-sub-command" "-a"]
+          result (cli/process-command test-command-config context args)]
       (is (= {:arguments []
               :exit-code 0
               :message "test-command: test-sub-command: exiting"
               :options {:activate true}}
-             (cli/process-command test-command-config context args))))))
+             (dissoc result :context)))
+      (is (every? #(contains? (:context result) %) [:options :sub-command->config :waiter-api])))))


### PR DESCRIPTION
## Changes proposed in this PR

- support for backup of tokens on a cluster to a file

## Why are we making these changes?

It allows us to maintain a manual backup of all tokens on a specific cluster.

## Example output 

```
$ lein run -- -a -b data.json http://localhost:9091
2018-03-05 14:43:24 INFO  token-syncer.main - command-line arguments: [-a -b data.json http://localhost:9091]
2018-03-05 14:43:24 INFO  eclipse.jetty.util.log - Logging initialized @7303ms to org.eclipse.jetty.util.log.Slf4jLog
2018-03-05 14:43:24 INFO  token-syncer.main - backing up tokens to data.json in accretion mode 
2018-03-05 14:43:24 INFO  token-syncer.backup - reading contents from data.json
2018-03-05 14:43:24 INFO  token-syncer.backup - found 2 tokens in data.json : (token0AAA.testtokencreatedeleteshamsimam689423.127.0.0.1 token1.testtokencreatedeleteshamsimam689423.127.0.0.1)
2018-03-05 14:43:24 INFO  token-syncer.waiter - token-syncer.101bed2f-25bc-4a67-ade1-16c155a17732 making GET request to http://localhost:9091/tokens
2018-03-05 14:43:25 INFO  token-syncer.backup - found 10 tokens on http://localhost:9091 : #{token0.testtokencreatedeleteshamsimam689423.127.0.0.1 token1.testtokencreatedeleteshamsimam689423.127.0.0.1 token2.testtokencreatedeleteshamsimam689423.127.0.0.1 token3.testtokencreatedeleteshamsimam689423.127.0.0.1 token4.testtokencreatedeleteshamsimam689423.127.0.0.1 token5.testtokencreatedeleteshamsimam689423.127.0.0.1 tok
en6.testtokencreatedeleteshamsimam689423.127.0.0.1 token7.testtokencreatedeleteshamsimam689423.127.0.0.1 token8.testtokencreatedeleteshamsimam689423.127.0.0.1 token9.testtokencreatedeleteshamsimam689423.127.0.0.1}
2018-03-05 14:43:25 INFO  token-syncer.waiter - token-syncer.c188ddf6-91f5-4fb2-97f1-695a1ec97897 making GET request to http://localhost:9091/token
2018-03-05 14:43:25 INFO  token-syncer.waiter - loading token0.testtokencreatedeleteshamsimam689423.127.0.0.1 on http://localhost:9091 responded with status 200 {content-type application/json, etag E-c4baf3b3e3f5af1cc19d344c2993339f, x-cid token-syncer.53e7ff81-b734-4baf-8bd0-59e263f1c038}
...
2018-03-05 14:43:25 INFO  token-syncer.waiter - token-syncer.290fdca2-9581-4755-8086-e0d70c12445f making GET request to http://localhost:9091/token
2018-03-05 14:43:25 INFO  token-syncer.waiter - loading token9.testtokencreatedeleteshamsimam689423.127.0.0.1 on http://localhost:9091 responded with status 200 {content-type application/json, etag E-ff589dd48e1b021d0a484e3b0e4416b2, x-cid token-syncer.d7dd2663-9c60-4bd1-ae1b-8e26840d51f4}
2018-03-05 14:43:25 INFO  token-syncer.backup - writing 11 tokens to data.json : (token0.testtokencreatedeleteshamsimam689423.127.0.0.1 token0AAA.testtokencreatedeleteshamsimam689423.127.0.0.1 token1.testtokencreatedeleteshamsimam689423.127.0.0.1 token2.testtokencreatedeleteshamsimam689423.127.0.0.1 token3.testtokencreatedeleteshamsimam689423.127.0.0.1 token4.testtokencreatedeleteshamsimam689423.127.0.0.1 token5.test
tokencreatedeleteshamsimam689423.127.0.0.1 token6.testtokencreatedeleteshamsimam689423.127.0.0.1 token7.testtokencreatedeleteshamsimam689423.127.0.0.1 token8.testtokencreatedeleteshamsimam689423.127.0.0.1 token9.testtokencreatedeleteshamsimam689423.127.0.0.1)
2018-03-05 14:43:25 INFO  token-syncer.main - exiting with code 0
```

