### PR TITLE
Refactor cors handling into dedicated middleware

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1232,12 +1232,10 @@
                                           {:src-router-id source-id})))
                                     basic-auth-handler (basic-authentication/wrap-basic-authentication handler router-comm-authenticated?)]
                                 (basic-auth-handler request)))))
-   :wrap-secure-request-fn (pc/fnk [[:routines authentication-method-wrapper-fn]
-                                    [:state cors-validator]]
+   :wrap-secure-request-fn (pc/fnk [[:routines authentication-method-wrapper-fn]]
                              (fn wrap-secure-request-fn
                                [request-handler]
                                (let [handler (-> request-handler
-                                                 (cors/handler cors-validator)
                                                  authentication-method-wrapper-fn)]
                                  (fn inner-wrap-secure-request-fn [{:keys [uri] :as request}]
                                    (log/debug "secure request received at" uri)

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1216,10 +1216,13 @@
                                           {:src-router-id source-id})))
                                     basic-auth-handler (basic-authentication/wrap-basic-authentication handler router-comm-authenticated?)]
                                 (basic-auth-handler request)))))
-   :wrap-secure-request-fn (pc/fnk [[:routines authentication-method-wrapper-fn]]
+   :wrap-secure-request-fn (pc/fnk [[:routines authentication-method-wrapper-fn]
+                                    [:state cors-validator]
+                                    [:settings cors-config]]
                              (fn wrap-secure-request-fn
-                               [request-handler]
-                               (let [handler (-> request-handler
+                               [handler]
+                               (let [handler (-> handler
+                                                 (cors/wrap-cors cors-validator (:max-age cors-config))
                                                  authentication-method-wrapper-fn)]
                                  (fn inner-wrap-secure-request-fn [{:keys [uri] :as request}]
                                    (log/debug "secure request received at" uri)

--- a/waiter/src/waiter/cors.clj
+++ b/waiter/src/waiter/cors.clj
@@ -44,7 +44,7 @@
                  "Access-Control-Max-Age" (str max-age)}})))
 
 (defn wrap-cors [request-handler cors-validator]
-  (fn [req]
+  (fn wrap-cors-fn [req]
     (let [{:keys [headers request-method]} req
           {:strs [origin]} headers
           bless #(if (and origin (request-allowed? cors-validator req))

--- a/waiter/src/waiter/cors.clj
+++ b/waiter/src/waiter/cors.clj
@@ -10,6 +10,8 @@
 ;;
 (ns waiter.cors
   (:require [clojure.core.async :as async]
+            [metrics.counters :as counters]
+            [waiter.metrics :as metrics]
             [waiter.utils :as utils])
   (:import java.util.regex.Pattern))
 
@@ -21,29 +23,38 @@
   (request-allowed? [this request]
     "Returns true if the CORS request is allowed."))
 
-(defn preflight-request? [request]
+(defn preflight-request?
+  "Determines if a request is a CORS preflight request."
+  [request]
   (= :options (:request-method request)))
 
-(defn preflight-handler [cors-validator max-age request]
-  (when-not (preflight-request? request)
-    (throw (ex-info "Not a preflight request" {})))
-  (let [{:keys [headers request-method]} request
-        {:strs [origin]} headers]
-    (when-not origin
-      (throw (ex-info "No origin provided" {:status 403})))
-    (when-not (preflight-allowed? cors-validator request)
-      (throw (ex-info "Cross-origin request not allowed" {:origin origin
-                                                          :request-method request-method
-                                                          :status 403})))
-    (let [{:strs [access-control-request-headers]} headers]
-      {:status 200
-       :headers {"Access-Control-Allow-Origin" origin
-                 "Access-Control-Allow-Headers" access-control-request-headers
-                 "Access-Control-Allow-Methods" "POST, GET, OPTIONS, DELETE"
-                 "Access-Control-Allow-Credentials" "true"
-                 "Access-Control-Max-Age" (str max-age)}})))
+(defn wrap-cors-preflight
+  "Preflight request handling middleware."
+  [handler cors-validator max-age]
+  (fn wrap-cors-preflight-fn [request]
+    (if (preflight-request? request)
+      (do
+        (counters/inc!  (metrics/waiter-counter "requests" "cors-preflight"))
+        (let [{:keys [headers request-method]} request
+              {:strs [origin]} headers]
+          (when-not origin
+            (throw (ex-info "No origin provided" {:status 403})))
+          (when-not (preflight-allowed? cors-validator request)
+            (throw (ex-info "Cross-origin request not allowed" {:origin origin
+                                                                :request-method request-method
+                                                                :status 403})))
+          (let [{:strs [access-control-request-headers]} headers]
+            {:status 200
+             :headers {"Access-Control-Allow-Origin" origin
+                       "Access-Control-Allow-Headers" access-control-request-headers
+                       "Access-Control-Allow-Methods" "POST, GET, OPTIONS, DELETE"
+                       "Access-Control-Allow-Credentials" "true"
+                       "Access-Control-Max-Age" (str max-age)}})))
+      (handler request))))
 
-(defn wrap-cors [request-handler cors-validator]
+(defn wrap-cors-request
+  "Middleware that handles CORS request authorization."
+  [handler cors-validator]
   (fn wrap-cors-fn [req]
     (let [{:keys [headers request-method]} req
           {:strs [origin]} headers
@@ -54,7 +65,7 @@
                    %)]
       (-> req
           (#(if (or (not origin) (request-allowed? cors-validator %))
-              (request-handler %)
+              (handler %)
               (throw (ex-info "Cross-origin request not allowed"
                               {:origin origin
                                :request-method request-method
@@ -62,6 +73,13 @@
           (#(if (map? %)
               (bless %)
               (async/go (bless (async/<! %)))))))))
+
+(defn wrap-cors
+  "Middleware that handles CORS preflights and requests."
+  [handler cors-validator max-age]
+  (-> handler
+      (wrap-cors-request cors-validator)
+      (wrap-cors-preflight cors-validator max-age)))
 
 (defrecord PatternBasedCorsValidator [pattern-matches?]
   CorsValidator

--- a/waiter/src/waiter/cors.clj
+++ b/waiter/src/waiter/cors.clj
@@ -55,15 +55,15 @@
 (defn wrap-cors-request
   "Middleware that handles CORS request authorization."
   [handler cors-validator]
-  (fn wrap-cors-fn [req]
-    (let [{:keys [headers request-method]} req
+  (fn wrap-cors-fn [request]
+    (let [{:keys [headers request-method]} request
           {:strs [origin]} headers
-          bless #(if (and origin (request-allowed? cors-validator req))
+          bless #(if (and origin (request-allowed? cors-validator request))
                    (update-in % [:headers] assoc
                               "Access-Control-Allow-Origin" origin
                               "Access-Control-Allow-Credentials" "true")
                    %)]
-      (-> req
+      (-> request
           (#(if (or (not origin) (request-allowed? cors-validator %))
               (handler %)
               (throw (ex-info "Cross-origin request not allowed"

--- a/waiter/src/waiter/cors.clj
+++ b/waiter/src/waiter/cors.clj
@@ -43,7 +43,7 @@
                  "Access-Control-Allow-Credentials" "true"
                  "Access-Control-Max-Age" (str max-age)}})))
 
-(defn handler [request-handler cors-validator]
+(defn wrap-cors [request-handler cors-validator]
   (fn [req]
     (let [{:keys [headers request-method]} req
           {:strs [origin]} headers
@@ -91,3 +91,13 @@
   "Creates a CORS validator that allows all cross-origin requests."
   [_]
   (->AllowAllCorsValidator))
+
+(defrecord DenyAllCorsValidator []
+  CorsValidator
+  (preflight-allowed? [_ _] false)
+  (request-allowed? [_ _] false))
+
+(defn deny-all-validator
+  "Creates a CORS validator that denies all cross-origin requests."
+  [_]
+  (->DenyAllCorsValidator))

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -67,12 +67,10 @@
    :handlers core/request-handlers
    :state core/state
    :http-server (pc/fnk [[:routines waiter-request?-fn websocket-request-authenticator]
-                         [:settings cors-config host port support-info websocket-config]
-                         [:state cors-validator]
+                         [:settings host port support-info websocket-config]
                          handlers] ; Insist that all systems are running before we start server
                   (let [options (merge websocket-config
                                        {:ring-handler (-> (core/ring-handler-factory waiter-request?-fn handlers)
-                                                          (cors/wrap-cors cors-validator (:max-age cors-config))
                                                           core/wrap-error-handling
                                                           core/correlation-id-middleware
                                                           (core/wrap-support-info support-info)

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -67,12 +67,12 @@
    :handlers core/request-handlers
    :state core/state
    :http-server (pc/fnk [[:routines waiter-request?-fn websocket-request-authenticator]
-                         [:settings host port websocket-config support-info]
+                         [:settings cors-config host port support-info websocket-config]
                          [:state cors-validator]
                          handlers] ; Insist that all systems are running before we start server
                   (let [options (merge websocket-config
                                        {:ring-handler (-> (core/ring-handler-factory waiter-request?-fn handlers)
-                                                          (cors/wrap-cors cors-validator)
+                                                          (cors/wrap-cors cors-validator (:max-age cors-config))
                                                           core/wrap-error-handling
                                                           core/correlation-id-middleware
                                                           (core/wrap-support-info support-info)

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -21,6 +21,7 @@
             [qbits.jet.server :as server]
             [schema.core :as s]
             [waiter.core :as core]
+            [waiter.cors :as cors]
             [waiter.correlation-id :as cid]
             [waiter.settings :as settings]
             [waiter.utils :as utils])
@@ -67,9 +68,11 @@
    :state core/state
    :http-server (pc/fnk [[:routines waiter-request?-fn websocket-request-authenticator]
                          [:settings host port websocket-config support-info]
+                         [:state cors-validator]
                          handlers] ; Insist that all systems are running before we start server
                   (let [options (merge websocket-config
                                        {:ring-handler (-> (core/ring-handler-factory waiter-request?-fn handlers)
+                                                          (cors/wrap-cors cors-validator)
                                                           core/wrap-error-handling
                                                           core/correlation-id-middleware
                                                           (core/wrap-support-info support-info)

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -21,7 +21,6 @@
             [qbits.jet.server :as server]
             [schema.core :as s]
             [waiter.core :as core]
-            [waiter.cors :as cors]
             [waiter.correlation-id :as cid]
             [waiter.settings :as settings]
             [waiter.utils :as utils])

--- a/waiter/test/waiter/cors_test.clj
+++ b/waiter/test/waiter/cors_test.clj
@@ -53,10 +53,10 @@
           {:keys [status] :as response} (handler request)]
       (is (= 403 status))))
   (testing "cors request allowed"
-    (let [deny-all (allow-all-validator {})
+    (let [allow-all (allow-all-validator {})
           request {:headers {"origin" "doesnt.matter"}}
           handler (-> (fn [request] {:status 200})
-                      (wrap-cors deny-all))
+                      (wrap-cors allow-all))
           {:keys [headers status] :as response} (handler request)]
       (is (= 200 status))
       (is (= "doesnt.matter" (get headers "Access-Control-Allow-Origin")))

--- a/waiter/test/waiter/cors_test.clj
+++ b/waiter/test/waiter/cors_test.clj
@@ -10,8 +10,8 @@
 ;;
 (ns waiter.cors-test
   (:require [clojure.test :refer :all]
-            [waiter.cors :refer :all]
-            [waiter.core :as core])
+            [waiter.core :as core]
+            [waiter.cors :refer :all])
   (:import waiter.cors.PatternBasedCorsValidator))
 
 (deftest pattern-validator-test
@@ -85,5 +85,5 @@
       (is (= "doesnt.matter" (get headers "Access-Control-Allow-Origin")))
       (is (= "x-test-header" (get headers "Access-Control-Allow-Headers")))
       (is (= "POST, GET, OPTIONS, DELETE" (get headers "Access-Control-Allow-Methods")))
-      (is (= "100" (get headers "Access-Control-Max-Age")))
+      (is (= (str max-age) (get headers "Access-Control-Max-Age")))
       (is (= "true" (get headers "Access-Control-Allow-Credentials"))))))

--- a/waiter/test/waiter/cors_test.clj
+++ b/waiter/test/waiter/cors_test.clj
@@ -43,12 +43,12 @@
   (is (thrown? Throwable (pattern-based-validator {:allowed-origins [#"foo" #"bar" "baz"]})))
   (is (instance? PatternBasedCorsValidator (pattern-based-validator {:allowed-origins [#"foo" #"bar" #"baz"]}))))
 
-(deftest test-wrap-cors
+(deftest test-wrap-cors-request
   (testing "cors request denied"
     (let [deny-all (deny-all-validator {})
           request {:headers {"origin" "doesnt.matter"}}
           handler (-> (fn [request] {:status 200})
-                      (wrap-cors deny-all)
+                      (wrap-cors-request deny-all)
                       (core/wrap-error-handling))
           {:keys [status] :as response} (handler request)]
       (is (= 403 status))))
@@ -56,8 +56,34 @@
     (let [allow-all (allow-all-validator {})
           request {:headers {"origin" "doesnt.matter"}}
           handler (-> (fn [request] {:status 200})
-                      (wrap-cors allow-all))
+                      (wrap-cors-request allow-all))
           {:keys [headers status] :as response} (handler request)]
       (is (= 200 status))
       (is (= "doesnt.matter" (get headers "Access-Control-Allow-Origin")))
+      (is (= "true" (get headers "Access-Control-Allow-Credentials"))))))
+
+(deftest test-wrap-cors-preflight
+  (testing "cors preflight request denied"
+    (let [deny-all (deny-all-validator {})
+          max-age 100
+          request {:request-method :options}
+          handler (-> (fn [request] {:status 200})
+                      (wrap-cors-preflight deny-all max-age)
+                      (core/wrap-error-handling))
+          {:keys [status] :as response} (handler request)]
+      (is (= 403 status))))
+  (testing "cors preflight request allowed"
+    (let [allow-all (allow-all-validator {})
+          max-age 100
+          request {:headers {"origin" "doesnt.matter"
+                             "access-control-request-headers" "x-test-header"}
+                   :request-method :options}
+          handler (-> (fn [request] {:status 200})
+                      (wrap-cors-preflight allow-all max-age))
+          {:keys [headers status] :as response} (handler request)]
+      (is (= 200 status))
+      (is (= "doesnt.matter" (get headers "Access-Control-Allow-Origin")))
+      (is (= "x-test-header" (get headers "Access-Control-Allow-Headers")))
+      (is (= "POST, GET, OPTIONS, DELETE" (get headers "Access-Control-Allow-Methods")))
+      (is (= "100" (get headers "Access-Control-Max-Age")))
       (is (= "true" (get headers "Access-Control-Allow-Credentials"))))))


### PR DESCRIPTION
## Changes proposed in this PR

Creates a middleware that handles CORS requests and preflights.
Adds unit tests.

## Why are we making these changes?

Consolidate CORS handling into one middleware.
