### PR TITLE
Waiter: adds support for token query parameter for token lookup

### DIFF
--- a/waiter/src/waiter/client_tools.clj
+++ b/waiter/src/waiter/client_tools.clj
@@ -852,8 +852,9 @@
 
 (defn get-token
   "Gets the token with the given name"
-  [waiter-url token & {:keys [cookies query-params] :or {cookies {}, query-params {"include" "metadata"}}}]
-  (let [request-headers (clojure.walk/stringify-keys {:host token})
+  [waiter-url token & {:keys [cookies query-params request-headers] :or
+                       {cookies {}, query-params {"include" "metadata"}}}]
+  (let [request-headers (or request-headers {"host" token})
         token-response (make-request waiter-url "/token"
                                      :cookies cookies
                                      :headers request-headers

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -264,7 +264,8 @@
   (let [request-params (:query-params (ring-params/params-request request))
         include-deleted (utils/param-contains? request-params "include" "deleted")
         show-metadata (utils/param-contains? request-params "include" "metadata")
-        {:keys [token]} (sd/retrieve-token-from-service-description-or-hostname headers headers waiter-hostnames)
+        token (or (get request-params "token")
+                  (:token (sd/retrieve-token-from-service-description-or-hostname headers headers waiter-hostnames)))
         token-description (sd/token->token-description kv-store token :include-deleted include-deleted)
         {:keys [service-description-template token-metadata]} token-description
         token-etag (token-description->etag token-description)]


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for `token` query parameter while retrieving tokens

## Why are we making these changes?

It allows retrieval for tokens using a browser and also opens the pathway to cleanup our code to avoid making `token` a reserved endpoint.

