### PR TITLE
Improves JSON error handling

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -646,6 +646,14 @@
           register-response (post-token waiter-url service-desc)]
       (is (= 400 (:status register-response))))))
 
+(deftest ^:parallel ^:integration-fast test-token-bad-payload
+  (testing-using-waiter-url
+    (let [{:keys [status]} (make-request waiter-url "/token"
+                                         :body "i'm bad at json"
+                                         :headers {"host" "test-token"}
+                                         :http-method-fn http/post)]
+      (is (= 400 status)))))
+
 (deftest ^:parallel ^:integration-fast test-token-environment-variables
   (testing-using-waiter-url
     (let [token (rand-name)


### PR DESCRIPTION
## Changes proposed in this PR

- Allow users to post JSON without setting `Content-Type` header
- Provides a JSON-specific error message when invalid JSON is `POST`ed
- Introduces Ring-style pattern for parsing JSON

## Why are we making these changes?

- Alleviate support burden
- Code clean up



