### PR TITLE
Removes reflection from set-idle-timeout!

### DIFF
--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -72,10 +72,8 @@
   [^HttpOutput output-stream idle-timeout-ms]
   (try
     (log/debug "executing pill to adjust idle timeout to" idle-timeout-ms "ms.")
-    (let [channel-field (.getDeclaredField HttpOutput "_channel")]
-      (.setAccessible channel-field true)
-      (let [^HttpChannel http-channel (.get channel-field output-stream)]
-        (.setIdleTimeout http-channel idle-timeout-ms)))
+    (let [^HttpChannel http-channel (.getHttpChannel output-stream)]
+      (.setIdleTimeout http-channel idle-timeout-ms))
     (catch Exception e
       (log/error e "gobbling unexpected error while setting idle timeout"))))
 


### PR DESCRIPTION
## Changes proposed in this PR

- Use getter instead of reflection 

## Why are we making these changes?

- Don't use reflection
