### PR TITLE
Add details to error pages

### DIFF
--- a/waiter/resources/web/error.html
+++ b/waiter/resources/web/error.html
@@ -120,6 +120,21 @@
       <tr>
         <td class="field">Time</td><td class="code"><%= timestamp %></td>
       </tr>
+      <% (when principal %>
+      <tr>
+        <td class="field">Principal</td><td class="code"><%= principal %></td>
+      </tr>
+      <% ) %>
+      <% (when service-id %>
+      <tr>
+      <td class="field">Service Id</td><td class="code"><%= service-id %></td>
+      </tr>
+      <% ) %>
+      <% (when instance-id %>
+      <tr>
+      <td class="field">Instance Id</td><td class="code"><%= instance-id %></td>
+      </tr>
+      <% ) %>
     </table>
   </div>
 </div>

--- a/waiter/resources/web/error.txt
+++ b/waiter/resources/web/error.txt
@@ -12,7 +12,10 @@ Request Info
   Query String: <%= (or query-string "") %>
         Method: <%= request-method %>
            CID: <%= cid %>
-          Time: <%= timestamp %>
+          Time: <%= timestamp %><% (when principal %>
+     Principal: <%= principal %><% ) %><% (when service-id %>
+    Service Id: <%= service-id %><% ) %><% (when instance-id %>
+   Instance Id: <%= instance-id %><% ) %>
 
 <% (when details %>
 Additional Info

--- a/waiter/src/waiter/auth/authentication.clj
+++ b/waiter/src/waiter/auth/authentication.clj
@@ -38,8 +38,8 @@
 (defn assoc-auth-params
   "Associate values for authenticated user in the request."
   ([request principal]
-   (assoc-auth-params request (first (str/split principal #"@" 2)) principal))
-  ([request user principal]
+   (assoc-auth-params request principal (first (str/split principal #"@" 2))))
+  ([request principal user]
    (assoc request
           :authorization/principal principal
           :authorization/user user)))
@@ -48,7 +48,7 @@
   "Invokes the given request-handler on the given request, adding the necessary
   auth headers on the way in, and the x-waiter-auth cookie on the way out."
   [handler request user principal password]
-  (let [assoc-auth-params-fn #(assoc-auth-params % user principal)
+  (let [assoc-auth-params-fn #(assoc-auth-params % principal user)
         handler' (middleware/wrap-update handler assoc-auth-params-fn)]
     (-> request
         handler'

--- a/waiter/src/waiter/auth/spnego.clj
+++ b/waiter/src/waiter/auth/spnego.clj
@@ -18,6 +18,7 @@
             [ring.middleware.cookies :as cookies]
             [ring.util.response :as rr]
             [waiter.auth.authentication :as auth]
+            [waiter.middleware :as middleware]
             [waiter.metrics :as metrics])
   (:import (org.apache.commons.codec.binary Base64)
            (org.eclipse.jetty.client.api Authentication$Result Request)
@@ -80,12 +81,13 @@
   [request-handler password]
   (fn require-gss-handler [{:keys [headers] :as req}]
     (let [waiter-cookie (auth/get-auth-cookie-value (get headers "cookie"))
-          [auth-principal _ :as decoded-auth-cookie] (auth/decode-auth-cookie waiter-cookie password)]
+          [auth-principal _ :as decoded-auth-cookie] (auth/decode-auth-cookie waiter-cookie password)
+          assoc-auth-params-fn #(auth/assoc-auth-params % auth-principal)]
       (cond
         ;; Use the cookie, if not expired
         (auth/decoded-auth-valid? decoded-auth-cookie)
-        (-> (auth/assoc-auth-in-request req auth-principal)
-            (request-handler))
+        (let [request-handler' (middleware/wrap-update request-handler assoc-auth-params-fn)]
+          (request-handler' req))
         ;; Try and authenticate using kerberos and add cookie in response when valid
         (get-in req [:headers "authorization"])
         (let [^GSSContext gss_context (gss-context-init)

--- a/waiter/src/waiter/auth/spnego.clj
+++ b/waiter/src/waiter/auth/spnego.clj
@@ -82,11 +82,11 @@
   (fn require-gss-handler [{:keys [headers] :as req}]
     (let [waiter-cookie (auth/get-auth-cookie-value (get headers "cookie"))
           [auth-principal _ :as decoded-auth-cookie] (auth/decode-auth-cookie waiter-cookie password)
-          assoc-auth-params-fn #(auth/assoc-auth-params % auth-principal)]
+          auth-params-map (auth/auth-params-map auth-principal)]
       (cond
         ;; Use the cookie, if not expired
         (auth/decoded-auth-valid? decoded-auth-cookie)
-        (let [request-handler' (middleware/wrap-update request-handler assoc-auth-params-fn)]
+        (let [request-handler' (middleware/wrap-merge request-handler auth-params-map)]
           (request-handler' req))
         ;; Try and authenticate using kerberos and add cookie in response when valid
         (get-in req [:headers "authorization"])

--- a/waiter/src/waiter/cookie_support.clj
+++ b/waiter/src/waiter/cookie_support.clj
@@ -16,6 +16,7 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [taoensso.nippy :as nippy]
+            [waiter.ring-utils :as ru]
             [waiter.utils :as utils])
   (:import clojure.lang.ExceptionInfo
            org.eclipse.jetty.util.UrlEncoded))
@@ -68,9 +69,7 @@
                                (string? existing-header) [existing-header set-cookie-header]
                                :else (conj existing-header set-cookie-header))]
               (assoc-in response [:headers "set-cookie"] new-header)))]
-    (if (map? response)
-      (add-cookie-into-response response)
-      (async/go (add-cookie-into-response (async/<! response))))))
+    (ru/update-response response add-cookie-into-response)))
 
 (defn decode-cookie
   "Decode Waiter encoded cookie."

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -39,7 +39,7 @@
   "Creates a map containing the username and principal from a request"
   [request]
   {:username (:authorization/user request)
-   :principal (:authenticated-principal request)})
+   :principal (:authorization/principal request)})
 
 (defn async-make-request-helper
   "Helper function that returns a function that can invoke make-request-fn."

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -38,8 +38,8 @@
 (defn make-auth-user-map
   "Creates a map containing the username and principal from a request"
   [request]
-  {:username (:authorization/user request)
-   :principal (:authorization/principal request)})
+  {:principal (:authorization/principal request)
+   :username (:authorization/user request)})
 
 (defn async-make-request-helper
   "Helper function that returns a function that can invoke make-request-fn."

--- a/waiter/src/waiter/middleware.clj
+++ b/waiter/src/waiter/middleware.clj
@@ -15,7 +15,8 @@
             [waiter.utils :as utils]))
 
 (defn wrap-update
-  "Wraps a handler, calling update on the request and response."
+  "Wraps a handler, calling update on the request and the response.
+  If there was an error, also updates the exception."
   [handler update-fn]
   (fn [request]
     (try
@@ -29,3 +30,9 @@
           (update-fn response)))
       (catch Exception e
         (throw (utils/update-exception e update-fn))))))
+
+(defn wrap-assoc
+  "Wraps a handler, calling assoc on the request and the response.
+  If there was an error, also calls assoc on the exception."
+  [handler k v]
+  (wrap-update handler #(assoc % k v)))

--- a/waiter/src/waiter/middleware.clj
+++ b/waiter/src/waiter/middleware.clj
@@ -14,18 +14,18 @@
             [waiter.async-utils :as au]
             [waiter.utils :as utils]))
 
-(defn wrap-context
-  "Wraps a handler, ensuring the request and response (or exception) contains data in the context map."
-  [handler context]
+(defn wrap-update
+  "Wraps a handler, calling update on the request and response."
+  [handler update-fn]
   (fn [request]
     (try
-      (let [response (handler (merge request context))]
+      (let [response (handler (update-fn request))]
         (if (au/chan? response)
           (async/go
             (try
-              (merge (<? response) context)
+              (update-fn (<? response))
               (catch Exception e
-                (utils/merge-exception e context))))
-          (merge response context)))
+                (utils/update-exception e update-fn))))
+          (update-fn response)))
       (catch Exception e
-        (throw (utils/merge-exception e context))))))
+        (throw (utils/update-exception e update-fn))))))

--- a/waiter/src/waiter/middleware.clj
+++ b/waiter/src/waiter/middleware.clj
@@ -36,3 +36,9 @@
   If there was an error, also calls assoc on the exception."
   [handler k v]
   (wrap-update handler #(assoc % k v)))
+
+(defn wrap-merge
+  "Wraps a handler, calling merge on the request and the response.
+  If there was an error, also calls merge on the exception."
+  [handler m]
+  (wrap-update handler #(merge % m)))

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -469,7 +469,7 @@
   (fn [request]
     (try-let [descriptor (request->descriptor-fn request)]
       (let [handler (-> handler
-                        (middleware/wrap-update #(assoc % :descriptor descriptor)))]
+                        (middleware/wrap-assoc :descriptor descriptor))]
         (handler request))
       (catch Exception e
         (if (missing-run-as-user? e)

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -590,7 +590,7 @@
                            (not (str/blank? last-updated-by)) (assoc :last-updated-by last-updated-by))]
         (log/info "Service has been suspended" response-map)
         (meters/mark! (metrics/service-meter service-id "response-rate" "error" "suspended"))
-        (-> {:details (str response-map), :message "Service has been suspended", :status 503}
+        (-> {:details response-map, :message "Service has been suspended", :status 503}
             (utils/data->error-response request)))
       (handler request))))
 
@@ -608,7 +608,7 @@
                             :service-id service-id}]
           (log/info "Max queue length exceeded" response-map)
           (meters/mark! (metrics/service-meter service-id "response-rate" "error" "queue-length"))
-          (-> {:details (str response-map), :message "Max queue length exceeded", :status 503}
+          (-> {:details response-map, :message "Max queue length exceeded", :status 503}
               (utils/data->error-response request)))
         (handler request)))))
 

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -469,7 +469,7 @@
   (fn [request]
     (try-let [descriptor (request->descriptor-fn request)]
       (let [handler (-> handler
-                        (middleware/wrap-context {:descriptor descriptor}))]
+                        (middleware/wrap-update #(assoc % :descriptor descriptor)))]
         (handler request))
       (catch Exception e
         (if (missing-run-as-user? e)

--- a/waiter/src/waiter/utils.clj
+++ b/waiter/src/waiter/utils.clj
@@ -544,3 +544,8 @@
   (if (instance? ExceptionInfo e)
     (ex-info (.getMessage e) (update-fn (ex-data e)) (.getCause e))
     (ex-info (.getMessage e) (update-fn {}) (.getCause e))))
+
+(defn assoc-exception
+  "Assoc-es data onto an exception, regardless of whether it's an ExceptionInfo or just Exception."
+  [^Exception e k v]
+  (update-exception #(assoc % k v)))

--- a/waiter/src/waiter/utils.clj
+++ b/waiter/src/waiter/utils.clj
@@ -544,8 +544,3 @@
   (if (instance? ExceptionInfo e)
     (ex-info (.getMessage e) (update-fn (ex-data e)) (.getCause e))
     (ex-info (.getMessage e) (update-fn {}) (.getCause e))))
-
-(defn assoc-exception
-  "Assoc-es data onto an exception, regardless of whether it's an ExceptionInfo or just Exception."
-  [^Exception e k v]
-  (update-exception #(assoc % k v)))

--- a/waiter/src/waiter/utils.clj
+++ b/waiter/src/waiter/utils.clj
@@ -219,8 +219,8 @@
      :principal principal
      :query-string query-string
      :request-method (-> (or request-method "") name str/upper-case)
-     :status status
      :service-id service-id
+     :status status
      :support-info support-info
      :timestamp (date-to-str request-time)
      :uri uri}))

--- a/waiter/src/waiter/utils.clj
+++ b/waiter/src/waiter/utils.clj
@@ -538,9 +538,9 @@
   (fn [request]
     (handler request)))
 
-(defn merge-exception
-  "Enriches an exception with a data map, regardless of whether it's an ExceptionInfo or just Exception."
-  [^Exception e m]
+(defn update-exception
+  "Updates an exception, regardless of whether it's an ExceptionInfo or just Exception."
+  [^Exception e update-fn]
   (if (instance? ExceptionInfo e)
-    (ex-info (.getMessage e) (merge (ex-data e) m) (.getCause e))
-    (ex-info (.getMessage e) m (.getCause e))))
+    (ex-info (.getMessage e) (update-fn (ex-data e)) (.getCause e))
+    (ex-info (.getMessage e) (update-fn {}) (.getCause e))))

--- a/waiter/src/waiter/websocket.clj
+++ b/waiter/src/waiter/websocket.clj
@@ -80,8 +80,8 @@
   [password process-request-fn {:keys [headers] :as request}]
   (let [auth-cookie (-> headers (get "cookie") str auth/get-auth-cookie-value) ;; auth-cookie is assumed to be valid
         [auth-principal auth-time] (auth/decode-auth-cookie auth-cookie password)
-        assoc-auth-params-fn #(auth/assoc-auth-params % auth-principal)
-        handler (middleware/wrap-update process-request-fn assoc-auth-params-fn)]
+        auth-params-map (auth/auth-params-map auth-principal)
+        handler (middleware/wrap-merge process-request-fn auth-params-map)]
     (log/info "processing websocket request" {:user auth-principal})
     (-> request
         (assoc :authorization/time auth-time)

--- a/waiter/src/waiter/websocket.clj
+++ b/waiter/src/waiter/websocket.clj
@@ -25,6 +25,7 @@
             [waiter.correlation-id :as cid]
             [waiter.headers :as headers]
             [waiter.metrics :as metrics]
+            [waiter.middleware :as middleware]
             [waiter.ring-utils :as ru]
             [waiter.scheduler :as scheduler]
             [waiter.statsd :as statsd]
@@ -78,11 +79,13 @@
    It populates the kerberos credentials and invokes process-request-fn."
   [password process-request-fn {:keys [headers] :as request}]
   (let [auth-cookie (-> headers (get "cookie") str auth/get-auth-cookie-value) ;; auth-cookie is assumed to be valid
-        [auth-principal auth-time] (auth/decode-auth-cookie auth-cookie password)]
+        [auth-principal auth-time] (auth/decode-auth-cookie auth-cookie password)
+        assoc-auth-params-fn #(auth/assoc-auth-params % auth-principal)
+        handler (middleware/wrap-update process-request-fn assoc-auth-params-fn)]
     (log/info "processing websocket request" {:user auth-principal})
-    (-> (auth/assoc-auth-in-request request auth-principal)
+    (-> request
         (assoc :authorization/time auth-time)
-        process-request-fn)))
+        handler)))
 
 (defn abort-request-callback-factory
   "Creates a callback to abort the http request."
@@ -118,7 +121,7 @@
                                   (headers/dissoc-hop-by-hop-headers)
                                   (dissoc-forbidden-headers)
                                   (assoc "Authorization" (str "Basic " (String. ^bytes (b64/encode (.getBytes (str "waiter:" service-password) "utf-8")) "utf-8")))
-                                  (headers/assoc-auth-headers (:authorization/user ws-request) (:authenticated-principal ws-request)))]
+                                  (headers/assoc-auth-headers (:authorization/user ws-request) (:authorization/principal ws-request)))]
                           (add-headers-to-upgrade-request! request headers)))
         response (async/promise-chan)
         ctrl-chan (async/chan)

