### PR TITLE
adds support for user-agent to the request log

### DIFF
--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -25,7 +25,7 @@
 (defn request->context
   "Convert a request into a context suitable for logging."
   [{:keys [headers query-string remote-addr request-id request-method request-time uri] :as request}]
-  (let [{:strs [host x-cid x-forwarded-for]} headers]
+  (let [{:strs [host user-agent x-cid x-forwarded-for]} headers]
     (cond-> {:cid x-cid
              :host host
              :path uri
@@ -34,7 +34,8 @@
              :scheme (-> request utils/request->scheme name)}
       request-method (assoc :method (-> request-method name str/upper-case))
       query-string (assoc :query-string query-string)
-      request-time (assoc :request-time (utils/date-to-str request-time)))))
+      request-time (assoc :request-time (utils/date-to-str request-time))
+      user-agent (assoc :user-agent user-agent))))
 
 (defn response->context
   "Convert a response into a context suitable for logging."

--- a/waiter/test/waiter/request_log_test.clj
+++ b/waiter/test/waiter/request_log_test.clj
@@ -14,8 +14,9 @@
             [waiter.request-log :refer :all]))
 
 (deftest test-request->context
-  (let [request {:headers {"x-cid" "123"
-                           "host" "host"}
+  (let [request {:headers {"host" "host"
+                           "user-agent" "test-user-agent"
+                           "x-cid" "123"}
                  :request-method :post
                  :query-string "a=1"
                  :remote-addr "127.0.0.1"
@@ -31,7 +32,8 @@
             :remote-addr "127.0.0.1"
             :request-id "abc"
             :request-time "2018-04-11T00:00:00.000Z"
-            :scheme "http"}
+            :scheme "http"
+            :user-agent "test-user-agent"}
            (request->context request)))))
 
 (deftest test-response->context


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for user-agent to the request log

## Why are we making these changes?

We would like to be able to determine the user-agent used in a request
