### PR TITLE
adds support for token history

### DIFF
--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -36,6 +36,16 @@
     (is (System/getenv "WAITER_URIS"))
     (is (> (count (waiter-urls)) 1))))
 
+(defn- basic-token-metadata
+  "Returns the common metadata used in the tests."
+  [current-time-ms]
+  {"last-update-time" current-time-ms
+   "last-update-user" "auth-user"
+   "owner" "test-user"
+   "previous" {"last-update-time" (- current-time-ms 30000)
+               "last-update-user" "another-auth-user"}
+   "root" "src1"})
+
 (defn- token->etag
   "Retrieves the etag for a token on a waiter router."
   [{:keys [load-token]} waiter-url token-name]
@@ -61,11 +71,8 @@
       (try
         ;; ARRANGE
         (let [last-update-time-ms (- (System/currentTimeMillis) 10000)
-              token-metadata {"deleted" true
-                              "last-update-time" last-update-time-ms
-                              "last-update-user" "auth-user"
-                              "owner" "test-user"
-                              "root" "src1"}
+              token-metadata (-> (basic-token-metadata last-update-time-ms)
+                                 (assoc "deleted" true))
               token-description (merge basic-description token-metadata)]
 
           (doseq [waiter-url waiter-urls]
@@ -110,10 +117,7 @@
       (try
         ;; ARRANGE
         (let [current-time-ms (System/currentTimeMillis)
-              token-metadata {"last-update-time" current-time-ms
-                              "last-update-user" "auth-user"
-                              "owner" "test-user"
-                              "root" "src1"}
+              token-metadata (basic-token-metadata current-time-ms)
               token-description (merge basic-description token-metadata)]
 
           (store-token (first waiter-urls) token-name nil (assoc token-description "deleted" true))
@@ -164,10 +168,7 @@
       (try
         ;; ARRANGE
         (let [current-time-ms (System/currentTimeMillis)
-              token-metadata {"last-update-time" current-time-ms
-                              "last-update-user" "auth-user"
-                              "owner" "test-user"
-                              "root" "src1"}
+              token-metadata (basic-token-metadata current-time-ms)
               token-description (merge basic-description token-metadata)]
 
           (store-token (first waiter-urls) token-name nil token-description)
@@ -214,10 +215,7 @@
       (try
         ;; ARRANGE
         (let [current-time-ms (System/currentTimeMillis)
-              token-metadata {"last-update-time" current-time-ms
-                              "last-update-user" "auth-user"
-                              "owner" "test-user"
-                              "root" "src1"}
+              token-metadata (basic-token-metadata current-time-ms)
               token-description (merge basic-description token-metadata)]
 
           (doseq [waiter-url waiter-urls]
@@ -258,10 +256,7 @@
       (try
         ;; ARRANGE
         (let [current-time-ms (System/currentTimeMillis)
-              token-metadata {"last-update-time" current-time-ms
-                              "last-update-user" "auth-user"
-                              "owner" "test-user"
-                              "root" "src1"}
+              token-metadata (basic-token-metadata current-time-ms)
               token-description (merge basic-description token-metadata)]
 
           (let [last-update-time-ms (- current-time-ms 10000)]
@@ -326,6 +321,8 @@
                                "last-update-time" (- last-update-time-ms index)
                                "last-update-user" (str "auth-user-" index)
                                "owner" (str "test-user-" index)
+                               "previous" {"last-update-time" (- current-time-ms 30000)
+                                           "last-update-user" "foo-user"}
                                "root" "common-root")))
               waiter-urls))
 
@@ -340,6 +337,8 @@
                                          "last-update-time" last-update-time-ms
                                          "last-update-user" "auth-user-0"
                                          "owner" "test-user-0"
+                                         "previous" {"last-update-time" (- current-time-ms 30000)
+                                                     "last-update-user" "foo-user"}
                                          "root" "common-root")
                     waiter-sync-result (constantly
                                          {:code :success/sync-update
@@ -388,6 +387,8 @@
                                "last-update-time" (- last-update-time-ms index)
                                "last-update-user" "auth-user"
                                "owner" "test-user"
+                               "previous" {"last-update-time" (- current-time-ms 30000)
+                                           "last-update-user" "foo-user"}
                                "root" waiter-url)))
               waiter-urls))
 
@@ -402,6 +403,8 @@
                                          "last-update-time" last-update-time-ms
                                          "last-update-user" "auth-user"
                                          "owner" "test-user"
+                                         "previous" {"last-update-time" (- current-time-ms 30000)
+                                                     "last-update-user" "foo-user"}
                                          "root" (first waiter-urls))
                     sync-result (->> (rest waiter-urls)
                                      (map-indexed
@@ -413,6 +416,8 @@
                                                                 "last-update-time" (- last-update-time-ms index 1)
                                                                 "last-update-user" "auth-user"
                                                                 "owner" "test-user"
+                                                                "previous" {"last-update-time" (- current-time-ms 30000)
+                                                                            "last-update-user" "foo-user"}
                                                                 "root" waiter-url)
                                                      :latest latest-description}}]))
                                      (into {}))
@@ -439,6 +444,8 @@
                                                "last-update-time" token-last-modified-time
                                                "last-update-user" "auth-user"
                                                "owner" "test-user"
+                                               "previous" {"last-update-time" (- current-time-ms 30000)
+                                                           "last-update-user" "foo-user"}
                                                "root" waiter-url)
                                 :headers {"content-type" "application/json"
                                           "etag" token-etag}

