### PR TITLE
Fixes CORS preflight

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1217,12 +1217,11 @@
                                     basic-auth-handler (basic-authentication/wrap-basic-authentication handler router-comm-authenticated?)]
                                 (basic-auth-handler request)))))
    :wrap-secure-request-fn (pc/fnk [[:routines authentication-method-wrapper-fn]
-                                    [:state cors-validator]
-                                    [:settings cors-config]]
+                                    [:state cors-validator]]
                              (fn wrap-secure-request-fn
                                [handler]
                                (let [handler (-> handler
-                                                 (cors/wrap-cors cors-validator (:max-age cors-config))
+                                                 (cors/wrap-cors-request cors-validator)
                                                  authentication-method-wrapper-fn)]
                                  (fn inner-wrap-secure-request-fn [{:keys [uri] :as request}]
                                    (log/debug "secure request received at" uri)

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -20,6 +20,7 @@
             [plumbing.graph :as graph]
             [qbits.jet.server :as server]
             [schema.core :as s]
+            [waiter.cors :as cors]
             [waiter.core :as core]
             [waiter.correlation-id :as cid]
             [waiter.settings :as settings]
@@ -66,10 +67,12 @@
    :handlers core/request-handlers
    :state core/state
    :http-server (pc/fnk [[:routines waiter-request?-fn websocket-request-authenticator]
-                         [:settings host port support-info websocket-config]
+                         [:settings cors-config host port support-info websocket-config]
+                         [:state cors-validator]
                          handlers] ; Insist that all systems are running before we start server
                   (let [options (merge websocket-config
                                        {:ring-handler (-> (core/ring-handler-factory waiter-request?-fn handlers)
+                                                          (cors/wrap-cors-preflight cors-validator (:max-age cors-config))
                                                           core/wrap-error-handling
                                                           core/correlation-id-middleware
                                                           (core/wrap-support-info support-info)


### PR DESCRIPTION
## Changes proposed in this PR

Move CORS preflight middleware before authentication

## Why are we making these changes?

CORS preflight requests do not support authentication.  This is a bugfix.

