### PR TITLE
uses wrap-descriptor logic for resolving service id in the /service-id endpoint

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1066,9 +1066,10 @@
    :service-id-handler-fn (pc/fnk [[:curator kv-store]
                                    [:routines request->descriptor-fn store-service-description-fn]
                                    wrap-secure-request-fn]
-                            (wrap-secure-request-fn
-                              (fn service-name-handler-fn [request]
-                                (handler/service-name-handler request request->descriptor-fn kv-store store-service-description-fn))))
+                            (-> (fn service-id-handler-fn [request]
+                                  (handler/service-id-handler request kv-store store-service-description-fn))
+                                (pr/wrap-descriptor request->descriptor-fn)
+                                wrap-secure-request-fn))
    :service-list-handler-fn (pc/fnk [[:daemons router-state-maintainer]
                                      [:routines prepend-waiter-url router-metrics-helpers service-id->service-description-fn]
                                      [:state entitlement-manager]

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -212,11 +212,11 @@
     (catch Exception ex
       (utils/exception->response ex request))))
 
-(defn service-name-handler
-  "Retrieves the app-name of the service specified by the request."
-  [request request->descriptor-fn kv-store store-service-description-fn]
+(defn service-id-handler
+  "Retrieves the service-id of the service specified by the request."
+  [{:keys [descriptor] :as request} kv-store store-service-description-fn]
   (try
-    (let [{:keys [service-id core-service-description]} (request->descriptor-fn request)]
+    (let [{:keys [service-id core-service-description]} descriptor]
       (when (not= core-service-description (sd/fetch-core kv-store service-id))
         ; eagerly store the service description for this service-id
         (store-service-description-fn service-id core-service-description))


### PR DESCRIPTION

## Changes proposed in this PR

- uses wrap-descriptor logic for resolving service id in the /service-id endpoint

## Why are we making these changes?

Reuse the descriptor resolution logic. Also, make it easy to introduce fallback support when we implement service fallback.
