### PR TITLE
Speeds up integration tests

### DIFF
--- a/waiter/config-minimesos.edn
+++ b/waiter/config-minimesos.edn
@@ -31,4 +31,7 @@
                                               :spnego-auth false}}}
 
  ; ---------- CORS ----------
- :cors-config {:kind :allow-all }}
+ :cors-config {:kind :allow-all }
+
+;; Require fewer failed health checks
+:health-check-config {:failed-check-threshold 2}}

--- a/waiter/config-shell.edn
+++ b/waiter/config-shell.edn
@@ -26,4 +26,7 @@
                     :kind :shell}
 
  ; ---------- CORS ----------
- :cors-config {:kind :allow-all}}
+ :cors-config {:kind :allow-all}
+
+;; Require fewer failed health checks
+:health-check-config {:failed-check-threshold 2}}

--- a/waiter/integration/waiter/async_request_integration_test.clj
+++ b/waiter/integration/waiter/async_request_integration_test.clj
@@ -184,7 +184,7 @@
           headers {:x-waiter-name (rand-name)
                    :x-waiter-concurrency-level 5}
           {:keys [request-headers service-id cookies]} (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))
-          request-processing-time-ms 60000
+          request-processing-time-ms 30000
           num-threads 20
           num-requests-to-delete 10
           async-responses (parallelize-requests

--- a/waiter/integration/waiter/deployment_errors_test.clj
+++ b/waiter/integration/waiter/deployment_errors_test.clj
@@ -52,8 +52,11 @@
 (deftest ^:parallel ^:integration-slow test-invalid-health-check-response
   (testing-using-waiter-url
     (let [headers {:x-waiter-name (rand-name)
+                   :x-waiter-grace-period-secs 15
                    ; health check endpoint always returns status 402
                    :x-waiter-health-check-url "/bad-status?status=402"
+                   :x-waiter-health-check-interval-secs 5
+                   :x-waiter-health-check-max-consecutive-failures 1
                    :x-waiter-queue-timeout 600000}
           response (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))]
       (with-service-cleanup (response->service-id response)
@@ -64,6 +67,9 @@
     (let [headers {:x-waiter-name (rand-name)
                    ; nothing to connect to
                    :x-waiter-cmd "sleep 3600"
+                   :x-waiter-grace-period-secs 15
+                   :x-waiter-health-check-interval-secs 5
+                   :x-waiter-health-check-max-consecutive-failures 1
                    :x-waiter-queue-timeout 600000}
           response (make-request-with-debug-info headers #(make-shell-request waiter-url %))]
       (with-service-cleanup (response->service-id response)
@@ -74,6 +80,9 @@
     (let [headers {:x-waiter-name (rand-name)
                    ; health check endpoint sleeps for 300000 ms (= 5 minutes)
                    :x-waiter-health-check-url "/sleep?sleep-ms=300000&status=400"
+                   :x-waiter-grace-period-secs 15
+                   :x-waiter-health-check-interval-secs 5
+                   :x-waiter-health-check-max-consecutive-failures 1
                    :x-waiter-queue-timeout 600000}
           response (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))]
       (with-service-cleanup (response->service-id response)

--- a/waiter/integration/waiter/request_timeout_test.clj
+++ b/waiter/integration/waiter/request_timeout_test.clj
@@ -101,7 +101,7 @@
 
 (deftest ^:parallel ^:integration-fast test-request-queue-timeout-slow-start-app
   (testing-using-waiter-url
-    (let [timeout-period-sec 30
+    (let [timeout-period-sec 10
           timeout-period-ms (time/in-millis (time/seconds timeout-period-sec))
           start-time-ms (System/currentTimeMillis)
           start-up-sleep-ms (* 2 timeout-period-ms)
@@ -116,7 +116,7 @@
 (deftest ^:parallel ^:integration-slow test-request-queue-timeout-faulty-app
   (testing-using-waiter-url
     (log/info (str "request-queue-timeout-faulty-app: if we can't get an instance quickly (should take " (colored-time "~1 minute") ")"))
-    (let [timeout-period-sec 60
+    (let [timeout-period-sec 10
           start-time-ms (System/currentTimeMillis)
           request-headers (walk/stringify-keys
                             {:x-waiter-name (rand-name)


### PR DESCRIPTION
## Changes proposed in this PR

- Tweaks parameters to make integration tests faster while hopefully maintaining reliability

## Why are we making these changes?

- We're weary of waiting for tests to finish

