### PR TITLE
Simplifies text rendered on interstitial page

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -697,13 +697,13 @@
             (->> [(async/thread ;; check interstitial rendering
                     (let [request-headers (assoc request-headers "host" token)
                           {:keys [body] :as response}
-                          (make-request router-url (str "/waiter-interstitial/" service-id "/some-endpoint")
+                          (make-request router-url "/waiter-interstitial/some-endpoint"
                                         :cookies cookies
                                         :headers request-headers
                                         :query-params {"a" "b"})]
                       (assert-response-status response 200)
                       (is (str/includes? body (str "<title>Waiter - Interstitial for " service-id "</title>")))
-                      (is (str/includes? body "/some-endpoint?a=b&x-waiter-bypass-interstitial="))))
+                      (is (str/includes? body (str "/some-endpoint?a=b&x-waiter-bypass-interstitial=")))))
                   (async/thread ;; GET request inside the interstitial period, using DNS token
                     (let [start-time (t/now)
                           endpoint "/hello"
@@ -715,7 +715,7 @@
                                         :http-method-fn http/get)
                           end-time (t/now)]
                       (assert-response-status response 303)
-                      (is (= (str "/waiter-interstitial/" service-id endpoint) (get headers "location")))
+                      (is (= (str "/waiter-interstitial" endpoint) (get headers "location")))
                       (is (= "true" (get headers "x-waiter-interstitial")))
                       (is (< (t/in-millis (t/interval start-time end-time))
                              (t/in-millis (t/seconds interstitial-secs))))))
@@ -730,7 +730,7 @@
                                         :http-method-fn http/post)
                           end-time (t/now)]
                       (assert-response-status response 303)
-                      (is (= (str "/waiter-interstitial/" service-id endpoint) (get headers "location")))
+                      (is (= (str "/waiter-interstitial" endpoint) (get headers "location")))
                       (is (= "true" (get headers "x-waiter-interstitial")))
                       (is (< (t/in-millis (t/interval start-time end-time))
                              (t/in-millis (t/seconds interstitial-secs))))))

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -697,13 +697,13 @@
             (->> [(async/thread ;; check interstitial rendering
                     (let [request-headers (assoc request-headers "host" token)
                           {:keys [body] :as response}
-                          (make-request router-url "/waiter-interstitial/some-endpoint"
+                          (make-request router-url (str "/waiter-interstitial/" service-id "/some-endpoint")
                                         :cookies cookies
                                         :headers request-headers
                                         :query-params {"a" "b"})]
                       (assert-response-status response 200)
                       (is (str/includes? body (str "<title>Waiter - Interstitial for " service-id "</title>")))
-                      (is (str/includes? body (str "/some-endpoint?a=b&x-waiter-bypass-interstitial=")))))
+                      (is (str/includes? body "/some-endpoint?a=b&x-waiter-bypass-interstitial="))))
                   (async/thread ;; GET request inside the interstitial period, using DNS token
                     (let [start-time (t/now)
                           endpoint "/hello"
@@ -715,7 +715,7 @@
                                         :http-method-fn http/get)
                           end-time (t/now)]
                       (assert-response-status response 303)
-                      (is (= (str "/waiter-interstitial" endpoint) (get headers "location")))
+                      (is (= (str "/waiter-interstitial/" service-id endpoint) (get headers "location")))
                       (is (= "true" (get headers "x-waiter-interstitial")))
                       (is (< (t/in-millis (t/interval start-time end-time))
                              (t/in-millis (t/seconds interstitial-secs))))))
@@ -730,7 +730,7 @@
                                         :http-method-fn http/post)
                           end-time (t/now)]
                       (assert-response-status response 303)
-                      (is (= (str "/waiter-interstitial" endpoint) (get headers "location")))
+                      (is (= (str "/waiter-interstitial/" service-id endpoint) (get headers "location")))
                       (is (= "true" (get headers "x-waiter-interstitial")))
                       (is (< (t/in-millis (t/interval start-time end-time))
                              (t/in-millis (t/seconds interstitial-secs))))))

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -702,7 +702,7 @@
                                         :headers request-headers
                                         :query-params {"a" "b"})]
                       (assert-response-status response 200)
