### PR TITLE
ts: adds support for limits on the number of pending tokens processed…

### DIFF
--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -83,12 +83,13 @@
                                                                     :token-etag token-etag}
                                                            :sync-result (pc/map-from-keys waiter-sync-result waiter-urls)}}
                                      :summary {:sync {:failed #{}
-                                                      :previously-synced #{}
                                                       :unmodified #{}
                                                       :updated #{token-name}}
-                                               :tokens {:num-previously-synced 0
-                                                        :num-processed 1
-                                                        :total 1}}}]
+                                               :tokens {:pending {:count 1 :value #{token-name}}
+                                                        :previously-synced {:count 0 :value #{}}
+                                                        :processed {:count 1 :value #{token-name}}
+                                                        :selected {:count 1 :value #{token-name}}
+                                                        :total {:count 1 :value #{token-name}}}}}]
                 (is (= expected-result actual-result))
                 (doseq [waiter-url waiter-urls]
                   (let [response (load-token waiter-url token-name)]
@@ -129,12 +130,13 @@
                                                                     :token-etag token-etag}
                                                            :sync-result (pc/map-from-keys waiter-sync-result (rest waiter-urls))}}
                                      :summary {:sync {:failed #{}
-                                                      :previously-synced #{}
                                                       :unmodified #{}
                                                       :updated #{token-name}}
-                                               :tokens {:num-previously-synced 0
-                                                        :num-processed 1
-                                                        :total 1}}}]
+                                               :tokens {:pending {:count 1 :value #{token-name}}
+                                                        :previously-synced {:count 0 :value #{}}
+                                                        :processed {:count 1 :value #{token-name}}
+                                                        :selected {:count 1 :value #{token-name}}
+                                                        :total {:count 1 :value #{token-name}}}}}]
                 (is (= expected-result actual-result))
                 (doseq [waiter-url waiter-urls]
                   (is (= {:description (assoc token-description "deleted" true)
@@ -175,12 +177,13 @@
                                                                     :token-etag token-etag}
                                                            :sync-result (pc/map-from-keys waiter-sync-result (rest waiter-urls))}}
                                      :summary {:sync {:failed #{}
-                                                      :previously-synced #{}
                                                       :unmodified #{}
                                                       :updated #{token-name}}
-                                               :tokens {:num-previously-synced 0
-                                                        :num-processed 1
-                                                        :total 1}}}]
+                                               :tokens {:pending {:count 1 :value #{token-name}}
+                                                        :previously-synced {:count 0 :value #{}}
+                                                        :processed {:count 1 :value #{token-name}}
+                                                        :selected {:count 1 :value #{token-name}}
+                                                        :total {:count 1 :value #{token-name}}}}}]
                 (is (= expected-result actual-result))
                 (doseq [waiter-url waiter-urls]
                   (is (= {:description token-description
@@ -215,12 +218,13 @@
               ;; ASSERT
               (let [expected-result {:details {}
                                      :summary {:sync {:failed #{}
-                                                      :previously-synced #{token-name}
                                                       :unmodified #{}
                                                       :updated #{}}
-                                               :tokens {:num-previously-synced 1
-                                                        :num-processed 0
-                                                        :total 1}}}]
+                                               :tokens {:pending {:count 0 :value #{}}
+                                                        :previously-synced {:count 1 :value #{token-name}}
+                                                        :processed {:count 0 :value #{}}
+                                                        :selected {:count 0 :value #{}}
+                                                        :total {:count 1 :value #{token-name}}}}}]
                 (is (= expected-result actual-result))
                 (doseq [waiter-url waiter-urls]
                   (is (= {:description token-description
@@ -265,12 +269,13 @@
                                                                     :token-etag token-etag}
                                                            :sync-result (pc/map-from-keys waiter-sync-result (rest waiter-urls))}}
                                      :summary {:sync {:failed #{}
-                                                      :previously-synced #{}
                                                       :unmodified #{}
                                                       :updated #{token-name}}
-                                               :tokens {:num-previously-synced 0
-                                                        :num-processed 1
-                                                        :total 1}}}]
+                                               :tokens {:pending {:count 1 :value #{token-name}}
+                                                        :previously-synced {:count 0 :value #{}}
+                                                        :processed {:count 1 :value #{token-name}}
+                                                        :selected {:count 1 :value #{token-name}}
+                                                        :total {:count 1 :value #{token-name}}}}}]
                 (is (= expected-result actual-result))
                 (doseq [waiter-url waiter-urls]
                   (is (= {:description token-description
@@ -324,12 +329,13 @@
                                                                     :token-etag token-etag}
                                                            :sync-result (pc/map-from-keys waiter-sync-result (rest waiter-urls))}}
                                      :summary {:sync {:failed #{}
-                                                      :previously-synced #{}
                                                       :unmodified #{}
                                                       :updated #{token-name}}
-                                               :tokens {:num-previously-synced 0
-                                                        :num-processed 1
-                                                        :total 1}}}]
+                                               :tokens {:pending {:count 1 :value #{token-name}}
+                                                        :previously-synced {:count 0 :value #{}}
+                                                        :processed {:count 1 :value #{token-name}}
+                                                        :selected {:count 1 :value #{token-name}}
+                                                        :total {:count 1 :value #{token-name}}}}}]
                 (is (= expected-result actual-result))
                 (doseq [waiter-url waiter-urls]
                   (is (= {:description latest-description
@@ -391,12 +397,13 @@
                                                                     :token-etag token-etag}
                                                            :sync-result sync-result}}
                                      :summary {:sync {:failed #{token-name}
-                                                      :previously-synced #{}
                                                       :unmodified #{}
                                                       :updated #{}}
-                                               :tokens {:num-previously-synced 0
-                                                        :num-processed 1
-                                                        :total 1}}}]
+                                               :tokens {:pending {:count 1 :value #{token-name}}
+                                                        :previously-synced {:count 0 :value #{}}
+                                                        :processed {:count 1 :value #{token-name}}
+                                                        :selected {:count 1 :value #{token-name}}
+                                                        :total {:count 1 :value #{token-name}}}}}]
                 (is (= expected-result actual-result))
                 (doall
                   (map-indexed

--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -56,9 +56,10 @@
   (testing "token sync hard-delete"
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
+          limit nil
           token-name (str "test-token-hard-delete-" (UUID/randomUUID))]
       (try
-         ;; ARRANGE
+        ;; ARRANGE
         (let [last-update-time-ms (- (System/currentTimeMillis) 10000)
               token-metadata {"deleted" true, "last-update-time" last-update-time-ms, "owner" "test-user", "root" "src1"}
               token-description (merge basic-description token-metadata)]
@@ -70,7 +71,7 @@
           (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
 
             ;; ACT
-            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls)]
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit)]
 
               ;; ASSERT
               (let [waiter-sync-result (constantly
@@ -99,9 +100,10 @@
   (testing "token sync soft-delete"
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
+          limit nil
           token-name (str "test-token-soft-delete-" (UUID/randomUUID))]
       (try
-         ;; ARRANGE
+        ;; ARRANGE
         (let [current-time-ms (System/currentTimeMillis)
               token-metadata {"last-update-time" current-time-ms, "owner" "test-user", "root" "src1"}
               token-description (merge basic-description token-metadata)]
@@ -114,10 +116,10 @@
 
           (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
 
-             ;; ACT
-            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls)]
+            ;; ACT
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit)]
 
-               ;; ASSERT
+              ;; ASSERT
               (let [waiter-sync-result (constantly
                                          {:code :success/soft-delete
                                           :details {:etag token-etag
@@ -148,9 +150,10 @@
   (testing "token exists on single cluster"
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
+          limit nil
           token-name (str "test-token-token-on-single-cluster-" (UUID/randomUUID))]
       (try
-         ;; ARRANGE
+        ;; ARRANGE
         (let [current-time-ms (System/currentTimeMillis)
               token-metadata {"last-update-time" current-time-ms, "owner" "test-user", "root" "src1"}
               token-description (merge basic-description token-metadata)]
@@ -159,10 +162,10 @@
 
           (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
 
-             ;; ACT
-            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls)]
+            ;; ACT
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit)]
 
-               ;; ASSERT
+              ;; ASSERT
               (let [waiter-sync-result (constantly
                                          {:code :success/sync-update
                                           :details {:etag token-etag
@@ -193,9 +196,10 @@
   (testing "token already synced"
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
+          limit nil
           token-name (str "test-token-already-synced-" (UUID/randomUUID))]
       (try
-         ;; ARRANGE
+        ;; ARRANGE
         (let [current-time-ms (System/currentTimeMillis)
               token-metadata {"last-update-time" current-time-ms, "owner" "test-user", "root" "src1"}
               token-description (merge basic-description token-metadata)]
@@ -205,10 +209,10 @@
 
           (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
 
-             ;; ACT
-            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls)]
+            ;; ACT
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit)]
 
-               ;; ASSERT
+              ;; ASSERT
               (let [expected-result {:details {}
                                      :summary {:sync {:failed #{}
                                                       :previously-synced #{token-name}
@@ -232,9 +236,10 @@
   (testing "token sync update"
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
+          limit nil
           token-name (str "test-token-update-" (UUID/randomUUID))]
       (try
-         ;; ARRANGE
+        ;; ARRANGE
         (let [current-time-ms (System/currentTimeMillis)
               token-metadata {"last-update-time" current-time-ms, "owner" "test-user", "root" "src1"}
               token-description (merge basic-description token-metadata)]
@@ -247,10 +252,10 @@
 
           (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
 
-             ;; ACT
-            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls)]
+            ;; ACT
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit)]
 
-               ;; ASSERT
+              ;; ASSERT
               (let [waiter-sync-result (constantly
                                          {:code :success/sync-update
                                           :details {:etag token-etag
@@ -281,9 +286,10 @@
   (testing "token sync update with different owners but same root"
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
+          limit nil
           token-name (str "test-token-different-owners-but-same-root-" (UUID/randomUUID))]
       (try
-         ;; ARRANGE
+        ;; ARRANGE
         (let [current-time-ms (System/currentTimeMillis)
               last-update-time-ms (- current-time-ms 10000)]
 
@@ -300,10 +306,10 @@
 
           (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
 
-             ;; ACT
-            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls)]
+            ;; ACT
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit)]
 
-               ;; ASSERT
+              ;; ASSERT
               (let [latest-description (assoc basic-description
                                          "cpus" 1
                                          "last-update-time" last-update-time-ms
@@ -339,9 +345,10 @@
   (testing "token sync update with different owners and different roots"
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
+          limit nil
           token-name (str "test-token-different-roots-" (UUID/randomUUID))]
       (try
-         ;; ARRANGE
+        ;; ARRANGE
         (let [current-time-ms (System/currentTimeMillis)
               last-update-time-ms (- current-time-ms 10000)]
 
@@ -358,10 +365,10 @@
 
           (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
 
-             ;; ACT
-            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls)]
+            ;; ACT
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit)]
 
-               ;; ASSERT
+              ;; ASSERT
               (let [latest-description (assoc basic-description
                                          "cpus" 1
                                          "last-update-time" last-update-time-ms

--- a/token-syncer/src/token_syncer/main.clj
+++ b/token-syncer/src/token_syncer/main.clj
@@ -44,6 +44,9 @@
          :default 30000
          :parse-fn #(Integer/parseInt %)
          :validate [#(< 0 % 300001) "Must be between 0 and 300000"]]
+        ["-l" "--limit limit" "The maximum number of tokens to attempt to sync"
+         :parse-fn #(Integer/parseInt %)
+         :validate [#(< 0 % 10001) "Must be between 0 and 10000"]]
         ["-t" "--connection-timeout-ms timeout" "The connection timeout in milliseconds"
          :default 1000
          :parse-fn #(Integer/parseInt %)
@@ -82,7 +85,7 @@
   (setup-exception-handler)
   (log/info "command-line arguments:" (vec args))
   (let [{:keys [arguments errors options summary]} (parse-cli-options args)
-        {:keys [help]} options
+        {:keys [help limit]} options
         cluster-urls arguments]
     (try
       (cond
@@ -105,7 +108,7 @@
             (log/info "executing token syncer in dry-run mode"))
           (let [waiter-api (init-waiter-api options)
                 cluster-urls-set (set cluster-urls)
-                sync-result (syncer/sync-tokens waiter-api cluster-urls-set)
+                sync-result (syncer/sync-tokens waiter-api cluster-urls-set limit)
                 exit-code (-> (get-in sync-result [:summary :sync :error] 0)
                               zero?
                               (if 0 1))]

--- a/token-syncer/test/token_syncer/main_test.clj
+++ b/token-syncer/test/token_syncer/main_test.clj
@@ -25,6 +25,8 @@
          (:options (parse-cli-options ["-h"]))))
   (is (= {:connection-timeout-ms 1000, :idle-timeout-ms 10000}
          (:options (parse-cli-options ["-i" "10000"]))))
+  (is (= {:connection-timeout-ms 1000, :idle-timeout-ms 30000, :limit 100}
+         (:options (parse-cli-options ["-l" "100"]))))
   (is (= {:connection-timeout-ms 10000, :idle-timeout-ms 30000}
          (:options (parse-cli-options ["-t" "10000"]))))
   (is (= {:connection-timeout-ms 10000, :idle-timeout-ms 20000}

--- a/token-syncer/test/token_syncer/syncer_test.clj
+++ b/token-syncer/test/token_syncer/syncer_test.clj
@@ -525,4 +525,4 @@
                         :tokens {:num-previously-synced 1
                                  :num-processed 3
                                  :total 4}}}
-             (sync-tokens waiter-api cluster-urls))))))
+             (sync-tokens waiter-api cluster-urls (inc (count token->latest-description))))))))


### PR DESCRIPTION
… while performing syncs across clusters

## Changes proposed in this PR

- adds support for the limit flag to control how many tokens are synced

## Why are we making these changes?

Allows us to limit the run time of individual invocations of the syncer by reducing the work done in each iteration

## Example output
```
$ lein run -- -l 2 http://localhost:9091 http://localhost:9093
2018-03-05 16:12:31 INFO  token-syncer.main - command-line arguments: [-l 2 http://localhost:9091 http://localhost:9093]
...
2018-03-05 16:12:32 INFO  token-syncer.syncer - completed syncing tokens limited to 2
2018-03-05 16:12:32 INFO  token-syncer.main - {:details
 {"token4.testtokencreatedeleteshamsimam689423.127.0.0.1"
  {:latest
   {:cluster-url "http://localhost:9091",
    :description
    {"health-check-url" "/probe",
     "name" "testtokencreatedeleteshamsimam689423",
     "owner" "shamsimam",
     "root" "c9091",
     "last-update-time" 1520277418718},
    :token-etag "E-ff412676f66acb7eeee8001a1b5cd0bd"},
   :sync-result
   {"http://localhost:9093"
    {:code :success/sync-update,
     :details
     {:status 200, :etag "E-ff412676f66acb7eeee8001a1b5cd0bd"}}}},
  "token5.testtokencreatedeleteshamsimam689423.127.0.0.1"
  {:latest
   {:cluster-url "http://localhost:9091",
    :description
    {"health-check-url" "/probe",
     "name" "testtokencreatedeleteshamsimam689423",
     "owner" "shamsimam",
     "root" "c9091",
     "last-update-time" 1520277418749},
    :token-etag "E-32393a28a3a6a0f9fcb86b514260c71c"},
   :sync-result
   {"http://localhost:9093"
    {:code :success/sync-update,
     :details
     {:status 200, :etag "E-32393a28a3a6a0f9fcb86b514260c71c"}}}}},
 :summary
 {:sync
  {:failed #{},
   :previously-synced
   #{"token1.testtokencreatedeleteshamsimam689423.127.0.0.1"
     "token2.testtokencreatedeleteshamsimam689423.127.0.0.1"
     "token3.testtokencreatedeleteshamsimam689423.127.0.0.1"
     "token0.testtokencreatedeleteshamsimam689423.127.0.0.1"},
   :unmodified #{},
   :updated
   #{"token4.testtokencreatedeleteshamsimam689423.127.0.0.1"
     "token5.testtokencreatedeleteshamsimam689423.127.0.0.1"}},
  :tokens {:num-previously-synced 4, :num-processed 2, :total 10}}}
2018-03-05 16:12:32 INFO  token-syncer.main - exiting with code 0

```
