### PR TITLE
introduces the `date-utils` class

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -21,7 +21,7 @@
             [waiter.interstitial :as interstitial]
             [waiter.service-description :as sd]
             [waiter.util.client-tools :refer :all]
-            [waiter.util.utils :as utils])
+            [waiter.util.date-utils :as du])
   (:import java.io.ByteArrayInputStream))
 
 (deftest ^:parallel ^:integration-fast test-basic-functionality
@@ -263,7 +263,7 @@
           (make-request-with-debug-info headers #(make-kitchen-request waiter-url % :http-method-fn http/get))
           _ (assert-response-status first-response 200)
           canary-request-time-from-header (-> (get headers "x-waiter-request-date")
-                                              (utils/str-to-date utils/formatter-rfc822))]
+                                              (du/str-to-date du/formatter-rfc822))]
       (with-service-cleanup
         service-id
         (is (pos? metrics-sync-interval-ms))
@@ -284,19 +284,19 @@
       (testing "without parameters"
         (let [service (service waiter-url service-id {})] ;; see my app as myself
           (is service)
-          (is (-> (get service "last-request-time") utils/str-to-date .getMillis pos?))
+          (is (-> (get service "last-request-time") du/str-to-date .getMillis pos?))
           (is (pos? (get-in service ["service-description" "cpus"])) service)))
 
       (testing "waiter user disabled" ;; see my app as myself
         (let [service (service waiter-url service-id {"force" "false"})]
           (is service)
-          (is (-> (get service "last-request-time") utils/str-to-date .getMillis pos?))
+          (is (-> (get service "last-request-time") du/str-to-date .getMillis pos?))
           (is (pos? (get-in service ["service-description" "cpus"])) service)))
 
       (testing "waiter user disabled and same user" ;; see my app as myself
         (let [service (service waiter-url service-id {"force" "false", "run-as-user" (retrieve-username)})]
           (is service)
-          (is (-> (get service "last-request-time") utils/str-to-date .getMillis pos?))
+          (is (-> (get service "last-request-time") du/str-to-date .getMillis pos?))
           (is (pos? (get-in service ["service-description" "cpus"])) service)))
 
       (testing "different run-as-user" ;; no such app
@@ -326,7 +326,7 @@
       (testing "list-apps-with-waiter-user-disabled-and-see-another-app" ;; can see another user's app
         (let [service (service waiter-url service-id {"force" "false", "run-as-user" current-user})]
           (is service)
-          (is (-> (get service "last-request-time") utils/str-to-date .getMillis pos?))
+          (is (-> (get service "last-request-time") du/str-to-date .getMillis pos?))
           (is (pos? (get-in service ["service-description" "cpus"])) service)))
       (delete-service waiter-url service-id))))
 

--- a/waiter/integration/waiter/instance_reservation_test.clj
+++ b/waiter/integration/waiter/instance_reservation_test.clj
@@ -14,7 +14,7 @@
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [waiter.util.client-tools :refer :all]
-            [waiter.util.utils :as utils])
+            [waiter.util.date-utils :as du])
   (:import (java.util.concurrent Semaphore)))
 
 ; Marked explicit due to:
@@ -58,7 +58,7 @@
           request-thread-done-atom (atom false)
           first-request-thread (launch-thread
                                  (log/info (str "Making initial request at "
-                                                (utils/date-to-str (t/now))
+                                                (du/date-to-str (t/now))
                                                 " (will take "
                                                 (colored-time (str ">" (t/in-minutes (t/millis long-request-time-ms)) "minutes"))
                                                 " to complete)."))

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -19,7 +19,7 @@
             [qbits.jet.client.http :as http]
             [waiter.service-description :as sd]
             [waiter.util.client-tools :refer :all]
-            [waiter.util.utils :as utils])
+            [waiter.util.date-utils :as du])
   (:import (java.net URL)
            (org.joda.time DateTime)))
 
