### PR TITLE
TS: makes token syncer return non-zero if there were errors during sync-ing

### DIFF
--- a/token-syncer/src/token_syncer/commands/syncer.clj
+++ b/token-syncer/src/token_syncer/commands/syncer.clj
@@ -248,8 +248,8 @@
 
                           :else
                           (let [sync-result (sync-tokens waiter-api cluster-urls-set limit)
-                                exit-code (-> (get-in sync-result [:summary :sync :error] 0)
-                                              zero?
+                                exit-code (-> (get-in sync-result [:summary :sync :failed])
+                                              empty?
                                               (if 0 1))]
                             (log/info (-> sync-result pp/pprint with-out-str str/trim))
                             {:exit-code exit-code

--- a/token-syncer/test/token_syncer/commands/syncer_test.clj
+++ b/token-syncer/test/token_syncer/commands/syncer_test.clj
@@ -599,4 +599,13 @@
                                   (is (= 20 limit)))]
         (is (= {:exit-code 0
                 :message "test-command: exiting with code 0"}
+               (cli/process-command test-command-config context args)))))
+    (let [args ["http://cluster-1.com" "http://cluster-2.com"]]
+      (with-redefs [sync-tokens (fn [in-waiter-api cluster-urls-set limit]
+                                  (is (= waiter-api in-waiter-api))
+                                  (is (= #{"http://cluster-1.com" "http://cluster-2.com"} cluster-urls-set))
+                                  (is (= 1000 limit))
+                                  {:summary {:sync {:failed #{"foo"}}}})]
+        (is (= {:exit-code 1
+                :message "test-command: exiting with code 1"}
                (cli/process-command test-command-config context args)))))))


### PR DESCRIPTION
## Changes proposed in this PR

- uses the `:failed` summary to determine exit code

## Why are we making these changes?

Ensures the token syncer doesn't return 0 (implying success) if there were errors during syncing tokens.
