### PR TITLE
adds the :on-the-fly? flag in the descriptor

### DIFF
--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -635,6 +635,7 @@
             (validate service-description-builder core-service-description {:allow-missing-required-fields? false})
             (validate service-description-builder service-description {:allow-missing-required-fields? false}))
           {:core-service-description core-service-description
+           :on-the-fly? contains-waiter-header?
            :service-authentication-disabled service-authentication-disabled
            :service-description service-description
            :service-id service-id


### PR DESCRIPTION
## Changes proposed in this PR

- adds the :on-the-fly? flag in the descriptor

## Why are we making these changes?

Allows us to easily track if a request was via an on-the-fly mechanism
