### PR TITLE
Prints report of longest running tests.

### DIFF
--- a/waiter/bin/ci/run-unit-tests.sh
+++ b/waiter/bin/ci/run-unit-tests.sh
@@ -3,4 +3,4 @@
 #
 # Runs the Waiter unit tests, and dumps log files if the tests fail.
 
-lein with-profiles +test-repl test || { echo "unit tests failed -- dumping logs"; tail -n +1 -- log/*.log; exit 1; }
+lein with-profiles +test-log test || { echo "unit tests failed -- dumping logs"; tail -n +1 -- log/*.log; exit 1; }


### PR DESCRIPTION
## Changes proposed in this PR

- Prints report of longest running tests.
- See build output for the report.
- Each individual test also includes duration on finish.

## Why are we making these changes?

- Helps us identify which tests are taking a long time.

