### PR TITLE
handles non-map responses in request-log

### DIFF
--- a/waiter/test/waiter/request_log_test.clj
+++ b/waiter/test/waiter/request_log_test.clj
@@ -87,3 +87,14 @@
                 :scheme "http"
                 :status 200}
                (dissoc log-entry :handle-request-latency-ns)))))))
+
+(deftest test-log-request!
+  (with-redefs [request->context identity
+                response->context identity
+                log identity]
+    (is (= {:request :foo :response :bar}
+           (log-request! {:request :foo} {:response :bar} {})))
+    (is (= {:context :baz :request :foo :response :bar}
+           (log-request! {:request :foo} {:response :bar} {:context :baz})))
+    (is (= {:request :foo}
+           (log-request! {:request :foo} (Object.) {})))))


### PR DESCRIPTION
## Changes proposed in this PR

- handles non-map responses in request-log

## Why are we making these changes?

Websocket handlers are not required to return maps as responses. As a result the request-log handler may not assume that request is a map.
