### PR TITLE
Renames apps to services in scheduler messages

### DIFF
--- a/waiter/src/waiter/interstitial.clj
+++ b/waiter/src/waiter/interstitial.clj
@@ -101,7 +101,7 @@
                                    set)
         healthy-instance-service-ids (->> scheduler-messages
                                           (keep (fn [[message-type message-data]]
-                                                  (when (and (= :update-app-instances message-type)
+                                                  (when (and (= :update-service-instances message-type)
                                                              (seq (:healthy-instances message-data)))
                                                     (:service-id message-data)))))
         service-ids-to-remove (set/difference current-available-service-ids available-service-ids)

--- a/waiter/src/waiter/interstitial.clj
+++ b/waiter/src/waiter/interstitial.clj
@@ -97,7 +97,7 @@
   (let [available-service-ids (->> scheduler-messages
                                    (some (fn [[message-type message-data]]
                                            (when (= :update-available-services message-type)
-                                             (:available-apps message-data))))
+                                             (:available-service-ids message-data))))
                                    set)
         healthy-instance-service-ids (->> scheduler-messages
                                           (keep (fn [[message-type message-data]]

--- a/waiter/src/waiter/interstitial.clj
+++ b/waiter/src/waiter/interstitial.clj
@@ -96,7 +96,7 @@
   [interstitial-state-atom service-id->service-description current-available-service-ids scheduler-messages]
   (let [available-service-ids (->> scheduler-messages
                                    (some (fn [[message-type message-data]]
-                                           (when (= :update-available-apps message-type)
+                                           (when (= :update-available-services message-type)
                                              (:available-apps message-data))))
                                    set)
         healthy-instance-service-ids (->> scheduler-messages

--- a/waiter/src/waiter/metrics.clj
+++ b/waiter/src/waiter/metrics.clj
@@ -378,7 +378,7 @@
                                      (filter (fn [[message-type _]] (= message-type :update-available-services)))
                                      first
                                      second
-                                     :available-apps
+                                     :available-service-ids
                                      set)
           service-id->state (pc/map-from-keys (fn service-id->state-fn [service-id]
                                                 (-> (get service-id->metrics service-id)

--- a/waiter/src/waiter/metrics.clj
+++ b/waiter/src/waiter/metrics.clj
@@ -375,7 +375,7 @@
     (let [service-id->metrics (async/<! service-id->metrics-chan)
           scheduler-messages (async/<! scheduler-state-chan)
           available-service-ids (->> scheduler-messages
-                                     (filter (fn [[message-type _]] (= message-type :update-available-apps)))
+                                     (filter (fn [[message-type _]] (= message-type :update-available-services)))
                                      first
                                      second
                                      :available-apps

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -359,7 +359,7 @@
 
 (defn- request-available-waiter-apps
   "Queries the scheduler and builds a list of available Waiter apps."
-  [scheduler service-id->service-description-fn]
+  [scheduler]
   (when-let [service->service-instances (timers/start-stop-time!
                                           (metrics/waiter-timer "core" "scheduler" "get-apps")
                                           (retry-on-transient-server-exceptions
@@ -437,7 +437,7 @@
     (log/trace "scheduler-syncer: querying scheduler")
     (if-let [service->service-instances (timers/start-stop-time!
                                           (metrics/waiter-timer "core" "scheduler" "app->available-tasks")
-                                          (do-health-checks (request-available-waiter-apps scheduler service-id->service-description-fn)
+                                          (do-health-checks (request-available-waiter-apps scheduler)
                                                             (fn available [instance health-check-path]
                                                               (available? instance health-check-path http-client))
                                                             service-id->service-description-fn))]

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -317,7 +317,7 @@
                                  (let [service->state (fn service->state [service-id] [service-id (get service->data service-id)])
                                        service->data' (into {} (map service->state (:available-apps message-data)))]
                                    (recur remaining-scheduler-messages service->data'))
-                                 (if (= :update-app-instances message-type)
+                                 (if (= :update-service-instances message-type)
                                    (let [{:keys [service-id failed-instances healthy-instances]} message-data
                                          service->data' (assoc service->data
                                                           service-id {"has-healthy-instances" (not (empty? healthy-instances))
@@ -469,7 +469,7 @@
                   scheduler-messages' (if service-instance-info
                                         ; Assume nil service-instance-info means there was a failure in invoking marathon
                                         (conj scheduler-messages
-                                              [:update-app-instances
+                                              [:update-service-instances
                                                (assoc service-instance-info
                                                  :service-id id
                                                  :failed-instances all-failed-instances

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -265,7 +265,7 @@
     (let [transformer-fn (fn [scheduler-messages out*]
                            (async/go
                              (doseq [[message-type message-data] scheduler-messages]
-                               (when (= :update-available-apps message-type)
+                               (when (= :update-available-services message-type)
                                  (when-let [global-state (service-id->metrics-fn)]
                                    (let [service->state (fn [service-id]
                                                           [service-id
@@ -313,7 +313,7 @@
                            (async/go
                              (loop [[[message-type message-data] & remaining-scheduler-messages] scheduler-messages
                                     service->data {}]
-                               (if (= :update-available-apps message-type)
+                               (if (= :update-available-services message-type)
                                  (let [service->state (fn service->state [service-id] [service-id (get service->data service-id)])
                                        service->data' (into {} (map service->state (:available-apps message-data)))]
                                    (recur remaining-scheduler-messages service->data'))
@@ -392,11 +392,11 @@
                                             (update :flags
                                                     (fn [flags]
                                                       (cond-> flags
-                                                        (not= error :connect-exception)
-                                                        (conj :has-connected)
+                                                              (not= error :connect-exception)
+                                                              (conj :has-connected)
 
-                                                        (not (contains? connection-errors error))
-                                                        (conj :has-responded))))))
+                                                              (not (contains? connection-errors error))
+                                                              (conj :has-responded))))))
             health-check-refs (map (fn [instance]
                                      (let [chan (async/promise-chan)]
                                        (if (:healthy? instance)
@@ -445,7 +445,7 @@
           (when (zero? (reduce + 0 (filter number? (vals (select-keys (:task-stats service) [:staged :running :healthy :unhealthy])))))
             (log/info "scheduler-syncer:" (:id service) "has no live instances!" (:task-stats service))))
         (loop [service-id->health-check-context' {}
-               scheduler-messages [[:update-available-apps {:available-apps available-service-ids :scheduler-sync-time request-apps-time}]]
+               scheduler-messages [[:update-available-services {:available-apps available-service-ids :scheduler-sync-time request-apps-time}]]
                [[{:keys [id]} {:keys [active-instances failed-instances]}] & remaining] (seq service->service-instances)]
           (if id
             (let [request-instances-time (t/now)

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -271,7 +271,7 @@
                                                           [service-id
                                                            (merge {"outstanding" 0 "total" 0}
                                                                   (select-keys (get global-state service-id) ["outstanding" "total"]))])
-                                         service->data (into {} (map service->state (:available-apps message-data)))]
+                                         service->data (into {} (map service->state (:available-service-ids message-data)))]
                                      (async/>! out* service->data)))))
                              (async/close! out*)))]
       (async/pipeline-async 1 service-data-chan transformer-fn scheduler-state-chan false))
@@ -315,7 +315,7 @@
                                     service->data {}]
                                (if (= :update-available-services message-type)
                                  (let [service->state (fn service->state [service-id] [service-id (get service->data service-id)])
-                                       service->data' (into {} (map service->state (:available-apps message-data)))]
+                                       service->data' (into {} (map service->state (:available-service-ids message-data)))]
                                    (recur remaining-scheduler-messages service->data'))
                                  (if (= :update-service-instances message-type)
                                    (let [{:keys [service-id failed-instances healthy-instances]} message-data
@@ -445,7 +445,7 @@
           (when (zero? (reduce + 0 (filter number? (vals (select-keys (:task-stats service) [:staged :running :healthy :unhealthy])))))
             (log/info "scheduler-syncer:" (:id service) "has no live instances!" (:task-stats service))))
         (loop [service-id->health-check-context' {}
-               scheduler-messages [[:update-available-services {:available-apps available-service-ids :scheduler-sync-time request-apps-time}]]
+               scheduler-messages [[:update-available-services {:available-service-ids available-service-ids :scheduler-sync-time request-apps-time}]]
                [[{:keys [id]} {:keys [active-instances failed-instances]}] & remaining] (seq service->service-instances)]
           (if id
             (let [request-instances-time (t/now)

--- a/waiter/src/waiter/state.clj
+++ b/waiter/src/waiter/state.clj
@@ -1176,7 +1176,7 @@
                          (log/trace "scheduler-state-chan received, type:" message-type)
                          (let [loop-state'
                                (case message-type
-                                 :update-available-apps
+                                 :update-available-services
                                  (let [{:keys [available-apps scheduler-sync-time]} message-data
                                        available-service-ids (into #{} available-apps)
                                        services-without-instances (remove #(contains? service-id->my-instance->slots %) available-service-ids)
@@ -1189,7 +1189,7 @@
                                    (when (or (not= service-id->healthy-instances service-id->healthy-instances')
                                              (not= service-id->unhealthy-instances service-id->unhealthy-instances')
                                              (seq services-without-instances))
-                                     (log/info "update-available-apps:"
+                                     (log/info "update-available-services:"
                                                (count service-id->healthy-instances') "services with healthy instances and"
                                                (count services-without-instances) "services without instances:"
                                                (vec services-without-instances)))

--- a/waiter/src/waiter/state.clj
+++ b/waiter/src/waiter/state.clj
@@ -1177,8 +1177,8 @@
                          (let [loop-state'
                                (case message-type
                                  :update-available-services
-                                 (let [{:keys [available-apps scheduler-sync-time]} message-data
-                                       available-service-ids (into #{} available-apps)
+                                 (let [{:keys [available-service-ids scheduler-sync-time]} message-data
+                                       available-service-ids (into #{} available-service-ids)
                                        services-without-instances (remove #(contains? service-id->my-instance->slots %) available-service-ids)
                                        service-id->healthy-instances' (select-keys service-id->healthy-instances available-service-ids)
                                        service-id->unhealthy-instances' (select-keys service-id->unhealthy-instances available-service-ids)

--- a/waiter/src/waiter/state.clj
+++ b/waiter/src/waiter/state.clj
@@ -1202,7 +1202,7 @@
                                      :service-id->deployment-error service-id->deployment-error'
                                      :time scheduler-sync-time))
 
-                                 :update-app-instances
+                                 :update-service-instances
                                  (let [{:keys [service-id healthy-instances unhealthy-instances failed-instances scheduler-sync-time]} message-data
                                        service-id->healthy-instances' (assoc service-id->healthy-instances service-id healthy-instances)
                                        service-id->unhealthy-instances' (assoc service-id->unhealthy-instances service-id unhealthy-instances)

--- a/waiter/src/waiter/statsd.clj
+++ b/waiter/src/waiter/statsd.clj
@@ -354,8 +354,8 @@
                 (gauge! metric-group "mem" mem))
               counts-by-metric-group)))
 
-(defn process-update-app-instances-message
-  "Merges the current map of resources by metric group with data from a :update-app-instances scheduler message"
+(defn process-update-service-instances-message
+  "Merges the current map of resources by metric group with data from a :update-service-instances scheduler message"
   [counts-by-metric-group {:keys [service-id healthy-instances unhealthy-instances failed-instances] :as message-data}
    service-id->service-description-fn]
   (try
@@ -374,7 +374,7 @@
         (log/warn "No service description found for service id" service-id)
         counts-by-metric-group))
     (catch Throwable e
-      (log/error e "Error processing update-app-instances message" message-data)
+      (log/error e "Error processing update-service-instances message" message-data)
       counts-by-metric-group)))
 
 (defn scheduler-messages->instance-counts-by-metric-group
@@ -385,8 +385,8 @@
          counts-by-metric-group {}]
     (let [counts-by-metric-group'
           (cond-> counts-by-metric-group
-                  (= message-type :update-app-instances)
-                  (process-update-app-instances-message message-data service-id->service-description-fn))]
+                  (= message-type :update-service-instances)
+                  (process-update-service-instances-message message-data service-id->service-description-fn))]
       (if (some? remaining)
         (recur remaining counts-by-metric-group')
         counts-by-metric-group'))))

--- a/waiter/test/waiter/interstitial_test.clj
+++ b/waiter/test/waiter/interstitial_test.clj
@@ -185,7 +185,7 @@
                                      (assoc {:initialized? false} :service-id->interstitial-promise)
                                      atom)
         available-service-ids' ["service-0" "service-7" "service-8" "service-9"]
-        scheduler-messages [[:update-available-services {:available-apps available-service-ids'}]
+        scheduler-messages [[:update-available-services {:available-service-ids available-service-ids'}]
                             [:update-service-instances {:healthy-instances [{:id "service-0.1"}]
                                                     :service-id "service-0"}]
                             [:update-service-instances {:healthy-instances [{:id "service-6.1"}]

--- a/waiter/test/waiter/interstitial_test.clj
+++ b/waiter/test/waiter/interstitial_test.clj
@@ -185,7 +185,7 @@
                                      (assoc {:initialized? false} :service-id->interstitial-promise)
                                      atom)
         available-service-ids' ["service-0" "service-7" "service-8" "service-9"]
-        scheduler-messages [[:update-available-apps {:available-apps available-service-ids'}]
+        scheduler-messages [[:update-available-services {:available-apps available-service-ids'}]
                             [:update-app-instances {:healthy-instances [{:id "service-0.1"}]
                                                     :service-id "service-0"}]
                             [:update-app-instances {:healthy-instances [{:id "service-6.1"}]

--- a/waiter/test/waiter/interstitial_test.clj
+++ b/waiter/test/waiter/interstitial_test.clj
@@ -186,13 +186,13 @@
                                      atom)
         available-service-ids' ["service-0" "service-7" "service-8" "service-9"]
         scheduler-messages [[:update-available-services {:available-apps available-service-ids'}]
-                            [:update-app-instances {:healthy-instances [{:id "service-0.1"}]
+                            [:update-service-instances {:healthy-instances [{:id "service-0.1"}]
                                                     :service-id "service-0"}]
-                            [:update-app-instances {:healthy-instances [{:id "service-6.1"}]
+                            [:update-service-instances {:healthy-instances [{:id "service-6.1"}]
                                                     :service-id "service-6"}]
-                            [:update-app-instances {:healthy-instances [{:id "service-8.1"}]
+                            [:update-service-instances {:healthy-instances [{:id "service-8.1"}]
                                                     :service-id "service-8"}]
-                            [:update-app-instances {:service-id "service-9"
+                            [:update-service-instances {:service-id "service-9"
                                                     :unhealthy-instances [{:id "service-9.1"}]}]]
         service-id->service-description (fn [service-id]
                                           {"interstitial-secs" (->> (str/last-index-of service-id "-")

--- a/waiter/test/waiter/metrics_test.clj
+++ b/waiter/test/waiter/metrics_test.clj
@@ -409,7 +409,7 @@
             (async/thread
               (while (not @exit-flag-atom)
                 (let [available-service-ids (remove #(str/includes? % (str @remove-target-atom)) @available-services-atom)
-                      scheduler-messages [[:update-available-apps {:available-apps available-service-ids}]]]
+                      scheduler-messages [[:update-available-services {:available-apps available-service-ids}]]]
                   (async/>!! scheduler-state-chan scheduler-messages)))
               (async/close! scheduler-state-chan))
             (async/thread

--- a/waiter/test/waiter/metrics_test.clj
+++ b/waiter/test/waiter/metrics_test.clj
@@ -409,7 +409,7 @@
             (async/thread
               (while (not @exit-flag-atom)
                 (let [available-service-ids (remove #(str/includes? % (str @remove-target-atom)) @available-services-atom)
-                      scheduler-messages [[:update-available-services {:available-apps available-service-ids}]]]
+                      scheduler-messages [[:update-available-services {:available-service-ids available-service-ids}]]]
                   (async/>!! scheduler-state-chan scheduler-messages)))
               (async/close! scheduler-state-chan))
             (async/thread

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -151,7 +151,7 @@
                                                   [[:update-available-services {:available-apps (vec @available-services-atom)}]]
                                                   (vec
                                                     (map (fn [service-id]
-                                                           [:update-app-instances
+                                                           [:update-service-instances
                                                             {:service-id service-id
                                                              :failed-instances (cond
                                                                                  (str/includes? service-id "broken") [{:id (str service-id ".failed1"), :host "failed1.example.com"},
@@ -203,7 +203,7 @@
                          [[:update-available-services {:available-apps (vec @available-services-atom)}]]
                          (vec
                            (map (fn [service-id]
-                                  [:update-app-instances
+                                  [:update-service-instances
                                    {:service-id service-id
                                     :failed-instances
                                     (cond
@@ -252,7 +252,7 @@
     (let [[[update-apps-msg update-apps] [update-instances-msg update-instances]] (async/<!! scheduler-state-chan)]
       (is (= :update-available-services update-apps-msg))
       (is (= (list "s1") (:available-apps update-apps)))
-      (is (= :update-app-instances update-instances-msg))
+      (is (= :update-service-instances update-instances-msg))
       (is (= [(assoc instance1 :healthy? true) instance2] (:healthy-instances update-instances)))
       (is (= [(assoc instance3
                 :healthy? false

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -148,7 +148,7 @@
               (let [global-state (pc/map-vals #(update-in % ["outstanding"] (fn [v] (max 0 (- v n))))
                                               initial-global-state)]
                 (async/>!! scheduler-state-chan (concat
-                                                  [[:update-available-services {:available-apps (vec @available-services-atom)}]]
+                                                  [[:update-available-services {:available-service-ids (vec @available-services-atom)}]]
                                                   (vec
                                                     (map (fn [service-id]
                                                            [:update-service-instances
@@ -200,7 +200,7 @@
           (dotimes [iteration 20]
             (async/>!! scheduler-state-chan
                        (concat
-                         [[:update-available-services {:available-apps (vec @available-services-atom)}]]
+                         [[:update-available-services {:available-service-ids (vec @available-services-atom)}]]
                          (vec
                            (map (fn [service-id]
                                   [:update-service-instances
@@ -251,7 +251,7 @@
     (async/>!! timeout-chan :timeout)
     (let [[[update-apps-msg update-apps] [update-instances-msg update-instances]] (async/<!! scheduler-state-chan)]
       (is (= :update-available-services update-apps-msg))
-      (is (= (list "s1") (:available-apps update-apps)))
+      (is (= (list "s1") (:available-service-ids update-apps)))
       (is (= :update-service-instances update-instances-msg))
       (is (= [(assoc instance1 :healthy? true) instance2] (:healthy-instances update-instances)))
       (is (= [(assoc instance3

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -148,7 +148,7 @@
               (let [global-state (pc/map-vals #(update-in % ["outstanding"] (fn [v] (max 0 (- v n))))
                                               initial-global-state)]
                 (async/>!! scheduler-state-chan (concat
-                                                  [[:update-available-apps {:available-apps (vec @available-services-atom)}]]
+                                                  [[:update-available-services {:available-apps (vec @available-services-atom)}]]
                                                   (vec
                                                     (map (fn [service-id]
                                                            [:update-app-instances
@@ -200,7 +200,7 @@
           (dotimes [iteration 20]
             (async/>!! scheduler-state-chan
                        (concat
-                         [[:update-available-apps {:available-apps (vec @available-services-atom)}]]
+                         [[:update-available-services {:available-apps (vec @available-services-atom)}]]
                          (vec
                            (map (fn [service-id]
                                   [:update-app-instances
@@ -250,7 +250,7 @@
         (start-scheduler-syncer clock scheduler scheduler-state-chan timeout-chan service-id->service-description-fn available? {} 5)]
     (async/>!! timeout-chan :timeout)
     (let [[[update-apps-msg update-apps] [update-instances-msg update-instances]] (async/<!! scheduler-state-chan)]
-      (is (= :update-available-apps update-apps-msg))
+      (is (= :update-available-services update-apps-msg))
       (is (= (list "s1") (:available-apps update-apps)))
       (is (= :update-app-instances update-instances-msg))
       (is (= [(assoc instance1 :healthy? true) instance2] (:healthy-instances update-instances)))

--- a/waiter/test/waiter/state_test.clj
+++ b/waiter/test/waiter/state_test.clj
@@ -996,19 +996,19 @@
       (async/>!! scheduler-state-chan [[:update-available-services {:available-apps [service-id]
                                                                     :scheduler-sync-time (t/now)}]])
       (async/<!! router-state-push-chan)
-      (async/>!! scheduler-state-chan [[:update-app-instances {:healthy-instances [instance]
-                                                               :unhealthy-instances []
-                                                               :sorted-instance-ids [(:id instance)]
-                                                               :service-id service-id
-                                                               :scheduler-sync-time (t/now)}]])
+      (async/>!! scheduler-state-chan [[:update-service-instances {:healthy-instances [instance]
+                                                                   :unhealthy-instances []
+                                                                   :sorted-instance-ids [(:id instance)]
+                                                                   :service-id service-id
+                                                                   :scheduler-sync-time (t/now)}]])
       (let [{:keys [service-id->healthy-instances service-id->expired-instances]} (async/<!! router-state-push-chan)]
         (is (= [instance] (get service-id->healthy-instances service-id)))
         (is (= [instance] (get service-id->expired-instances service-id))))
-      (async/>!! scheduler-state-chan [[:update-app-instances {:healthy-instances []
-                                                               :unhealthy-instances []
-                                                               :sorted-instance-ids []
-                                                               :service-id service-id
-                                                               :scheduler-sync-time (t/now)}]])
+      (async/>!! scheduler-state-chan [[:update-service-instances {:healthy-instances []
+                                                                   :unhealthy-instances []
+                                                                   :sorted-instance-ids []
+                                                                   :service-id service-id
+                                                                   :scheduler-sync-time (t/now)}]])
       (let [{:keys [service-id->healthy-instances service-id->expired-instances]} (async/<!! router-state-push-chan)]
         (is (empty? (get service-id->healthy-instances service-id)))
         (is (empty? (get service-id->expired-instances service-id))))
@@ -1073,7 +1073,7 @@
                           failed-instances (failed-instances-fn service-id index)
                           healthy-instances (healthy-instances-fn service-id index n)
                           unhealthy-instances (unhealthy-instances-fn service-id index)
-                          service-instances-message [:update-app-instances
+                          service-instances-message [:update-service-instances
                                                      (assoc {:healthy-instances healthy-instances
                                                              :unhealthy-instances unhealthy-instances}
                                                        :service-id service-id
@@ -1184,7 +1184,7 @@
                     (let [service-id (str "service-" index)
                           failed-instances (failed-instances-fn service-id index)
                           unhealthy-instances (unhealthy-instances-fn service-id index)
-                          service-instances-message [:update-app-instances
+                          service-instances-message [:update-service-instances
                                                      (assoc {:healthy-instances [] ; no healthy instances
                                                              :unhealthy-instances unhealthy-instances}
                                                        :service-id service-id

--- a/waiter/test/waiter/state_test.clj
+++ b/waiter/test/waiter/state_test.clj
@@ -993,7 +993,7 @@
       (let [{:keys [router-state-push-mult]} (start-router-state-maintainer scheduler-state-chan router-chan router-id exit-chan service-id->service-description-fn deployment-error-config)]
         (async/tap router-state-push-mult router-state-push-chan))
       (async/>!! router-chan {router-id (str "http://www." router-id ".com")})
-      (async/>!! scheduler-state-chan [[:update-available-services {:available-apps [service-id]
+      (async/>!! scheduler-state-chan [[:update-available-services {:available-service-ids [service-id]
                                                                     :scheduler-sync-time (t/now)}]])
       (async/<!! router-state-push-chan)
       (async/>!! scheduler-state-chan [[:update-service-instances {:healthy-instances [instance]
@@ -1065,7 +1065,7 @@
             (let [current-time (t/plus start-time (t/minutes n))]
               (let [services (services-fn n)]
                 (loop [index 0
-                       scheduler-messages [[:update-available-services {:available-apps services
+                       scheduler-messages [[:update-available-services {:available-service-ids services
                                                                         :scheduler-sync-time current-time}]]]
                   (if (>= index (count services))
                     (async/>!! scheduler-state-chan scheduler-messages)
@@ -1177,7 +1177,7 @@
             (let [current-time (t/plus start-time (t/minutes n))]
               (let [services (services-fn n)]
                 (loop [index 0
-                       scheduler-messages [[:update-available-services {:available-apps services
+                       scheduler-messages [[:update-available-services {:available-service-ids services
                                                                         :scheduler-sync-time current-time}]]]
                   (if (>= index (count services))
                     (async/>!! scheduler-state-chan scheduler-messages)

--- a/waiter/test/waiter/state_test.clj
+++ b/waiter/test/waiter/state_test.clj
@@ -993,8 +993,8 @@
       (let [{:keys [router-state-push-mult]} (start-router-state-maintainer scheduler-state-chan router-chan router-id exit-chan service-id->service-description-fn deployment-error-config)]
         (async/tap router-state-push-mult router-state-push-chan))
       (async/>!! router-chan {router-id (str "http://www." router-id ".com")})
-      (async/>!! scheduler-state-chan [[:update-available-apps {:available-apps [service-id]
-                                                                :scheduler-sync-time (t/now)}]])
+      (async/>!! scheduler-state-chan [[:update-available-services {:available-apps [service-id]
+                                                                    :scheduler-sync-time (t/now)}]])
       (async/<!! router-state-push-chan)
       (async/>!! scheduler-state-chan [[:update-app-instances {:healthy-instances [instance]
                                                                :unhealthy-instances []
@@ -1065,8 +1065,8 @@
             (let [current-time (t/plus start-time (t/minutes n))]
               (let [services (services-fn n)]
                 (loop [index 0
-                       scheduler-messages [[:update-available-apps {:available-apps services
-                                                                    :scheduler-sync-time current-time}]]]
+                       scheduler-messages [[:update-available-services {:available-apps services
+                                                                        :scheduler-sync-time current-time}]]]
                   (if (>= index (count services))
                     (async/>!! scheduler-state-chan scheduler-messages)
                     (let [service-id (str "service-" index)
@@ -1168,8 +1168,8 @@
                                {:message nil :flags #{:connect-exception}} {:flags #{:timeout-exception :never-passed-health-checks}}]
               failed-instances-fn (fn [service-id index]
                                     (vec (map (fn [x] (merge (get failed-messages (mod index (count failed-messages)))
-                                                        {:id (str service-id "." x "1")
-                                                         :started-at start-time}))
+                                                             {:id (str service-id "." x "1")
+                                                              :started-at start-time}))
                                               (range (if (zero? (mod index 2)) 1 0)))))
               deployment-error-fn (fn [service-id index]
                                     (get-deployment-error [] (unhealthy-instances-fn service-id index) (failed-instances-fn service-id index) deployment-error-config))]
@@ -1177,8 +1177,8 @@
             (let [current-time (t/plus start-time (t/minutes n))]
               (let [services (services-fn n)]
                 (loop [index 0
-                       scheduler-messages [[:update-available-apps {:available-apps services
-                                                                    :scheduler-sync-time current-time}]]]
+                       scheduler-messages [[:update-available-services {:available-apps services
+                                                                        :scheduler-sync-time current-time}]]]
                   (if (>= index (count services))
                     (async/>!! scheduler-state-chan scheduler-messages)
                     (let [service-id (str "service-" index)

--- a/waiter/test/waiter/statsd_test.clj
+++ b/waiter/test/waiter/statsd_test.clj
@@ -77,7 +77,7 @@
 (deftest test-scheduler-messages->instance-counts-by-metric-group
   (testing "Conversion of scheduler messages to instance counts by metric group"
     (testing "should produce aggregate instance counts by metric group"
-      (let [messages [[:update-available-apps {}]
+      (let [messages [[:update-available-services {}]
                       [:update-app-instances {:service-id :fee
                                               :healthy-instances [:i]
                                               :unhealthy-instances [:i :i]

--- a/waiter/test/waiter/statsd_test.clj
+++ b/waiter/test/waiter/statsd_test.clj
@@ -78,30 +78,30 @@
   (testing "Conversion of scheduler messages to instance counts by metric group"
     (testing "should produce aggregate instance counts by metric group"
       (let [messages [[:update-available-services {}]
-                      [:update-app-instances {:service-id :fee
-                                              :healthy-instances [:i]
-                                              :unhealthy-instances [:i :i]
-                                              :failed-instances [:i :i :i]}]
-                      [:update-app-instances {:service-id :fie
-                                              :healthy-instances [:i]
-                                              :unhealthy-instances [:i :i]
-                                              :failed-instances [:i :i :i]}]
-                      [:update-app-instances {:service-id :foe
-                                              :healthy-instances [:i :i :i]
-                                              :unhealthy-instances [:i :i :i]
-                                              :failed-instances [:i :i :i]}]
-                      [:update-app-instances {:service-id :fum
-                                              :healthy-instances [:i :i :i]
-                                              :unhealthy-instances [:i :i :i]
-                                              :failed-instances [:i :i :i]}]
-                      [:update-app-instances {:service-id :qux
-                                              :healthy-instances [:i :i :i]
-                                              :unhealthy-instances [:i :i :i]
-                                              :failed-instances [:i :i :i]}]
-                      [:update-app-instances {:service-id :eek
-                                              :healthy-instances [:i]
-                                              :unhealthy-instances [:i :i]
-                                              :failed-instances [:i :i :i]}]]
+                      [:update-service-instances {:service-id :fee
+                                                  :healthy-instances [:i]
+                                                  :unhealthy-instances [:i :i]
+                                                  :failed-instances [:i :i :i]}]
+                      [:update-service-instances {:service-id :fie
+                                                  :healthy-instances [:i]
+                                                  :unhealthy-instances [:i :i]
+                                                  :failed-instances [:i :i :i]}]
+                      [:update-service-instances {:service-id :foe
+                                                  :healthy-instances [:i :i :i]
+                                                  :unhealthy-instances [:i :i :i]
+                                                  :failed-instances [:i :i :i]}]
+                      [:update-service-instances {:service-id :fum
+                                                  :healthy-instances [:i :i :i]
+                                                  :unhealthy-instances [:i :i :i]
+                                                  :failed-instances [:i :i :i]}]
+                      [:update-service-instances {:service-id :qux
+                                                  :healthy-instances [:i :i :i]
+                                                  :unhealthy-instances [:i :i :i]
+                                                  :failed-instances [:i :i :i]}]
+                      [:update-service-instances {:service-id :eek
+                                                  :healthy-instances [:i]
+                                                  :unhealthy-instances [:i :i]
+                                                  :failed-instances [:i :i :i]}]]
             service-id->service-description #(% {:fee {"metric-group" "foo", "cpus" 0.1, "mem" 128}
                                                  :fie {"metric-group" "bar", "cpus" 0.2, "mem" 256}
                                                  :foe {"metric-group" "bar", "cpus" 0.4, "mem" 512}
@@ -128,31 +128,31 @@
     (testing "should be resilient to empty service description"
       (is (= {nil {:healthy-instances 1, :unhealthy-instances 2, :failed-instances 3, :cpus 0, :mem 0}}
              (statsd/scheduler-messages->instance-counts-by-metric-group
-               [[:update-app-instances {:service-id :fee
-                                        :healthy-instances [:i]
-                                        :unhealthy-instances [:i :i]
-                                        :failed-instances [:i :i :i]}]]
+               [[:update-service-instances {:service-id :fee
+                                            :healthy-instances [:i]
+                                            :unhealthy-instances [:i :i]
+                                            :failed-instances [:i :i :i]}]]
                (constantly {})))))))
 
-(deftest test-process-update-app-instances-message
-  (testing "Processing of an :update-app-instances scheduler message"
+(deftest test-process-update-service-instances-message
+  (testing "Processing of an :update-service-instances scheduler message"
 
     (testing "should not let exceptions bubble out"
       (let [misbehaving-fn (fn [_] (throw (Exception. "I'm misbehaving")))]
-        (is (= {} (statsd/process-update-app-instances-message {} {} misbehaving-fn)))
+        (is (= {} (statsd/process-update-service-instances-message {} {} misbehaving-fn)))
         (is (= {"foo" {:healthy-instances 1, :unhealthy-instances 2, :failed-instances 3, :cpus 0.5, :mem 384}}
-               (statsd/process-update-app-instances-message
+               (statsd/process-update-service-instances-message
                  {"foo" {:healthy-instances 1, :unhealthy-instances 2, :failed-instances 3, :cpus 0.5, :mem 384}}
                  {:service-id "bar"}
                  misbehaving-fn)))))
 
     (testing "should not include instance counts when service description is nil"
-      (is (= {} (statsd/process-update-app-instances-message {}
-                                                             {:service-id :fee
-                                                              :healthy-instances [:i]
-                                                              :unhealthy-instances [:i :i]
-                                                              :failed-instances [:i :i :i]}
-                                                             (constantly nil)))))))
+      (is (= {} (statsd/process-update-service-instances-message {}
+                                                                 {:service-id :fee
+                                                                  :healthy-instances [:i]
+                                                                  :unhealthy-instances [:i :i]
+                                                                  :failed-instances [:i :i :i]}
+                                                                 (constantly nil)))))))
 
 (deftest test-process-scheduler-messages
   (testing "Processing a batch of scheduler messages"


### PR DESCRIPTION
## Changes proposed in this PR

- renames `update-available-apps` to `update-available-services`
- renames `update-app-instances` to `update-service-instances`
- renames `available-apps` to `available-service-ids`
- uses `condp` instead of nested `if`-else in `scheduler-broken-services-gc`
- removes unused argument in `request-available-waiter-apps`

## Why are we making these changes?

We would like to consistently use the same term to identify services in the codebase

