### PR TITLE
Increase grace period for kitchen test apps

### DIFF
--- a/waiter/integration/waiter/new_app_test.clj
+++ b/waiter/integration/waiter/new_app_test.clj
@@ -55,8 +55,10 @@
 (deftest ^:parallel ^:integration-fast test-default-grace-period
   (testing-using-waiter-url
     (if (can-query-for-grace-period? waiter-url)
-      (let [headers {:x-waiter-name (rand-name)}
-            {:keys [service-id]} (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))
+      (let [headers (-> (kitchen-request-headers)
+                        (merge {:x-waiter-name (rand-name)})
+                        (dissoc :x-waiter-grace-period-secs))
+            {:keys [service-id]} (make-request-with-debug-info headers #(make-request waiter-url "/endpoint" :headers %))
             settings-json (waiter-settings waiter-url)
             default-grace-period (get-in settings-json [:service-description-defaults :grace-period-secs])]
         (is (= default-grace-period (service-id->grace-period waiter-url service-id)))
@@ -67,9 +69,10 @@
   (testing-using-waiter-url
     (if (can-query-for-grace-period? waiter-url)
       (let [custom-grace-period-secs 120
-            headers {:x-waiter-name (rand-name)
-                     :x-waiter-grace-period-secs custom-grace-period-secs}
-            {:keys [service-id]} (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))]
+            headers (-> (kitchen-request-headers)
+                        (merge {:x-waiter-name (rand-name)
+                                :x-waiter-grace-period-secs custom-grace-period-secs}))
+            {:keys [service-id]} (make-request-with-debug-info headers #(make-request waiter-url "/endpoint" :headers %))]
         (is (= custom-grace-period-secs (service-id->grace-period waiter-url service-id)))
         (delete-service waiter-url service-id))
       (log/warn "test-custom-grace-period cannot run because the target Waiter is not using Marathon"))))

--- a/waiter/integration/waiter/new_app_test.clj
+++ b/waiter/integration/waiter/new_app_test.clj
@@ -56,7 +56,7 @@
   (testing-using-waiter-url
     (if (can-query-for-grace-period? waiter-url)
       (let [headers (-> (kitchen-request-headers)
-                        (merge {:x-waiter-name (rand-name)})
+                        (assoc :x-waiter-name (rand-name))
                         (dissoc :x-waiter-grace-period-secs))
             {:keys [service-id]} (make-request-with-debug-info headers #(make-request waiter-url "/endpoint" :headers %))
             settings-json (waiter-settings waiter-url)
@@ -70,8 +70,8 @@
     (if (can-query-for-grace-period? waiter-url)
       (let [custom-grace-period-secs 120
             headers (-> (kitchen-request-headers)
-                        (merge {:x-waiter-name (rand-name)
-                                :x-waiter-grace-period-secs custom-grace-period-secs}))
+                        (assoc :x-waiter-name (rand-name)
+                               :x-waiter-grace-period-secs custom-grace-period-secs))
             {:keys [service-id]} (make-request-with-debug-info headers #(make-request waiter-url "/endpoint" :headers %))]
         (is (= custom-grace-period-secs (service-id->grace-period waiter-url service-id)))
         (delete-service waiter-url service-id))

--- a/waiter/src/waiter/client_tools.clj
+++ b/waiter/src/waiter/client_tools.clj
@@ -294,13 +294,14 @@
 
 (defn kitchen-params
   []
-  {:cpus 0.1
-   :mem 256
-   :cmd-type "shell"
-   :version "version-does-not-matter"
+  {:cmd-type "shell"
    :cmd (kitchen-cmd "-p $PORT0")
+   :cpus 0.1
+   :grace-period-secs 120
    :health-check-url "/status"
-   :idle-timeout-mins 10})
+   :idle-timeout-mins 10
+   :mem 256
+   :version "version-does-not-matter"})
 
 (defn kitchen-request-headers
   [& {:keys [prefix] :or {prefix "x-waiter-"}}]

--- a/waiter/src/waiter/client_tools.clj
+++ b/waiter/src/waiter/client_tools.clj
@@ -319,6 +319,7 @@
   (let [headers (cond->
                   (-> {:x-waiter-cpus 0.1
                        :x-waiter-mem 256
+                       :x-waiter-grace-period-secs 120
                        :x-waiter-health-check-url "/status"
                        :x-waiter-idle-timeout-mins 10}
                       (merge custom-headers)


### PR DESCRIPTION
## Changes proposed in this PR

Increase the grace period for test apps

## Why are we making these changes?

During tests, it's more likely than desirable that instances are killed before they're allowed to start up.  This is probably due to resource constraints in Travis.  This PR increases the grace period from 30 seconds to 2 minutes.

