### PR TITLE
Use Travis Docker VMs only when needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,9 +54,9 @@ matrix:
     - env: "NAME='Waiter integration tests: shell-fast'"
       services: docker
       before_script: cd waiter && $LEIN_DEPS_CMD
-      script: ./bin/ci/run-integration-tests.sh parallel-test integration-fast
+      script: ./bin/ci/run-integration-tests-shell-scheduler.sh parallel-test integration-fast
 
     - env: "NAME='Waiter integration tests: shell-slow'"
       services: docker
       before_script: cd waiter && $LEIN_DEPS_CMD
-      script: ./bin/ci/run-integration-tests.sh parallel-test integration-slow
+      script: ./bin/ci/run-integration-tests-shell-scheduler.sh parallel-test integration-slow

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,62 @@
-sudo: required
 dist: trusty
 group: deprecated-2017Q4
 language: java
-jdk:
-- oraclejdk8
-services:
-  - docker
+jdk: oraclejdk8
+
+addons:
+  artifacts: true
+
 branches:
-  only:
-  - master
-env:
-  global:
-    - DEPS_CMD='lein with-profiles +test voom build-deps'
-    - LEIN_GET='wget https://raw.githubusercontent.com/technomancy/leiningen/2.8.1/bin/lein'
-    - LEIN_CHMOD='chmod +x ./lein'
-    - _JAVA_OPTIONS='' # Avoid unwanted _JAVA_OPTIONS set by Travis CI
-  matrix:
-    - TEST_DIR=kitchen TEST_CMD='lein test'
-    - TEST_DIR=token-syncer TEST_CMD='./bin/ci/run-all-tests.sh'
-    - TEST_DIR=waiter TEST_CMD=./bin/ci/run-unit-tests.sh
-    - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests.sh parallel-test integration-fast'
-    - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests.sh parallel-test integration-slow'
-    - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests-shell-scheduler.sh parallel-test integration-fast'
-    - TEST_DIR=waiter TEST_CMD='./bin/ci/run-integration-tests-shell-scheduler.sh parallel-test integration-slow'
+  only: master
+
 cache:
   directories:
+    - $HOME/.lein
     - $HOME/.m2
     - $HOME/.voom-repos
-before_script: ($LEIN_GET && $LEIN_CHMOD && export PATH=$(pwd):$PATH && cd $TEST_DIR && $DEPS_CMD)
-script: cd $TEST_DIR && $TEST_CMD
-addons:
-    artifacts: true
+
+env:
+  global:
+    - LEIN_DEPS_CMD='lein with-profiles +test voom build-deps'
+    - PATH="$HOME/.lein/bin:$PATH"
+
+before_install:
+  - unset _JAVA_OPTIONS  # Avoid unwanted _JAVA_OPTIONS set by Travis CI
+  - echo "Sudo-enabled build? ${TRAVIS_SUDO}"
+
+install:
+  - ./waiter/bin/ci/install-lein
+
+matrix:
+  include:
+    - env: NAME='Kitchen tests'
+      before_script: cd kitchen && $LEIN_DEPS_CMD
+      script: lein test
+
+    - env: NAME='Token syncer tests'
+      before_script: cd token-syncer && $LEIN_DEPS_CMD
+      script: ./bin/ci/run-all-tests.sh
+
+    - env: NAME='Waiter unit tests'
+      before_script: cd waiter && $LEIN_DEPS_CMD
+      script: ./bin/ci/run-unit-tests.sh
+
+    - env: "NAME='Waiter integration tests: marathon-fast'"
+      services: docker
+      before_script: cd waiter && $LEIN_DEPS_CMD
+      script: ./bin/ci/run-integration-tests.sh parallel-test integration-fast
+
+    - env: "NAME='Waiter integration tests: marathon-slow'"
+      services: docker
+      before_script: cd waiter && $LEIN_DEPS_CMD
+      script: ./bin/ci/run-integration-tests.sh parallel-test integration-slow
+
+    - env: "NAME='Waiter integration tests: shell-fast'"
+      services: docker
+      before_script: cd waiter && $LEIN_DEPS_CMD
+      script: ./bin/ci/run-integration-tests.sh parallel-test integration-fast
+
+    - env: "NAME='Waiter integration tests: shell-slow'"
+      services: docker
+      before_script: cd waiter && $LEIN_DEPS_CMD
+      script: ./bin/ci/run-integration-tests.sh parallel-test integration-slow

--- a/token-syncer/bin/ci/run-all-tests.sh
+++ b/token-syncer/bin/ci/run-all-tests.sh
@@ -4,4 +4,11 @@
 # Runs the Token-Syncer unit and integration tests, and dumps log files if the tests fail.
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ "$TRAVIS" ]; then
+    # Don't exceed the Travis container 4GB max
+    export JVM_OPTS="-Xmx700m"
+    export LEIN_JVM_OPTS="-Xmx200m"
+fi
+
 ${DIR}/run-unit-tests.sh && ${DIR}/run-integration-tests.sh test integration

--- a/token-syncer/bin/test.sh
+++ b/token-syncer/bin/test.sh
@@ -9,7 +9,7 @@
 #
 # Waits for waiter servers to be listening and then runs the token-syncer tests using the provided test selector.
 
-set -v
+set -x
 
 function timeout() {
     perl -e 'alarm shift; exec @ARGV' "$@";

--- a/waiter/bin/ci/install-lein
+++ b/waiter/bin/ci/install-lein
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -ex
+
+lein_bin=$HOME/.lein/bin
+
+if ! [ -f $lein_bin/lein ]; then
+    mkdir -p $lein_bin
+    cd $lein_bin
+    wget 'https://raw.githubusercontent.com/technomancy/leiningen/2.8.1/bin/lein'
+    chmod a+x ./lein
+fi

--- a/waiter/bin/run-using-shell-scheduler.sh
+++ b/waiter/bin/run-using-shell-scheduler.sh
@@ -22,3 +22,8 @@ if [ "${RECOMPILE}" != "0" ]; then
 fi
 
 WAITER_AUTH_RUN_AS_USER=$(id -un) lein run config-shell.edn
+
+EXIT_CODE=$?
+
+echo "Waiter quit with code $EXIT_CODE"
+exit $EXIT_CODE


### PR DESCRIPTION
## Changes proposed in this PR

Update Travis YAML file to expand the test matrix like we did for Cook.

## Why are we making these changes?

Not all of our tests require the docker service. Explicitly including the docker service only where we actually use it lets the simpler test suites run in a container rather than a VM. The Travis containers have faster start-up time, plus more CPUs and RAM allocated.