### PR TITLE
Removes reflection from consume-request-stream

### DIFF
--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -50,7 +50,7 @@
   (fn [{:keys [body] :as request}]
     (let [resp (handler request)]
       (if (and (instance? ServletInputStream body)
-               (not (.isFinished body))
+               (not (.isFinished ^ServletInputStream body))
                (not (instance? ManyToManyChannel resp)))
         (try
           (slurp body)


### PR DESCRIPTION
## Changes proposed in this PR

- Add type hint to avoid reflection

## Why are we making these changes?

- Removes usage of reflection