@@ -175,7 +175,7 @@
                                                  (cond-> service-description
                                                          last-update-time
                                                          (assoc "last-update-time"
-                                                                (-> last-update-time utils/str-to-date .getMillis))))
+                                                                (-> last-update-time du/str-to-date .getMillis))))
                       expected-etag (str "E-"
                                          (-> body
                                              json/read-str
@@ -405,7 +405,7 @@
                 (let [token-response (get-token waiter-url token)
                       response-body (json/read-str (:body token-response))]
                   (is (= {"health-check-url" "/probe-2"
-                          "last-update-time" (-> last-update-time DateTime. utils/date-to-str)
+                          "last-update-time" (-> last-update-time DateTime. du/date-to-str)
                           "last-update-user" (retrieve-username)
                           "name" service-id-prefix,
                           "owner" (retrieve-username)
@@ -481,7 +481,7 @@
                     response-body (json/read-str (:body token-response))]
                 (is (= {"deleted" true
                         "health-check-url" "/probe"
-                        "last-update-time" (-> last-update-time DateTime. utils/date-to-str)
+                        "last-update-time" (-> last-update-time DateTime. du/date-to-str)
                         "last-update-user" (retrieve-username)
                         "name" service-id-prefix
                         "owner" (retrieve-username)

--- a/waiter/integration/waiter/websocket_integration_test.clj
+++ b/waiter/integration/waiter/websocket_integration_test.clj
@@ -19,6 +19,7 @@
             [qbits.jet.client.http :as http]
             [qbits.jet.client.websocket :as ws-client]
             [waiter.util.client-tools :refer :all]
+            [waiter.util.date-utils :as du]
             [waiter.util.utils :as utils]
             [waiter.websocket :as websocket])
   (:import (java.net HttpCookie)
@@ -103,7 +104,7 @@
           (make-request-with-debug-info waiter-headers #(make-kitchen-request waiter-url % :http-method-fn http/get))
           _ (assert-response-status canary-response 200)
           first-request-time-header (-> (get headers "x-waiter-request-date")
-                                        (utils/str-to-date utils/formatter-rfc822))
+                                        (du/str-to-date du/formatter-rfc822))
           num-iterations 5]
       (is (pos? metrics-sync-interval-ms))
       (with-service-cleanup

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -52,6 +52,7 @@
             [waiter.statsd :as statsd]
             [waiter.token :as token]
             [waiter.util.async-utils :as au]
+            [waiter.util.date-utils :as du]
             [waiter.util.ring-utils :as ru]
             [waiter.util.utils :as utils]
             [waiter.websocket :as ws]
@@ -189,7 +190,7 @@
                                 backend-log-url (when backend-directory
                                                   (generate-log-url-fn instance))
                                 request-date (when request-time
-                                               (utils/date-to-str request-time utils/formatter-rfc822))]
+                                               (du/date-to-str request-time du/formatter-rfc822))]
                             (update response :headers
                                     (fn [headers]
                                       (cond-> headers
@@ -354,7 +355,7 @@
                                             (filter (fn [[service state]]
                                                       (when-let [gc-service (gc-service? service state current-time)]
                                                         (log/info service "with state" (:state state) "and last modified time"
-                                                                  (utils/date-to-str (:last-modified-time state)) "marked for deletion")
+                                                                  (du/date-to-str (:last-modified-time state)) "marked for deletion")
                                                         gc-service))
                                                     service->state'))
                             apps-successfully-gced (filter (fn [service]
@@ -894,7 +895,7 @@
                                  scheduler-state-mult-chan (async/mult scheduler-state-chan)
                                  http-client (http/client {:connect-timeout health-check-timeout-ms
                                                            :idle-timeout health-check-timeout-ms})
-                                 timeout-chan (chime/chime-ch (utils/time-seq (t/now) (t/seconds scheduler-syncer-interval-secs)))]
+                                 timeout-chan (chime/chime-ch (du/time-seq (t/now) (t/seconds scheduler-syncer-interval-secs)))]
                              (assoc (scheduler/start-scheduler-syncer
                                       clock scheduler scheduler-state-chan timeout-chan service-id->service-description-fn
                                       scheduler/available? http-client failed-check-threshold)

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -33,6 +33,7 @@
             [waiter.service :as service]
             [waiter.service-description :as sd]
             [waiter.statsd :as statsd]
+            [waiter.util.date-utils :as du]
             [waiter.util.ring-utils :as ru]
             [waiter.util.utils :as utils]))
 
@@ -162,7 +163,7 @@
                       walk/keywordize-keys
                       (update :started-at (fn [started-at]
                                             (when started-at
-                                              (utils/str-to-date started-at))))
+                                              (du/str-to-date started-at))))
                       scheduler/process-instance-killed!))
                 (utils/map->json-response {:instance-id instance-id
                                            :blacklist-period period-in-ms}))
@@ -789,7 +790,7 @@
                       :message "Welcome to Waiter"
                       :port port
                       :support-info support-info
-                      :timestamp (utils/date-to-str request-time)}
+                      :timestamp (du/date-to-str request-time)}
         content-type (utils/request->content-type request)]
     (try
       (case request-method

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -25,6 +25,7 @@
             [waiter.correlation-id :as cid]
             [waiter.request-log :as rlog]
             [waiter.settings :as settings]
+            [waiter.util.date-utils :as du]
             [waiter.util.utils :as utils])
   (:import clojure.core.async.impl.channels.ManyToManyChannel
            java.io.IOException
@@ -101,7 +102,7 @@
     (let [async-threads (System/getProperty "clojure.core.async.pool-size")
           settings (assoc (settings/load-settings config-file (retrieve-git-version))
                      :async-threads async-threads
-                     :started-at (utils/date-to-str (t/now)))]
+                     :started-at (du/date-to-str (t/now)))]
       (log/info "core.async threadpool configured to use" async-threads "threads.")
       (log/info "loaded settings:\n" (with-out-str (clojure.pprint/pprint settings)))
       (let [app-map (wire-app settings)]

--- a/waiter/src/waiter/metrics_sync.clj
+++ b/waiter/src/waiter/metrics_sync.clj
@@ -23,6 +23,7 @@
             [waiter.correlation-id :as cid]
             [waiter.metrics :as metrics]
             [waiter.util.async-utils :as au]
+            [waiter.util.date-utils :as du]
             [waiter.util.utils :as utils])
   (:import (qbits.jet.websocket WebSocket)))
 