-                      (is (str/includes? body (str "<title>Waiter - Interstitial for " service-id "</title>")))
+                      (is (str/includes? body (str "<title>Waiter - Interstitial</title>")))
                       (is (str/includes? body (str "/some-endpoint?a=b&x-waiter-bypass-interstitial=")))))
                   (async/thread ;; GET request inside the interstitial period, using DNS token
                     (let [start-time (t/now)

--- a/waiter/resources/web/interstitial.html
+++ b/waiter/resources/web/interstitial.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-    <title>Waiter - Interstitial for <%= service-id %></title>
+    <title>Waiter - Interstitial</title>
     <meta http-equiv="x-ua-compatible" content="IE=edge" />
     <style type="text/css">
    html {
@@ -13,7 +13,7 @@
      background-color: rgba(0, 0, 0, 0.85);
      height: 100%;
      left: 0;
-     line-height: 1;
+     line-height: 1.2;
      position: fixed;
      text-align: center;
      top: 0;
@@ -78,10 +78,9 @@
                 </svg>
                 <div class="additional-info">
                     <ul>
-                        <li>Service ID: <span class="code"><%= service-id %></span></li>
-                        <li>Name: <span class="code"><%= (get service-description "name") %></span></li>
-                        <li>Version: <span class="code"><%= (get service-description "version") %></span></li>
-                        <li>Command: <span class="code"><%= (get service-description "cmd") %></span></li>
+                        <% (doseq [[name value] display-parameters] %>
+                        <li><%= name %>: <span class="code"><%= value %></span></li>
+                        <% ) %>
                     </ul>
                 </div>
             </div>

--- a/waiter/resources/web/interstitial.html
+++ b/waiter/resources/web/interstitial.html
@@ -43,18 +43,6 @@
      padding-top: 1em;
      width: 50em;
    }
-
-   .additional-info li {
-     line-height: 2em;
-     text-align: left;
-   }
-
-   span.code {
-     font-family: "Lucida Console", Monaco, monospace;
-     margin-left: 0em;
-     line-height: 2em;
-   }
-
     </style>
 </head>
 <body>
@@ -76,13 +64,6 @@
                                  values="175.7 75.30000000000001;1 250;175.7 75.30000000000001"></animate>
                     </circle>
                 </svg>
-                <div class="additional-info">
-                    <ul>
-                        <% (doseq [[name value] display-parameters] %>
-                        <li><%= name %>: <span class="code"><%= value %></span></li>
-                        <% ) %>
-                    </ul>
-                </div>
             </div>
         </div>
     </div>

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -194,16 +194,16 @@
                             (update response :headers
                                     (fn [headers]
                                       (cond-> headers
-                                        request-time (assoc "x-waiter-request-date" request-date)
-                                        request-id (assoc "x-waiter-request-id" request-id)
-                                        router-id (assoc "x-waiter-router-id" router-id)
-                                        descriptor (assoc "x-waiter-service-id" (:service-id descriptor))
-                                        instance (assoc "x-waiter-backend-id" (:id instance)
-                                                        "x-waiter-backend-host" (:host instance)
-                                                        "x-waiter-backend-port" (str (:port instance))
-                                                        "x-waiter-backend-proto" (:protocol instance))
-                                        backend-directory (assoc "x-waiter-backend-directory" backend-directory
-                                                                 "x-waiter-backend-log-url" backend-log-url))))))]
+                                              request-time (assoc "x-waiter-request-date" request-date)
+                                              request-id (assoc "x-waiter-request-id" request-id)
+                                              router-id (assoc "x-waiter-router-id" router-id)
+                                              descriptor (assoc "x-waiter-service-id" (:service-id descriptor))
+                                              instance (assoc "x-waiter-backend-id" (:id instance)
+                                                              "x-waiter-backend-host" (:host instance)
+                                                              "x-waiter-backend-port" (str (:port instance))
+                                                              "x-waiter-backend-proto" (:protocol instance))
+                                              backend-directory (assoc "x-waiter-backend-directory" backend-directory
+                                                                       "x-waiter-backend-log-url" backend-log-url))))))]
         (ru/update-response response add-headers))
       (handler request))))
 
