### PR TITLE
Adds ability to disable auth for certain tests

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -835,13 +835,13 @@
 
         (testing "successful request"
           (let [{:keys [body] :as response}
-                (make-request waiter-url "/hello-world" :headers request-headers :spnego-auth false)]
+                (make-request waiter-url "/hello-world" :headers request-headers :disable-auth true)]
             (assert-response-status response 200)
             (is (= "Hello World" body))))
 
         (testing "backend request headers"
           (let [{:keys [body] :as response}
-                (make-request waiter-url "/request-info" :headers request-headers :spnego-auth false)
+                (make-request waiter-url "/request-info" :headers request-headers :disable-auth true)
                 {:strs [headers]} (json/read-str (str body))
                 service-id (retrieve-service-id waiter-url (:request-headers response))]
             (assert-response-status response 200)

--- a/waiter/src/waiter/client_tools.clj
+++ b/waiter/src/waiter/client_tools.clj
@@ -223,10 +223,12 @@
 
 (defn make-request
   ([waiter-url path &
-    {:keys [body client cookies content-type form-params headers http-method-fn multipart query-params verbose]
+    {:keys [body client cookies content-type disable-auth form-params headers
+            http-method-fn multipart query-params verbose]
      :or {body nil
           client http-client
           cookies []
+          disable-auth false
           headers {}
           http-method-fn http/get
           query-params {}
@@ -241,7 +243,7 @@
          (log/info "request url:" request-url)
          (log/info "request headers:" (into (sorted-map) request-headers)))
        (let [waiter-auth-cookie (some #(= authentication/AUTH-COOKIE-NAME (:name %)) cookies)
-             add-spnego-auth (and use-spnego (not waiter-auth-cookie))
+             add-spnego-auth (and (not disable-auth) use-spnego (not waiter-auth-cookie))
              {:keys [body headers status]}
              (async/<!! (http-method-fn
                           client


### PR DESCRIPTION
## Changes proposed in this PR

Add explicit option for disable auth for certain tests

## Why are we making these changes?

We need the ability to indicate that authentication should not be performed.  If we set the USE_SPNEGO environment variable to true, authentication is performed in cases where we specifically don't want it to be performed for testing purposes.

We have a couple of tests that attempt to disable auth, but, in fact, don't.  The tests pass anyway for other reasons.


