### PR TITLE
Websocket request-log cleanup

### DIFF
--- a/waiter/src/waiter/metrics_sync.clj
+++ b/waiter/src/waiter/metrics_sync.clj
@@ -155,7 +155,9 @@
             (send router-metrics-agent register-router-ws :router-id->incoming-ws source-router-id request encrypt router-metrics-agent)
             (process-incoming-router-metrics source-router-id encrypt decrypt router-metrics-agent metrics-sync-interval-ms request))))
       (catch Exception e
-        (log/error e "error in processing incoming router metrics request")))))
+        (log/error e "error in processing incoming router metrics request")))
+    ;; return an empty response map to maintain consistency with the http case
+    {}))
 
 (defn preserve-metrics-from-routers
   "Removes last-update-time and metrics entries for obsolete routers from the agent state."

--- a/waiter/src/waiter/websocket.clj
+++ b/waiter/src/waiter/websocket.clj
@@ -359,7 +359,8 @@
       (catch Exception e
         (async/>!! request-close-promise-chan :process-error)
         (log/error e "error while processing websocket response"))))
-  {}) ;; return an empty response map to maintain consistency with the http case
+  ;; return an empty response map to maintain consistency with the http case
+  {})
 
 (defn wrap-ws-close-on-error
   "Closes the out chan when the handler returns an error."


### PR DESCRIPTION
## Changes proposed in this PR

- websockets return empty response map to maintain consistency with the http case

## Why are we making these changes?

Returning map as the response allows the request-log to treat all responses equally.

