### PR TITLE
ts: adds support for sub-commands in the token syncer

### DIFF
--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -56,7 +56,7 @@
   (testing "token sync hard-delete"
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
-          limit nil
+          limit 10
           token-name (str "test-token-hard-delete-" (UUID/randomUUID))]
       (try
         ;; ARRANGE
@@ -101,7 +101,7 @@
   (testing "token sync soft-delete"
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
-          limit nil
+          limit 10
           token-name (str "test-token-soft-delete-" (UUID/randomUUID))]
       (try
         ;; ARRANGE
@@ -152,7 +152,7 @@
   (testing "token exists on single cluster"
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
-          limit nil
+          limit 10
           token-name (str "test-token-token-on-single-cluster-" (UUID/randomUUID))]
       (try
         ;; ARRANGE
@@ -199,7 +199,7 @@
   (testing "token already synced"
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
-          limit nil
+          limit 10
           token-name (str "test-token-already-synced-" (UUID/randomUUID))]
       (try
         ;; ARRANGE
@@ -240,7 +240,7 @@
   (testing "token sync update"
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
-          limit nil
+          limit 10
           token-name (str "test-token-update-" (UUID/randomUUID))]
       (try
         ;; ARRANGE
@@ -291,7 +291,7 @@
   (testing "token sync update with different owners but same root"
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
-          limit nil
+          limit 10
           token-name (str "test-token-different-owners-but-same-root-" (UUID/randomUUID))]
       (try
         ;; ARRANGE
@@ -351,7 +351,7 @@
   (testing "token sync update with different owners and different roots"
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
-          limit nil
+          limit 10
           token-name (str "test-token-different-roots-" (UUID/randomUUID))]
       (try
         ;; ARRANGE

--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -13,8 +13,8 @@
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [plumbing.core :as pc]
-            [token-syncer.main :as main]
-            [token-syncer.syncer :as syncer])
+            [token-syncer.commands.syncer :as syncer]
+            [token-syncer.main :as main])
   (:import (java.util UUID)))
 
 (def basic-description {"cmd" "echo 'Hello World'", "cpus" 1, "mem" 2048, "metric-group" "syncer-test"})

--- a/token-syncer/src/token_syncer/cli.clj
+++ b/token-syncer/src/token_syncer/cli.clj
@@ -33,46 +33,49 @@
    guaranteed to contain the following keys: exit-code and message.
 
    `config-map` is a map with the following keys:
-     `build-context`: (fn [context options-map])
-                        where `context` is the same as `parent-context` and
-                              `options-map` is the result of the call to `clojure.tools.cli/parse-opts`.
-     `command-name`: The name of the command that is being run.
-     `execute-command`: (fn [context arguments] ...)
-                          where `context` is the result of the call to `build-context` and
-                                `arguments` is a list of unprocessed arguments (e.g. non-options from `args`).
-     `option-specs`: Option specifications as defined in `clojure.tools.cli/parse-opts`.
-                     The help option (-h and --help) are always added while executing any command, hence these
-                     options are reserved for use in the option specs.
-     `retrieve-documentation`: (fn [command-name parent-context summary] ...)
-                                 where `command-name` is the name of the command,
-                                       `parent-context` is a map that specifies the context, and
-                                       `summary` is a string containing a minimal options summary.
+     `:command-name`: The name of the command that is being run.
+     `:execute-command`: (fn [context options-map arguments] ...)
+                           where `context` is the same as `parent-context`,
+                                 `options-map` is the result of the call to `clojure.tools.cli/parse-opts`, and
+                                 `arguments` is a list of unprocessed arguments (e.g. non-options from `args`).
+     `:option-specs`: Option specifications as defined in `clojure.tools.cli/parse-opts`.
+                      The help option (-h and --help) are always added while executing any command, hence these
+                      options are reserved for use in the option specs.
+     `:retrieve-documentation`: (fn [command-name parent-context summary] ...)
+                                  where `command-name` is the name of the command,
+                                        `parent-context` is a map that specifies the context, and
+                                        `summary` is a string containing a minimal options summary.
+                                  It should return a map containing the keys :description and :usage.
    `parent-context` is a map that specifies the context in which the command is running.
    `args` is the arguments passed to the command (including any options)."
   [config-map parent-context args]
-  (let [{:keys [build-context command-name execute-command option-specs retrieve-documentation]} config-map
+  (let [{:keys [command-name execute-command option-specs retrieve-documentation]} config-map
         option-specs' (conj option-specs ["-h" "--help" "Displays this message"])
         options-map (tools-cli/parse-opts args option-specs' :in-order true)
         {:keys [arguments errors options summary]} options-map
         {:keys [help]} options]
     (cond
       help
-      (do
-        (.println System/out (retrieve-documentation command-name parent-context summary))
+      (let [{:keys [description usage]} (retrieve-documentation command-name parent-context)
+            doc-string (str "Name: " command-name \newline
+                            (when usage (str "Usage: " usage \newline))
+                            (when description (str "Description: " description \newline))
+                            "Options:" \newline summary)]
+        (println doc-string)
         {:exit-code 0
          :message (str command-name ": displayed documentation")})
 
       (seq errors)
       (do
         (log/error "error in parsing commands for" command-name errors)
-        (.println System/err (str "error in parsing commands for " command-name ":"))
-        (doseq [error-message errors]
-          (.println System/err error-message))
+        (binding [*out* *err*]
+          (println (str "error in parsing commands for " command-name ":"))
+          (doseq [error-message errors]
+            (println error-message)))
         {:data errors
          :exit-code 1
          :message (str command-name ": error in parsing arguments")})
 
       :else
-      (-> (build-context parent-context options-map)
-          (execute-command arguments)
+      (-> (execute-command parent-context options-map arguments)
           (sanitize-result command-name)))))

--- a/token-syncer/src/token_syncer/cli.clj
+++ b/token-syncer/src/token_syncer/cli.clj
@@ -1,0 +1,78 @@
+;;
+;;       Copyright (c) 2018 Two Sigma Investments, LP.
+;;       All Rights Reserved
+;;
+;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
+;;       Two Sigma Investments, LP.
+;;
+;;       The copyright notice above does not evidence any
+;;       actual or intended publication of such source code.
+;;
+(ns token-syncer.cli
+  (:require [clojure.tools.cli :as tools-cli]
+            [clojure.tools.logging :as log]))
+
+(defn- sanitize-result
+  "Sanitizes the result map to include entries for exit-code and message."
+  [result command-name]
+  (-> result
+      (update :exit-code (fn [exit-code]
+                           (cond
+                             (nil? exit-code)
+                             (do
+                               (log/info command-name "exit code is defaulting to 0")
+                               0)
+                             :else exit-code)))
+      (update :message (fn [message]
+                         (as-> message m
+                               (or m "exiting")
+                               (str command-name ": " m))))))
+
+(defn process-command
+  "Processes a command line option using the specified configuration in `config-map` and returns a map that is
+   guaranteed to contain the following keys: exit-code and message.
+
+   `config-map` is a map with the following keys:
+     `build-context`: (fn [context options-map])
+                        where `context` is the same as `parent-context` and
+                              `options-map` is the result of the call to `clojure.tools.cli/parse-opts`.
+     `command-name`: The name of the command that is being run.
+     `execute-command`: (fn [context arguments] ...)
+                          where `context` is the result of the call to `build-context` and
+                                `arguments` is a list of unprocessed arguments (e.g. non-options from `args`).
+     `option-specs`: Option specifications as defined in `clojure.tools.cli/parse-opts`.
+                     The help option (-h and --help) are always added while executing any command, hence these
+                     options are reserved for use in the option specs.
+     `retrieve-documentation`: (fn [command-name parent-context summary] ...)
+                                 where `command-name` is the name of the command,
+                                       `parent-context` is a map that specifies the context, and
+                                       `summary` is a string containing a minimal options summary.
+   `parent-context` is a map that specifies the context in which the command is running.
+   `args` is the arguments passed to the command (including any options)."
+  [config-map parent-context args]
+  (let [{:keys [build-context command-name execute-command option-specs retrieve-documentation]} config-map
+        option-specs' (conj option-specs ["-h" "--help" "Displays this message"])
+        options-map (tools-cli/parse-opts args option-specs' :in-order true)
+        {:keys [arguments errors options summary]} options-map
+        {:keys [help]} options]
+    (cond
+      help
+      (do
+        (.println System/out (retrieve-documentation command-name parent-context summary))
+        {:exit-code 0
+         :message (str command-name ": displayed documentation")})
+
+      (seq errors)
+      (do
+        (log/error "error in parsing commands for" command-name errors)
+        (.println System/err (str "error in parsing commands for " command-name ":"))
+        (doseq [error-message errors]
+          (.println System/err error-message))
+        {:data errors
+         :exit-code 1
+         :message (str command-name ": error in parsing arguments")})
+
+      :else
+      (-> (build-context parent-context options-map)
+          (execute-command arguments)
+          (sanitize-result command-name)))))

--- a/token-syncer/src/token_syncer/commands/syncer.clj
+++ b/token-syncer/src/token_syncer/commands/syncer.clj
@@ -237,14 +237,9 @@
       (throw th))))
 
 (def sync-clusters-config
-  {:build-context (fn build-sync-clusters-context
-                    [parent-context {:keys [options]}]
-                    {:context parent-context
-                     :options options})
-   :execute-command (fn execute-sync-clusters-command
-                      [{:keys [context options]} arguments]
-                      (let [{:keys [waiter-api]} context
-                            {:keys [limit]} options
+  {:execute-command (fn execute-sync-clusters-command
+                      [{:keys [waiter-api]} {:keys [options]} arguments]
+                      (let [{:keys [limit]} options
                             cluster-urls-set (set arguments)]
                         (cond
                           (<= (-> cluster-urls-set set count) 1)
@@ -264,9 +259,6 @@
                    :parse-fn #(Integer/parseInt %)
                    :validate [#(< 0 % 10001) "Must be between 1 and 10000"]]]
    :retrieve-documentation (fn retrieve-sync-clusters-documentation
-                             [command-name _ summary]
-                             (str "Name: " command-name " - performs token syncing across Waiter clusters" \newline
-                                  "Usage: " command-name " [OPTION]... URL URL..." \newline
-                                  "Description: syncs tokens among (at least two) Waiter clusters in the URL(s)." \newline
-                                  "Options:" \newline
-                                  summary \newline))})
+                             [command-name _]
+                             {:description (str "Syncs tokens across (at least two) Waiter clusters specified in the URL(s)")
+                              :usage (str command-name " [OPTION]... URL URL...")})})

--- a/token-syncer/src/token_syncer/commands/syncer.clj
+++ b/token-syncer/src/token_syncer/commands/syncer.clj
@@ -8,8 +8,10 @@
 ;;       The copyright notice above does not evidence any
 ;;       actual or intended publication of such source code.
 ;;
-(ns token-syncer.syncer
-  (:require [clojure.set :as set]
+(ns token-syncer.commands.syncer
+  (:require [clojure.pprint :as pp]
+            [clojure.set :as set]
+            [clojure.string :as str]
             [clojure.tools.logging :as log]
             [plumbing.core :as pc]
             [token-syncer.utils :as utils]))
@@ -220,13 +222,10 @@
     (log/info "syncing tokens on clusters:" cluster-urls)
     (let [cluster-urls-set (set cluster-urls)
           {:keys [all-tokens pending-tokens synced-tokens]} (load-and-classify-tokens load-token-list cluster-urls-set)
-          use-limited-tokens? (and (integer? limit) (pos? limit))
-          selected-tokens (cond->> (sort pending-tokens)
-                                   use-limited-tokens? (take limit))
+          selected-tokens (->> (sort pending-tokens)
+                               (take limit))
           token-sync-result (perform-token-syncs waiter-api cluster-urls-set selected-tokens)]
-      (log/info "completed syncing tokens"
-                (str (when use-limited-tokens?
-                       (str "limited to " (min limit (count pending-tokens))))))
+      (log/info "completed syncing tokens (limited to " (min limit (count pending-tokens)) "tokens)")
       {:details token-sync-result
        :summary (-> {:all-tokens all-tokens
                      :already-synced-tokens synced-tokens
@@ -236,3 +235,38 @@
     (catch Throwable th
       (log/error th "unable to sync tokens")
       (throw th))))
+
+(def sync-clusters-config
+  {:build-context (fn build-sync-clusters-context
+                    [parent-context {:keys [options]}]
+                    {:context parent-context
+                     :options options})
+   :execute-command (fn execute-sync-clusters-command
+                      [{:keys [context options]} arguments]
+                      (let [{:keys [waiter-api]} context
+                            {:keys [limit]} options
+                            cluster-urls-set (set arguments)]
+                        (cond
+                          (<= (-> cluster-urls-set set count) 1)
+                          {:exit-code 1
+                           :message (str "at least two different cluster urls required, provided: " (vec arguments))}
+
+                          :else
+                          (let [sync-result (sync-tokens waiter-api cluster-urls-set limit)
+                                exit-code (-> (get-in sync-result [:summary :sync :error] 0)
+                                              zero?
+                                              (if 0 1))]
+                            (log/info (-> sync-result pp/pprint with-out-str str/trim))
+                            {:exit-code exit-code
+                             :message (str "exiting with code " exit-code)}))))
+   :option-specs [["-l" "--limit LIMIT" "The maximum number of tokens to attempt to sync, must be between 1 and 10000"
+                   :default 1000
+                   :parse-fn #(Integer/parseInt %)
+                   :validate [#(< 0 % 10001) "Must be between 1 and 10000"]]]
+   :retrieve-documentation (fn retrieve-sync-clusters-documentation
+                             [command-name _ summary]
+                             (str "Name: " command-name " - performs token syncing across Waiter clusters" \newline
+                                  "Usage: " command-name " [OPTION]... URL URL..." \newline
+                                  "Description: syncs tokens among (at least two) Waiter clusters in the URL(s)." \newline
+                                  "Options:" \newline
+                                  summary \newline))})

--- a/token-syncer/test/token_syncer/cli_test.clj
+++ b/token-syncer/test/token_syncer/cli_test.clj
@@ -1,0 +1,47 @@
+;;
+;;       Copyright (c) 2018 Two Sigma Investments, LP.
+;;       All Rights Reserved
+;;
+;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
+;;       Two Sigma Investments, LP.
+;;
+;;       The copyright notice above does not evidence any
+;;       actual or intended publication of such source code.
+;;
+(ns token-syncer.cli-test
+  (:require [clojure.test :refer :all]
+            [token-syncer.cli :refer :all]))
+
+(deftest test-process-command
+  (let [build-context (fn [parent-context {:keys [options]}]
+                        (assoc parent-context :options options))
+        command-name "test-command"
+        execute-command (fn [context arguments]
+                          {:data {:arguments arguments
+                                  :context context}
+                           :exit-code 0})
+        option-specs [["-a" "--activate" "For test only, configures the activate flag"]
+                      ["-b" "--build-number BUILD" "For test only, name of binary"
+                       :default 1
+                       :parse-fn #(Integer/parseInt %)
+                       :validate [pos? "Must be positive"]]
+                      ["-f" "--fee NAME" "For test only, the fee name"]
+                      [nil "--fum" "For test only, the fum flag"]]
+        command-config {:build-context build-context
+                        :command-name command-name
+                        :execute-command execute-command
+                        :option-specs option-specs}
+        parent-context {}]
+
+    (is (= {:data {:arguments ["sub-command" "-x" "--y" "z"]
+                   :context {:options {:activate true :build-number 100 :fee "fie" :fum true}}}
+            :exit-code 0
+            :message (str command-name ": exiting")}
+           (->> ["-a" "-b" "100" "--fee" "fie" "--fum" "sub-command" "-x" "--y" "z"]
+                (process-command command-config parent-context))))
+
+    (is (= {:data ["Unknown option: \"-c\"" "Unknown option: \"-d\""]
+            :exit-code 1
+            :message (str command-name ": error in parsing arguments")}
+           (->> ["-a" "-b" "200" "-c" "-d" "400" "sub-command" "-x" "--y" "z"]
+                (process-command command-config parent-context))))))

--- a/token-syncer/test/token_syncer/commands/syncer_test.clj
+++ b/token-syncer/test/token_syncer/commands/syncer_test.clj
@@ -572,9 +572,10 @@
               :message "test-command: at least two different cluster urls required, provided: []"}
              (cli/process-command test-command-config context args))))
     (let [args ["-h"]]
-      (is (= {:exit-code 0
-              :message "test-command: displayed documentation"}
-             (cli/process-command test-command-config context args))))
+      (with-out-str
+        (is (= {:exit-code 0
+                :message "test-command: displayed documentation"}
+               (cli/process-command test-command-config context args)))))
     (let [args ["http://cluster-1.com"]]
       (is (= {:exit-code 1
               :message "test-command: at least two different cluster urls required, provided: [\"http://cluster-1.com\"]"}
@@ -587,7 +588,7 @@
       (with-redefs [sync-tokens (fn [in-waiter-api cluster-urls-set limit]
                                   (is (= waiter-api in-waiter-api))
                                   (is (= #{"http://cluster-1.com" "http://cluster-2.com"} cluster-urls-set))
-                                  (is (nil? limit)))]
+                                  (is (= 1000 limit)))]
         (is (= {:exit-code 0
                 :message "test-command: exiting with code 0"}
                (cli/process-command test-command-config context args)))))

--- a/token-syncer/test/token_syncer/main_test.clj
+++ b/token-syncer/test/token_syncer/main_test.clj
@@ -10,27 +10,52 @@
 ;;
 (ns token-syncer.main-test
   (:require [clojure.test :refer :all]
+            [clojure.tools.cli :as tools-cli]
+            [token-syncer.cli :as cli]
             [token-syncer.main :refer :all]))
 
 (deftest test-parse-cli-options
-  (is (= ["Unknown option: \"-c\""]
-         (:errors (parse-cli-options ["-c" "abcd"]))))
-  (is (= ["Unknown option: \"-c\""]
-         (:errors (parse-cli-options ["-c" "abcd,abcd"]))))
-  (is (= {:connection-timeout-ms 1000, :idle-timeout-ms 30000}
-         (:options (parse-cli-options ["-c" "abcd,efgh"]))))
-  (is (= {:connection-timeout-ms 1000, :dry-run true, :idle-timeout-ms 30000}
-         (:options (parse-cli-options ["-d" "abcd,efgh"]))))
-  (is (= {:connection-timeout-ms 1000, :help true, :idle-timeout-ms 30000}
-         (:options (parse-cli-options ["-h"]))))
-  (is (= {:connection-timeout-ms 1000, :idle-timeout-ms 10000}
-         (:options (parse-cli-options ["-i" "10000"]))))
-  (is (= {:connection-timeout-ms 1000, :idle-timeout-ms 30000, :limit 100}
-         (:options (parse-cli-options ["-l" "100"]))))
-  (is (= {:connection-timeout-ms 10000, :idle-timeout-ms 30000}
-         (:options (parse-cli-options ["-t" "10000"]))))
-  (is (= {:connection-timeout-ms 10000, :idle-timeout-ms 20000}
-         (:options (parse-cli-options ["-i" "20000" "-t" "10000"]))))
-  (let [parsed-arguments (parse-cli-options ["-i" "20000" "-t" "10000" "c1.com" "c2.com" "c2.com"])]
-    (is (= ["c1.com" "c2.com" "c2.com"] (:arguments parsed-arguments)))
-    (is (= {:connection-timeout-ms 10000, :idle-timeout-ms 20000} (:options parsed-arguments)))))
+  (let [option-specs (:option-specs base-command-config)
+        parse-cli-options (fn [args] (tools-cli/parse-opts args option-specs))]
+    (is (= ["Unknown option: \"-c\""]
+           (:errors (parse-cli-options ["-c" "abcd"]))))
+    (is (= ["Unknown option: \"-c\""]
+           (:errors (parse-cli-options ["-c" "abcd,abcd"]))))
+    (is (= {:connection-timeout-ms 1000, :idle-timeout-ms 30000}
+           (:options (parse-cli-options ["-c" "abcd,efgh"]))))
+    (is (= {:connection-timeout-ms 1000, :dry-run true, :idle-timeout-ms 30000}
+           (:options (parse-cli-options ["-d" "abcd,efgh"]))))
+    (is (= {:connection-timeout-ms 1000, :idle-timeout-ms 10000}
+           (:options (parse-cli-options ["-i" "10000"]))))
+    (is (= {:connection-timeout-ms 10000, :idle-timeout-ms 30000}
+           (:options (parse-cli-options ["-t" "10000"]))))
+    (is (= {:connection-timeout-ms 10000, :idle-timeout-ms 20000}
+           (:options (parse-cli-options ["-i" "20000" "-t" "10000"]))))
+    (let [parsed-arguments (parse-cli-options ["-i" "20000" "-t" "10000" "c1.com" "c2.com" "c2.com"])]
+      (is (= ["c1.com" "c2.com" "c2.com"] (:arguments parsed-arguments)))
+      (is (= {:connection-timeout-ms 10000, :idle-timeout-ms 20000} (:options parsed-arguments))))))
+
+(deftest test-base-command-config
+  (let [test-sub-command-config {:build-context (fn build-base-context
+                                                  [context {:keys [options]}]
+                                                  (assoc context :options options))
+                                 :execute-command (fn execute-base-command
+                                                    [context arguments]
+                                                    {:arguments arguments
+                                                     :options (:options context)
+                                                     :exit-code 0})
+                                 :option-specs [["-a" "--activate" "For test only, activate"]]
+                                 :retrieve-documentation (constantly "")}
+        sub-command->config {"test-sub-command" test-sub-command-config}
+        context {:sub-command->config sub-command->config}
+        test-command-config (assoc base-command-config :command-name "test-command")]
+    (let [args ["-d" "test-sub-command" "-h"]]
+      (is (= {:exit-code 0
+              :message "test-command: test-sub-command: displayed documentation"}
+             (cli/process-command test-command-config context args))))
+    (let [args ["-d" "test-sub-command" "-a"]]
+      (is (= {:arguments []
+              :exit-code 0
+              :message "test-command: test-sub-command: exiting"
+              :options {:activate true}}
+             (cli/process-command test-command-config context args))))))

--- a/token-syncer/test/token_syncer/main_test.clj
+++ b/token-syncer/test/token_syncer/main_test.clj
@@ -36,13 +36,10 @@
       (is (= {:connection-timeout-ms 10000, :idle-timeout-ms 20000} (:options parsed-arguments))))))
 
 (deftest test-base-command-config
-  (let [test-sub-command-config {:build-context (fn build-base-context
-                                                  [context {:keys [options]}]
-                                                  (assoc context :options options))
-                                 :execute-command (fn execute-base-command
-                                                    [context arguments]
+  (let [test-sub-command-config {:execute-command (fn execute-base-command
+                                                    [_ {:keys [options]} arguments]
                                                     {:arguments arguments
-                                                     :options (:options context)
+                                                     :options options
                                                      :exit-code 0})
                                  :option-specs [["-a" "--activate" "For test only, activate"]]
                                  :retrieve-documentation (constantly "")}
@@ -50,9 +47,10 @@
         context {:sub-command->config sub-command->config}
         test-command-config (assoc base-command-config :command-name "test-command")]
     (let [args ["-d" "test-sub-command" "-h"]]
-      (is (= {:exit-code 0
-              :message "test-command: test-sub-command: displayed documentation"}
-             (cli/process-command test-command-config context args))))
+      (with-out-str
+        (is (= {:exit-code 0
+                :message "test-command: test-sub-command: displayed documentation"}
+               (cli/process-command test-command-config context args)))))
     (let [args ["-d" "test-sub-command" "-a"]]
       (is (= {:arguments []
               :exit-code 0


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for running sub-commands

## Why are we making these changes?

This will help to introduce sub-command support in [the backup PR](https://github.com/twosigma/waiter/pull/214).

## Example output:
```
$ lein run sync-clusters -l 2 http://localhost:9091 http://localhost:9093 
2018-03-06 15:15:06 INFO  token-syncer.main - command-line arguments: [sync-clusters -l 2 http://localhost:9091 http://localhost:9093]
2018-03-06 15:15:06 INFO  eclipse.jetty.util.log - Logging initialized @7397ms to org.eclipse.jetty.util.log.Slf4jLog
2018-03-06 15:15:06 INFO  token-syncer.commands.syncer - syncing tokens on clusters: #{http://localhost:9093 http://localhost:9091}
2018-03-06 15:15:06 INFO  token-syncer.waiter - token-syncer.fa1a44ce-3f94-45ba-b109-ce4fa57e9765 making GET request to http://localhost:9093/tokens
2018-03-06 15:15:07 INFO  token-syncer.waiter - token-syncer.f3fe3ea9-a4f7-40a0-9111-89f6ac6d4386 making GET request to http://localhost:9091/tokens
2018-03-06 15:15:07 INFO  token-syncer.commands.syncer - found 0 across the clusters, 0 previously synced
2018-03-06 15:15:07 INFO  token-syncer.commands.syncer - completed syncing tokens limited to 0
2018-03-06 15:15:07 INFO  token-syncer.commands.syncer - {:details {},
 :summary
 {:sync {:failed #{}, :unmodified #{}, :updated #{}},
  :tokens
  {:pending {:count 0, :value #{}},
   :previously-synced {:count 0, :value #{}},
   :processed {:count 0, :value #{}},
   :selected {:count 0, :value #{}},
   :total {:count 0, :value #{}}}}}
2018-03-06 15:15:07 INFO  token-syncer.main - token-syncer: sync-clusters: exiting with code 0
```

### Documentation output
```
$ lein run -- -h
2018-03-06 18:41:05 INFO  token-syncer.main - command-line arguments: [-h]
Name: token-syncer - performs token syncing operations on Waiter cluster(s)
Usage: token-syncer [OPTION]... SUB-COMMAND [OPTION]...
Description: delegates operations to the sub-commands (see Sub-commands section below).
Sub-commands: sync-clusters [use token-syncerSUB-COMMAND -h to see documentation on the sub-command(s)].
Options:
  -d, --dry-run                               Runs the syncer in dry run mode where it doesn't perform any write operations
  -i, --idle-timeout-ms TIMEOUT        30000  The idle timeout in milliseconds, must be between 1 and 300000
  -t, --connection-timeout-ms TIMEOUT  1000   The connection timeout in milliseconds, must be between 1 and 300000
  -h, --help                                  Displays this message
```

```
$ lein run sync-clusters -h
2018-03-06 18:41:19 INFO  token-syncer.main - command-line arguments: [sync-clusters -h]
2018-03-06 18:41:19 INFO  eclipse.jetty.util.log - Logging initialized @9078ms to org.eclipse.jetty.util.log.Slf4jLog
Name: sync-clusters - performs token syncing across Waiter clusters
Usage: sync-clusters [OPTION]... URL URL...
Description: syncs tokens among (at least two) Waiter clusters in the URL(s).
Options:
  -l, --limit LIMIT  1000  The maximum number of tokens to attempt to sync, must be between 1 and 10000
  -h, --help               Displays this message
```