--- a/token-syncer/project.clj
+++ b/token-syncer/project.clj
@@ -10,7 +10,7 @@
 ;;
 (defproject token-syncer "0.1.0-SNAPSHOT"
   :dependencies [^{:voom {:repo "https://github.com/twosigma/jet.git" :branch "waiter-patch"}}
-                 [cc.qbits/jet "0.7.10-20180124_201515-g857338f"]
+                 [cc.qbits/jet "0.7.10-20180410_173552-gb29616d"]
                  [clj-time "0.12.0"]
                  [commons-codec/commons-codec "1.10"]
                  [org.clojure/clojure "1.8.0"]

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -527,7 +527,7 @@
 
  :token-config {
                 ;; Configures the amount of history we store for a token.
-                ;; When it is at least 1, it enables blue/green deployment of services.
+                ;; It must be a positive integer.
                 :history-length 5}
 
  ;; Waiter supports making websocket connections to backends.

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -525,6 +525,11 @@
                        ;; flagged as never-passed-health-checks upon failure
                        :failed-check-threshold 5}
 
+ :token-config {
+                ;; Configures the amount of history we store for a token.
+                ;; When it is at least 1, it enables blue/green deployment of services.
+                :history-length 5}
+
  ;; Waiter supports making websocket connections to backends.
  ;; The maximum binary and text message sizes in the websocket request or response can be configured
  ;; as follows, the values are in bytes:

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1175,12 +1175,13 @@
                         (fn status-handler-fn [_] {:body "ok" :headers {} :status 200}))
    :token-handler-fn (pc/fnk [[:curator kv-store]
                               [:routines make-inter-router-requests-sync-fn synchronize-fn validate-service-description-fn]
+                              [:settings [:token-config history-length]]
                               [:state clock entitlement-manager token-root waiter-hostnames]
                               wrap-secure-request-fn]
                        (wrap-secure-request-fn
                          (fn token-handler-fn [request]
                            (token/handle-token-request
-                             clock synchronize-fn kv-store token-root waiter-hostnames entitlement-manager
+                             clock synchronize-fn kv-store token-root history-length waiter-hostnames entitlement-manager
                              make-inter-router-requests-sync-fn validate-service-description-fn request))))
    :token-list-handler-fn (pc/fnk [[:curator kv-store]
                                    wrap-secure-request-fn]

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -132,7 +132,7 @@
    (s/required-key :support-info) [{(s/required-key :label) schema/non-empty-string
                                     (s/required-key :link) {(s/required-key :type) s/Keyword
                                                             (s/required-key :value) schema/non-empty-string}}]
-   (s/required-key :token-config) {(s/required-key :history-length) schema/non-negative-int}
+   (s/required-key :token-config) {(s/required-key :history-length) schema/positive-int}
    (s/required-key :websocket-config) {(s/required-key :ws-max-binary-message-size) schema/positive-int
                                        (s/required-key :ws-max-text-message-size) schema/positive-int}
    (s/required-key :work-stealing) {(s/required-key :offer-help-interval-ms) schema/positive-int

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -132,6 +132,7 @@
    (s/required-key :support-info) [{(s/required-key :label) schema/non-empty-string
                                     (s/required-key :link) {(s/required-key :type) s/Keyword
                                                             (s/required-key :value) schema/non-empty-string}}]
+   (s/required-key :token-config) {(s/required-key :history-length) schema/non-negative-int}
    (s/required-key :websocket-config) {(s/required-key :ws-max-binary-message-size) schema/positive-int
                                        (s/required-key :ws-max-text-message-size) schema/positive-int}
    (s/required-key :work-stealing) {(s/required-key :offer-help-interval-ms) schema/positive-int
@@ -313,6 +314,7 @@
    :support-info [{:label "Waiter on GitHub"
                    :link {:type :url
                           :value "http://github.com/twosigma/waiter"}}]
+   :token-config {:history-length 5}
    :websocket-config {:ws-max-binary-message-size (* 1024 1024 40)
                       :ws-max-text-message-size (* 1024 1024 40)}
    :work-stealing {:offer-help-interval-ms 100

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -1540,7 +1540,10 @@
               service-description-template-2 (token->service-description-template kv-store token)]
           (is (= service-description-template service-description-template-2))
           (is (= (select-keys in-service-description service-description-keys) service-description-template))
-          (is (= (select-keys in-service-description token-metadata-keys) token-metadata))))
+          (is (= (-> in-service-description
+                     (assoc "previous" {})
+                     (select-keys token-metadata-keys))
+                 token-metadata))))
 
       (testing "test:deleted:token->service-description-2"
         (kv/store kv-store token (assoc in-service-description "deleted" true))
@@ -1553,7 +1556,7 @@
               service-description-template-2 (token->service-description-template kv-store token)]
           (is (empty? service-description-template-2))
           (is (= (select-keys in-service-description service-description-keys) service-description-template))
-          (is (= {"deleted" true, "owner" "tu3"} token-metadata)))))))
+          (is (= {"deleted" true, "owner" "tu3", "previous" {}} token-metadata)))))))
 
 (deftest test-service-suspend-resume
   (let [kv-store (kv/->LocalKeyValueStore (atom {}))


### PR DESCRIPTION
## Changes proposed in this PR

- add support for preserving token history
- the amount of history stored is configurable with `history-length` config

## Why are we making these changes?

This helps track the change history (limited by the history length). It also provides support for enabling blue-green deployment where we can figure out the service-id of the previous version of the service for a given token.

<img width="672" alt="screen shot 2018-04-12 at 1 03 29 am" src="https://user-images.githubusercontent.com/6611249/38659102-821f5026-3ded-11e8-8e30-a6812db18da0.png">


