### PR TITLE
Disables Server header

### DIFF
--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -86,7 +86,8 @@
                                         :join? false
                                         :max-threads 250
                                         :port port
-                                        :request-header-size 32768})]
+                                        :request-header-size 32768
+                                        :send-server-version? false})]
                     (server/run-jetty options)))})
 
 (defn start-waiter [config-file]


### PR DESCRIPTION
## Changes proposed in this PR

- Avoids adding `Server` header to all responses

## Why are we making these changes?

- Avoid polluting proxied responses with the `Server` header
- Reduce bandwidth

