### PR TITLE
Allows token-syncer to update previously soft-deleted tokens

### DIFF
--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -159,6 +159,59 @@
         (finally
           (cleanup-token waiter-api waiter-urls token-name))))))
 
+(deftest ^:integration test-token-update-previously-soft-deleted
+  (testing "token sync update previously soft-deleted"
+    (let [waiter-urls (waiter-urls)
+          {:keys [load-token store-token] :as waiter-api} (waiter-api)
+          limit 10
+          token-name (str "test-token-update-previously-soft-deleted-" (UUID/randomUUID))]
+      (try
+        ;; ARRANGE
+        (let [current-time-ms (System/currentTimeMillis)
+              token-metadata (basic-token-metadata current-time-ms)
+              token-description (merge basic-description token-metadata)]
+
+          (store-token (first waiter-urls) token-name nil (assoc token-description "deleted" true))
+          (doseq [waiter-url (rest waiter-urls)]
+            (let [last-update-time-ms (- current-time-ms 10000)]
+              (store-token waiter-url token-name nil
+                           (assoc token-description
+                             "deleted" true
+                             "last-update-time" last-update-time-ms))))
+
+          (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
+
+            ;; ACT
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit)]
+
+              ;; ASSERT
+              (let [waiter-sync-result (constantly
+                                         {:code :success/soft-delete
+                                          :details {:etag token-etag
+                                                    :status 200}})
+                    expected-result {:details {token-name {:latest {:cluster-url (first waiter-urls)
+                                                                    :description (assoc token-description "deleted" true)
+                                                                    :token-etag token-etag}
+                                                           :sync-result (pc/map-from-keys waiter-sync-result (rest waiter-urls))}}
+                                     :summary {:sync {:failed #{}
+                                                      :unmodified #{}
+                                                      :updated #{token-name}}
+                                               :tokens {:pending {:count 1 :value #{token-name}}
+                                                        :previously-synced {:count 0 :value #{}}
+                                                        :processed {:count 1 :value #{token-name}}
+                                                        :selected {:count 1 :value #{token-name}}
+                                                        :total {:count 1 :value #{token-name}}}}}]
+                (is (= expected-result actual-result))
+                (doseq [waiter-url waiter-urls]
+                  (is (= {:description (assoc token-description "deleted" true)
+                          :headers {"content-type" "application/json"
+                                    "etag" token-etag}
+                          :status 200
+                          :token-etag token-etag}
+                         (load-token waiter-url token-name))))))))
+        (finally
+          (cleanup-token waiter-api waiter-urls token-name))))))
+
 (deftest ^:integration test-token-token-on-single-cluster
   (testing "token exists on single cluster"
     (let [waiter-urls (waiter-urls)

--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -50,8 +50,7 @@
   "Retrieves the etag for a token on a waiter router."
   [{:keys [load-token]} waiter-url token-name]
   (-> (load-token waiter-url token-name)
-      (get :token-etag)
-      str))
+      (get :token-etag)))
 
 (defn- cleanup-token
   [{:keys [hard-delete-token] :as waiter-api} waiter-urls token-name]
@@ -151,10 +150,8 @@
                 (is (= expected-result actual-result))
                 (doseq [waiter-url waiter-urls]
                   (is (= {:description (assoc token-description "deleted" true)
-                          :headers {"content-type" "application/json"
-                                    "etag" token-etag}
-                          :status 200
-                          :token-etag token-etag}
+                          :headers {"content-type" "application/json"}
+                          :status 200}
                          (load-token waiter-url token-name))))))))
         (finally
           (cleanup-token waiter-api waiter-urls token-name))))))
@@ -204,10 +201,8 @@
                 (is (= expected-result actual-result))
                 (doseq [waiter-url waiter-urls]
                   (is (= {:description (assoc token-description "deleted" true)
-                          :headers {"content-type" "application/json"
-                                    "etag" token-etag}
-                          :status 200
-                          :token-etag token-etag}
+                          :headers {"content-type" "application/json"}
+                          :status 200}
                          (load-token waiter-url token-name))))))))
         (finally
           (cleanup-token waiter-api waiter-urls token-name))))))

--- a/token-syncer/src/token_syncer/commands/syncer.clj
+++ b/token-syncer/src/token_syncer/commands/syncer.clj
@@ -96,8 +96,9 @@
                    :details {:cluster description
                              :latest latest-token-description}}
 