@@ -605,7 +605,7 @@
    ; This function is only included here for initializing the scheduler above.
    ; Prefer accessing the non-starred version of this function through the routines map.
    :service-id->service-description-fn* (pc/fnk [[:curator kv-store]
-                                                [:settings service-description-defaults metric-group-mappings]]
+                                                 [:settings service-description-defaults metric-group-mappings]]
                                           (fn service-id->service-description
                                             [service-id & {:keys [effective?] :or {effective? true}}]
                                             (sd/service-id->service-description
@@ -1247,13 +1247,10 @@
                                             (handler/request-consent-handler
                                               token->service-description-template service-description->service-id
                                               consent-expiry-days request))))
-   :waiter-request-interstitial-handler-fn (pc/fnk [[:routines request->descriptor-fn]
-                                                    wrap-secure-request-fn]
-                                             (let [handler (-> interstitial/display-interstitial-handler
-                                                               (pr/wrap-descriptor request->descriptor-fn))]
-                                               (wrap-secure-request-fn
-                                                 (fn waiter-request-interstitial-handler-fn [request]
-                                                   (handler request)))))
+   :waiter-request-interstitial-handler-fn (pc/fnk [wrap-secure-request-fn]
+                                             (wrap-secure-request-fn
+                                               (fn waiter-request-interstitial-handler-fn [request]
+                                                 (interstitial/display-interstitial-handler request))))
    :welcome-handler-fn (pc/fnk [settings]
                          (partial handler/welcome-handler settings))
    :work-stealing-handler-fn (pc/fnk [[:state instance-rpc-chan]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -114,7 +114,7 @@
                      "waiter-auth" :waiter-auth-handler-fn
                      "waiter-consent" {"" :waiter-acknowledge-consent-handler-fn
                                        ["/" [#".*" :path]] :waiter-request-consent-handler-fn}
-                     "waiter-interstitial" {["/" [#".*" :path]] :waiter-request-interstitial-handler-fn}
+                     "waiter-interstitial" {["/" :service-id "/" [#".*" :path]] :waiter-request-interstitial-handler-fn}
                      "waiter-kill-instance" {["/" :service-id] :kill-instance-handler-fn}
                      "work-stealing" :work-stealing-handler-fn}]]
     (or (bidi/match-route routes uri)
@@ -1247,13 +1247,11 @@
                                             (handler/request-consent-handler
                                               token->service-description-template service-description->service-id
                                               consent-expiry-days request))))
-   :waiter-request-interstitial-handler-fn (pc/fnk [[:routines request->descriptor-fn]
+   :waiter-request-interstitial-handler-fn (pc/fnk [[:routines service-id->service-description-fn]
                                                     wrap-secure-request-fn]
-                                             (let [handler (-> interstitial/display-interstitial-handler
-                                                               (pr/wrap-descriptor request->descriptor-fn))]
-                                               (wrap-secure-request-fn
-                                                 (fn waiter-request-interstitial-handler-fn [request]
-                                                   (handler request)))))
+                                             (wrap-secure-request-fn
+                                               (fn waiter-request-interstitial-handler-fn [request]
+                                                 (interstitial/display-interstitial-handler service-id->service-description-fn request))))
    :welcome-handler-fn (pc/fnk [settings]
                          (partial handler/welcome-handler settings))
    :work-stealing-handler-fn (pc/fnk [[:state instance-rpc-chan]

--- a/waiter/src/waiter/interstitial.clj
+++ b/waiter/src/waiter/interstitial.clj
@@ -241,7 +241,7 @@
              (assoc request :query-string)
              handler)
         ;; redirect to interstitial page
-        (let [location (str "/waiter-interstitial/" service-id uri (when-not (str/blank? query-string) (str "?" query-string)))]
+        (let [location (str "/waiter-interstitial" uri (when-not (str/blank? query-string) (str "?" query-string)))]
           (counters/inc! (metrics/service-counter service-id "request-counts" "interstitial"))
           (meters/mark! (metrics/waiter-meter "interstitial" "redirect"))
           {:headers {"location" location
@@ -249,10 +249,9 @@
            :status 303})))))
 
 (defn display-interstitial-handler
-  "Renders the interstitial page for the specified service."
-  [service-id->service-description-fn {:keys [query-string request-time route-params]}]
-  (let [{:keys [path service-id]} route-params
-        service-description (service-id->service-description-fn service-id)
+  [{:keys [descriptor query-string request-time route-params]}]
+  (let [{:keys [service-description service-id]} descriptor
+        {:keys [path]} route-params
         target-url (str "/" path "?"
                         (when (not (str/blank? query-string))
                           (str query-string "&"))

--- a/waiter/src/waiter/interstitial.clj
+++ b/waiter/src/waiter/interstitial.clj
@@ -241,7 +241,7 @@
              (assoc request :query-string)
              handler)
         ;; redirect to interstitial page
-        (let [location (str "/waiter-interstitial" uri (when-not (str/blank? query-string) (str "?" query-string)))]
+        (let [location (str "/waiter-interstitial/" service-id uri (when-not (str/blank? query-string) (str "?" query-string)))]
           (counters/inc! (metrics/service-counter service-id "request-counts" "interstitial"))
           (meters/mark! (metrics/waiter-meter "interstitial" "redirect"))
           {:headers {"location" location
@@ -249,9 +249,10 @@
            :status 303})))))
 
 (defn display-interstitial-handler
-  [{:keys [descriptor query-string request-time route-params]}]
-  (let [{:keys [service-description service-id]} descriptor
-        {:keys [path]} route-params
+  "Renders the interstitial page for the specified service."
+  [service-id->service-description-fn {:keys [query-string request-time route-params]}]
+  (let [{:keys [path service-id]} route-params
+        service-description (service-id->service-description-fn service-id)
         target-url (str "/" path "?"
                         (when (not (str/blank? query-string))
                           (str query-string "&"))

--- a/waiter/test/waiter/interstitial_test.clj
+++ b/waiter/test/waiter/interstitial_test.clj
@@ -369,28 +369,16 @@
   (let [request-time (t/now)]
     (with-redefs [render-interstitial-template identity
                   t/now (constantly request-time)]
-      (let [service-id "test-service-id"
-            service-description {"cmd" "lorem ipsum dolor sit amet"
-                                 "interstitial-secs" 10}
-            descriptor {:service-id service-id
-                        :sources {:headers service-description}}]
-        (let [request {:descriptor descriptor
-                       :request-time request-time
-                       :route-params {:path "test"
-                                      :service-id service-id}}
-              response (display-interstitial-handler request)]
-          (is (= {:body {:display-parameters []
-                         :target-url (str "/test?" (request-time->interstitial-param-string request-time))}
-                  :status 200}
-                 response)))
-        (let [descriptor (assoc-in descriptor [:sources :token-sequence] ["token-1" "token-2"])
-              request {:descriptor descriptor
-                       :query-string "a=b&c=d"
-                       :request-time request-time
-                       :route-params {:path "test"
-                                      :service-id service-id}}
-              response (display-interstitial-handler request)]
-          (is (= {:body {:display-parameters [["Tokens" "token-1, token-2"]]
-                         :target-url (str "/test?a=b&c=d&" (request-time->interstitial-param-string request-time))}
-                  :status 200}
-                 response)))))))
+      (let [request {:request-time request-time
+                     :route-params {:path "test"}}
+            response (display-interstitial-handler request)]
+        (is (= {:body {:target-url (str "/test?" (request-time->interstitial-param-string request-time))}
+                :status 200}
+               response)))
+      (let [request {:query-string "a=b&c=d"
+                     :request-time request-time
+                     :route-params {:path "test"}}
+            response (display-interstitial-handler request)]
+        (is (= {:body {:target-url (str "/test?a=b&c=d&" (request-time->interstitial-param-string request-time))}
+                :status 200}
+               response))))))

--- a/waiter/test/waiter/interstitial_test.clj
+++ b/waiter/test/waiter/interstitial_test.clj
@@ -288,7 +288,7 @@
                      :scheme :https
                      :uri "/test"}
             response ((wrap-interstitial handler interstitial-state-atom) request)]
-        (is (= {:headers {"location" (str "/waiter-interstitial/" service-id "/test")
+        (is (= {:headers {"location" (str "/waiter-interstitial/test")
                           "x-waiter-interstitial" "true"}
                 :status 303}
                response))
@@ -334,7 +334,7 @@
                          :request-time request-time
                          :scheme :http}
                 response ((wrap-interstitial handler interstitial-state-atom) request)]
-            (is (= {:headers {"location" (str "/waiter-interstitial/" service-id "?a=b")
+            (is (= {:headers {"location" (str "/waiter-interstitial?a=b")
                               "x-waiter-interstitial" "true"}
                     :status 303}
                    response)))
@@ -347,7 +347,7 @@
                          :request-time request-time
                          :scheme :http}
                 response ((wrap-interstitial handler interstitial-state-atom) request)]
-            (is (= {:headers {"location" (str "/waiter-interstitial/" service-id "?c=d&x-waiter-bypass-interstitial=1&a=b")
+            (is (= {:headers {"location" (str "/waiter-interstitial?c=d&x-waiter-bypass-interstitial=1&a=b")
                               "x-waiter-interstitial" "true"}
                     :status 303}
                    response)))
@@ -360,7 +360,7 @@
                          :scheme :https
                          :uri "/test"}
                 response ((wrap-interstitial handler interstitial-state-atom) request)]
-            (is (= {:headers {"location" (str "/waiter-interstitial/" service-id "/test")
+            (is (= {:headers {"location" (str "/waiter-interstitial/test")
                               "x-waiter-interstitial" "true"}
                     :status 303}
                    response))))))))
@@ -372,23 +372,24 @@
       (let [service-id "test-service-id"
             service-description {"cmd" "lorem ipsum dolor sit amet"
                                  "interstitial-secs" 10}
-            service-id->service-description-fn (fn [in-service-id]
-                                                 (is (= in-service-id service-id))
-                                                 service-description)]
-        (let [request {:request-time request-time
+            descriptor {:service-description service-description
+                        :service-id service-id}]
+        (let [request {:descriptor descriptor
+                       :request-time request-time
                        :route-params {:path "test"
                                       :service-id service-id}}
-              response (display-interstitial-handler service-id->service-description-fn request)]
+              response (display-interstitial-handler request)]
           (is (= {:body {:service-description service-description
                          :service-id service-id
                          :target-url (str "/test?" (request-time->interstitial-param-string request-time))}
                   :status 200}
                  response)))
-        (let [request {:query-string "a=b&c=d"
+        (let [request {:descriptor descriptor
+                       :query-string "a=b&c=d"
                        :request-time request-time
                        :route-params {:path "test"
                                       :service-id service-id}}
-              response (display-interstitial-handler service-id->service-description-fn request)]
+              response (display-interstitial-handler request)]
           (is (= {:body {:service-description service-description
                          :service-id service-id
                          :target-url (str "/test?a=b&c=d&" (request-time->interstitial-param-string request-time))}

--- a/waiter/test/waiter/interstitial_test.clj
+++ b/waiter/test/waiter/interstitial_test.clj
@@ -372,26 +372,25 @@
       (let [service-id "test-service-id"
             service-description {"cmd" "lorem ipsum dolor sit amet"
                                  "interstitial-secs" 10}
-            descriptor {:service-description service-description
-                        :service-id service-id}]
+            descriptor {:service-id service-id
+                        :sources {:headers service-description}}]
         (let [request {:descriptor descriptor
                        :request-time request-time
                        :route-params {:path "test"
                                       :service-id service-id}}
               response (display-interstitial-handler request)]
-          (is (= {:body {:service-description service-description
-                         :service-id service-id
+          (is (= {:body {:display-parameters []
                          :target-url (str "/test?" (request-time->interstitial-param-string request-time))}
                   :status 200}
                  response)))
-        (let [request {:descriptor descriptor
+        (let [descriptor (assoc-in descriptor [:sources :token-sequence] ["token-1" "token-2"])
+              request {:descriptor descriptor
                        :query-string "a=b&c=d"
                        :request-time request-time
                        :route-params {:path "test"
                                       :service-id service-id}}
               response (display-interstitial-handler request)]
-          (is (= {:body {:service-description service-description
-                         :service-id service-id
+          (is (= {:body {:display-parameters [["Tokens" "token-1, token-2"]]
                          :target-url (str "/test?a=b&c=d&" (request-time->interstitial-param-string request-time))}
                   :status 200}
                  response)))))))

--- a/waiter/test/waiter/interstitial_test.clj
+++ b/waiter/test/waiter/interstitial_test.clj
@@ -288,7 +288,7 @@
                      :scheme :https
                      :uri "/test"}
             response ((wrap-interstitial handler interstitial-state-atom) request)]
-        (is (= {:headers {"location" (str "/waiter-interstitial/test")
+        (is (= {:headers {"location" (str "/waiter-interstitial/" service-id "/test")
                           "x-waiter-interstitial" "true"}
                 :status 303}
                response))
@@ -334,7 +334,7 @@
                          :request-time request-time
                          :scheme :http}
                 response ((wrap-interstitial handler interstitial-state-atom) request)]
-            (is (= {:headers {"location" (str "/waiter-interstitial?a=b")
+            (is (= {:headers {"location" (str "/waiter-interstitial/" service-id "?a=b")
                               "x-waiter-interstitial" "true"}
                     :status 303}
                    response)))
@@ -347,7 +347,7 @@
                          :request-time request-time
                          :scheme :http}
                 response ((wrap-interstitial handler interstitial-state-atom) request)]
-            (is (= {:headers {"location" (str "/waiter-interstitial?c=d&x-waiter-bypass-interstitial=1&a=b")
+            (is (= {:headers {"location" (str "/waiter-interstitial/" service-id "?c=d&x-waiter-bypass-interstitial=1&a=b")
                               "x-waiter-interstitial" "true"}
                     :status 303}
                    response)))
@@ -360,7 +360,7 @@
                          :scheme :https
                          :uri "/test"}
                 response ((wrap-interstitial handler interstitial-state-atom) request)]
-            (is (= {:headers {"location" (str "/waiter-interstitial/test")
+            (is (= {:headers {"location" (str "/waiter-interstitial/" service-id "/test")
                               "x-waiter-interstitial" "true"}
                     :status 303}
                    response))))))))
@@ -372,24 +372,23 @@
       (let [service-id "test-service-id"
             service-description {"cmd" "lorem ipsum dolor sit amet"
                                  "interstitial-secs" 10}
-            descriptor {:service-description service-description
-                        :service-id service-id}]
-        (let [request {:descriptor descriptor
-                       :request-time request-time
+            service-id->service-description-fn (fn [in-service-id]
+                                                 (is (= in-service-id service-id))
+                                                 service-description)]
+        (let [request {:request-time request-time
                        :route-params {:path "test"
                                       :service-id service-id}}
-              response (display-interstitial-handler request)]
+              response (display-interstitial-handler service-id->service-description-fn request)]
           (is (= {:body {:service-description service-description
                          :service-id service-id
                          :target-url (str "/test?" (request-time->interstitial-param-string request-time))}
                   :status 200}
                  response)))
-        (let [request {:descriptor descriptor
-                       :query-string "a=b&c=d"
+        (let [request {:query-string "a=b&c=d"
                        :request-time request-time
                        :route-params {:path "test"
                                       :service-id service-id}}
-              response (display-interstitial-handler request)]
+              response (display-interstitial-handler service-id->service-description-fn request)]
           (is (= {:body {:service-description service-description
                          :service-id service-id
                          :target-url (str "/test?a=b&c=d&" (request-time->interstitial-param-string request-time))}


### PR DESCRIPTION
## Changes proposed in this PR

- simplifies interstitial/display-interstitial-handler by reducing text that is rendered

## Why are we making these changes?

This change allows us to choose any service specific to the token and does not promise the service id or the command that we will run.

Screenshot:

<img width="913" alt="screen shot 2018-04-27 at 9 53 29 am" src="https://user-images.githubusercontent.com/6611249/39369215-4c41886e-4a01-11e8-915a-412366e9760d.png">


