### PR TITLE
marks `test-retry-failed-instances` as flaky

### DIFF
--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -533,7 +533,9 @@
             (is (= {:num-reserved-ports 11} ex-data))
             (is (= "Unable to reserve 20 ports" (.getMessage ex)))))))))
 
-(deftest test-retry-failed-instances
+; Marked explicit due to:
+; - https://github.com/twosigma/waiter/issues/235
+(deftest ^:explicit test-retry-failed-instances
   (let [scheduler-config {:health-check-timeout-ms 1
                           :port-grace-period-ms 1
                           :port-range [10000 11000]


### PR DESCRIPTION
## Changes proposed in this PR

- marks `test-retry-failed-instances` as flaky

## Why are we making these changes?

Unit tests fail every now and then due to the flaky test. 
I have seen it on consistently on a Mac, but haven't seen it on Travis.
Created issue: https://github.com/twosigma/waiter/issues/235
