### PR TITLE
Simplify Leiningen usage in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,14 @@ branches:
 cache:
   directories:
     - $HOME/.lein
+    - $HOME/.local/bin
     - $HOME/.m2
     - $HOME/.voom-repos
-
-env:
-  global:
-    - LEIN_DEPS_CMD='lein with-profiles +test voom build-deps'
-    - PATH="$HOME/.lein/bin:$PATH"
 
 before_install:
   - unset _JAVA_OPTIONS  # Avoid unwanted _JAVA_OPTIONS set by Travis CI
   - echo "Sudo-enabled build? ${TRAVIS_SUDO}"
+  - voom-build() { lein with-profiles +test voom build-deps; }
 
 install:
   - ./waiter/bin/ci/install-lein
@@ -30,33 +27,33 @@ install:
 matrix:
   include:
     - env: NAME='Kitchen tests'
-      before_script: cd kitchen && $LEIN_DEPS_CMD
+      before_script: cd kitchen && voom-build
       script: lein test
 
     - env: NAME='Token syncer tests'
-      before_script: cd token-syncer && $LEIN_DEPS_CMD
+      before_script: cd token-syncer && voom-build
       script: ./bin/ci/run-all-tests.sh
 
     - env: NAME='Waiter unit tests'
-      before_script: cd waiter && $LEIN_DEPS_CMD
+      before_script: cd waiter && voom-build
       script: ./bin/ci/run-unit-tests.sh
 
     - env: "NAME='Waiter integration tests: marathon-fast'"
       services: docker
-      before_script: cd waiter && $LEIN_DEPS_CMD
+      before_script: cd waiter && voom-build
       script: ./bin/ci/run-integration-tests.sh parallel-test integration-fast
 
     - env: "NAME='Waiter integration tests: marathon-slow'"
       services: docker
-      before_script: cd waiter && $LEIN_DEPS_CMD
+      before_script: cd waiter && voom-build
       script: ./bin/ci/run-integration-tests.sh parallel-test integration-slow
 
     - env: "NAME='Waiter integration tests: shell-fast'"
       services: docker
-      before_script: cd waiter && $LEIN_DEPS_CMD
+      before_script: cd waiter && voom-build
       script: ./bin/ci/run-integration-tests-shell-scheduler.sh parallel-test integration-fast
 
     - env: "NAME='Waiter integration tests: shell-slow'"
       services: docker
-      before_script: cd waiter && $LEIN_DEPS_CMD
+      before_script: cd waiter && voom-build
       script: ./bin/ci/run-integration-tests-shell-scheduler.sh parallel-test integration-slow

--- a/waiter/bin/ci/install-lein
+++ b/waiter/bin/ci/install-lein
@@ -2,7 +2,7 @@
 
 set -ex
 
-lein_bin=$HOME/.lein/bin
+lein_bin=$HOME/.local/bin
 
 if ! [ -f $lein_bin/lein ]; then
     mkdir -p $lein_bin


### PR DESCRIPTION
## Changes proposed in this PR

- Store `lein` script in a more standard location: ~/.local/bin
- Change `$LEIN_DEPS_CMD` environment variable to a more accurately named function: `voom-build`

## Why are we making these changes?

I'm putting more scripts in `~/.local/bin` in the K8s branch, and it's nice to have all of our custom-installed scripts in the same directory.

Also, aesthetics.