### PR TITLE
moves healthy-service-ids logic to update-scheduler-state

### DIFF
--- a/waiter/src/waiter/interstitial.clj
+++ b/waiter/src/waiter/interstitial.clj
@@ -94,10 +94,10 @@
    In particular, it resolves all promises for services which have healthy instances.
    It also removes from the interstitial state any resolved promises for services which are no longer available."
   [interstitial-state-atom service-id->service-description current-available-service-ids scheduler-messages]
-  (let [summary-data (-> (fn [[message-type message-data]]
-                           (when (= :update-available-services message-type)
-                             message-data))
-                         (some scheduler-messages))
+  (let [summary-data (some (fn [[message-type message-data]]
+                             (when (= :update-available-services message-type)
+                               message-data))
+                           scheduler-messages)
         available-service-ids (-> summary-data :available-service-ids set)
         healthy-service-ids (-> summary-data :healthy-service-ids set)
         service-ids-to-remove (set/difference current-available-service-ids available-service-ids)

--- a/waiter/src/waiter/interstitial.clj
+++ b/waiter/src/waiter/interstitial.clj
@@ -94,29 +94,25 @@
    In particular, it resolves all promises for services which have healthy instances.
    It also removes from the interstitial state any resolved promises for services which are no longer available."
   [interstitial-state-atom service-id->service-description current-available-service-ids scheduler-messages]
-  (let [available-service-ids (->> scheduler-messages
-                                   (some (fn [[message-type message-data]]
-                                           (when (= :update-available-services message-type)
-                                             (:available-service-ids message-data))))
-                                   set)
-        healthy-instance-service-ids (->> scheduler-messages
-                                          (keep (fn [[message-type message-data]]
-                                                  (when (and (= :update-service-instances message-type)
-                                                             (seq (:healthy-instances message-data)))
-                                                    (:service-id message-data)))))
+  (let [summary-data (-> (fn [[message-type message-data]]
+                           (when (= :update-available-services message-type)
+                             message-data))
+                         (some scheduler-messages))
+        available-service-ids (-> summary-data :available-service-ids set)
+        healthy-service-ids (-> summary-data :healthy-service-ids set)
         service-ids-to-remove (set/difference current-available-service-ids available-service-ids)
         removed-service-ids (remove-resolved-interstitial-promises! interstitial-state-atom service-ids-to-remove)]
     (doseq [service-id available-service-ids]
       (let [{:strs [interstitial-secs]} (service-id->service-description service-id)]
         (when (pos? interstitial-secs)
           (ensure-service-interstitial! interstitial-state-atom service-id interstitial-secs))))
-    (doseq [service-id healthy-instance-service-ids]
+    (doseq [service-id healthy-service-ids]
       (when-let [interstitial-promise (service-id->interstitial-promise @interstitial-state-atom service-id)]
         (resolve-promise! service-id interstitial-promise :healthy-instance-found)))
     (-> current-available-service-ids
         (set/difference removed-service-ids)
         (set/union available-service-ids)
-        (set/union healthy-instance-service-ids))))
+        (set/union healthy-service-ids))))
 
 (defn interstitial-maintainer
   "Long running daemon process that listens for scheduler state updates and triggers changes in the

--- a/waiter/src/waiter/interstitial.clj
+++ b/waiter/src/waiter/interstitial.clj
@@ -94,12 +94,10 @@
    In particular, it resolves all promises for services which have healthy instances.
    It also removes from the interstitial state any resolved promises for services which are no longer available."
   [interstitial-state-atom service-id->service-description current-available-service-ids scheduler-messages]
-  (let [summary-data (some (fn [[message-type message-data]]
-                             (when (= :update-available-services message-type)
-                               message-data))
-                           scheduler-messages)
-        available-service-ids (-> summary-data :available-service-ids set)
-        healthy-service-ids (-> summary-data :healthy-service-ids set)
+  (let [{:keys [available-service-ids healthy-service-ids]} (some (fn [[message-type message-data]]
+                                                                    (when (= :update-available-services message-type)
+                                                                      message-data))
+                                                                  scheduler-messages)
         service-ids-to-remove (set/difference current-available-service-ids available-service-ids)
         removed-service-ids (remove-resolved-interstitial-promises! interstitial-state-atom service-ids-to-remove)]
     (doseq [service-id available-service-ids]

--- a/waiter/src/waiter/metrics.clj
+++ b/waiter/src/waiter/metrics.clj
@@ -378,8 +378,7 @@
                                      (filter (fn [[message-type _]] (= message-type :update-available-services)))
                                      first
                                      second
-                                     :available-service-ids
-                                     set)
+                                     :available-service-ids)
           service-id->state (pc/map-from-keys (fn service-id->state-fn [service-id]
                                                 (-> (get service-id->metrics service-id)
                                                     (select-keys ["outstanding" "total"])

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -443,10 +443,14 @@
                                                               (available? instance health-check-path http-client))
                                                             service-id->service-description-fn))]
       (let [available-services (keys service->service-instances)
-            available-service-ids (map :id available-services)]
+            available-service-ids (->> available-services (map :id ) (set ))]
         (log/debug "scheduler-syncer:" (count service->service-instances) "available services:" available-service-ids)
         (doseq [service available-services]
-          (when (zero? (reduce + 0 (filter number? (vals (select-keys (:task-stats service) [:staged :running :healthy :unhealthy])))))
+          (when (->> (select-keys (:task-stats service) [:staged :running :healthy :unhealthy])
+                     vals
+                     (filter number?)
+                     (reduce + 0)
+                     zero?)
             (log/info "scheduler-syncer:" (:id service) "has no live instances!" (:task-stats service))))
         (loop [service-id->health-check-context' {}
                healthy-service-ids #{}

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -501,12 +501,7 @@
                         (seq healthy-instances) (conj service-id))
                 scheduler-messages'
                 remaining))
-            (let [healthy-service-ids (->> scheduler-messages
-                                           (keep (fn [[message-type message-data]]
-                                                   (when (and (= :update-service-instances message-type)
-                                                              (seq (:healthy-instances message-data)))
-                                                     (:service-id message-data)))))
-                  summary-message [:update-available-services
+            (let [summary-message [:update-available-services
                                    {:available-service-ids available-service-ids
                                     :healthy-service-ids healthy-service-ids
                                     :scheduler-sync-time request-apps-time}]]

--- a/waiter/src/waiter/state.clj
+++ b/waiter/src/waiter/state.clj
@@ -1179,7 +1179,6 @@
                                (case message-type
                                  :update-available-services
                                  (let [{:keys [available-service-ids scheduler-sync-time]} message-data
-                                       available-service-ids (into #{} available-service-ids)
                                        services-without-instances (remove #(contains? service-id->my-instance->slots %) available-service-ids)
                                        service-id->healthy-instances' (select-keys service-id->healthy-instances available-service-ids)
                                        service-id->unhealthy-instances' (select-keys service-id->unhealthy-instances available-service-ids)

--- a/waiter/test/waiter/interstitial_test.clj
+++ b/waiter/test/waiter/interstitial_test.clj
@@ -176,6 +176,7 @@
   (let [resolved-service-ids #{"service-1" "service-3" "service-5" "service-7"}
         unresolved-service-ids #{"service-2" "service-4" "service-6"}
         all-service-ids (set/union resolved-service-ids unresolved-service-ids)
+        healthy-service-ids #{"service-0" "service-6" "service-8"}
         interstitial-state-atom (->> all-service-ids
                                      (pc/map-from-keys (fn [service-id]
                                                          (let [p (promise)]
@@ -185,15 +186,16 @@
                                      (assoc {:initialized? false} :service-id->interstitial-promise)
                                      atom)
         available-service-ids' ["service-0" "service-7" "service-8" "service-9"]
-        scheduler-messages [[:update-available-services {:available-service-ids available-service-ids'}]
+        scheduler-messages [[:update-available-services {:available-service-ids available-service-ids'
+                                                         :healthy-service-ids healthy-service-ids}]
                             [:update-service-instances {:healthy-instances [{:id "service-0.1"}]
-                                                    :service-id "service-0"}]
+                                                        :service-id "service-0"}]
                             [:update-service-instances {:healthy-instances [{:id "service-6.1"}]
-                                                    :service-id "service-6"}]
+                                                        :service-id "service-6"}]
                             [:update-service-instances {:healthy-instances [{:id "service-8.1"}]
-                                                    :service-id "service-8"}]
+                                                        :service-id "service-8"}]
                             [:update-service-instances {:service-id "service-9"
-                                                    :unhealthy-instances [{:id "service-9.1"}]}]]
+                                                        :unhealthy-instances [{:id "service-9.1"}]}]]
         service-id->service-description (fn [service-id]
                                           {"interstitial-secs" (->> (str/last-index-of service-id "-")
                                                                     inc

--- a/waiter/test/waiter/interstitial_test.clj
+++ b/waiter/test/waiter/interstitial_test.clj
@@ -185,8 +185,8 @@
                                                            p)))
                                      (assoc {:initialized? false} :service-id->interstitial-promise)
                                      atom)
-        available-service-ids' ["service-0" "service-7" "service-8" "service-9"]
-        scheduler-messages [[:update-available-services {:available-service-ids available-service-ids'
+        available-service-ids #{"service-0" "service-7" "service-8" "service-9"}
+        scheduler-messages [[:update-available-services {:available-service-ids available-service-ids
                                                          :healthy-service-ids healthy-service-ids}]
                             [:update-service-instances {:healthy-instances [{:id "service-0.1"}]
                                                         :service-id "service-0"}]
@@ -210,7 +210,7 @@
     (let [response-chan (async/promise-chan)
           _ (async/>!! query-chan {:response-chan response-chan})
           state (async/<!! response-chan)]
-      (is (= (set/union (set available-service-ids') unresolved-service-ids)
+      (is (= (set/union (set available-service-ids) unresolved-service-ids)
              (set (get-in state [:maintainer :available-service-ids]))))
       (is (get-in state [:interstitial :initialized?]))
       (is (= {"service-2" :not-realized

--- a/waiter/test/waiter/metrics_test.clj
+++ b/waiter/test/waiter/metrics_test.clj
@@ -408,7 +408,7 @@
                 service-id->metrics-chan (:service-id->metrics-chan result-chans)]
             (async/thread
               (while (not @exit-flag-atom)
-                (let [available-service-ids (remove #(str/includes? % (str @remove-target-atom)) @available-services-atom)
+                (let [available-service-ids (set (remove #(str/includes? % (str @remove-target-atom)) @available-services-atom))
                       scheduler-messages [[:update-available-services {:available-service-ids available-service-ids}]]]
                   (async/>!! scheduler-state-chan scheduler-messages)))
               (async/close! scheduler-state-chan))

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -258,7 +258,7 @@
     (let [[[update-apps-msg update-apps] [update-instances-msg update-instances]] (async/<!! scheduler-state-chan)]
       (is (= :update-available-services update-apps-msg))
       (is (= (list "s1" "s2") (:available-service-ids update-apps)))
-      (is (= (list "s1") (:healthy-service-ids update-apps)))
+      (is (= #{"s1"} (:healthy-service-ids update-apps)))
       (is (= :update-service-instances update-instances-msg))
       (is (= [(assoc instance1 :healthy? true) instance2] (:healthy-instances update-instances)))
       (is (= [instance3-unhealthy] (:unhealthy-instances update-instances)))

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -148,7 +148,7 @@
               (let [global-state (pc/map-vals #(update-in % ["outstanding"] (fn [v] (max 0 (- v n))))
                                               initial-global-state)]
                 (async/>!! scheduler-state-chan (concat
-                                                  [[:update-available-services {:available-service-ids (vec @available-services-atom)}]]
+                                                  [[:update-available-services {:available-service-ids (set @available-services-atom)}]]
                                                   (vec
                                                     (map (fn [service-id]
                                                            [:update-service-instances
@@ -200,7 +200,7 @@
           (dotimes [iteration 20]
             (async/>!! scheduler-state-chan
                        (concat
-                         [[:update-available-services {:available-service-ids (vec @available-services-atom)}]]
+                         [[:update-available-services {:available-service-ids (set @available-services-atom)}]]
                          (vec
                            (map (fn [service-id]
                                   [:update-service-instances
@@ -257,7 +257,7 @@
     (async/>!! timeout-chan :timeout)
     (let [[[update-apps-msg update-apps] [update-instances-msg update-instances]] (async/<!! scheduler-state-chan)]
       (is (= :update-available-services update-apps-msg))
-      (is (= (list "s1" "s2") (:available-service-ids update-apps)))
+      (is (= #{"s1" "s2"} (:available-service-ids update-apps)))
       (is (= #{"s1"} (:healthy-service-ids update-apps)))
       (is (= :update-service-instances update-instances-msg))
       (is (= [(assoc instance1 :healthy? true) instance2] (:healthy-instances update-instances)))

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -234,6 +234,8 @@
         scheduler (reify ServiceScheduler
                     (get-apps->instances [_]
                       {(->Service "s1" {} {} {}) {:active-instances [instance1 instance2 instance3]
+                                                  :failed-instances []}
+                       (->Service "s2" {} {} {}) {:active-instances []
                                                   :failed-instances []}})
                     (service-id->state [_ _]
                       {:service-specific-state []})
@@ -247,17 +249,19 @@
                                         :status 400})))
         start-time-ms (-> (clock) .getMillis)
         {:keys [exit-chan query-chan]}
-        (start-scheduler-syncer clock scheduler scheduler-state-chan timeout-chan service-id->service-description-fn available? {} 5)]
+        (start-scheduler-syncer clock scheduler scheduler-state-chan timeout-chan service-id->service-description-fn available? {} 5)
+        instance3-unhealthy (assoc instance3
+                              :flags #{:has-connected :has-responded}
+                              :healthy? false
+                              :health-check-status 400)]
     (async/>!! timeout-chan :timeout)
     (let [[[update-apps-msg update-apps] [update-instances-msg update-instances]] (async/<!! scheduler-state-chan)]
       (is (= :update-available-services update-apps-msg))
-      (is (= (list "s1") (:available-service-ids update-apps)))
+      (is (= (list "s1" "s2") (:available-service-ids update-apps)))
+      (is (= (list "s1") (:healthy-service-ids update-apps)))
       (is (= :update-service-instances update-instances-msg))
       (is (= [(assoc instance1 :healthy? true) instance2] (:healthy-instances update-instances)))
-      (is (= [(assoc instance3
-                :healthy? false
-                :health-check-status 400
-                :flags #{:has-connected :has-responded})] (:unhealthy-instances update-instances)))
+      (is (= [instance3-unhealthy] (:unhealthy-instances update-instances)))
       (is (= "s1" (:service-id update-instances))))
     ;; Retrieves scheduler state without service-id
     (let [response-chan (async/promise-chan)
@@ -268,13 +272,12 @@
       (doseq [required-key [:service-id->health-check-context
                             :state]]
         (is (contains? response required-key)))
-      (is (= {"s1"
-              {:instance-id->unhealthy-instance {"s1.i3" (assoc instance3
-                                                           :healthy? false
-                                                           :health-check-status 400
-                                                           :flags #{:has-connected :has-responded})},
-               :instance-id->tracked-failed-instance {},
-               :instance-id->failed-health-check-count {"s1.i3" 1}}}
+      (is (= {"s1" {:instance-id->unhealthy-instance {"s1.i3" instance3-unhealthy},
+                    :instance-id->tracked-failed-instance {},
+                    :instance-id->failed-health-check-count {"s1.i3" 1}}
+              "s2" {:instance-id->failed-health-check-count {}
+                    :instance-id->tracked-failed-instance {}
+                    :instance-id->unhealthy-instance {}}}
              (:service-id->health-check-context response))))
     ;; Retrieves scheduler state with service-id
     (let [response-chan (async/promise-chan)

--- a/waiter/test/waiter/state_test.clj
+++ b/waiter/test/waiter/state_test.clj
@@ -993,7 +993,7 @@
       (let [{:keys [router-state-push-mult]} (start-router-state-maintainer scheduler-state-chan router-chan router-id exit-chan service-id->service-description-fn deployment-error-config)]
         (async/tap router-state-push-mult router-state-push-chan))
       (async/>!! router-chan {router-id (str "http://www." router-id ".com")})
-      (async/>!! scheduler-state-chan [[:update-available-services {:available-service-ids [service-id]
+      (async/>!! scheduler-state-chan [[:update-available-services {:available-service-ids #{service-id}
                                                                     :scheduler-sync-time (t/now)}]])
       (async/<!! router-state-push-chan)
       (async/>!! scheduler-state-chan [[:update-service-instances {:healthy-instances [instance]
@@ -1065,7 +1065,7 @@
             (let [current-time (t/plus start-time (t/minutes n))]
               (let [services (services-fn n)]
                 (loop [index 0
-                       scheduler-messages [[:update-available-services {:available-service-ids services
+                       scheduler-messages [[:update-available-services {:available-service-ids (set services)
                                                                         :scheduler-sync-time current-time}]]]
                   (if (>= index (count services))
                     (async/>!! scheduler-state-chan scheduler-messages)
@@ -1177,7 +1177,7 @@
             (let [current-time (t/plus start-time (t/minutes n))]
               (let [services (services-fn n)]
                 (loop [index 0
-                       scheduler-messages [[:update-available-services {:available-service-ids services
+                       scheduler-messages [[:update-available-services {:available-service-ids (set services)
                                                                         :scheduler-sync-time current-time}]]]
                   (if (>= index (count services))
                     (async/>!! scheduler-state-chan scheduler-messages)


### PR DESCRIPTION
## Changes proposed in this PR

- moves healthy-service-ids logic to update-scheduler-state
- return available-service-ids as a set in the scheduler messages

## Why are we making these changes?

Moves the logic to determine services with healthy instances to the scheduler syncer. This centralizes the logic and avoids repetition in any of the consumers of the scheduler state.

It also return `available-service-ids` as a set in the scheduler messages as a couple of the consumers were converting it to a set. In addition `transient-metrics-state-producer` was expecting it to be a set, so that path should also work now.