### PR TITLE
Creates wrap-response-status-metrics

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -994,9 +994,9 @@
                                                                       determine-priority-fn process-response-fn pr/process-exception-in-http-request
                                                                       pr/abort-http-request-callback-factory local-usage-agent request))]
                            (-> inner-process-request-fn
-                               pr/wrap-response-status-metrics
                                pr/wrap-too-many-requests
                                pr/wrap-suspended-service
+                               pr/wrap-response-status-metrics
                                (pr/wrap-descriptor request->descriptor-fn)
                                wrap-secure-request-fn
                                wrap-auth-bypass-fn)))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -994,6 +994,7 @@
                                                                       determine-priority-fn process-response-fn pr/process-exception-in-http-request
                                                                       pr/abort-http-request-callback-factory local-usage-agent request))]
                            (-> inner-process-request-fn
+                               pr/wrap-response-status-metrics
                                pr/wrap-too-many-requests
                                pr/wrap-suspended-service
                                (pr/wrap-descriptor request->descriptor-fn)


### PR DESCRIPTION
## Changes proposed in this PR

Create wrap-response-status-metrics middleware to handle updating metrics 

## Why are we making these changes?

- Centralized middleware ensures we handle all cases and ensures we record the actual status we're returning.

