### PR TITLE
Removes reflection for buffer length

### DIFF
--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -315,7 +315,7 @@
                         (confirm-live-connection)
                         (let [buffer (timers/start-stop-time! stream-read-body (async/<! body))
                               bytes-read (if buffer
-                                           (alength buffer)
+                                           (count buffer)
                                            -1)]
                           (if-not (= -1 bytes-read)
                             (do


### PR DESCRIPTION
## Changes proposed in this PR

Use `count` instead of `alength`

## Why are we making these changes?

Stops using reflection to determine the buffer length.

