### PR TITLE
Override of lein parallel-test thread count via env

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -114,9 +114,12 @@
                      ;; enable remote debugger to connect on port 5005
                      ["-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"]}
              :test {:jvm-opts
-                    [~(str "-Dwaiter.test.kitchen.cmd=" (or
-                                                          (System/getenv "WAITER_TEST_KITCHEN_CMD")
-                                                          (.getCanonicalPath (clojure.java.io/file "../kitchen/bin/run.sh"))))]}
+                    [~(str "-Dwaiter.test.kitchen.cmd=" (or (System/getenv "WAITER_TEST_KITCHEN_CMD")
+                                                            (.getCanonicalPath (clojure.java.io/file "../kitchen/bin/run.sh"))))]
+                    :parallel-test {:pools {:serial (constantly 1)
+                                            :parallel (fn []
+                                                        (or (some-> (System/getenv "LEIN_TEST_THREADS") Long/valueOf)
+                                                            (.availableProcessors (Runtime/getRuntime))))}}}
              :test-console {:jvm-opts
                             ["-Dlog4j.configuration=log4j-console.properties"]}
              :test-log {:jvm-opts


### PR DESCRIPTION
## Changes proposed in this PR

Allow manually setting the number of threads used by `lein parallel-test` via an environment variable: `LEIN_TEST_THREADS`. If the variable isn't present, then it falls back to the default (i.e., the number of processors detected by the JVM).

## Why are we making these changes?

The Kubernetes scheduler (wip) integration tests run *much* faster with 4 threads in Travis (default is 2).