### PR TITLE
Response headers atom

### DIFF
--- a/waiter/src/waiter/async_request.clj
+++ b/waiter/src/waiter/async_request.clj
@@ -139,8 +139,9 @@
    The function assumes location begins with a slash.
    This method wires up the completion and status check callbacks for the monitoring system.
    It also modifies the status check endpoint in the response header."
-  [router-id async-request-store-atom make-http-request-fn instance-rpc-chan service-id metric-group {:keys [host port] :as instance}
-   {:keys [request-id] :as reason-map} request-properties location response-headers]
+  [router-id async-request-store-atom make-http-request-fn instance-rpc-chan response
+   service-id metric-group {:keys [host port] :as instance}
+   {:keys [request-id] :as reason-map} request-properties location]
   (let [correlation-id (cid/get-correlation-id)
         status-endpoint (scheduler/end-point-url instance location)
         _ (log/info "status endpoint for async request is" status-endpoint)
@@ -172,4 +173,5 @@
     (let [param-map {:host host, :location location, :port port, :request-id request-id, :router-id router-id, :service-id service-id}
           status-location (route-params->uri "/waiter-async/status/" param-map)]
       (log/info "updating status location to" status-location "from" location)
-      (swap! response-headers assoc "location" status-location))))
+      (-> response
+          (assoc-in [:headers "location"] status-location)))))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -691,10 +691,10 @@
    :post-process-async-request-response-fn (pc/fnk [[:state async-request-store-atom instance-rpc-chan router-id]
                                                     make-http-request-fn]
                                              (fn post-process-async-request-response-wrapper
-                                               [service-id metric-group instance _ reason-map request-properties location response-headers]
+                                               [response service-id metric-group instance _ reason-map request-properties location]
                                                (async-req/post-process-async-request-response
-                                                 router-id async-request-store-atom make-http-request-fn instance-rpc-chan service-id metric-group
-                                                 instance reason-map request-properties location response-headers)))
+                                                 router-id async-request-store-atom make-http-request-fn instance-rpc-chan response
+                                                 service-id metric-group instance reason-map request-properties location)))
    :prepend-waiter-url (pc/fnk [[:settings port hostname]]
                          (let [hostname (if (sequential? hostname) (first hostname) hostname)]
                            (fn [endpoint-url]

--- a/waiter/src/waiter/metrics.clj
+++ b/waiter/src/waiter/metrics.clj
@@ -449,6 +449,16 @@
      (~handle-elapsed-nanos-fn elapsed#)
      out#))
 
+(defmacro with-timer
+  "Times the operation specified by body using the provided
+  timer and calls handle-elapsed-nanos-fn with the epased
+  time in nanoseconds. Returns [value of body, nanos]."
+  [timer & body]
+  `(let [^Timer$Context start# (metrics.timers/start ~timer)
+         out# (do ~@body)
+         elapsed# (metrics.timers/stop start#)]
+     {:out out# :elapsed elapsed#}))
+
 (defn stream-metric-map
   "Returns a map containing metrics used for reporting streaming metrics for a given service."
   [service-id]

--- a/waiter/src/waiter/metrics.clj
+++ b/waiter/src/waiter/metrics.clj
@@ -452,7 +452,7 @@
 (defmacro with-timer
   "Times the operation specified by body using the provided
   timer and calls handle-elapsed-nanos-fn with the epased
-  time in nanoseconds. Returns [value of body, nanos]."
+  time in nanoseconds. Returns a map with :out and :elapsed keys."
   [timer & body]
   `(let [^Timer$Context start# (metrics.timers/start ~timer)
          out# (do ~@body)

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -526,9 +526,8 @@
                         ; request-state-chan should be explicitly closed after the request finishes processing
                         request-state-chan (async/tap control-mult (au/latest-chan) false)
                         queue-timeout-ms (:queue-timeout-ms instance-request-properties)
-                        instance-timer (metrics/service-timer service-id "get-available-instance")
                         timed-instance (metrics/with-timer
-                                         instance-timer
+                                         (metrics/service-timer service-id "get-available-instance")
                                          (fa/<? (prepare-instance instance-rpc-chan service-id reason-map
                                                                   start-new-service-fn request-state-chan queue-timeout-ms
                                                                   reservation-status-promise metric-group)))
@@ -539,9 +538,8 @@
                           (log/info "suggested instance:" (:id instance) (:host instance) (:port instance))
                           (confirm-live-connection-without-abort)
                           (let [endpoint (request->endpoint request waiter-headers)
-                                backend-timer (metrics/service-timer service-id "backend-response")
                                 timed-response (metrics/with-timer
-                                                 backend-timer
+                                                 (metrics/service-timer service-id "backend-response")
                                                  (async/<!
                                                    (make-request-fn instance request instance-request-properties
                                                                     passthrough-headers endpoint metric-group)))

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -196,19 +196,19 @@
           (do
             (deliver reservation-status-promise :client-error)
             (-> "Connection unexpectedly closed while sending request"
-                (wrap-exception error instance 400 @response-headers)))
+                (wrap-exception error instance 400 response-headers)))
 
           (instance? TimeoutException error)
           (do
             (deliver reservation-status-promise :instance-error)
             (-> (utils/message :backend-request-timed-out)
-                (wrap-exception error instance 504 @response-headers)))
+                (wrap-exception error instance 504 response-headers)))
 
           :else
           (do
             (deliver reservation-status-promise :instance-error)
             (-> (utils/message :backend-request-failed)
-                (wrap-exception error instance 502 @response-headers))))))
+                (wrap-exception error instance 502 response-headers))))))
 
 (defn http-method-fn
   "Retrieves the qbits.jet.client.http client function that corresponds to the http method."
@@ -563,7 +563,7 @@
                                 request-abort-callback (request-abort-callback-factory response)
                                 confirm-live-connection-with-abort (confirm-live-connection-factory request-abort-callback)]
                             (when error
-                              (throw-response-error error reservation-status-promise instance response-headers))
+                              (throw-response-error error reservation-status-promise instance @response-headers))
                             (process-backend-response-fn local-usage-agent instance-request-properties descriptor instance request
                                                          reason-map response-headers reservation-status-promise
                                                          confirm-live-connection-with-abort request-state-chan response))

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -488,10 +488,10 @@
           confirm-live-connection-factory #(confirm-live-connection-factory control-mult reservation-status-promise %1)
           confirm-live-connection-without-abort (confirm-live-connection-factory nil)
           waiter-debug-enabled? (utils/request->debug-enabled? request)
