### PR TITLE
Adds support for last-update-user metadata during token updates

### DIFF
--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -61,7 +61,11 @@
       (try
         ;; ARRANGE
         (let [last-update-time-ms (- (System/currentTimeMillis) 10000)
-              token-metadata {"deleted" true, "last-update-time" last-update-time-ms, "owner" "test-user", "root" "src1"}
+              token-metadata {"deleted" true
+                              "last-update-time" last-update-time-ms
+                              "last-update-user" "auth-user"
+                              "owner" "test-user"
+                              "root" "src1"}
               token-description (merge basic-description token-metadata)]
 
           (doseq [waiter-url waiter-urls]
@@ -106,7 +110,10 @@
       (try
         ;; ARRANGE
         (let [current-time-ms (System/currentTimeMillis)
-              token-metadata {"last-update-time" current-time-ms, "owner" "test-user", "root" "src1"}
+              token-metadata {"last-update-time" current-time-ms
+                              "last-update-user" "auth-user"
+                              "owner" "test-user"
+                              "root" "src1"}
               token-description (merge basic-description token-metadata)]
 
           (store-token (first waiter-urls) token-name nil (assoc token-description "deleted" true))
@@ -157,7 +164,10 @@
       (try
         ;; ARRANGE
         (let [current-time-ms (System/currentTimeMillis)
-              token-metadata {"last-update-time" current-time-ms, "owner" "test-user", "root" "src1"}
+              token-metadata {"last-update-time" current-time-ms
+                              "last-update-user" "auth-user"
+                              "owner" "test-user"
+                              "root" "src1"}
               token-description (merge basic-description token-metadata)]
 
           (store-token (first waiter-urls) token-name nil token-description)
@@ -204,7 +214,10 @@
       (try
         ;; ARRANGE
         (let [current-time-ms (System/currentTimeMillis)
-              token-metadata {"last-update-time" current-time-ms, "owner" "test-user", "root" "src1"}
+              token-metadata {"last-update-time" current-time-ms
+                              "last-update-user" "auth-user"
+                              "owner" "test-user"
+                              "root" "src1"}
               token-description (merge basic-description token-metadata)]
 
           (doseq [waiter-url waiter-urls]
@@ -245,14 +258,20 @@
       (try
         ;; ARRANGE
         (let [current-time-ms (System/currentTimeMillis)
-              token-metadata {"last-update-time" current-time-ms, "owner" "test-user", "root" "src1"}
+              token-metadata {"last-update-time" current-time-ms
+                              "last-update-user" "auth-user"
+                              "owner" "test-user"
+                              "root" "src1"}
               token-description (merge basic-description token-metadata)]
 
           (let [last-update-time-ms (- current-time-ms 10000)]
             (store-token (first waiter-urls) token-name nil token-description)
             (doseq [waiter-url (rest waiter-urls)]
               (store-token waiter-url token-name nil
-                           (assoc token-description "cpus" 2, "mem" 2048, "last-update-time" last-update-time-ms))))
+                           (assoc token-description
+                             "cpus" 2
+                             "mem" 2048
+                             "last-update-time" last-update-time-ms))))
 
           (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
 
@@ -305,6 +324,7 @@
                              (assoc basic-description
                                "cpus" (inc index)
                                "last-update-time" (- last-update-time-ms index)
+                               "last-update-user" (str "auth-user-" index)
                                "owner" (str "test-user-" index)
                                "root" "common-root")))
               waiter-urls))
@@ -318,6 +338,7 @@
               (let [latest-description (assoc basic-description
                                          "cpus" 1
                                          "last-update-time" last-update-time-ms
+                                         "last-update-user" "auth-user-0"
                                          "owner" "test-user-0"
                                          "root" "common-root")
                     waiter-sync-result (constantly
@@ -365,6 +386,7 @@
                              (assoc basic-description
                                "cpus" (inc index)
                                "last-update-time" (- last-update-time-ms index)
+                               "last-update-user" "auth-user"
                                "owner" "test-user"
                                "root" waiter-url)))
               waiter-urls))
@@ -378,6 +400,7 @@
               (let [latest-description (assoc basic-description
                                          "cpus" 1
                                          "last-update-time" last-update-time-ms
+                                         "last-update-user" "auth-user"
                                          "owner" "test-user"
                                          "root" (first waiter-urls))
                     sync-result (->> (rest waiter-urls)
@@ -388,6 +411,7 @@
                                            :details {:cluster (assoc basic-description
                                                                 "cpus" (+ index 2)
                                                                 "last-update-time" (- last-update-time-ms index 1)
+                                                                "last-update-user" "auth-user"
                                                                 "owner" "test-user"
                                                                 "root" waiter-url)
                                                      :latest latest-description}}]))
@@ -413,6 +437,7 @@
                         (is (= {:description (assoc basic-description
                                                "cpus" (inc index)
                                                "last-update-time" token-last-modified-time
+                                               "last-update-user" "auth-user"
                                                "owner" "test-user"
                                                "root" waiter-url)
                                 :headers {"content-type" "application/json"

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -882,4 +882,4 @@
             (delete-service waiter-url service-id)))
 
         (finally
-          (delete-token-and-assert waiter-url token))))))
+          #_(delete-token-and-assert waiter-url token))))))

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -882,4 +882,4 @@
             (delete-service waiter-url service-id)))
 
         (finally
-          #_(delete-token-and-assert waiter-url token))))))
+          (delete-token-and-assert waiter-url token))))))

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -110,7 +110,7 @@
 (def ^:const on-the-fly-service-description-keys (set/union service-description-keys #{"token"}))
 
 ; keys allowed in metadata for tokens, these need to be distinct from service description keys
-(def ^:const token-metadata-keys #{"deleted" "last-update-time" "owner" "root"})
+(def ^:const token-metadata-keys #{"deleted" "last-update-time" "last-update-user" "owner" "root"})
 
 ; keys allowed in the token data
 (def ^:const token-data-keys (set/union service-description-keys token-metadata-keys))


### PR DESCRIPTION
## Changes proposed in this PR

- add support for last-update-user metadata during token updates

## Why are we making these changes?

Knowing who the last modifier of a token is is useful.

<img width="614" alt="token-last-update-user" src="https://user-images.githubusercontent.com/6611249/38383227-8da3150c-38d1-11e8-83a7-3315c0c9bb9c.png">

