### PR TITLE
Via headers

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -48,6 +48,7 @@
           (is (get-in body-json ["headers" "authorization"]) (str body))
           (is (get-in body-json ["headers" "x-waiter-auth-principal"]) (str body))
           (is (get-in body-json ["headers" "x-cid"]) (str body))
+          (is (get-in body-json ["headers" "via"]) (str body))
           (is (nil? (get-in body-json ["headers" "content-type"])) (str body))
           (is (= "0" (get-in body-json ["headers" "content-length"])) (str body))
           (is (= "text/plain" (get-in body-json ["headers" "accept"])) (str body))))

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -53,6 +53,12 @@
           (is (= "0" (get-in body-json ["headers" "content-length"])) (str body))
           (is (= "text/plain" (get-in body-json ["headers" "accept"])) (str body))))
 
+      (testing "loop detection"
+        (let [response (make-kitchen-request waiter-url
+                                             (assoc request-headers
+                                                    "via" (str "1.1 " service-id)))]
+          (assert-response-status response 482)))
+
       (testing "http methods"
         (log/info "Basic test for empty body in request")
         (let [http-method-helper (fn http-method-helper [http-method]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -997,6 +997,7 @@
                                pr/wrap-too-many-requests
                                pr/wrap-suspended-service
                                pr/wrap-response-status-metrics
+                               pr/wrap-loop-detection
                                (pr/wrap-descriptor request->descriptor-fn)
                                wrap-secure-request-fn
                                wrap-auth-bypass-fn)))

--- a/waiter/src/waiter/headers.clj
+++ b/waiter/src/waiter/headers.clj
@@ -93,3 +93,11 @@
   (cond-> headers
           username (assoc "x-waiter-auth-principal" username)
           principal (assoc "x-waiter-authenticated-principal" principal)))
+
+(defn append-header
+  "Appends a value onto a header in a response."
+  [headers header value]
+  (update headers header (fn [existing-value]
+                           (if existing-value
+                             (str existing-value ", " value)
+                             value))))

--- a/waiter/test/waiter/headers_test.clj
+++ b/waiter/test/waiter/headers_test.clj
@@ -141,10 +141,10 @@
     (is (= "value1"
            (-> {}
                (append-header "test-header" "value1")
-               (get-in [:headers "test-header"])))))
+               (get "test-header")))))
 
   (testing "header already exists"
     (is (= "value1, value2"
-         (-> {:headers {"test-header" "value1"}}
+         (-> {"test-header" "value1"}
              (append-header "test-header" "value2")
-             (get-in [:headers "test-header"]))))))
+             (get "test-header"))))))

--- a/waiter/test/waiter/headers_test.clj
+++ b/waiter/test/waiter/headers_test.clj
@@ -134,3 +134,17 @@
       (let [token (apply str (repeat 30 "foo"))]
         (is (= 90 (count token)))
         (is (= {"x-waiter-token" token} (truncate-header-values {"x-waiter-token" token})))))))
+
+
+(deftest test-append-header
+  (testing "header doesn't already exists"
+    (is (= "value1"
+           (-> {}
+               (append-header "test-header" "value1")
+               (get-in [:headers "test-header"])))))
+
+  (testing "header already exists"
+    (is (= "value1, value2"
+         (-> {:headers {"test-header" "value1"}}
+             (append-header "test-header" "value2")
+             (get-in [:headers "test-header"]))))))


### PR DESCRIPTION
## Changes proposed in this PR

Adds `Via` header in requests to services and responses from services.

## Why are we making these changes?

- RFC compliance.
- Users can tell if an error is coming from their app or from Waiter itself by inspecting the `Via` header.
- Adds basic loop detection if someone was to setup a proxy as service that forwarded requests back to Waiter.
