### PR TITLE
handles NPE in authentication

### DIFF
--- a/waiter/src/waiter/auth/authentication.clj
+++ b/waiter/src/waiter/auth/authentication.clj
@@ -36,7 +36,7 @@
   (cookie-support/add-encoded-cookie response password AUTH-COOKIE-NAME [principal (System/currentTimeMillis)] 1))
 
 (defn auth-params-map
-  "Creates a map intendted to be merged into requests/responses."
+  "Creates a map intended to be merged into requests/responses."
   ([principal]
    (auth-params-map principal (first (str/split principal #"@" 2))))
   ([principal user]

--- a/waiter/src/waiter/auth/spnego.clj
+++ b/waiter/src/waiter/auth/spnego.clj
@@ -81,12 +81,12 @@
   [request-handler password]
   (fn require-gss-handler [{:keys [headers] :as req}]
     (let [waiter-cookie (auth/get-auth-cookie-value (get headers "cookie"))
-          [auth-principal _ :as decoded-auth-cookie] (auth/decode-auth-cookie waiter-cookie password)
-          auth-params-map (auth/auth-params-map auth-principal)]
+          [auth-principal _ :as decoded-auth-cookie] (auth/decode-auth-cookie waiter-cookie password)]
       (cond
         ;; Use the cookie, if not expired
         (auth/decoded-auth-valid? decoded-auth-cookie)
-        (let [request-handler' (middleware/wrap-merge request-handler auth-params-map)]
+        (let [auth-params-map (auth/auth-params-map auth-principal)
+              request-handler' (middleware/wrap-merge request-handler auth-params-map)]
           (request-handler' req))
         ;; Try and authenticate using kerberos and add cookie in response when valid
         (get-in req [:headers "authorization"])

--- a/waiter/src/waiter/utils.clj
+++ b/waiter/src/waiter/utils.clj
@@ -552,4 +552,4 @@
   [^Exception e update-fn]
   (if (instance? ExceptionInfo e)
     (ex-info (.getMessage e) (update-fn (ex-data e)) (.getCause e))
-    (ex-info (.getMessage e) (update-fn {}) (.getCause e))))
+    (ex-info (.getMessage e) (update-fn {}) e)))

--- a/waiter/src/waiter/websocket.clj
+++ b/waiter/src/waiter/websocket.clj
@@ -28,8 +28,7 @@
             [waiter.middleware :as middleware]
             [waiter.ring-utils :as ru]
             [waiter.scheduler :as scheduler]
-            [waiter.statsd :as statsd]
-            [waiter.utils :as utils])
+            [waiter.statsd :as statsd])
   (:import (java.net HttpCookie SocketTimeoutException URLDecoder URLEncoder)
            (java.nio ByteBuffer)
            (org.eclipse.jetty.websocket.api MessageTooLargeException UpgradeRequest)


### PR DESCRIPTION
## Changes proposed in this PR

- allows spengo authentication to function
- preserve exception when it is a native Java exception

## Why are we making these changes?

We need a working spengo auth as well as a means to see the stacktrace when an exception is thrown.

