### PR TITLE
Response with instance

### DIFF
--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -66,7 +66,7 @@
    :daemons core/daemons
    :handlers core/request-handlers
    :state core/state
-   :http-server (pc/fnk [[:routines waiter-request?-fn websocket-request-authenticator]
+   :http-server (pc/fnk [[:routines prepend-waiter-url waiter-request?-fn websocket-request-authenticator]
                          [:settings cors-config host port support-info websocket-config]
                          [:state cors-validator router-id]
                          handlers] ; Insist that all systems are running before we start server
@@ -74,7 +74,7 @@
                                        {:ring-handler (-> (core/ring-handler-factory waiter-request?-fn handlers)
                                                           (cors/wrap-cors-preflight cors-validator (:max-age cors-config))
                                                           core/wrap-error-handling
-                                                          core/wrap-debug
+                                                          (core/wrap-debug prepend-waiter-url)
                                                           core/correlation-id-middleware
                                                           (core/wrap-request-info router-id support-info)
                                                           consume-request-stream)

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -66,7 +66,7 @@
    :daemons core/daemons
    :handlers core/request-handlers
    :state core/state
-   :http-server (pc/fnk [[:routines prepend-waiter-url waiter-request?-fn websocket-request-authenticator]
+   :http-server (pc/fnk [[:routines generate-log-url-fn waiter-request?-fn websocket-request-authenticator]
                          [:settings cors-config host port support-info websocket-config]
                          [:state cors-validator router-id]
                          handlers] ; Insist that all systems are running before we start server
@@ -74,7 +74,7 @@
                                        {:ring-handler (-> (core/ring-handler-factory waiter-request?-fn handlers)
                                                           (cors/wrap-cors-preflight cors-validator (:max-age cors-config))
                                                           core/wrap-error-handling
-                                                          (core/wrap-debug prepend-waiter-url)
+                                                          (core/wrap-debug generate-log-url-fn)
                                                           core/correlation-id-middleware
                                                           (core/wrap-request-info router-id support-info)
                                                           consume-request-stream)

--- a/waiter/src/waiter/ring_utils.clj
+++ b/waiter/src/waiter/ring_utils.clj
@@ -35,3 +35,10 @@
   [request]
   (let [encoding (or (ring-request/character-encoding request) "UTF-8")]
     (ring-params/assoc-query-params request encoding)))
+
+(defn error-response?
+  "Determines if a response is an error"
+  [{:keys [status]}]
+  (and status
+       (>= status 400)
+       (<= status 599)))

--- a/waiter/src/waiter/ring_utils.clj
+++ b/waiter/src/waiter/ring_utils.clj
@@ -26,7 +26,7 @@
   "Tries to parse a request body as JSON, if error, throw 400."
   [{:keys [body] {:strs [content-type]} :headers :as request}]
   (try
-    (assoc request :body (-> body slurp (json/read-str)))
+    (assoc request :body (-> body slurp json/read-str))
     (catch Exception e
       (throw (ex-info "Invalid JSON payload" {:status 400} e)))))
 

--- a/waiter/src/waiter/websocket.clj
+++ b/waiter/src/waiter/websocket.clj
@@ -355,7 +355,7 @@
                   (log/debug "ignoring exception generated from closed connection")))))))
       (catch Exception e
         (async/>!! request-close-promise-chan :process-error)
-        (throw e))))
+        (log/error e "error while processing websocket response"))))
   {}) ;; return an empty response map to maintain consistency with the http case
 
 (defn wrap-ws-close-on-error

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -283,7 +283,7 @@
 (deftest test-service-view-logs-handler
   (let [scheduler (marathon/->MarathonScheduler (Object.) {:slave-port 5051} (fn [] nil) "/home/path/"
                                                 (atom {}) (atom {}) 0 (constantly true))
-        configuration {:routines {:prepend-waiter-url identity}
+        configuration {:routines {:generate-log-url-fn (partial handler/generate-log-url identity)}
                        :state {:scheduler scheduler}
                        :wrap-secure-request-fn utils/wrap-identity}
         handlers {:service-view-logs-handler-fn ((:service-view-logs-handler-fn request-handlers) configuration)}
@@ -389,8 +389,8 @@
                                      (sd/can-manage-service? kv-store entitlement-manager service-id auth-user))
         configuration {:curator {:kv-store nil}
                        :routines {:allowed-to-manage-service?-fn allowed-to-manage-service?
-                                  :make-inter-router-requests-sync-fn nil
-                                  :prepend-waiter-url nil}
+                                  :generate-log-url-fn nil
+                                  :make-inter-router-requests-sync-fn nil}
                        :state {:router-id "router-id"
                                :scheduler (Object.)}
                        :wrap-secure-request-fn utils/wrap-identity}
@@ -461,8 +461,8 @@
         waiter-request?-fn (fn [_] true)
         configuration {:curator {:kv-store nil}
                        :routines {:allowed-to-manage-service?-fn (constantly true)
-                                  :make-inter-router-requests-sync-fn nil
-                                  :prepend-waiter-url #(str "http://www.example.com" %)}
+                                  :generate-log-url-fn (partial handler/generate-log-url #(str "http://www.example.com" %))
+                                  :make-inter-router-requests-sync-fn nil}
                        :state {:router-id "router-id"
                                :scheduler (Object.)}
                        :wrap-secure-request-fn utils/wrap-identity}


### PR DESCRIPTION
Note: this is based on #232

## Changes proposed in this PR

- Refactors process, includes `:instance` in the response, and changes the exception handling

## Why are we making these changes?

- The instance in the response allows more debug headers to be centralized in `wrap-debug`.
- `process` takes fewer parameters, has fewer responsibilities
