### PR TITLE
Creates wrap-debug-info

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -43,6 +43,7 @@
             [waiter.metrics-sync :as metrics-sync]
             [waiter.password-store :as password-store]
             [waiter.process-request :as pr]
+            [waiter.ring-utils :as ru]
             [waiter.scaling :as scaling]
             [waiter.scheduler :as scheduler]
             [waiter.service :as service]
@@ -185,12 +186,10 @@
                           (update response :headers
                                   (fn [headers]
                                     (-> headers
-                                        (assoc "X-Waiter-Request-Date" (utils/date-to-str request-time utils/formatter-rfc822))
-                                        (assoc "X-Waiter-Request-Id" request-id)
-                                        (assoc "X-Waiter-Router-Id" router-id)))))]
-        (if (au/chan? response)
-          (async/go (add-headers (async/<! response)))
-          (add-headers response)))
+                                        (assoc "x-waiter-request-date" (utils/date-to-str request-time utils/formatter-rfc822))
+                                        (assoc "x-waiter-request-id" request-id)
+                                        (assoc "x-waiter-router-id" router-id)))))]
+        (ru/update-response response add-headers))
       (handler request))))
 
 (defn wrap-error-handling

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -760,14 +760,14 @@
 
 (defn welcome-handler
   "Response with a welcome page."
-  [{:keys [host hostname port support-info]} {:keys [request-method] :as request}]
+  [{:keys [host hostname port support-info]} {:keys [request-method request-time] :as request}]
   (let [welcome-info {:cid (cid/get-correlation-id)
                       :host host
                       :hostname hostname
                       :message "Welcome to Waiter"
                       :port port
                       :support-info support-info
-                      :timestamp (utils/date-to-str (t/now))}
+                      :timestamp (utils/date-to-str request-time)}
         content-type (utils/request->content-type request)]
     (try
       (case request-method

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -68,19 +68,20 @@
    :state core/state
    :http-server (pc/fnk [[:routines waiter-request?-fn websocket-request-authenticator]
                          [:settings cors-config host port support-info websocket-config]
-                         [:state cors-validator]
+                         [:state cors-validator router-id]
                          handlers] ; Insist that all systems are running before we start server
                   (let [options (merge websocket-config
                                        {:ring-handler (-> (core/ring-handler-factory waiter-request?-fn handlers)
                                                           (cors/wrap-cors-preflight cors-validator (:max-age cors-config))
                                                           core/wrap-error-handling
+                                                          core/wrap-debug
                                                           core/correlation-id-middleware
-                                                          (core/wrap-support-info support-info)
+                                                          (core/wrap-request-info router-id support-info)
                                                           consume-request-stream)
                                         :websocket-acceptor websocket-request-authenticator
                                         :websocket-handler (-> (core/websocket-handler-factory handlers)
                                                                core/correlation-id-middleware
-                                                               (core/wrap-support-info support-info))
+                                                               (core/wrap-request-info router-id support-info))
                                         :host host
                                         :join? false
                                         :max-threads 250

--- a/waiter/src/waiter/ring_utils.clj
+++ b/waiter/src/waiter/ring_utils.clj
@@ -1,0 +1,20 @@
+;;
+;;       Copyright (c) 2018 Two Sigma Investments, LP.
+;;       All Rights Reserved
+;;
+;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
+;;       Two Sigma Investments, LP.
+;;
+;;       The copyright notice above does not evidence any
+;;       actual or intended publication of such source code.
+;;
+(ns waiter.ring-utils
+  (:require [clojure.core.async :as async]
+            [waiter.async-utils :as au]))
+
+(defn update-response
+  "Updates a response, handling the case where it may be a chan."
+  [response response-fn]
+  (if (au/chan? response)
+    (async/go (response-fn (async/<! response)))
+    (response-fn response)))

--- a/waiter/src/waiter/utils.clj
+++ b/waiter/src/waiter/utils.clj
@@ -207,7 +207,7 @@
   "Creates a context from a data map and a request.
    The data map is expected to contain the following keys: details, message, and status."
   [{:keys [details message status]}
-   {:keys [headers query-string request-method support-info uri]}]
+   {:keys [headers query-string request-method request-time support-info uri]}]
   (let [{:strs [host x-cid]} headers]
     {:cid x-cid
      :details details
@@ -217,7 +217,7 @@
      :request-method (-> (or request-method "") name str/upper-case)
      :status status
      :support-info support-info
-     :timestamp (date-to-str (t/now))
+     :timestamp (date-to-str request-time)
      :uri uri}))
 
 (let [html-fn (template/fn

--- a/waiter/test/waiter/ring_utils_test.clj
+++ b/waiter/test/waiter/ring_utils_test.clj
@@ -1,0 +1,19 @@
+;;
+;;       Copyright (c) 2018 Two Sigma Investments, LP.
+;;       All Rights Reserved
+;;
+;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
+;;       Two Sigma Investments, LP.
+;;
+;;       The copyright notice above does not evidence any
+;;       actual or intended publication of such source code.
+;;
+(ns waiter.ring-utils-test
+  (:require [clojure.core.async :as async]
+            [clojure.test :refer :all]
+            [waiter.ring-utils :refer :all]))
+
+(deftest test-update-response
+  (let [update-fn (fn [response] (assoc response :k :v))]
+    (is (= {:k :v} (update-response {} update-fn)))
+    (is (= {:k :v} (async/<!! (update-response (async/go {}) update-fn))))))


### PR DESCRIPTION
## Changes proposed in this PR

- Centralizes some debugging info in middleware

## Why are we making these changes?

- x-waiter-debug applies to all requests, not just process
- Removes some responsibilities from process

