### PR TITLE
Disables allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,15 +21,8 @@ env:
     - TEST_DIR=waiter TEST_CMD=./bin/ci/run-unit-tests.sh
     - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests.sh parallel-test integration-fast'
     - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests.sh parallel-test integration-slow'
-    - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests.sh parallel-test explicit'
     - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests-shell-scheduler.sh parallel-test integration-fast'
     - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests-shell-scheduler.sh parallel-test integration-slow'
-    - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests-shell-scheduler.sh parallel-test explicit'
-matrix:
-    fast_finish: true
-    allow_failures:
-      - env: TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests.sh parallel-test explicit'
-      - env: TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests-shell-scheduler.sh parallel-test explicit'
 cache:
   directories:
     - $HOME/.m2


### PR DESCRIPTION
## Changes proposed in this PR

Turn off "allowed failure" tests

## Why are we making these changes?

We rarely ever look at these tests, yet they take up precious build slots on Travis.  I end up manually stopping them nearly always.

