### PR TITLE
Creates wrap-descriptor

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -84,7 +84,8 @@
                  [ring/ring-core "1.5.0"
                   :exclusions [org.clojure/tools.reader]]
                  [ring-basic-authentication "1.0.5"]
-                 [slingshot "0.12.2"]]
+                 [slingshot "0.12.2"]
+                 [try-let "1.1.0"]]
 
   :resource-paths ["resources"]
   :main waiter.main

--- a/waiter/src/waiter/middleware.clj
+++ b/waiter/src/waiter/middleware.clj
@@ -1,0 +1,31 @@
+;;
+;;       Copyright (c) 2018 Two Sigma Investments, LP.
+;;       All Rights Reserved
+;;
+;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
+;;       Two Sigma Investments, LP.
+;;
+;;       The copyright notice above does not evidence any
+;;       actual or intended publication of such source code.
+;;
+(ns waiter.middleware
+  (:require [clojure.core.async :as async]
+            [full.async :refer (<?? <? go-try)]
+            [waiter.async-utils :as au]
+            [waiter.utils :as utils]))
+
+(defn wrap-context
+  "Wraps a handler, ensuring the request and response (or exception) contains data in the context map."
+  [handler context]
+  (fn [request]
+    (try
+      (let [response (handler (merge request context))]
+        (if (au/chan? response)
+          (async/go
+            (try
+              (merge (<? response) context)
+              (catch Exception e
+                (utils/merge-exception e context))))
+          (merge response context)))
+      (catch Exception e
+        (throw (utils/merge-exception e context))))))

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -30,6 +30,7 @@
             [waiter.handler :as handler]
             [waiter.headers :as headers]
             [waiter.metrics :as metrics]
+            [waiter.middleware :as middleware]
             [waiter.scheduler :as scheduler]
             [waiter.service :as service]
             [waiter.service-description :as sd]