-          add-debug-header (fn [response header value]
-                             (if waiter-debug-enabled?
-                               (assoc-in response [:headers header] value)
-                               response))]
+          assoc-debug-header (fn [response header value]
+                               (if waiter-debug-enabled?
+                                 (assoc-in response [:headers header] value)
+                                 response))]
       (async/go
         (if waiter-debug-enabled?
           (log/info "process request to" (get-in request [:headers "host"]) "at path" (:uri request))
@@ -557,14 +557,14 @@
                                   (process-backend-response-fn local-usage-agent instance-request-properties descriptor instance request
                                                                reason-map reservation-status-promise confirm-live-connection-with-abort
                                                                request-state-chan response))
-                                (add-debug-header "x-waiter-backend-response-ns" (str response-elapsed))))
+                                (assoc-debug-header "x-waiter-backend-response-ns" (str response-elapsed))))
                           (catch Exception e
                             (deliver reservation-status-promise :generic-error)
                             ; close request-state-chan to mark the request as finished
                             (async/close! request-state-chan)
                             (handle-process-exception e request)))
                         (assoc :instance instance)
-                        (add-debug-header "x-waiter-get-available-instance-ns" (str instance-elapsed))))))
+                        (assoc-debug-header "x-waiter-get-available-instance-ns" (str instance-elapsed))))))
               (catch Exception e ; Handle case where we couldn't get an instance
                 (counters/dec! (metrics/service-counter service-id "request-counts" "outstanding"))
                 (statsd/gauge-delta! metric-group "request_outstanding" -1)

--- a/waiter/src/waiter/service.clj
+++ b/waiter/src/waiter/service.clj
@@ -222,61 +222,56 @@
   "Starts a `clojure.core.async/go` block to query the router state to get an
    available instance to send a request. It will continue to query the state until
    an instance is available."
-  [instance-rpc-chan service-id reason-map app-not-found-fn queue-timeout-ms metric-group add-debug-header-into-response!]
+  [instance-rpc-chan service-id reason-map app-not-found-fn queue-timeout-ms metric-group]
   (async/go
     (cid/with-correlation-id
       (:cid reason-map)
       (try
-        (metrics/with-timer!
-          (metrics/service-timer service-id "get-available-instance")
-          (fn [nanos]
-            (add-debug-header-into-response! "X-Waiter-Get-Available-Instance-ns" nanos)
-            (statsd/histo! metric-group "get_instance" nanos))
-          (counters/inc! (metrics/service-counter service-id "request-counts" "waiting-for-available-instance"))
-          (statsd/gauge-delta! metric-group "request_waiting_for_instance" +1)
-          (let [expiry-time (t/plus (t/now) (t/millis queue-timeout-ms))]
-            (loop [iterations 1]
-              (let [instance (get-rand-inst instance-rpc-chan service-id reason-map #{} queue-timeout-ms)]
-                (if-not (nil? (:id instance)) ; instance is nil or :no-matching-instance-found
-                  (do
-                    (histograms/update!
-                      (metrics/service-histogram service-id "iterations-to-find-available-instance")
-                      iterations)
-                    instance)
-                  (if (and instance (not= instance :no-matching-instance-found))
-                    ; instance is a deployment error if it (1) does not have an :id tag, (2) is not nil, and (3) does not equal :no-matching-instance-found
-                    (ex-info (str "Deployment error: " (utils/message instance)) {:service-id service-id :status 503})
-                    (if-not (t/before? (t/now) expiry-time) 
-                      (do
-                        ;; No instances were started in a reasonable amount of time
-                        (meters/mark! (metrics/service-meter service-id "no-available-instance-timeout"))
-                        (statsd/inc! metric-group "no_instance_timeout")
-                        (let [outstanding-requests (counters/value (metrics/service-counter service-id "request-counts" "outstanding"))
-                              requests-waiting-to-stream (counters/value (metrics/service-counter service-id "request-counts" "waiting-to-stream"))
-                              waiting-for-available-instance (counters/value (metrics/service-counter service-id "request-counts" "waiting-for-available-instance"))
-                              healthy-instances (counters/value (metrics/service-counter service-id "instance-counts" "healthy")) 
-                              unhealthy-instances (counters/value (metrics/service-counter service-id "instance-counts" "unhealthy"))
-                              failed-instances (counters/value (metrics/service-counter service-id "instance-counts" "failed"))]
-                          (ex-info (str "After " (t/in-seconds (t/millis queue-timeout-ms))
-                                        " seconds, no instance available to handle request."
-                                        (when (and (zero? healthy-instances) (or (pos? unhealthy-instances) (pos? failed-instances)))
-                                          " Check that your service is able to start properly!")
-                                        (when (and (pos? outstanding-requests) (pos? healthy-instances))
-                                          " Check that your service is able to scale properly!"))
-                                   {:service-id service-id
-                                    :outstanding-requests outstanding-requests
-                                    :requests-waiting-to-stream requests-waiting-to-stream
-                                    :waiting-for-available-instance waiting-for-available-instance
-                                    :slots-assigned (counters/value (metrics/service-counter service-id "instance-counts" "slots-assigned"))
-                                    :slots-available (counters/value (metrics/service-counter service-id "instance-counts" "slots-available"))
-                                    :slots-in-use (counters/value (metrics/service-counter service-id "instance-counts" "slots-in-use"))
-                                    :work-stealing-offers-received (counters/value (metrics/service-counter service-id "work-stealing" "received-from" "in-flight"))
-                                    :work-stealing-offers-sent (counters/value (metrics/service-counter service-id "work-stealing" "sent-to" "in-flight"))
-                                    :status 503})))
-                      (do
-                        (app-not-found-fn)
-                        (async/<! (async/timeout 1500))
-                        (recur (inc iterations))))))))))
+        (counters/inc! (metrics/service-counter service-id "request-counts" "waiting-for-available-instance"))
+        (statsd/gauge-delta! metric-group "request_waiting_for_instance" +1)
+        (let [expiry-time (t/plus (t/now) (t/millis queue-timeout-ms))]
+          (loop [iterations 1]
+            (let [instance (get-rand-inst instance-rpc-chan service-id reason-map #{} queue-timeout-ms)]
+              (if-not (nil? (:id instance)) ; instance is nil or :no-matching-instance-found
+                (do
+                  (histograms/update!
+                    (metrics/service-histogram service-id "iterations-to-find-available-instance")
+                    iterations)
+                  instance)
+                (if (and instance (not= instance :no-matching-instance-found))
+                  ; instance is a deployment error if it (1) does not have an :id tag, (2) is not nil, and (3) does not equal :no-matching-instance-found
+                  (ex-info (str "Deployment error: " (utils/message instance)) {:service-id service-id :status 503})
+                  (if-not (t/before? (t/now) expiry-time)
+                    (do
+                      ;; No instances were started in a reasonable amount of time
+                      (meters/mark! (metrics/service-meter service-id "no-available-instance-timeout"))
+                      (statsd/inc! metric-group "no_instance_timeout")
+                      (let [outstanding-requests (counters/value (metrics/service-counter service-id "request-counts" "outstanding"))
+                            requests-waiting-to-stream (counters/value (metrics/service-counter service-id "request-counts" "waiting-to-stream"))
+                            waiting-for-available-instance (counters/value (metrics/service-counter service-id "request-counts" "waiting-for-available-instance"))
+                            healthy-instances (counters/value (metrics/service-counter service-id "instance-counts" "healthy")) 
+                            unhealthy-instances (counters/value (metrics/service-counter service-id "instance-counts" "unhealthy"))
+                            failed-instances (counters/value (metrics/service-counter service-id "instance-counts" "failed"))]
+                        (ex-info (str "After " (t/in-seconds (t/millis queue-timeout-ms))
+                                      " seconds, no instance available to handle request."
+                                      (when (and (zero? healthy-instances) (or (pos? unhealthy-instances) (pos? failed-instances)))
+                                        " Check that your service is able to start properly!")
+                                      (when (and (pos? outstanding-requests) (pos? healthy-instances))
+                                        " Check that your service is able to scale properly!"))
+                                 {:service-id service-id
+                                  :outstanding-requests outstanding-requests
+                                  :requests-waiting-to-stream requests-waiting-to-stream
+                                  :waiting-for-available-instance waiting-for-available-instance
+                                  :slots-assigned (counters/value (metrics/service-counter service-id "instance-counts" "slots-assigned"))
+                                  :slots-available (counters/value (metrics/service-counter service-id "instance-counts" "slots-available"))
+                                  :slots-in-use (counters/value (metrics/service-counter service-id "instance-counts" "slots-in-use"))
+                                  :work-stealing-offers-received (counters/value (metrics/service-counter service-id "work-stealing" "received-from" "in-flight"))
+                                  :work-stealing-offers-sent (counters/value (metrics/service-counter service-id "work-stealing" "sent-to" "in-flight"))
+                                  :status 503})))
+                    (do
+                      (app-not-found-fn)
+                      (async/<! (async/timeout 1500))
+                      (recur (inc iterations)))))))))
         (catch Exception e
           (log/error e "Error in get-available-instance")
           e)

--- a/waiter/src/waiter/websocket.clj
+++ b/waiter/src/waiter/websocket.clj
@@ -290,7 +290,7 @@
 (defn process-response!
   "Processes a response resulting from a websocket request.
    It includes asynchronously streaming the content."
-  [local-usage-agent instance-request-properties descriptor _ request _ _ reservation-status-promise
+  [local-usage-agent instance-request-properties descriptor _ request _ reservation-status-promise
    confirm-live-connection-with-abort request-state-chan response]
   (let [{:keys [service-description service-id]} descriptor
         {:strs [metric-group]} service-description

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -276,11 +276,11 @@
             (let [reservation-status-promise (promise)
                   post-process-data (atom {})
                   post-process-async-request-response-fn
-                  (fn [_ _ _ auth-user _ _ location _]
+                  (fn [_ _ _ _ auth-user _ _ location]
                     (reset! post-process-data {:auth-user (:username auth-user), :location location}))]
               (inspect-for-202-async-request-response
-                post-process-async-request-response-fn {} "service-id" "metric-group" {}
-                endpoint request {} response (atom {}) reservation-status-promise)
+                response post-process-async-request-response-fn {} "service-id" "metric-group" {}
+                endpoint request {} reservation-status-promise)
               (deliver reservation-status-promise :not-async)
               (assoc @post-process-data :result @reservation-status-promise)))]
     (testing "202-missing-location-header"


### PR DESCRIPTION
It may be easier to follow this PR commit by commit.

## Changes proposed in this PR

- Removes `response-headers` atom

## Why are we making these changes?

- Complect the code

