### PR TITLE
Disables spnego for minimesos

### DIFF
--- a/waiter/config-minimesos.edn
+++ b/waiter/config-minimesos.edn
@@ -25,7 +25,10 @@
                     :marathon {
                                ;; The URL for your Marathon HTTP API:
                                :url #config/env "WAITER_MARATHON"
-                               :mesos-slave-port 5051}}
+                               :mesos-slave-port 5051
+                               :http-options {:conn-timeout 10000
+                                              :socket-timeout 10000
+                                              :spnego-auth false}}}
 
  ; ---------- CORS ----------
  :cors-config {:kind :allow-all }}


### PR DESCRIPTION
## Changes proposed in this PR

Disable spnego for minimesos

## Why are we making these changes?

The tests passed, but spammed log files with massive amounts of spnego exceptions.

