### PR TITLE
Give kitchen more start time in deployment error tests

### DIFF
--- a/waiter/integration/waiter/deployment_errors_test.clj
+++ b/waiter/integration/waiter/deployment_errors_test.clj
@@ -52,7 +52,7 @@
 (deftest ^:parallel ^:integration-slow test-invalid-health-check-response
   (testing-using-waiter-url
     (let [headers {:x-waiter-name (rand-name)
-                   :x-waiter-grace-period-secs 15
+                   :x-waiter-grace-period-secs 45
                    ; health check endpoint always returns status 402
                    :x-waiter-health-check-url "/bad-status?status=402"
                    :x-waiter-health-check-interval-secs 5
@@ -80,7 +80,7 @@
     (let [headers {:x-waiter-name (rand-name)
                    ; health check endpoint sleeps for 300000 ms (= 5 minutes)
                    :x-waiter-health-check-url "/sleep?sleep-ms=300000&status=400"
-                   :x-waiter-grace-period-secs 15
+                   :x-waiter-grace-period-secs 45
                    :x-waiter-health-check-interval-secs 5
                    :x-waiter-health-check-max-consecutive-failures 1
                    :x-waiter-queue-timeout 600000}


### PR DESCRIPTION
## Changes proposed in this PR

- Bump `Grace-Period-Seconds` up to 45 (from 15) for two of the deployment-error integration tests.

## Why are we making these changes?

I was seeing consistent failures of these two tests in my Kubernetes branch, and I traced the error back to this setting. Since I'm running these tests with 4 threads for k8s (related: #276), I think Kitchen is taking a bit longer to start up. Adding 30 seconds here seems better than having to repeatedly restart the whole test suite, hoping Kitchen will win the race...