@@ -465,39 +466,51 @@
 
 (defn process-exception-in-http-request
   "Processes exceptions thrown while processing a http request."
-  [track-process-error-metrics-fn request descriptor exception]
-  (if (missing-run-as-user? exception)
-    (let [{:keys [query-string uri]} request
-          location (str "/waiter-consent" uri (when (not (str/blank? query-string)) (str "?" query-string)))]
-      (counters/inc! (metrics/waiter-counter "auto-run-as-requester" "redirect"))
-      (meters/mark! (metrics/waiter-meter "auto-run-as-requester" "redirect"))
-      {:headers {"location" location}
-       :status 303})
-    (do
-      (track-process-error-metrics-fn descriptor)
-      (let [{:keys [status] :as error-response} (utils/exception->response exception request)]
-        (when descriptor
-          (let [{:keys [service-description service-id]} descriptor]
-            (track-response-status-metrics service-id service-description status)))
-        error-response))))
+  [track-process-error-metrics-fn {:keys [descriptor] :as request} exception]
+  (track-process-error-metrics-fn descriptor)
+  (let [{:keys [status] :as error-response} (utils/exception->response exception request)
+        {:keys [service-description service-id]} descriptor]
+    (track-response-status-metrics service-id service-description status)
+    error-response))
 
 (defn track-process-error-metrics
   "Updates metrics for process errors."
   [descriptor]
   (meters/mark! (metrics/waiter-meter "core" "process-errors"))
-  (when descriptor
-    (let [{:keys [service-description service-id]} descriptor
-          {:strs [metric-group]} service-description]
-      (meters/mark! (metrics/service-meter service-id "process-error"))
-      (statsd/inc! metric-group "process_error"))))
+  (let [{:keys [service-description service-id]} descriptor
+        {:strs [metric-group]} service-description]
+    (meters/mark! (metrics/service-meter service-id "process-error"))
+    (statsd/inc! metric-group "process_error")))
+
+(defn wrap-descriptor
+  "Adds the descriptor to the request/response.
+   Redirects users in the case of missing user/run-as-requestor."
+  [handler request->descriptor-fn]
+  (fn [request]
+    (try
+      (let [descriptor (request->descriptor-fn request)
+            handler (-> handler
+                        (middleware/wrap-context {:descriptor descriptor}))]
+        (handler request))
+      (catch Exception e
+        (if (missing-run-as-user? e)
+          (let [{:keys [query-string uri]} request
+                location (str "/waiter-consent" uri (when (not (str/blank? query-string)) (str "?" query-string)))]
+            (counters/inc! (metrics/waiter-counter "auto-run-as-requester" "redirect"))
+            (meters/mark! (metrics/waiter-meter "auto-run-as-requester" "redirect"))
+            {:headers {"location" location}
+             :status 303})
+          (do
+            (meters/mark! (metrics/waiter-meter "core" "process-errors"))
+            (utils/exception->response e request)))))))
 
 (let [process-timer (metrics/waiter-timer "core" "process")]
   (defn process
     "Process the incoming request and stream back the response."
-    [router-id make-request-fn instance-rpc-chan request->descriptor-fn start-new-service-fn
+    [router-id make-request-fn instance-rpc-chan start-new-service-fn
      instance-request-properties handlers prepend-waiter-url determine-priority-fn process-backend-response-fn
      process-exception-fn request-abort-callback-factory local-usage-agent
-     {:keys [ctrl] :as request}]
+     {:keys [ctrl descriptor] :as request}]
     (let [reservation-status-promise (promise)
           control-mult (async/mult ctrl)
           request (-> request (dissoc :ctrl) (assoc :ctrl-mult control-mult))
@@ -518,7 +531,7 @@
           process-timer
           (try
             (confirm-live-connection-without-abort)
-            (let [{:keys [service-id service-description] :as descriptor} (request->descriptor-fn request)
+            (let [{:keys [service-id service-description]} descriptor
                   {:strs [metric-group]} service-description
                   ^DateTime request-time (t/now)]
               (->> (utils/date-to-str request-time utils/formatter-rfc822)
@@ -598,7 +611,7 @@
             (catch Exception e
               (let [{:keys [descriptor source]} (ex-data e)
                     exception (if (= source :pr/process) (.getCause e) e)]
-                (-> (process-exception-fn track-process-error-metrics request descriptor exception)
+                (-> (process-exception-fn track-process-error-metrics request exception)
                     (update :headers (fn [headers]
                                        (merge @response-headers headers))))))))))))
 

--- a/waiter/src/waiter/utils.clj
+++ b/waiter/src/waiter/utils.clj
@@ -24,6 +24,7 @@
             [taoensso.nippy :as nippy]
             [taoensso.nippy.compression :as compression])
   (:import clojure.core.async.impl.channels.ManyToManyChannel
+           clojure.lang.ExceptionInfo
            clojure.lang.PersistentQueue
            java.io.OutputStreamWriter
            java.lang.Process
@@ -536,3 +537,10 @@
   [handler]
   (fn [request]
     (handler request)))
+
+(defn merge-exception
+  "Enriches an exception with a data map, regardless of whether it's an ExceptionInfo or just Exception."
+  [^Exception e m]
+  (if (instance? ExceptionInfo e)
+    (ex-info (.getMessage e) (merge (ex-data e) m) (.getCause e))
+    (ex-info (.getMessage e) m (.getCause e))))

--- a/waiter/src/waiter/utils.clj
+++ b/waiter/src/waiter/utils.clj
@@ -544,3 +544,11 @@
   (if (instance? ExceptionInfo e)
     (ex-info (.getMessage e) (merge (ex-data e) m) (.getCause e))
     (ex-info (.getMessage e) m (.getCause e))))
+
+(defmacro tryv
+  "Like try, but [result exception]"
+  [& body]
+  `(try
+     [(do
+        ~@body) nil]
+     (catch Exception e# [nil e#])))

--- a/waiter/src/waiter/utils.clj
+++ b/waiter/src/waiter/utils.clj
@@ -544,11 +544,3 @@
   (if (instance? ExceptionInfo e)
     (ex-info (.getMessage e) (merge (ex-data e) m) (.getCause e))
     (ex-info (.getMessage e) m (.getCause e))))
-
-(defmacro tryv
-  "Like try, but [result exception]"
-  [& body]
-  `(try
-     [(do
-        ~@body) nil]
-     (catch Exception e# [nil e#])))

--- a/waiter/src/waiter/websocket.clj
+++ b/waiter/src/waiter/websocket.clj
@@ -358,10 +358,12 @@
 
 (defn process-exception-in-request
   "Processes exceptions thrown while processing a websocket request."
-  [track-process-error-metrics-fn {:keys [out] :as request} descriptor exception]
+  [track-process-error-metrics-fn {:keys [descriptor out] :as request} exception]
   (log/error exception "error in processing websocket request")
+  (log/info "descriptor is " descriptor)
   (track-process-error-metrics-fn descriptor)
   (let [exception-response (utils/exception->response exception request)]
+    ; FIXME writing http response into websocket stream
     (async/go
       (async/>! out exception-response)
       (async/close! out))

--- a/waiter/src/waiter/websocket.clj
+++ b/waiter/src/waiter/websocket.clj
@@ -360,7 +360,6 @@
   "Processes exceptions thrown while processing a websocket request."
   [track-process-error-metrics-fn {:keys [descriptor out] :as request} exception]
   (log/error exception "error in processing websocket request")
-  (log/info "descriptor is " descriptor)
   (track-process-error-metrics-fn descriptor)
   (let [exception-response (utils/exception->response exception request)]
     ; FIXME writing http response into websocket stream

--- a/waiter/test/waiter/middleware_test.clj
+++ b/waiter/test/waiter/middleware_test.clj
@@ -1,0 +1,43 @@
+;;
+;;       Copyright (c) 2018 Two Sigma Investments, LP.
+;;       All Rights Reserved
+;;
+;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
+;;       Two Sigma Investments, LP.
+;;
+;;       The copyright notice above does not evidence any
+;;       actual or intended publication of such source code.
+;;
+(ns waiter.middleware-test
+  (:require [clojure.core.async :as async]
+            [clojure.test :refer :all]
+            [waiter.middleware :refer :all]))
+
+(deftest test-wrap-context
+  (testing "wrap context, sync"
+    (let [handler (-> (fn [request]
+                        (is (= :value (:key request)))
+                        {:status 200})
+                      (wrap-context {:key :value}))]
+      (is (= :value (-> {} handler :key)))))
+  (testing "wrap context, async"
+    (let [handler (-> (fn [request]
+                        (is (= :value (:key request)))
+                        (async/go {:status 200}))
+                      (wrap-context {:key :value}))]
+      (is (= :value (-> {} handler async/<!! :key)))))
+  (testing "wrap context, sync w/ exception"
+    (let [handler (-> (fn [request]
+                        (is (= :value (:key request)))
+                        (throw (ex-data "test" {})))
+                      (wrap-context {:key :value}))]
+      (try
+        (handler {})
+        (catch Exception e
+          (is (= :value (-> e ex-data :key)))))))
+  (testing "wrap context, async w/ exception"
+    (let [handler (-> (fn [request]
+                        (is (= :value (:key request)))
+                        (async/go (ex-info "test" {})))
+                      (wrap-context {:key :value}))]
+      (is (= :value (-> {} handler async/<!! ex-data :key))))))

--- a/waiter/test/waiter/utils_test.clj
+++ b/waiter/test/waiter/utils_test.clj
@@ -585,3 +585,7 @@
            (merge-by merge-fn {:a 1, :b 2} {:a 3} {:b 4} {:m 5})))
     (is (= {:a 4, :b 2, :m 20}
            (merge-by merge-fn {:a 1, :b 2} {:a 3, :m 4} {:m 5})))))
+
+(deftest test-merge-exception
+  (is (= {:a 1 :b 2} (ex-data (merge-exception (ex-info "test" {:a 1}) {:b 2}))))
+  (is (= {:b 2} (ex-data (merge-exception (RuntimeException. "test") {:b 2})))))

--- a/waiter/test/waiter/websocket_test.clj
+++ b/waiter/test/waiter/websocket_test.clj
@@ -348,8 +348,7 @@
   (let [out (async/chan 1)
         request {:out out :headers {"accept" "application/json"}}
         ex (Exception.)
-        desc "error descriptor"
-        _ (process-exception-in-request identity request desc ex)
+        _ (process-exception-in-request identity request ex)
         ex-msg (-> out async/<!! :body json/read-str (get-in ["waiter-error" "message"]))]
     ;; response should indicate an internal server error
     (is (= "Internal error" ex-msg))


### PR DESCRIPTION
## Changes proposed in this PR

* Moves `request->descriptor` out of `process` and into `wrap-descriptor`
* Introduces `wrap-context` as a general method "double wrapping" request/response pairs to pass context both upstream and downstream.

## Why are we making these changes?
* Demonstrate a pattern for passing context upstream and downstream.
* First step toward factoring of `process` method.
* `descriptor` ultimately available for logging.
* Some unit tests related are simplified due to factoring of `process` method.
* Further simplifications can be made:
  * Examples
    * Tracking response codes by metric-group can now be done via middleware since `descriptor` is available
    * Moving `handle-too-many-requests`/`handle-suspended-service` outside of process