@@ -182,7 +183,7 @@
   [{:keys [router-id router-id->outgoing-ws] :as router-metrics-state} encrypt router-metrics tag]
   (with-catch
     router-metrics-state
-    (let [time (utils/date-to-str (t/now))
+    (let [time (du/date-to-str (t/now))
           metrics-data {:router-metrics router-metrics, :source-router-id router-id, :time time}]
       (doseq [[target-router-id {:keys [out request-id]}] (seq router-id->outgoing-ws)]
         (let [encrypted-data (timers/start-stop-time!

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -37,6 +37,7 @@
             [waiter.statsd :as statsd]
             [waiter.token :as token]
             [waiter.util.async-utils :as au]
+            [waiter.util.date-utils :as du]
             [waiter.util.ring-utils :as ru]
             [waiter.util.utils :as utils])
   (:import (java.io InputStream IOException)
@@ -578,7 +579,7 @@
     (if (get suspended-state :suspended false)
       (let [{:keys [last-updated-by time]} suspended-state
             response-map (cond-> {:service-id service-id}
-                           time (assoc :suspended-at (utils/date-to-str time))
+                           time (assoc :suspended-at (du/date-to-str time))
                            (not (str/blank? last-updated-by)) (assoc :last-updated-by last-updated-by))]
         (log/info "Service has been suspended" response-map)
         (meters/mark! (metrics/service-meter service-id "response-rate" "error" "suspended"))

--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -14,6 +14,7 @@
             [clojure.tools.logging :as log]
             [metrics.timers :as timers]
             [waiter.metrics :as metrics]
+            [waiter.util.date-utils :as du]
             [waiter.util.ring-utils :as ru]
             [waiter.util.utils :as utils]))
 
@@ -34,7 +35,7 @@
              :scheme (-> request utils/request->scheme name)}
       request-method (assoc :method (-> request-method name str/upper-case))
       query-string (assoc :query-string query-string)
-      request-time (assoc :request-time (utils/date-to-str request-time))
+      request-time (assoc :request-time (du/date-to-str request-time))
       user-agent (assoc :user-agent user-agent))))
 
 (defn response->context

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -21,6 +21,7 @@
             [slingshot.slingshot :as ss]
             [waiter.metrics :as metrics]
             [waiter.util.async-utils :as au]
+            [waiter.util.date-utils :as du]
             [waiter.util.utils :as utils])
   (:import (clojure.lang PersistentQueue)
            (java.io EOFException)
@@ -283,7 +284,7 @@
                                   (let [service-description (service-id->service-description-fn service-id)
                                         idle-timeout-mins (get service-description "idle-timeout-mins")
                                         timeout-time (t/plus last-modified-time (t/minutes idle-timeout-mins))]
-                                    (log/debug service-id "timeout:" (utils/date-to-str timeout-time) "current:" (utils/date-to-str current-time))
+                                    (log/debug service-id "timeout:" (du/date-to-str timeout-time) "current:" (du/date-to-str current-time))
                                     (t/after? current-time timeout-time)))))
           perform-gc-fn (fn [service-id]
                           (log/info "deleting idle service" service-id)
@@ -607,7 +608,7 @@
    (let [max-instances-to-keep 10]
      (add-instance-to-buffered-collection!
        service-id->killed-instances-transient-store max-instances-to-keep service-id
-       (assoc instance :killed-at (utils/date-to-str (t/now)))
+       (assoc instance :killed-at (du/date-to-str (t/now)))
        #(PersistentQueue/EMPTY) pop))))
 
 (defn environment

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -24,6 +24,7 @@
             [waiter.scheduler :as scheduler]
             [waiter.service-description :as sd]
             [waiter.util.async-utils :as au]
+            [waiter.util.date-utils :as du]
             [waiter.util.utils :as utils])
   (:import (org.joda.time.format DateTimeFormat)))
 
@@ -58,7 +59,7 @@
                               (merge
                                 (common-extractor-fn instance-id failed-marathon-task)
                                 {:id instance-id
-                                 :started-at (some-> failed-marathon-task :timestamp (utils/str-to-date formatter-marathon))
+                                 :started-at (some-> failed-marathon-task :timestamp (du/str-to-date formatter-marathon))
                                  :healthy? false
                                  :port 0})))
           max-instances-to-keep 10]
@@ -161,7 +162,7 @@
                                 (merge
                                   (common-extractor-fn instance-id %)
                                   {:id instance-id
-                                   :started-at (some-> % :startedAt (utils/str-to-date formatter-marathon))
+                                   :started-at (some-> % :startedAt (du/str-to-date formatter-marathon))
                                    :healthy? (healthy?-fn %)
                                    ;; first port must be used for the web server, extra ports can be used freely.
                                    :port (-> % :ports first)
@@ -302,7 +303,7 @@
           (get @service-id->kill-info-store service-id)
           use-force (t/after? current-time (t/plus kill-failing-since (t/millis force-kill-after-ms)))
           _ (when use-force
-              (log/info "using force killing" id "as kills have been failing since" (utils/date-to-str kill-failing-since)))
+              (log/info "using force killing" id "as kills have been failing since" (du/date-to-str kill-failing-since)))
           params {:force use-force, :scale true}
           {:keys [killed?] :as kill-result} (process-kill-instance-request marathon-api service-id id params)]
       (if killed?

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -22,6 +22,7 @@
             [schema.core :as s]
             [waiter.metrics :as metrics]
             [waiter.scheduler :as scheduler]
+            [waiter.util.date-utils :as du]
             [waiter.util.utils :as utils])
   (:import java.io.File
            java.lang.UNIXProcess
@@ -414,7 +415,7 @@
   "Runs health checks against all active instances of all services in a loop"
   [id->service-agent port->reservation-atom port-grace-period-ms timeout-ms http-client]
   (log/info "starting update-health")
-  (utils/start-timer-task
+  (du/start-timer-task
     (t/millis timeout-ms)
     (fn []
       (send id->service-agent update-service-health port->reservation-atom port-grace-period-ms http-client))))
@@ -472,7 +473,7 @@
   "Relaunches failed instances in a loop"
   [id->service-agent port->reservation-atom port-range timeout-ms]
   (log/info "starting retry-failed-instances")
-  (utils/start-timer-task
+  (du/start-timer-task
     (t/millis timeout-ms)
     (fn []
       (send id->service-agent maintain-instance-scale port->reservation-atom port-range))))

--- a/waiter/src/waiter/state.clj
+++ b/waiter/src/waiter/state.clj
@@ -26,6 +26,7 @@
             [waiter.metrics :as metrics]
             [waiter.scheduler :as scheduler]
             [waiter.util.async-utils :as au]
+            [waiter.util.date-utils :as du]
             [waiter.util.utils :as utils]
             [waiter.work-stealing :as work-stealing])
   (:import clojure.lang.PersistentQueue))
