### PR TITLE
Provide service-description to the service factory

### DIFF
--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -305,7 +305,7 @@
                                       (fn assoc-log-url-to-instances [instances]
                                         (when (not-empty instances)
                                           (map #(assoc-log-url generate-log-url-fn %) instances)))]
-                                  (-> (scheduler/get-instances scheduler service-id core-service-description)
+                                  (-> (scheduler/get-instances scheduler service-id)
                                       (update-in [:active-instances] assoc-log-url-to-instances)
                                       (update-in [:failed-instances] assoc-log-url-to-instances)
                                       (update-in [:killed-instances] assoc-log-url-to-instances)))

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -61,11 +61,12 @@
 
 (defn wire-app
   [settings]
-  {:settings (pc/fnk dummy-symbol-for-fnk-schema-logic :- settings/settings-schema [] settings)
-   :curator core/curator
-   :routines core/routines
+  {:curator core/curator
    :daemons core/daemons
    :handlers core/request-handlers
+   :routines core/routines
+   :scheduler core/scheduler
+   :settings (pc/fnk dummy-symbol-for-fnk-schema-logic :- settings/settings-schema [] settings)
    :state core/state
    :http-server (pc/fnk [[:routines generate-log-url-fn waiter-request?-fn websocket-request-authenticator]
                          [:settings cors-config host port support-info websocket-config]

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -60,13 +60,13 @@
 
 (defprotocol ServiceScheduler
 
-  (get-apps->instances [this service-id->service-description]
+  (get-apps->instances [this]
     "Returns a map of scheduler/Service records -> scheduler/ServiceInstance records.")
 
   (get-apps [this]
     "Returns a list of scheduler/Service records")
 
-  (get-instances [this ^String service-id service-description]
+  (get-instances [this ^String service-id]
     "Retrieve a {:active-instances [...]. :failed-instances [...]} map of scheduler/ServiceInstance records for the given service-id.
      The active-instances should not be assumed to be healthy (or live).
      The failed-instances are guaranteed to be dead.")
@@ -359,7 +359,7 @@
                                           (metrics/waiter-timer "core" "scheduler" "get-apps")
                                           (retry-on-transient-server-exceptions
                                             "request-available-waiter-apps"
-                                            (get-apps->instances scheduler service-id->service-description-fn)))]
+                                            (get-apps->instances scheduler)))]
     (log/trace "request-available-waiter-apps:apps" (keys service->service-instances))
     service->service-instances))
 

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -531,9 +531,10 @@
 ;   :shell-scheduler/pid
 ;
 (defrecord ShellScheduler [work-directory id->service-agent port->reservation-atom port-grace-period-ms port-range]
+
   scheduler/ServiceScheduler
 
-  (get-apps->instances [_ _]
+  (get-apps->instances [_]
     (let [id->service @id->service-agent]
       (into {} (map (fn [[_ service-entry]]
                       (service-entry->instances service-entry))
@@ -543,7 +544,7 @@
     (let [id->service @id->service-agent]
       (map (fn [[_ {:keys [service]}]] service) id->service)))
 
-  (get-instances [_ service-id _]
+  (get-instances [_ service-id]
     (let [id->service @id->service-agent
           service-entry (get id->service service-id)]
       (second (service-entry->instances service-entry))))

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -587,8 +587,8 @@
   (let [current-time (t/now)
         service-id "service-1"
         instance-id "service-1.A"
-        make-marathon-scheduler #(->MarathonScheduler {} {} (fn [] nil) "/home/path/"
-                                                      (atom {}) %1 %2 (constantly true))
+        make-marathon-scheduler #(->MarathonScheduler {} {} (constantly nil) "/home/path/"
+                                                      (atom {}) %1 (constantly nil) %2 (constantly true))
         successful-kill-result {:instance-id instance-id :killed? true :service-id service-id}
         failed-kill-result {:instance-id instance-id :killed? false :service-id service-id}]
     (with-redefs [t/now (fn [] current-time)]
@@ -639,10 +639,10 @@
 
 (deftest test-service-id->state
   (let [service-id "service-id"
-        marathon-scheduler (->MarathonScheduler {} {} (fn [] nil) "/home/path/"
+        marathon-scheduler (->MarathonScheduler {} {} (constantly nil) "/home/path/"
                                                 (atom {service-id [:failed-instances]})
                                                 (atom {service-id :kill-call-info})
-                                                100 (constantly true))
+                                                (constantly nil) 100 (constantly true))
         state (scheduler/service-id->state marathon-scheduler service-id)]
     (is (= {:failed-instances [:failed-instances], :killed-instances [], :kill-info :kill-call-info} state))))
 
@@ -650,8 +650,8 @@
   (let [current-time (t/now)
         current-time-str (utils/date-to-str current-time)
         marathon-api (Object.)
-        marathon-scheduler (->MarathonScheduler marathon-api {} (fn [] nil) "/home/path/"
-                                                (atom {}) (atom {}) 60000 (constantly true))
+        marathon-scheduler (->MarathonScheduler marathon-api {} (constantly nil) "/home/path/"
+                                                (atom {}) (atom {}) (constantly nil) 60000 (constantly true))
         make-instance (fn [service-id instance-id]
                         {:id instance-id
                          :service-id service-id})]
@@ -840,7 +840,7 @@
                (process-kill-instance-request marathon-api service-id instance-id {})))))))
 
 (deftest test-delete-app
-  (let [scheduler (->MarathonScheduler {} {} nil nil (atom {}) (atom {}) nil nil)]
+  (let [scheduler (->MarathonScheduler {} {} nil nil (atom {}) (atom {}) (constantly nil) nil nil)]
 
     (with-redefs [marathon/delete-app (constantly {:deploymentId 12345})]
       (is (= {:result :deleted

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -48,7 +48,7 @@
   "Gets the task-stats for the first service in the given scheduler"
   [scheduler]
   (-> scheduler
-      (scheduler/get-apps->instances {})
+      scheduler/get-apps->instances
       keys
       first
       :task-stats))
@@ -259,7 +259,7 @@
              (scheduler/scale-app scheduler "foo" 1)))
       (ensure-agent-finished scheduler)
       ;; Successfully kill one instance, instances: 1
-      (let [instance (first (:active-instances (scheduler/get-instances scheduler "foo" {})))]
+      (let [instance (first (:active-instances (scheduler/get-instances scheduler "foo")))]
         (is (= {:killed? true, :success true, :result :deleted, :message (str "Deleted " (:id instance))}
                (scheduler/kill-instance scheduler instance))))
       (force-update-service-health scheduler scheduler-config)
@@ -284,7 +284,7 @@
            (create-test-service scheduler "foo")))
     (ensure-agent-finished scheduler)
     (with-redefs [perform-health-check (constantly true)]
-      (let [instance (first (:active-instances (scheduler/get-instances scheduler "foo" {})))]
+      (let [instance (first (:active-instances (scheduler/get-instances scheduler "foo")))]
         (is (= {:killed? true, :success true, :result :deleted, :message (str "Deleted " (:id instance))}
                (scheduler/kill-instance scheduler instance)))
         (is (= {:success true, :result :deleted, :message "Deleted foo"}
@@ -332,7 +332,7 @@
                              (let [c (async/chan)]
                                (async/go (async/>! c {:status 200}))
                                c))]
-      (let [instance (first (:active-instances (scheduler/get-instances scheduler "foo" {})))]
+      (let [instance (first (:active-instances (scheduler/get-instances scheduler "foo")))]
         ;; We force a health check to occur
         (force-update-service-health scheduler scheduler-config)
         (is (= 1 @health-check-count-atom))
@@ -551,12 +551,12 @@
            (create-test-service scheduler "foo" {"cmd" "sleep 10000" "mem" 0.1})))
     ;; Instance should get marked as failed
     (force-update-service-health scheduler scheduler-config)
-    (let [instances (scheduler/get-instances scheduler "foo" {})]
+    (let [instances (scheduler/get-instances scheduler "foo")]
       (is (= 1 (count (:failed-instances instances)))))
     ;; Loop should continue to launch additional instances after initial failure
     (force-maintain-instance-scale scheduler)
     (force-update-service-health scheduler scheduler-config)
-    (let [instances (scheduler/get-instances scheduler "foo" {})]
+    (let [instances (scheduler/get-instances scheduler "foo")]
       (is (= 2 (count (:failed-instances instances)))))
     (is (= {:success true, :result :deleted, :message "Deleted foo"}
            (scheduler/delete-app scheduler "foo")))))
@@ -574,7 +574,7 @@
     ;; Instance should be marked as unhealthy and failed
     (with-redefs [perform-health-check (constantly false)]
       (force-update-service-health scheduler scheduler-config))
-    (let [instances (scheduler/get-instances scheduler "foo" {})]
+    (let [instances (scheduler/get-instances scheduler "foo")]
       (is (= 0 (count (:active-instances instances))))
       (is (= 1 (count (:failed-instances instances)))))))
 

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -232,7 +232,7 @@
         instance2 (->ServiceInstance "s1.i2" "s1" started-at true nil #{} nil "host" 123 [] "proto" "/log" "test")
         instance3 (->ServiceInstance "s1.i3" "s1" started-at nil nil #{} nil "host" 123 [] "proto" "/log" "test")
         scheduler (reify ServiceScheduler
-                    (get-apps->instances [_ _]
+                    (get-apps->instances [_]
                       {(->Service "s1" {} {} {}) {:active-instances [instance1 instance2 instance3]
                                                   :failed-instances []}})
                     (service-id->state [_ _]


### PR DESCRIPTION
## Changes proposed in this PR

Provide the `service-id->service-description-fn` mapping to the scheduler through the `create-component` context.

## Why are we making these changes?

Other schedulers (e.g., Kubernetes) may need additional information from the service description in order to implement some of the Waiter `Scheduler` object API methods. We'd rather plumb this mapping through in one spot (to provide it to the scheduler's initialization function) than plumb it through to every scheduler method invocation.