### PR TITLE
respects descriptor present in the response while wrapping the descriptor

### DIFF
--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -451,8 +451,9 @@
   [handler request->descriptor-fn]
   (fn [request]
     (try-let [descriptor (request->descriptor-fn request)]
-      (let [handler (-> handler
-                        (middleware/wrap-assoc :descriptor descriptor))]
+      (let [req-update-fn #(assoc % :descriptor descriptor)
+            res-update-fn #(utils/assoc-if-absent % :descriptor descriptor)
+            handler (middleware/wrap-update handler req-update-fn res-update-fn)]
         (handler request))
       (catch Exception e
         (if (missing-run-as-user? e)


### PR DESCRIPTION

## Changes proposed in this PR

- respects descriptor present in the response while wrapping the descriptor

## Why are we making these changes?

We should respect certain downstream properties set in the response. This is especially true when we implement service fallback as we do not want to override the descriptor in the response.
