### PR TITLE
adds WAITER_SERVICE_ID environment variable

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -225,7 +225,8 @@
             body-json (json/read-str (str body))]
         (is (= 200 status))
         (testing "waiter configured environment variables"
-          (is (every? #(contains? body-json %) ["HOME" "LOGNAME" "USER" "WAITER_CPUS" "WAITER_MEM_MB" "WAITER_USERNAME"])
+          (is (every? #(contains? body-json %)
+                      ["HOME" "LOGNAME" "USER" "WAITER_CPUS" "WAITER_MEM_MB" "WAITER_SERVICE_ID" "WAITER_USERNAME"])
               (str body-json)))
         (testing "on-the-fly environment variables"
           (is (every? #(contains? body-json %) ["BEGIN_DATE" "END_DATE" "TIME2" "TIMESTAMP"])

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -615,4 +615,5 @@
           "WAITER_CPUS" (-> cpus str)
           "WAITER_MEM_MB" (-> mem str)
           "WAITER_PASSWORD" (service-id->password-fn service-id)
+          "WAITER_SERVICE_ID" service-id
           "WAITER_USERNAME" "waiter"}))

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -549,6 +549,7 @@
                             "WAITER_CPUS" "1"
                             "WAITER_MEM_MB" "1536"
                             "WAITER_PASSWORD" "test-service-1-password"
+                            "WAITER_SERVICE_ID" "test-service-1"
                             "WAITER_USERNAME" "waiter"}
                       :cmd "test-command"
                       :cpus 1

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -392,6 +392,7 @@
                                 "WAITER_CPUS" "2"
                                 "WAITER_MEM_MB" "32"
                                 "WAITER_PASSWORD" "password"
+                                "WAITER_SERVICE_ID" "foo"
                                 "WAITER_USERNAME" "waiter"}
                   :service-description {"backend-proto" "http"
                                         "cmd" "sleep 10000"
@@ -410,6 +411,7 @@
                                 "WAITER_CPUS" "2"
                                 "WAITER_MEM_MB" "32"
                                 "WAITER_PASSWORD" "password"
+                                "WAITER_SERVICE_ID" "bar"
                                 "WAITER_USERNAME" "waiter"}
                   :service-description {"backend-proto" "http"
                                         "cmd" "sleep 10000"
@@ -428,6 +430,7 @@
                                 "WAITER_CPUS" "2"
                                 "WAITER_MEM_MB" "32"
                                 "WAITER_PASSWORD" "password"
+                                "WAITER_SERVICE_ID" "baz"
                                 "WAITER_USERNAME" "waiter"}
                   :service-description {"backend-proto" "http"
                                         "cmd" "sleep 10000"
@@ -467,6 +470,7 @@
                                                   "WAITER_CPUS" "2"
                                                   "WAITER_MEM_MB" "32"
                                                   "WAITER_PASSWORD" "password"
+                                                  "WAITER_SERVICE_ID" "foo"
                                                   "WAITER_USERNAME" "waiter"}
                                     :service-description {"backend-proto" "http"
                                                           "cmd" "ls"
@@ -575,7 +579,7 @@
       (is (= 1 (count (:failed-instances instances)))))))
 
 (deftest test-pid->memory
-  (with-redefs [sh/sh (fn [& args]
+  (with-redefs [sh/sh (fn [& _]
                         {:out (str "PID  PPID   RSS\n"
                                    "  1     0     1\n"
                                    "  2     1    10\n"


### PR DESCRIPTION
## Changes proposed in this PR

- adds WAITER_SERVICE_ID environment variable

## Why are we making these changes?

We provide a scheduler agnostic way for individual running tasks to access their service-id.