--- a/waiter/test/waiter/auth/authenticator_test.clj
+++ b/waiter/test/waiter/auth/authenticator_test.clj
@@ -22,8 +22,8 @@
     (let [request-handler (wrap-auth-handler authenticator identity)
           request {}
           expected-request (assoc request
-                             :authorization/user username
-                             :authenticated-principal username)
+                             :authorization/principal username
+                             :authorization/user username)
           actual-result (request-handler request)]
       (is (= expected-request (dissoc actual-result :headers)))
       (is (str/includes? (get-in actual-result [:headers "set-cookie"]) "x-waiter-auth="))

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -127,8 +127,8 @@
         (is (str/includes? body "Missing host, location, port, request-id, router-id or service-id in uri"))))
 
     (testing "error-in-checking-backend-status"
-      (let [request {:authorization/user "test-user"
-                     :authenticated-principal "test-user@DOMAIN"
+      (let [request {:authorization/pricipal "test-user@DOMAIN"
+                     :authorization/user "test-user"
                      :headers {"accept" "application/json"}
                      :request-method :http-method
                      :route-params (make-route-params "local")}
@@ -173,8 +173,8 @@
                                                  (is (= (if (= router-type "local") my-router-id remote-router-id) target-router-id))
                                                  (is (= service-id in-service-id))
                                                  (is (= (request-id-fn router-type) request-id)))
-                    request {:authorization/user "test-user"
-                             :authenticated-principal "test-user@DOMAIN"
+                    request {:authorization/principal "test-user@DOMAIN"
+                             :authorization/user "test-user"
                              :headers {"accept" "application/json"}
                              :request-method request-method,
                              :route-params (make-route-params router-type)}
@@ -278,8 +278,8 @@
         (is (str/includes? body "Missing host, location, port, request-id, router-id or service-id in uri"))))
 
     (testing "error-in-checking-backend-status"
-      (let [request {:authorization/user "test-user"
-                     :authenticated-principal "test-user@DOMAIN"
+      (let [request {:authorization/principal "test-user@DOMAIN"
+                     :authorization/user "test-user"
                      :headers {"accept" "application/json"}
                      :route-params (make-route-params "local")
                      :request-method :http-method}
@@ -329,8 +329,8 @@
                                                  (is (= (if (= router-type "local") my-router-id remote-router-id) target-router-id))
                                                  (is (= service-id in-service-id))
                                                  (is (= (request-id-fn router-type) request-id)))
-                    request {:authorization/user "test-user"
-                             :authenticated-principal "test-user@DOMAIN"
+                    request {:authorization/principal "test-user@DOMAIN"
+                             :authorization/user "test-user"
                              :request-method request-method
                              :route-params (make-route-params router-type)}
                     make-http-request-fn (fn [instance in-request end-route metric-group]

--- a/waiter/test/waiter/middleware_test.clj
+++ b/waiter/test/waiter/middleware_test.clj
@@ -13,31 +13,31 @@
             [clojure.test :refer :all]
             [waiter.middleware :refer :all]))
 
-(deftest test-wrap-context
-  (testing "wrap context, sync"
+(deftest test-wrap-update
+  (testing "sync"
     (let [handler (-> (fn [request]
                         (is (= :value (:key request)))
                         {:status 200})
-                      (wrap-context {:key :value}))]
+                      (wrap-update #(assoc % :key :value)))]
       (is (= :value (-> {} handler :key)))))
-  (testing "wrap context, async"
+  (testing "async"
     (let [handler (-> (fn [request]
                         (is (= :value (:key request)))
                         (async/go {:status 200}))
-                      (wrap-context {:key :value}))]
+                      (wrap-update #(assoc % :key :value)))]
       (is (= :value (-> {} handler async/<!! :key)))))
-  (testing "wrap context, sync w/ exception"
+  (testing "sync w/ exception"
     (let [handler (-> (fn [request]
                         (is (= :value (:key request)))
                         (throw (ex-data "test" {})))
-                      (wrap-context {:key :value}))]
+                      (wrap-update #(assoc % :key :value)))]
       (try
         (handler {})
         (catch Exception e
           (is (= :value (-> e ex-data :key)))))))
-  (testing "wrap context, async w/ exception"
+  (testing "async w/ exception"
     (let [handler (-> (fn [request]
                         (is (= :value (:key request)))
                         (async/go (ex-info "test" {})))
-                      (wrap-context {:key :value}))]
+                      (wrap-update #(assoc % :key :value)))]
       (is (= :value (-> {} handler async/<!! ex-data :key))))))

--- a/waiter/test/waiter/middleware_test.clj
+++ b/waiter/test/waiter/middleware_test.clj
@@ -18,19 +18,19 @@
     (let [handler (-> (fn [request]
                         (is (= :value (:key request)))
                         {:status 200})
-                      (wrap-update #(assoc % :key :value)))]
+                      (wrap-assoc :key :value))]
       (is (= :value (-> {} handler :key)))))
   (testing "async"
     (let [handler (-> (fn [request]
                         (is (= :value (:key request)))
                         (async/go {:status 200}))
-                      (wrap-update #(assoc % :key :value)))]
+                      (wrap-assoc :key :value))]
       (is (= :value (-> {} handler async/<!! :key)))))
   (testing "sync w/ exception"
     (let [handler (-> (fn [request]
                         (is (= :value (:key request)))
                         (throw (ex-data "test" {})))
-                      (wrap-update #(assoc % :key :value)))]
+                      (wrap-assoc :key :value))]
       (try
         (handler {})
         (catch Exception e
@@ -39,5 +39,5 @@
     (let [handler (-> (fn [request]
                         (is (= :value (:key request)))
                         (async/go (ex-info "test" {})))
-                      (wrap-update #(assoc % :key :value)))]
+                      (wrap-assoc :key :value))]
       (is (= :value (-> {} handler async/<!! ex-data :key))))))

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -352,8 +352,8 @@
 
 (deftest test-make-request
   (let [instance {:service-id "test-service-id", :host "example.com", :port 8080, :protocol "proto"}
-        request {:authorization/user "test-user"
-                 :authenticated-principal "test-user@test.com"
+        request {:authorization/principal "test-user@test.com"
+                 :authorization/user "test-user"
                  :body "body"}
         request-properties {:connection-timeout-ms 123456, :initial-socket-timeout-ms 654321}
         passthrough-headers {"accept" "text/html"

--- a/waiter/test/waiter/utils_test.clj
+++ b/waiter/test/waiter/utils_test.clj
@@ -586,6 +586,6 @@
     (is (= {:a 4, :b 2, :m 20}
            (merge-by merge-fn {:a 1, :b 2} {:a 3, :m 4} {:m 5})))))
 
-(deftest test-merge-exception
-  (is (= {:a 1 :b 2} (ex-data (merge-exception (ex-info "test" {:a 1}) {:b 2}))))
-  (is (= {:b 2} (ex-data (merge-exception (RuntimeException. "test") {:b 2})))))
+(deftest test-update-exception
+  (is (= {:a 1 :b 2} (ex-data (update-exception (ex-info "test" {:a 1}) #(assoc % :b 2)))))
+  (is (= {:b 2} (ex-data (update-exception (RuntimeException. "test") #(assoc % :b 2))))))

--- a/waiter/test/waiter/websocket_test.clj
+++ b/waiter/test/waiter/websocket_test.clj
@@ -131,10 +131,11 @@
             process-request-atom (atom false)
             process-request-fn (fn process-request-fn [in-request]
                                  (is (= in-request
-                                        (assoc request :authorization/time auth-time
-                                                       :authorization/user auth-user
-                                                       :authenticated-principal auth-principal)))
-                                 (reset! process-request-atom true))]
+                                        (assoc request :authorization/principal auth-principal
+                                                       :authorization/time auth-time
+                                                       :authorization/user auth-user)))
+                                 (reset! process-request-atom true)
+                                 {})]
         (with-redefs [auth/get-auth-cookie-value identity
                       auth/decode-auth-cookie (fn [in-cookie in-password]
                                                 (is (= cookie-value in-cookie))


### PR DESCRIPTION
Based on #241 

## Changes proposed in this PR

- Adds `principal`, `service-id`, and `instance-id` to error pages.

## Why are we making these changes?

- Help debugging when errors occur

