### PR TITLE
ts: avoids contacting waiter if the syncer knows it has the latest version of the token

### DIFF
--- a/token-syncer/test/token_syncer/commands/backup_test.clj
+++ b/token-syncer/test/token_syncer/commands/backup_test.clj
@@ -55,9 +55,9 @@
                                    :token-etag (str "etag-" token)})
                     :load-token-list (fn [cluster-url]
                                        (is (= test-cluster-url cluster-url))
-                                       [{"token" "token-1"}
-                                        {"token" "token-2"}
-                                        {"token" "token-3"}])}
+                                       [{"etag" "etag-token-1", "token" "token-1"}
+                                        {"etag" "etag-token-2", "token" "token-2"}
+                                        {"etag" "etag-token-3", "token" "token-3"}])}
         file-operations-api {:read-from-file read-from-file
                              :write-to-file write-to-file}]
 
@@ -65,10 +65,10 @@
       (with-temp-file
         [my-temp-file (create-temp-file)]
         (let [my-temp-file-path (file->path my-temp-file)
-              initial-content {"token-1" {"foo1" "bar", "hello" "world1"}
-                               "token-3" {"foo3" "bar", "hello" "world3"}
-                               "token-5" {"foo5" "bar", "hello" "world5"}
-                               "token-7" {"foo7" "bar", "hello" "world7"}}]
+              initial-content {"token-1" {"foo1" "bar", "hello" "world1", "token-etag" "etag-token-1-old"}
+                               "token-3" {"foo3" "bar", "hello" "world3", "token-etag" "etag-token-3-old"}
+                               "token-5" {"foo5" "bar", "hello" "world5", "token-etag" "etag-token-5-old"}
+                               "token-7" {"foo7" "bar", "hello" "world7", "token-etag" "etag-token-7-old"}}]
           (write-to-file my-temp-file-path initial-content)
 
           (backup-tokens waiter-api file-operations-api test-cluster-url my-temp-file-path true)
@@ -79,8 +79,8 @@
                              "token-etag" "etag-token-2"}
                   "token-3" {"description" {"cpus" 1, "mem" 1024, "name" "token-3", "owner" "test-user"}
                              "token-etag" "etag-token-3"}
-                  "token-5" {"foo5" "bar", "hello" "world5"}
-                  "token-7" {"foo7" "bar", "hello" "world7"}}
+                  "token-5" {"foo5" "bar", "hello" "world5", "token-etag" "etag-token-5-old"}
+                  "token-7" {"foo7" "bar", "hello" "world7", "token-etag" "etag-token-7-old"}}
                  (read-from-file my-temp-file-path))))))
 
     (testing "backup without accrete mode"


### PR DESCRIPTION
## Changes proposed in this PR
- Uses the etag to determine whether to contact Waiter to load the token description

## Why are we making these changes?
- Reduces the load on Waiter while performing a backup

## Example output

### Latest token not present in output file
```
2018-03-12 17:31:25 INFO  token-syncer.main - command-line arguments: [backup-tokens tokens.txt http://localhost:9091]
2018-03-12 17:31:25 INFO  eclipse.jetty.util.log - Logging initialized @7738ms to org.eclipse.jetty.util.log.Slf4jLog
2018-03-12 17:31:26 INFO  token-syncer.commands.backup - backing up tokens from http://localhost:9091 to tokens.txt in overwrite mode 
2018-03-12 17:31:26 INFO  token-syncer.commands.backup - reading contents from tokens.txt
2018-03-12 17:31:26 INFO  token-syncer.commands.backup - found 1 tokens in tokens.txt : (testauthenticationdisabledsupportshamsimam476114.127.0.0.1)
2018-03-12 17:31:26 INFO  token-syncer.waiter - token-syncer.47e69b41-a4db-4734-947d-a69eb3b62d99 making GET request to http://localhost:9091/tokens
2018-03-12 17:31:26 INFO  token-syncer.commands.backup - found 1 tokens on http://localhost:9091 : (testauthenticationdisabledsupportshamsimam476114.127.0.0.1)
2018-03-12 17:31:26 INFO  token-syncer.waiter - token-syncer.19d882e6-0427-4863-8492-3ebf61930946 making GET request to http://localhost:9091/token
2018-03-12 17:31:26 INFO  token-syncer.waiter - loading testauthenticationdisabledsupportshamsimam476114.127.0.0.1 on http://localhost:9091 responded with status 200 {content-type application/json, etag E-86b23ae7e4fc15aa6b17717f33ad0b1a, x-cid token-syncer.19d882e6-0427-4863-8492-3ebf61930946}
2018-03-12 17:31:26 INFO  token-syncer.commands.backup - writing 1 tokens to tokens.txt : (testauthenticationdisabledsupportshamsimam476114.127.0.0.1)
2018-03-12 17:31:26 INFO  token-syncer.main - token-syncer: backup-tokens: exiting with code 0
```

### Latest token present in output file
```
2018-03-12 17:27:42 INFO  token-syncer.main - command-line arguments: [backup-tokens tokens.txt http://localhost:9091]
2018-03-12 17:27:42 INFO  eclipse.jetty.util.log - Logging initialized @7231ms to org.eclipse.jetty.util.log.Slf4jLog
2018-03-12 17:27:43 INFO  token-syncer.commands.backup - backing up tokens from http://localhost:9091 to tokens.txt in overwrite mode 
2018-03-12 17:27:43 INFO  token-syncer.commands.backup - reading contents from tokens.txt
2018-03-12 17:27:43 INFO  token-syncer.commands.backup - found 1 tokens in tokens.txt : (testauthenticationdisabledsupportshamsimam476114.127.0.0.1)
2018-03-12 17:27:43 INFO  token-syncer.waiter - token-syncer.ca8aa5f9-bc83-4628-8f01-67acbe1481eb making GET request to http://localhost:9091/tokens
2018-03-12 17:27:43 INFO  token-syncer.commands.backup - found 1 tokens on http://localhost:9091 : (testauthenticationdisabledsupportshamsimam476114.127.0.0.1)
2018-03-12 17:27:43 INFO  token-syncer.commands.backup - using existing token description for testauthenticationdisabledsupportshamsimam476114.127.0.0.1 with etag E-86b23ae7e4fc15aa6b17717f33ad0b1a
2018-03-12 17:27:43 INFO  token-syncer.commands.backup - writing 1 tokens to tokens.txt : (testauthenticationdisabledsupportshamsimam476114.127.0.0.1)
2018-03-12 17:27:43 INFO  token-syncer.main - token-syncer: backup-tokens: exiting with code 0
```

Note the difference in log output where one says it is contacting Waiter despite having loaded the token (with the same name) from the backup file.