-                  (not= latest-token-description (get-in cluster-url->token-data [cluster-url :description]))
-                  (let [token-etag (:token-etag token-data)
+                  (not= latest-token-description description)
+                  (let [token-etag (when-not (get description "deleted")
+                                     (:token-etag token-data))
                         {:keys [headers status] :as response} (store-token cluster-url token token-etag latest-token-description)]
                     {:code (if (get latest-token-description "deleted")
                              (if (utils/successful? response) :success/soft-delete :error/soft-delete)

--- a/token-syncer/src/token_syncer/commands/syncer.clj
+++ b/token-syncer/src/token_syncer/commands/syncer.clj
@@ -97,8 +97,7 @@
                              :latest latest-token-description}}
 
                   (not= latest-token-description description)
-                  (let [token-etag (when-not (get description "deleted")
-                                     (:token-etag token-data))
+                  (let [token-etag (:token-etag token-data)
                         {:keys [headers status] :as response} (store-token cluster-url token token-etag latest-token-description)]
                     {:code (if (get latest-token-description "deleted")
                              (if (utils/successful? response) :success/soft-delete :error/soft-delete)

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -428,14 +428,6 @@
                   (assert-response-status response 412)
                   (is (str/includes? (str body) "Cannot modify stale token"))))
 
-              (testing "hard-delete without etag"
-                (let [{:keys [body] :as response} (make-request waiter-url "/token"
-                                                                :headers {"host" token}
-                                                                :http-method-fn http/delete
-                                                                :query-params {"hard-delete" true})]
-                  (assert-response-status response 400)
-                  (is (str/includes? (str body) "Must specify if-match header for token hard deletes"))))
-
               (testing "hard-delete with invalid etag"
                 (let [{:keys [body] :as response} (make-request waiter-url "/token"
                                                                 :headers {"host" token

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -428,6 +428,14 @@
                   (assert-response-status response 412)
                   (is (str/includes? (str body) "Cannot modify stale token"))))
 
+              (testing "hard-delete without etag"
+                (let [{:keys [body] :as response} (make-request waiter-url "/token"
+                                                                :headers {"host" token}
+                                                                :http-method-fn http/delete
+                                                                :query-params {"hard-delete" true})]
+                  (assert-response-status response 400)
+                  (is (str/includes? (str body) "Must specify if-match header for token hard deletes"))))
+
               (testing "hard-delete with invalid etag"
                 (let [{:keys [body] :as response} (make-request waiter-url "/token"
                                                                 :headers {"host" token

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -453,7 +453,8 @@
   (defn token-data->token-hash
     "Converts the merged map of service-description and token-metadata to a hash."
     [token-data]
-    (when (seq token-data)
+    (when (and (seq token-data)
+               (not (get token-data "deleted")))
       (str hash-prefix (-> token-data
                            (select-keys token-data-keys)
                            (dissoc "previous")

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -236,15 +236,11 @@
           (let [token-owner (get token-metadata "owner")
                 version-hash (get headers "if-match")]
             (if hard-delete
-              (do
-                (when-not version-hash
-                  (throw (ex-info "Must specify if-match header for token hard deletes"
-                                  {:request-headers headers, :status 400})))
-                (when-not (authz/administer-token? entitlement-manager authenticated-user token token-metadata)
-                  (throw (ex-info "Cannot hard-delete token"
-                                  {:metadata token-metadata
-                                   :status 403
-                                   :user authenticated-user}))))
+              (when-not (authz/administer-token? entitlement-manager authenticated-user token token-metadata)
+                (throw (ex-info "Cannot hard-delete token"
+                                {:metadata token-metadata
+                                 :status 403
+                                 :user authenticated-user})))
               (when-not (authz/manage-token? entitlement-manager authenticated-user token token-metadata)
                 (throw (ex-info "User not allowed to delete token"
                                 {:owner token-owner

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -198,9 +198,9 @@
                    :headers {"x-waiter-token" token}
                    :query-params {"hard-delete" "true"}
                    :request-method :delete})]
-            (is (= 200 status))
-            (is (= {"delete" token "hard-delete" true "success" true} (json/read-str body)))
-            (is (nil? (kv/fetch kv-store token))))
+            (is (= 400 status))
+            (is (str/includes? body "Must specify if-match header for token hard deletes"))
+            (is (kv/fetch kv-store token)))
           (finally
             (kv/delete kv-store token))))
 

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -198,9 +198,9 @@
                    :headers {"x-waiter-token" token}
                    :query-params {"hard-delete" "true"}
                    :request-method :delete})]
-            (is (= 400 status))
-            (is (str/includes? body "Must specify if-match header for token hard deletes"))
-            (is (kv/fetch kv-store token) "Entry deleted from kv-store!"))
+            (is (= 200 status))
+            (is (= {"delete" token "hard-delete" true "success" true} (json/read-str body)))
+            (is (nil? (kv/fetch kv-store token))))
           (finally
             (kv/delete kv-store token))))
 


### PR DESCRIPTION
## Changes proposed in this PR

- do not require etag while updating soft-deleted token
- requires etags for hard delete of active tokens

## Why are we making these changes?

We would like the token syncer to be able to sync tokens.