@@ -715,7 +716,7 @@
                                    c ([_] :item-handled)
                                    timeout ([_]
                                              (cid/cinfo (:cid reason-map) "timeout in handling"
-                                                        (assoc-in (update-in reason-map [:time] utils/date-to-str)
+                                                        (assoc-in (update-in reason-map [:time] du/date-to-str)
                                                                   [:state :timeout]
                                                                   (metrics/retrieve-local-stats-for-service service-id)))
                                              (async/put! c {:id reason-map
@@ -1211,9 +1212,9 @@
                                        expiry-mins-int (int (get service-description "instance-expiry-mins"))
                                        expiry-mins (t/minutes expiry-mins-int)
                                        expired-instances (filter #(and (pos? expiry-mins-int)
-                                                                       (utils/older-than? scheduler-sync-time expiry-mins %))
+                                                                       (du/older-than? scheduler-sync-time expiry-mins %))
                                                                  healthy-instances)
-                                       starting-instances (filter #(not (utils/older-than? scheduler-sync-time grace-period-secs %)) unhealthy-instances)
+                                       starting-instances (filter #(not (du/older-than? scheduler-sync-time grace-period-secs %)) unhealthy-instances)
                                        service-id->expired-instances' (assoc service-id->expired-instances service-id expired-instances)
                                        service-id->starting-instances' (assoc service-id->starting-instances service-id starting-instances)
                                        service-id->failed-instances' (assoc service-id->failed-instances service-id failed-instances)
@@ -1299,7 +1300,7 @@
    sends the list to the router state maintainer."
   [discovery router-chan router-syncer-interval-ms router-syncer-delay-ms]
   (log/info "Starting router syncer")
-  (utils/start-timer-task
+  (du/start-timer-task
     (t/millis router-syncer-interval-ms)
     #(retrieve-peer-routers discovery router-chan)
     :delay-ms router-syncer-delay-ms))

--- a/waiter/src/waiter/statsd.clj
+++ b/waiter/src/waiter/statsd.clj
@@ -15,6 +15,7 @@
             [clojure.tools.logging :as log]
             [metrics.counters :as counters]
             [waiter.metrics :as metrics]
+            [waiter.util.date-utils :as du]
             [waiter.util.utils :as utils])
   (:import (clojure.lang PersistentQueue)
            (java.net InetAddress DatagramPacket DatagramSocket)))
@@ -163,8 +164,8 @@
           (when config-histogram-max-size
             (reset! histogram-max-size config-histogram-max-size))
           (when (> config-publish-interval-ms 0)
-            (utils/start-timer-task (t/millis config-publish-interval-ms) trigger-publish
-                                    :delay-ms config-publish-interval-ms)))))
+            (du/start-timer-task (t/millis config-publish-interval-ms) trigger-publish
+                                 :delay-ms config-publish-interval-ms)))))
 
     (defn add-value
       "Given the current map of [metric-group metric metric-type] -> value(s), adds the value to the map

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -24,6 +24,7 @@
             [waiter.correlation-id :as cid]
             [waiter.mesos.marathon :as marathon]
             [waiter.statsd :as statsd]
+            [waiter.util.date-utils :as du]
             [waiter.util.utils :as utils])
   (:import (java.net HttpCookie URI)
            (java.util.concurrent Callable Future Executors)
@@ -128,7 +129,7 @@
 (defmacro time-it
   ([name & body]
    `(do
-      (let [date-str# (utils/date-to-str (t/now))]
+      (let [date-str# (du/date-to-str (t/now))]
         (log/info (str INFO (cyan ~name) " started at " date-str#)))
       (let [start-time-ms# (System/currentTimeMillis)
             execution-result# (atom nil)
@@ -886,4 +887,4 @@
   [waiter-url service-id]
   (when-let [last-request-time-str (-> (service waiter-url service-id {})
                                        (get "last-request-time"))]
-    (utils/str-to-date last-request-time-str)))
+    (du/str-to-date last-request-time-str)))

--- a/waiter/src/waiter/util/date_utils.clj
+++ b/waiter/src/waiter/util/date_utils.clj
@@ -1,0 +1,63 @@
+;;
+;;       Copyright (c) 2018 Two Sigma Investments, LP.
+;;       All Rights Reserved
+;;
+;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
+;;       Two Sigma Investments, LP.
+;;
+;;       The copyright notice above does not evidence any
+;;       actual or intended publication of such source code.
+;;
+(ns waiter.util.date-utils
+  (:require [chime :as chime]
+            [clj-time.core :as t]
+            [clj-time.format :as f]
+            [clojure.tools.logging :as log])
+  (:import (org.joda.time DateTime ReadablePeriod)))
+
+(def formatter-iso8601 (:date-time f/formatters))
+(def formatter-rfc822 (:rfc822 f/formatters))
+
+(defn date-to-str
+  ([^DateTime date-time]
+   (date-to-str date-time formatter-iso8601))
+  ([^DateTime date-time formatter]
+   (when date-time
+     (f/unparse
+       (f/with-zone formatter t/utc)
+       (.withZone date-time t/utc)))))
+
+(defn str-to-date
+  (^DateTime [date-str]
+   (str-to-date date-str formatter-iso8601))
+  (^DateTime [date-str formatter]
+   (try
+     (f/parse
+       (f/with-zone formatter t/utc)
+       date-str)
+     (catch Exception ex
+       (log/error "unable to parse" date-str "with formatter" formatter)
+       (throw ex)))))
+
+(defn time-seq
+  "Returns a sequence of date-time values growing over specific period.
+  Takes as input the starting value and the growing value, returning a
+  lazy infinite sequence."
+  [start ^ReadablePeriod period]
+  (iterate (fn [^DateTime t] (.plus t period)) start))
+
+(defn start-timer-task
+  "Executes the callback functions sequentially as specified intervals. Returns
+  a function that will cancel the timer when called."
+  [interval-period callback-fn & {:keys [delay-ms] :or {delay-ms 0}}]
+  (chime/chime-at
+    (time-seq (t/plus (t/now) (t/millis delay-ms)) interval-period)
+    (fn [_] (callback-fn))
+    {:error-handler (fn [ex] (log/error ex (str "Exception in timer task.")))}))
+
+(defn older-than? [current-time duration {:keys [started-at]}]
+  (if (and duration started-at)
+    (t/after? current-time (t/plus started-at duration))
+    false))
+
+

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -20,7 +20,6 @@
             [waiter.auth.authentication :as auth]
             [waiter.authorization :as authz]
             [waiter.core :refer :all]
-            [waiter.cors :as cors]
             [waiter.curator :as curator]
             [waiter.discovery :as discovery]
             [waiter.handler :as handler]
@@ -31,6 +30,7 @@
             [waiter.scheduler :as scheduler]
             [waiter.service-description :as sd]
             [waiter.test-helpers :refer :all]
+            [waiter.util.date-utils :as du]
             [waiter.util.utils :as utils])
   (:import java.io.StringBufferInputStream))
 
@@ -505,7 +505,7 @@
                                          "host" "10.141.141.11"
                                          "log-url" "http://www.example.com/apps/test-service-1/logs?instance-id=test-service-1.A&host=10.141.141.11"
                                          "port" 31045,
-                                         "started-at" (utils/date-to-str started-time utils/formatter-iso8601)}]}))
+                                         "started-at" (du/date-to-str started-time du/formatter-iso8601)}]}))
             (is (= (get body-json "metrics")
                    {"aggregate" {"routers-sent-requests-to" 0}}))
             (is (= (get body-json "num-active-instances") 1))

--- a/waiter/test/waiter/metrics_sync_test.clj
+++ b/waiter/test/waiter/metrics_sync_test.clj
@@ -19,6 +19,7 @@
             [waiter.metrics :as metrics]
             [waiter.metrics-sync :refer :all]
             [waiter.test-helpers :as test-helpers]
+            [waiter.util.date-utils :as du]
             [waiter.util.utils :as utils])
   (:import (org.eclipse.jetty.websocket.client WebSocketClient)
            (org.joda.time DateTime)
@@ -178,13 +179,13 @@
                                                                 "router-4" ws-request-4}
                                        :fee :fie}
               out-router-metrics-state (publish-router-metrics in-router-metrics-state encrypt router-metrics "core")]
-          (let [output-data {:data {:router-metrics router-metrics, :source-router-id "router-1", :time (utils/date-to-str test-start-time)}}]
+          (let [output-data {:data {:router-metrics router-metrics, :source-router-id "router-1", :time (du/date-to-str test-start-time)}}]
             (is (= output-data (async/<!! (:out ws-request-2))))
             (is (= output-data (async/<!! (:out ws-request-3))))
             (is (= output-data (async/<!! (:out ws-request-4)))))
           (is (= (-> in-router-metrics-state
                      (assoc-in [:metrics :routers "router-1"] router-metrics)
-                     (assoc-in [:last-update-times "router-1"] (utils/date-to-str test-start-time)))
+                     (assoc-in [:last-update-times "router-1"] (du/date-to-str test-start-time)))
                  out-router-metrics-state)))))))
 
 (deftest test-update-metrics-router-state-no-new-nor-missing-router-ids

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -20,7 +20,7 @@
             [waiter.mesos.marathon :as marathon]
             [waiter.mesos.mesos :as mesos]
             [waiter.scheduler :as scheduler]
-            [waiter.util.utils :as utils])
+            [waiter.util.date-utils :as du])
   (:import waiter.scheduler.marathon.MarathonScheduler))
 
 (deftest test-response-data->service-instances
@@ -111,7 +111,7 @@
                                                   :port 31045,
                                                   :protocol "https",
                                                   :service-id "test-app-1234",
-                                                  :started-at (utils/str-to-date "2014-09-13T00:24:46.959Z" formatter-marathon)}),
+                                                  :started-at (du/str-to-date "2014-09-13T00:24:46.959Z" formatter-marathon)}),
                                                (scheduler/make-ServiceInstance
                                                  {:extra-ports [],
                                                   :healthy? true,
@@ -122,7 +122,7 @@
                                                   :port 31234,
                                                   :protocol "https",
                                                   :service-id "test-app-1234",
-                                                  :started-at (utils/str-to-date "2014-09-13T00:24:56.965Z" formatter-marathon)}),
+                                                  :started-at (du/str-to-date "2014-09-13T00:24:56.965Z" formatter-marathon)}),
                                                (scheduler/make-ServiceInstance
                                                  {:extra-ports [12321 90384 56463],
                                                   :healthy? false,
@@ -133,7 +133,7 @@
                                                   :port 41234,
                                                   :protocol "https",
                                                   :service-id "test-app-1234",
-                                                  :started-at (utils/str-to-date "2014-09-14T00:24:46.965Z" formatter-marathon)}))
+                                                  :started-at (du/str-to-date "2014-09-14T00:24:46.965Z" formatter-marathon)}))
                            :failed-instances (list
                                                (scheduler/make-ServiceInstance
                                                  {:extra-ports [],
@@ -145,7 +145,7 @@
                                                   :port 0,
                                                   :protocol "https",
                                                   :service-id "test-app-1234",
-                                                  :started-at (utils/str-to-date "2014-09-12T23:23:41.711Z" formatter-marathon)}))
+                                                  :started-at (du/str-to-date "2014-09-12T23:23:41.711Z" formatter-marathon)}))
                            :killed-instances []}
                           :service-id->service-description {"test-app-1234" {"backend-proto" "https"}}},
                          {
@@ -209,7 +209,7 @@
                                                   :port 31045,
                                                   :protocol "http",
                                                   :service-id "test-app-1234",
-                                                  :started-at (utils/str-to-date "2014-09-13T00:24:46.959Z" formatter-marathon)}),
+                                                  :started-at (du/str-to-date "2014-09-13T00:24:46.959Z" formatter-marathon)}),
                                                (scheduler/make-ServiceInstance
                                                  {:extra-ports [],
                                                   :healthy? true,
@@ -220,7 +220,7 @@
                                                   :port 31234,
                                                   :protocol "http",
                                                   :service-id "test-app-1234",
-                                                  :started-at (utils/str-to-date "2014-09-13T00:24:46.965Z" formatter-marathon)}),
+                                                  :started-at (du/str-to-date "2014-09-13T00:24:46.965Z" formatter-marathon)}),
                                                (scheduler/make-ServiceInstance
                                                  {:extra-ports [],
                                                   :healthy? false,
@@ -231,7 +231,7 @@
                                                   :port 41234,
                                                   :protocol "http",
                                                   :service-id "test-app-1234",
-                                                  :started-at (utils/str-to-date "2014-09-13T00:24:46.965Z" formatter-marathon)}))
+                                                  :started-at (du/str-to-date "2014-09-13T00:24:46.965Z" formatter-marathon)}))
                            :failed-instances []
                            :killed-instances []}
                           :service-id->service-description {"test-app-1234" {"backend-proto" "http"}}})]
@@ -341,7 +341,7 @@
                          :host "10.141.141.11"
                          :port 31045
                          :protocol "https"
-                         :started-at (utils/str-to-date "2014-09-13T00:24:46.959Z" formatter-marathon)})
+                         :started-at (du/str-to-date "2014-09-13T00:24:46.959Z" formatter-marathon)})
                       (scheduler/make-ServiceInstance
                         {:id "test-app-1234.B"
                          :service-id "test-app-1234"
@@ -349,7 +349,7 @@
                          :host "10.141.141.12"
                          :port 31234
                          :protocol "https"
-                         :started-at (utils/str-to-date "2014-09-13T00:24:46.965Z" formatter-marathon)}))
+                         :started-at (du/str-to-date "2014-09-13T00:24:46.965Z" formatter-marathon)}))
                     :failed-instances []
                     :killed-instances []}
                    (scheduler/make-Service {:id "test-app-6789", :instances 3, :task-count 3})
@@ -362,7 +362,7 @@
                          :host "10.141.141.11"
                          :port 31045
                          :protocol "http"
-                         :started-at (utils/str-to-date "2014-09-13T00:24:46.959Z" formatter-marathon)})
+                         :started-at (du/str-to-date "2014-09-13T00:24:46.959Z" formatter-marathon)})
                       (scheduler/make-ServiceInstance
                         {:id "test-app-6789.B"
                          :service-id "test-app-6789"
@@ -370,7 +370,7 @@
                          :host "10.141.141.12"
                          :port 36789
                          :protocol "http"
-                         :started-at (utils/str-to-date "2014-09-13T00:24:56.965Z" formatter-marathon)})
+                         :started-at (du/str-to-date "2014-09-13T00:24:56.965Z" formatter-marathon)})
                       (scheduler/make-ServiceInstance
                         {:id "test-app-6789.C"
                          :service-id "test-app-6789"
@@ -378,7 +378,7 @@
                          :host "10.141.141.13"
                          :port 46789
                          :protocol "http"
-                         :started-at (utils/str-to-date "2014-09-14T00:24:46.965Z" formatter-marathon)}))
+                         :started-at (du/str-to-date "2014-09-14T00:24:46.965Z" formatter-marathon)}))
                     :failed-instances
                     (list
                       (scheduler/make-ServiceInstance
@@ -388,7 +388,7 @@
                          :host "10.141.141.10"
                          :port 0
                          :protocol "http"
-                         :started-at (utils/str-to-date "2014-09-12T23:23:41.711Z" formatter-marathon)
+                         :started-at (du/str-to-date "2014-09-12T23:23:41.711Z" formatter-marathon)
                          :message "Abnormal executor termination"}))
                     :killed-instances []})
         service-id->failed-instances-transient-store (atom {})
@@ -648,7 +648,7 @@
 
 (deftest test-killed-instances-transient-store
   (let [current-time (t/now)
-        current-time-str (utils/date-to-str current-time)
+        current-time-str (du/date-to-str current-time)
         marathon-api (Object.)
         marathon-scheduler (->MarathonScheduler marathon-api {} (constantly nil) "/home/path/"
                                                 (atom {}) (atom {}) (constantly nil) 60000 (constantly true))
@@ -706,7 +706,7 @@
 
 (deftest test-max-failed-instances-cache
   (let [current-time (t/now)
-        current-time-str (utils/date-to-str current-time formatter-marathon)
+        current-time-str (du/date-to-str current-time formatter-marathon)
         service-id->failed-instances-transient-store (atom {})
         common-extractor-fn (constantly {:service-id "service-1"})]
     (testing "test-max-failed-instances-cache"
@@ -725,7 +725,7 @@
                          (scheduler/make-ServiceInstance
                            {:id (str "service-1." n)
                             :service-id "service-1"
-                            :started-at (utils/str-to-date current-time-str formatter-marathon)
+                            :started-at (du/str-to-date current-time-str formatter-marathon)
                             :healthy? false
                             :port 0}))
               (str "Failed instances does not contain instance service-1." n)))))))

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -19,7 +19,7 @@
             [waiter.core :as core]
             [waiter.curator :as curator]
             [waiter.scheduler :refer :all]
-            [waiter.util.utils :as utils])
+            [waiter.util.date-utils :as du])
   (:import (java.net ConnectException SocketTimeoutException)
            (java.util.concurrent TimeoutException)))
 
@@ -39,7 +39,7 @@
       (is (= test-instance-1 test-instance-3)))))
 
 (deftest test-record-ServiceInstance
-  (let [start-time (utils/str-to-date "2014-09-13T00:24:46.959Z" utils/formatter-iso8601)
+  (let [start-time (du/str-to-date "2014-09-13T00:24:46.959Z" du/formatter-iso8601)
         test-instance (->ServiceInstance
                         "instance-id"
                         "service-id"
@@ -460,7 +460,7 @@
 
 (deftest test-killed-instances-transient-store
   (let [current-time (t/now)
-        current-time-str (utils/date-to-str current-time)
+        current-time-str (du/date-to-str current-time)
         make-instance (fn [service-id instance-id]
                         {:id instance-id
                          :service-id service-id})]
@@ -511,7 +511,7 @@
 
 (deftest test-max-killed-instances-cache
   (let [current-time (t/now)
-        current-time-str (utils/date-to-str current-time)
+        current-time-str (du/date-to-str current-time)
         make-instance (fn [service-id instance-id]
                         {:id instance-id, :service-id service-id, :killed-at current-time-str})]
     (with-redefs [t/now (fn [] current-time)]

--- a/waiter/test/waiter/state_test.clj
+++ b/waiter/test/waiter/state_test.clj
@@ -20,7 +20,7 @@
             [waiter.discovery :as discovery]
             [waiter.state :refer :all]
             [waiter.util.async-utils :as au]
-            [waiter.util.utils :as utils])
+            [waiter.util.date-utils :as du])
   (:import (org.joda.time DateTime)))
 
 (deftest test-find-instance-to-offer-with-concurrency-level-1
@@ -1096,7 +1096,7 @@
                                                 expiry-mins-int (Integer/parseInt (str/replace service "service-" ""))
                                                 expiry-mins (t/minutes expiry-mins-int)]
                                             (filter #(and (pos? expiry-mins-int)
-                                                          (utils/older-than? current-time expiry-mins %1))
+                                                          (du/older-than? current-time expiry-mins %1))
                                                     healthy-instances)))
                                         expected-services)
                                       :service-id->starting-instances
@@ -1104,7 +1104,7 @@
                                         (fn [service]
                                           (let [unhealthy-instances (unhealthy-instances-fn service (index-fn service))
                                                 grace-period-mins (t/minutes (Integer/parseInt (str/replace service "service-" "")))]
-                                            (filter #(not (utils/older-than? current-time grace-period-mins %)) unhealthy-instances)))
+                                            (filter #(not (du/older-than? current-time grace-period-mins %)) unhealthy-instances)))
                                         expected-services)
                                       :service-id->my-instance->slots
                                       (pc/map-from-keys

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -20,6 +20,7 @@
             [waiter.service-description :as sd]
             [waiter.test-helpers :refer :all]
             [waiter.token :refer :all]
+            [waiter.util.date-utils :as du]
             [waiter.util.utils :as utils])
   (:import (clojure.lang ExceptionInfo)
            (java.io StringBufferInputStream)
@@ -452,7 +453,7 @@
                  :request-method :get})]
           (is (= 200 status))
           (is (= "application/json" (get headers "content-type")))
-          (is (-> body json/read-str (get "last-update-time") utils/str-to-date))
+          (is (-> body json/read-str (get "last-update-time") du/str-to-date))
           (let [body-map (-> body str json/read-str)]
             (doseq [key sd/service-description-keys]
               (is (= (get service-description-2 key) (get body-map key))))
@@ -485,7 +486,7 @@
                  :request-method :get})]
           (is (= 200 status))
           (is (= "application/json" (get headers "content-type")))
-          (is (-> body json/read-str (get "last-update-time") utils/str-to-date))
+          (is (-> body json/read-str (get "last-update-time") du/str-to-date))
           (let [body-map (-> body str json/read-str)]
             (doseq [key sd/service-description-keys]
               (is (= (get service-description-2 key) (get body-map key))))


### PR DESCRIPTION

## Changes proposed in this PR

- introduces the `date-utils` class
- removes unused `extract-expired-keys`

## Why are we making these changes?

Starts the splitting of `utils.clj` into smaller utils classes.
