### PR TITLE
Pass through special characters in query strings to the backend

### DIFF
--- a/kitchen/src/kitchen/core.clj
+++ b/kitchen/src/kitchen/core.clj
@@ -320,13 +320,15 @@
 
 (defn- request-info-handler
   "Returns the info received in the request."
-  [{:keys [body headers request-method] :as request}]
+  [{:keys [body headers query-string request-method uri]}]
   (when (instance? InputStream body)
     (slurp body))
   {:status 200
    :headers {"Content-Type" "application/json"}
-   :body (json/write-str {:headers headers
-                          :request-method request-method})})
+   :body (json/write-str (cond-> {:request-method request-method
+                                  :uri uri}
+                                 (seq headers) (assoc :headers headers)
+                                 query-string (assoc :query-string query-string)))})
 
 (defn- unchunked-handler
   "Handles requests that may potentially fail, uses unchunked response."

--- a/kitchen/src/kitchen/core.clj
+++ b/kitchen/src/kitchen/core.clj
@@ -515,8 +515,12 @@
           (add-cid-into-response [request response]
             (update-in response [:headers "x-cid"] (fn [cid] (or cid (get-in request [:headers "x-cid"])))))]
     (fn correlation-id-middleware-fn [request]
-      (let [{:keys [headers request-method uri] :as request} (-> request add-cid-into-request add-request-id-into-request)]
-        (printlog request (str "request received uri:" uri ", method" request-method ", headers:" (into (sorted-map) headers)))
+      (let [{:keys [headers query-string request-method uri] :as request}
+            (-> request add-cid-into-request add-request-id-into-request)]
+        (printlog request (str "request received uri:" uri
+                               ", method:" request-method
+                               (when query-string (str ", query-string:" query-string))
+                               (when (seq headers) (str ", headers:" (into (sorted-map) headers)))))
         (let [response (handler request)]
           (if (map? response)
             (add-cid-into-response request response)

--- a/kitchen/test/kitchen/core_test.clj
+++ b/kitchen/test/kitchen/core_test.clj
@@ -178,7 +178,8 @@
         request {:headers {"foo" "bar", "lorem" "ipsum"}
                  :in in
                  :out out
-                 :request-method :get}
+                 :request-method :get
+                 :uri "/uri"}
         websocket-handler (websocket-handler-factory {:ws-max-binary-message-size 32768
                                                       :ws-max-text-message-size 32768})]
     (reset! async-requests {})
@@ -198,7 +199,8 @@
       (async/>!! in "request-info")
       (let [response (-> (async/<!! out) json/read-str)]
         (is (= {"headers" {"foo" "bar", "lorem" "ipsum"}
-                "request-method" "get"}
+                "request-method" "get"
+                "uri" "/uri"}
                response))))
 
     (testing "kitchen-state"

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -22,8 +22,8 @@
             [waiter.util.client-tools :refer :all]
             [waiter.util.date-utils :as du])
   (:import (java.io ByteArrayInputStream)
-           (org.eclipse.jetty.util UrlEncoded)
-           [java.net HttpURLConnection]))
+           (java.net HttpURLConnection)
+           (org.eclipse.jetty.util UrlEncoded)))
 
 (deftest ^:parallel ^:integration-fast test-basic-functionality
   (testing-using-waiter-url

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -59,7 +59,7 @@
                                             waiter-url
                                             (assoc request-headers :accept "application/json")
                                             :path "/request-info"
-                                            :query-string bad-query-string)]
+                                            :query-params bad-query-string)]
           (assert-response-status response 200)
           (is (= bad-query-string (get (json/read-str body) "query-string"))))
 
@@ -69,7 +69,7 @@
                                             waiter-url
                                             (assoc request-headers :accept "application/json")
                                             :path "/request-info"
-                                            :query-string bad-query-string)]
+                                            :query-params bad-query-string)]
           (assert-response-status response 200)
           (is (= bad-query-string (get (json/read-str body) "query-string")))))
 

--- a/waiter/integration/waiter/streaming_test.clj
+++ b/waiter/integration/waiter/streaming_test.clj
@@ -12,8 +12,8 @@
   (:require [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [waiter.util.client-tools :refer :all])
-  (:import (java.io IOException)
-           (java.net HttpURLConnection)))
+  (:import (java.net HttpURLConnection URL)
+           (java.io IOException)))
 
 (deftest ^:parallel ^:integration-fast test-streaming
   (testing-using-waiter-url
@@ -63,6 +63,7 @@
         request-url (str HTTP-SCHEME waiter-url path)
         correlation-id (rand-name)
         _ (log/info "request-url =" request-url ", correlation-id =" correlation-id)
+        ^HttpURLConnection url-connection (-> request-url (URL.) (.openConnection))
         streaming-timeout-ms (get-in (waiter-settings waiter-url) [:instance-request-properties :streaming-timeout-ms])
         streaming-timeout-limit-ms (streaming-timeout-limit-fn streaming-timeout-ms)
         kitchen-request-headers (merge (kitchen-request-headers)
@@ -71,8 +72,14 @@
                                         :x-kitchen-chunk-size (chunk-size-fn data-size-in-bytes)
                                         :x-kitchen-chunk-delay (chunk-delay-fn streaming-timeout-ms)
                                         :x-waiter-debug true
-                                        :x-waiter-name service-name})
-        ^HttpURLConnection url-connection (open-url-connection request-url :post kitchen-request-headers)]
+                                        :x-waiter-name service-name})]
+    (doto url-connection
+      (.setRequestMethod "POST")
+      (.setUseCaches false)
+      (.setDoInput true)
+      (.setDoOutput true))
+    (doseq [[key value] kitchen-request-headers]
+      (.setRequestProperty url-connection (name key) (str value)))
     (when-let [request-streaming-timeout (streaming-timeout-fn streaming-timeout-ms)]
       (.setRequestProperty url-connection "x-waiter-streaming-timeout" (str request-streaming-timeout)))
     (let [service-id (-> url-connection

--- a/waiter/src/waiter/async_request.clj
+++ b/waiter/src/waiter/async_request.clj
@@ -141,7 +141,7 @@
    It also modifies the status check endpoint in the response header."
   [router-id async-request-store-atom make-http-request-fn instance-rpc-chan response
    service-id metric-group {:keys [host port] :as instance}
-   {:keys [request-id] :as reason-map} request-properties location]
+   {:keys [request-id] :as reason-map} request-properties location query-string]
   (let [correlation-id (cid/get-correlation-id)
         status-endpoint (scheduler/end-point-url instance location)
         _ (log/info "status endpoint for async request is" status-endpoint)
@@ -153,7 +153,7 @@
     ;; trigger execution of monitoring system
     (letfn [(make-get-request-fn []
               (counters/inc! (metrics/service-counter service-id "request-counts" "async-monitor"))
-              (let [request-stub {:body nil, :headers {}, :request-method :get}]
+              (let [request-stub {:body nil :headers {} :query-string query-string :request-method :get}]
                 (make-http-request-fn instance request-stub location metric-group)))
             (release-instance-fn [status]
               (log/info "decrementing outstanding requests as an async request has completed:" status)

--- a/waiter/src/waiter/async_request.clj
+++ b/waiter/src/waiter/async_request.clj
@@ -144,7 +144,7 @@
    {:keys [request-id] :as reason-map} request-properties location query-string]
   (let [correlation-id (cid/get-correlation-id)
         status-endpoint (scheduler/end-point-url instance location)
-        _ (log/info "status endpoint for async request is" status-endpoint)
+        _ (log/info "status endpoint for async request is" status-endpoint query-string)
         {:keys [async-check-interval-ms async-request-timeout-ms]} request-properties
         exit-chan (async/chan 1)]
     ;; register async request
@@ -171,7 +171,9 @@
                              async-check-interval-ms async-request-timeout-ms correlation-id exit-chan))
     ;; modify the location header in the response
     (let [param-map {:host host, :location location, :port port, :request-id request-id, :router-id router-id, :service-id service-id}
-          status-location (route-params->uri "/waiter-async/status/" param-map)]
-      (log/info "updating status location to" status-location "from" location)
+          status-location (route-params->uri "/waiter-async/status/" param-map)
+          status-url (cond-> status-location
+                             query-string (str "?" query-string))]
+      (log/info "updating status location to" status-location "from" location "with query string" query-string)
       (-> response
-          (assoc-in [:headers "location"] status-location)))))
+          (assoc-in [:headers "location"] status-url)))))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -688,8 +688,9 @@
    :make-http-request-fn (pc/fnk [[:settings instance-request-properties]
                                   [:state http-client]
                                   make-basic-auth-fn service-id->password-fn]
-                           (handler/async-make-request-helper http-client instance-request-properties make-basic-auth-fn service-id->password-fn
-                                                              pr/prepare-request-properties pr/make-request))
+                           (handler/async-make-request-helper
+                             http-client instance-request-properties make-basic-auth-fn service-id->password-fn
+                             pr/prepare-request-properties pr/make-request))
    :make-inter-router-requests-async-fn (pc/fnk [[:curator discovery]
                                                  [:settings [:instance-request-properties initial-socket-timeout-ms]]
                                                  [:state http-client passwords router-id]
@@ -719,10 +720,11 @@
    :post-process-async-request-response-fn (pc/fnk [[:state async-request-store-atom instance-rpc-chan router-id]
                                                     make-http-request-fn]
                                              (fn post-process-async-request-response-wrapper
-                                               [response service-id metric-group instance _ reason-map request-properties location]
+                                               [response service-id metric-group instance _ reason-map request-properties
+                                                location query-string]
                                                (async-req/post-process-async-request-response
                                                  router-id async-request-store-atom make-http-request-fn instance-rpc-chan response
-                                                 service-id metric-group instance reason-map request-properties location)))
+                                                 service-id metric-group instance reason-map request-properties location query-string)))
    :prepend-waiter-url (pc/fnk [[:settings port hostname]]
                          (let [hostname (if (sequential? hostname) (first hostname) hostname)]
                            (fn [endpoint-url]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -683,8 +683,8 @@
                          (->> (kv/zk-keys curator (str base-path "/" relative-path))
                               (filter (fn [k] (not (str/starts-with? k "^"))))))))
    :make-basic-auth-fn (pc/fnk []
-                         (fn make-basic-auth-fn [endpoint username password]
-                           (BasicAuthentication$BasicResult. (URI. endpoint) username password)))
+                         (fn make-basic-auth-fn [uri username password]
+                           (BasicAuthentication$BasicResult. (URI. uri) username password)))
    :make-http-request-fn (pc/fnk [[:settings instance-request-properties]
                                   [:state http-client]
                                   make-basic-auth-fn service-id->password-fn]

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -21,7 +21,6 @@
             [metrics.timers :as timers]
             [qbits.jet.client.http :as http]
             [qbits.jet.servlet :as servlet]
-            [ring.util.codec :as ring-codec]
             [slingshot.slingshot :refer [try+]]
             [waiter.async-request :as async-req]
             [waiter.auth.authentication :as auth]

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -10,7 +10,6 @@
 ;;
 (ns waiter.process-request
   (:require [clojure.core.async :as async]
-            [clojure.set :as set]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [full.async :as fa]

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -189,9 +189,7 @@
   [^HttpClient http-client make-basic-auth-fn request-method endpoint query-string headers body app-password
    {:keys [username principal]} idle-timeout output-buffer-size]
   (let [auth (make-basic-auth-fn endpoint "waiter" app-password)
-        headers (headers/assoc-auth-headers headers username principal)
-        query-params (when-not (str/blank? query-string)
-                       (ring-codec/form-decode query-string))]
+        headers (headers/assoc-auth-headers headers username principal)]
     (http/request
       http-client
       {:as :bytes
@@ -203,7 +201,7 @@
        :follow-redirects? false
        :idle-timeout idle-timeout
        :method request-method
-       :query-string query-params
+       :query-string query-string
        :url endpoint})))
 
 (defn make-request

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -26,7 +26,7 @@
             [waiter.statsd :as statsd]
             [waiter.util.date-utils :as du]
             [waiter.util.utils :as utils])
-  (:import (java.net HttpCookie HttpURLConnection URI URL)
+  (:import (java.net HttpCookie URI)
            (java.util.concurrent Callable Future Executors)
            (org.eclipse.jetty.util HttpCookieStore$Empty)
            (org.joda.time Period)
@@ -150,19 +150,6 @@
   [name & body]
   `(using-waiter-url
      (time-it ~name ~@body)))
-
-(defn open-url-connection
-  "Opens a HttpURLConnection with the specified request url (query string in the url), method and headers."
-  [request-url request-method request-headers]
-  (let [^HttpURLConnection url-connection (-> request-url (URL.) (.openConnection))]
-    (doto url-connection
-      (.setRequestMethod (str/upper-case (name request-method)))
-      (.setUseCaches false)
-      (.setDoInput true)
-      (.setDoOutput true))
-    (doseq [[key value] request-headers]
-      (.setRequestProperty url-connection (name key) (str value)))
-    url-connection))
 
 (defn make-http-client
   "Instantiates and returns a new HttpClient without a cookie store"

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -238,7 +238,7 @@
 (defn make-request
   ([waiter-url path &
     {:keys [body client cookies content-type disable-auth form-params headers
-            method multipart query-params verbose]
+            method multipart query-params query-string verbose]
      :or {body nil
           client http-client
           cookies []
@@ -246,6 +246,7 @@
           headers {}
           method :get
           query-params {}
+          query-string nil
           verbose false}}]
    (let [request-url (str
                        (when-not (str/starts-with? waiter-url HTTP-SCHEME) HTTP-SCHEME)
@@ -265,7 +266,7 @@
                                    :follow-redirects? false
                                    :headers request-headers
                                    :method method
-                                   :query-string query-params
+                                   :query-string (or query-string query-params)
                                    :url request-url}
                                   multipart (assoc :multipart multipart)
                                   add-spnego-auth (assoc :auth (spnego/spnego-authentication (URI. request-url)))
@@ -326,8 +327,8 @@
 
 (defn make-light-request
   [waiter-url custom-headers &
-   {:keys [body cookies debug method path query-params]
-    :or {body nil cookies {} debug true method :post path "/endpoint" query-params {}}}]
+   {:keys [body cookies debug method path query-params query-string]
+    :or {body nil cookies {} debug true method :post path "/endpoint" query-params {} query-string nil}}]
   (let [headers (cond->
                   (-> {:x-waiter-cpus 0.1
                        :x-waiter-mem 256
@@ -343,12 +344,13 @@
                   :cookies cookies
                   :headers headers
                   :method method
-                  :query-params query-params)))
+                  :query-params query-params
+                  :query-string query-string)))
 
 (defn make-shell-request
   [waiter-url custom-headers &
-   {:keys [body cookies debug method path query-params]
-    :or {body nil cookies {} debug true method :post path "/endpoint" query-params {}}}]
+   {:keys [body cookies debug method path query-params query-string]
+    :or {body nil cookies {} debug true method :post path "/endpoint" query-params {} query-string nil}}]
   (make-light-request
     waiter-url
     (assoc
@@ -360,13 +362,14 @@
     :debug debug
     :method method
     :path path
+    :query-string query-string
     :query-params query-params))
 
 (defn make-kitchen-request
   "Makes an on-the-fly request to the Kitchen test app."
   [waiter-url custom-headers &
-   {:keys [body cookies debug method path query-params]
-    :or {body nil cookies {} debug true method :post path "/endpoint" query-params {}}}]
+   {:keys [body cookies debug method path query-params query-string]
+    :or {body nil cookies {} debug true method :post path "/endpoint" query-params {} query-string nil}}]
   {:pre [(not (str/blank? waiter-url))]}
   (make-shell-request
     waiter-url
@@ -379,7 +382,8 @@
     :debug debug
     :method method
     :path path
-    :query-params query-params))
+    :query-params query-params
+    :query-string query-string))
 
 (defn retrieve-service-id [waiter-url waiter-headers & {:keys [verbose] :or {verbose false}}]
   (let [service-id-result (make-request waiter-url "/service-id" :headers waiter-headers)

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -225,7 +225,7 @@
 (defn make-request
   ([waiter-url path &
     {:keys [body client cookies content-type disable-auth form-params headers
-            method multipart query-params query-string verbose]
+            method multipart query-params verbose]
      :or {body nil
           client http-client
           cookies []
@@ -233,7 +233,6 @@
           headers {}
           method :get
           query-params {}
-          query-string nil
           verbose false}}]
    (let [request-url (str
                        (when-not (str/starts-with? waiter-url HTTP-SCHEME) HTTP-SCHEME)
@@ -253,7 +252,7 @@
                                    :follow-redirects? false
                                    :headers request-headers
                                    :method method
-                                   :query-string (or query-string query-params)
+                                   :query-string query-params
                                    :url request-url}
                                   multipart (assoc :multipart multipart)
                                   add-spnego-auth (assoc :auth (spnego/spnego-authentication (URI. request-url)))
@@ -314,8 +313,8 @@
 
 (defn make-light-request
   [waiter-url custom-headers &
-   {:keys [body cookies debug method path query-params query-string]
-    :or {body nil cookies {} debug true method :post path "/endpoint" query-params {} query-string nil}}]
+   {:keys [body cookies debug method path query-params]
+    :or {body nil cookies {} debug true method :post path "/endpoint" query-params {}}}]
   (let [headers (cond->
                   (-> {:x-waiter-cpus 0.1
                        :x-waiter-mem 256
@@ -331,13 +330,12 @@
                   :cookies cookies
                   :headers headers
                   :method method
-                  :query-params query-params
-                  :query-string query-string)))
+                  :query-params query-params)))
 
 (defn make-shell-request
   [waiter-url custom-headers &
-   {:keys [body cookies debug method path query-params query-string]
-    :or {body nil cookies {} debug true method :post path "/endpoint" query-params {} query-string nil}}]
+   {:keys [body cookies debug method path query-params]
+    :or {body nil cookies {} debug true method :post path "/endpoint" query-params {}}}]
   (make-light-request
     waiter-url
     (assoc
@@ -349,14 +347,13 @@
     :debug debug
     :method method
     :path path
-    :query-string query-string
     :query-params query-params))
 
 (defn make-kitchen-request
   "Makes an on-the-fly request to the Kitchen test app."
   [waiter-url custom-headers &
-   {:keys [body cookies debug method path query-params query-string]
-    :or {body nil cookies {} debug true method :post path "/endpoint" query-params {} query-string nil}}]
+   {:keys [body cookies debug method path query-params]
+    :or {body nil cookies {} debug true method :post path "/endpoint" query-params {}}}]
   {:pre [(not (str/blank? waiter-url))]}
   (make-shell-request
     waiter-url
@@ -369,8 +366,7 @@
     :debug debug
     :method method
     :path path
-    :query-params query-params
-    :query-string query-string))
+    :query-params query-params))
 
 (defn retrieve-service-id [waiter-url waiter-headers & {:keys [verbose] :or {verbose false}}]
   (let [service-id-result (make-request waiter-url "/service-id" :headers waiter-headers)

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -26,7 +26,7 @@
             [waiter.statsd :as statsd]
             [waiter.util.date-utils :as du]
             [waiter.util.utils :as utils])
-  (:import (java.net HttpCookie URI)
+  (:import (java.net HttpCookie HttpURLConnection URI URL)
            (java.util.concurrent Callable Future Executors)
            (org.eclipse.jetty.util HttpCookieStore$Empty)
            (org.joda.time Period)
@@ -150,6 +150,19 @@
   [name & body]
   `(using-waiter-url
      (time-it ~name ~@body)))
+
+(defn open-url-connection
+  "Opens a HttpURLConnection with the specified request url (query string in the url), method and headers."
+  [request-url request-method request-headers]
+  (let [^HttpURLConnection url-connection (-> request-url (URL.) (.openConnection))]
+    (doto url-connection
+      (.setRequestMethod (str/upper-case (name request-method)))
+      (.setUseCaches false)
+      (.setDoInput true)
+      (.setDoOutput true))
+    (doseq [[key value] request-headers]
+      (.setRequestProperty url-connection (name key) (str value)))
+    url-connection))
 
 (defn make-http-client
   "Instantiates and returns a new HttpClient without a cookie store"
@@ -313,8 +326,8 @@
 
 (defn make-light-request
   [waiter-url custom-headers &
-   {:keys [body cookies debug method path]
-    :or {body nil cookies {} debug true method :post path "/endpoint"}}]
+   {:keys [body cookies debug method path query-params]
+    :or {body nil cookies {} debug true method :post path "/endpoint" query-params {}}}]
   (let [headers (cond->
                   (-> {:x-waiter-cpus 0.1
                        :x-waiter-mem 256
@@ -329,12 +342,13 @@
                   :body body
                   :cookies cookies
                   :headers headers
-                  :method method)))
+                  :method method
+                  :query-params query-params)))
 
 (defn make-shell-request
   [waiter-url custom-headers &
-   {:keys [body cookies debug method path]
-    :or {body nil cookies {} debug true method :post path "/endpoint"}}]
+   {:keys [body cookies debug method path query-params]
+    :or {body nil cookies {} debug true method :post path "/endpoint" query-params {}}}]
   (make-light-request
     waiter-url
     (assoc
@@ -345,13 +359,14 @@
     :cookies cookies
     :debug debug
     :method method
-    :path path))
+    :path path
+    :query-params query-params))
 
 (defn make-kitchen-request
   "Makes an on-the-fly request to the Kitchen test app."
   [waiter-url custom-headers &
-   {:keys [body cookies debug method path]
-    :or {body nil cookies {} debug true method :post path "/endpoint"}}]
+   {:keys [body cookies debug method path query-params]
+    :or {body nil cookies {} debug true method :post path "/endpoint" query-params {}}}]
   {:pre [(not (str/blank? waiter-url))]}
   (make-shell-request
     waiter-url
@@ -363,7 +378,8 @@
     :cookies cookies
     :debug debug
     :method method
-    :path path))
+    :path path
+    :query-params query-params))
 
 (defn retrieve-service-id [waiter-url waiter-headers & {:keys [verbose] :or {verbose false}}]
   (let [service-id-result (make-request waiter-url "/service-id" :headers waiter-headers)

--- a/waiter/test/waiter/async_request_test.clj
+++ b/waiter/test/waiter/async_request_test.clj
@@ -287,9 +287,10 @@
         reason-map {:request-id request-id}
         request-properties {:async-check-interval-ms 100, :async-request-timeout-ms 200}
         location (str "/location/" request-id)
+        query-string "a=b&c=d|e"
         make-http-request-fn (fn [in-instance in-request end-route metric-group]
                                (is (= instance in-instance))
-                               (is (= {:body nil, :headers {}, :request-method :get} in-request))
+                               (is (= {:body nil :headers {} :query-string "a=b&c=d|e" :request-method :get} in-request))
                                (is (= "/location/request-2394613984619" end-route))
                                (is (= "test-metric-group" metric-group)))
         instance-rpc-chan (async/chan 1)
@@ -308,7 +309,7 @@
                     (reset! complete-async-request-atom complete-async-request-fn))]
       (let [{:keys [headers]} (post-process-async-request-response
                                 router-id async-request-store-atom make-http-request-fn instance-rpc-chan response
-                                service-id metric-group instance reason-map request-properties location)]
+                                service-id metric-group instance reason-map request-properties location query-string)]
         (is (get @async-request-store-atom request-id))
         (is (= (str "/waiter-async/status/" request-id "/" router-id "/" service-id "/" host "/" port location)
                (get headers "location")))

--- a/waiter/test/waiter/async_request_test.clj
+++ b/waiter/test/waiter/async_request_test.clj
@@ -311,7 +311,7 @@
                                 router-id async-request-store-atom make-http-request-fn instance-rpc-chan response
                                 service-id metric-group instance reason-map request-properties location query-string)]
         (is (get @async-request-store-atom request-id))
-        (is (= (str "/waiter-async/status/" request-id "/" router-id "/" service-id "/" host "/" port location)
+        (is (= (str "/waiter-async/status/" request-id "/" router-id "/" service-id "/" host "/" port location "?" query-string)
                (get headers "location")))
         (let [complete-async-request-fn @complete-async-request-atom]
           (is complete-async-request-fn)

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -208,8 +208,9 @@
             (let [reservation-status-promise (promise)
                   post-process-data (atom {})
                   post-process-async-request-response-fn
-                  (fn [_ _ _ _ auth-user _ _ location]
-                    (reset! post-process-data {:auth-user (:username auth-user), :location location}))]
+                  (fn [_ _ _ _ auth-user _ _ location query-string]
+                    (reset! post-process-data
+                            {:auth-user (:username auth-user) :location location :query-string query-string}))]
               (inspect-for-202-async-request-response
                 response post-process-async-request-response-fn {} "service-id" "metric-group" {}
                 endpoint request {} reservation-status-promise)
@@ -220,7 +221,7 @@
              (execute-inspect-for-202-async-request-response
                "http://www.example.com:1234/query/for/status"
                {:authorization/user "test-user"}
-               {:status 202, :headers {}}))))
+               {:status 202 :headers {}}))))
     (testing "200-not-async"
       (is (= {:result :not-async}
              (execute-inspect-for-202-async-request-response
@@ -240,47 +241,47 @@
                {:authorization/user "test-user"}
                {:status 404, :headers {"location" "/result/location"}}))))
     (testing "202-absolute-location"
-      (is (= {:auth-user "test-user", :location "/result/location", :result :success-async}
+      (is (= {:auth-user "test-user" :location "/result/location" :query-string nil :result :success-async}
              (execute-inspect-for-202-async-request-response
                "http://www.example.com:1234/query/for/status"
                {:authorization/user "test-user"}
-               {:status 202, :headers {"location" "/result/location"}}))))
+               {:status 202 :headers {"location" "/result/location"}}))))
     (testing "202-relative-location-1"
-      (is (= {:auth-user "test-user", :location "/query/result/location", :result :success-async}
+      (is (= {:auth-user "test-user" :location "/query/result/location" :query-string nil :result :success-async}
              (execute-inspect-for-202-async-request-response
                "http://www.example.com:1234/query/for/status"
                {:authorization/user "test-user"}
-               {:status 202, :headers {"location" "../result/location"}}))))
+               {:status 202 :headers {"location" "../result/location"}}))))
     (testing "202-relative-location-2"
-      (is (= {:auth-user "test-user", :location "/query/for/result/location", :result :success-async}
+      (is (= {:auth-user "test-user" :location "/query/for/result/location" :query-string nil :result :success-async}
              (execute-inspect-for-202-async-request-response
                "http://www.example.com:1234/query/for/status"
                {:authorization/user "test-user"}
-               {:status 202, :headers {"location" "result/location"}}))))
+               {:status 202 :headers {"location" "result/location"}}))))
     (testing "202-relative-location-two-levels"
-      (is (= {:auth-user "test-user", :location "/result/location", :result :success-async}
+      (is (= {:auth-user "test-user" :location "/result/location" :query-string "a=b&c=d|e" :result :success-async}
              (execute-inspect-for-202-async-request-response
                "http://www.example.com:1234/query/for/status"
-               {:authorization/user "test-user"}
-               {:status 202, :headers {"location" "../../result/location"}}))))
+               {:authorization/user "test-user" :query-string "a=b&c=d|e"}
+               {:status 202 :headers {"location" "../../result/location"}}))))
     (testing "202-absolute-url-same-host-port"
-      (is (= {:auth-user "test-user", :location "/retrieve/result/location", :result :success-async}
+      (is (= {:auth-user "test-user" :location "/retrieve/result/location" :query-string nil :result :success-async}
              (execute-inspect-for-202-async-request-response
                "http://www.example.com:1234/query/for/status"
                {:authorization/user "test-user"}
-               {:status 202, :headers {"location" "http://www.example.com:1234/retrieve/result/location"}}))))
+               {:status 202 :headers {"location" "http://www.example.com:1234/retrieve/result/location"}}))))
     (testing "202-absolute-url-different-host"
       (is (= {:result :not-async}
              (execute-inspect-for-202-async-request-response
                "http://www.example.com:1234/query/for/status"
                {:authorization/user "test-user"}
-               {:status 202, :headers {"location" "http://www.example2.com:1234/retrieve/result/location"}}))))
+               {:status 202 :headers {"location" "http://www.example2.com:1234/retrieve/result/location"}}))))
     (testing "202-absolute-url-different-port"
       (is (= {:result :not-async}
              (execute-inspect-for-202-async-request-response
                "http://www.example.com:1234/query/for/status"
                {:authorization/user "test-user"}
-               {:status 202, :headers {"location" "http://www.example.com:5678/retrieve/result/location"}}))))))
+               {:status 202 :headers {"location" "http://www.example.com:5678/retrieve/result/location"}}))))))
 
 (deftest test-make-request
   (let [instance {:service-id "test-service-id", :host "example.com", :port 8080, :protocol "proto"}

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -92,7 +92,7 @@
     (doseq [item test-endpoints]
       (testing (str "Test retrieve endpoint with headers and query string: " item)
         (let [dummy-request (assoc (request item :post {:a 1 :b 2}) :query-string "foo=bar&baz=1234")
-              expected-endpoint (if (contains? legacy-endpoints item) custom-legacy-endpoint (str item "?foo=bar&baz=1234"))]
+              expected-endpoint (if (contains? legacy-endpoints item) custom-legacy-endpoint item)]
           (is (= expected-endpoint
                  (request->endpoint dummy-request waiter-headers))))))))
 

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -259,11 +259,11 @@
                {:authorization/user "test-user"}
                {:status 202 :headers {"location" "result/location"}}))))
     (testing "202-relative-location-two-levels"
-      (is (= {:auth-user "test-user" :location "/result/location" :query-string "a=b&c=d|e" :result :success-async}
+      (is (= {:auth-user "test-user" :location "/result/location" :query-string "p=q&r=s|t" :result :success-async}
              (execute-inspect-for-202-async-request-response
-               "http://www.example.com:1234/query/for/status"
+               "http://www.example.com:1234/query/for/status?u=v&w=x|y|z"
                {:authorization/user "test-user" :query-string "a=b&c=d|e"}
-               {:status 202 :headers {"location" "../../result/location"}}))))
+               {:status 202 :headers {"location" "../../result/location?p=q&r=s|t"}}))))
     (testing "202-absolute-url-same-host-port"
       (is (= {:auth-user "test-user" :location "/retrieve/result/location" :query-string nil :result :success-async}
              (execute-inspect-for-202-async-request-response


### PR DESCRIPTION
## Changes proposed in this PR

- avoids passing the query-string as part of the endpoint in make-request and `BasicAuthentication$BasicResult`
- explicitly convert the query string into a map to pass into our library function for `make-request`
- adds `uri` and `query-string` to `/request-info` output in kitchen
- introduces `open-url-connection` helper function
- adds integration test to reproduce bad behavior with invalid characters in query strings

## Why are we making these changes?

We would like to have Waiter be resilient to the presence of special characters in the query string.

### Previous log output

This was the error that was thrown before:
```
2018-05-01 11:26:03,271 ERROR waiter.process-request [async-dispatch-13] - [CID=4ff4388f3191-295e3b322333b8d6] error during process
java.net.URISyntaxException: Illegal character in query at index 41: http://127.0.0.4:10003/request-info?bad=a|b
	at java.net.URI$Parser.fail(URI.java:2848)
	at java.net.URI$Parser.checkChars(URI.java:3021)
	at java.net.URI$Parser.parseHierarchical(URI.java:3111)
	at java.net.URI$Parser.parse(URI.java:3053)
	at java.net.URI.<init>(URI.java:588)
	at waiter.core$fn__37987$fnk37986_positional__37988$make_basic_auth_fn__37989.invoke(core.clj:681)
	at waiter.process_request$make_http_request.invokeStatic(process_request.clj:220)
	at waiter.process_request$make_http_request.invoke(process_request.clj:216)
...
```

and then later when we tried to pass in the query string in endpoint with our library:
```
2018-05-01 12:03:04,845 ERROR waiter.process-request [async-dispatch-50] - [CID=51f97bec24f6-36056137f5bdefc9] error during process
java.lang.IllegalArgumentException: Illegal character in query at index 41: http://127.0.0.5:10000/request-info?bad=a|b
	at java.net.URI.create(URI.java:852)
	at org.eclipse.jetty.client.HttpClient.newRequest(HttpClient.java:418)
	at qbits.jet.client.http$request.invokeStatic(http.clj:302)
	at qbits.jet.client.http$request.invoke(http.clj:275)
	at qbits.jet.client.http$get.invokeStatic(http.clj:398)
	at qbits.jet.client.http$get.invoke(http.clj:396)
	at waiter.process_request$make_http_request.invokeStatic(process_request.clj:227)
	at waiter.process_request$make_http_request.invoke(process_request.clj:219)
...
```

### Reference `ring-codec/form-decode` implementation:

```
(defn form-decode-str
  "Decode the supplied www-form-urlencoded string using the specified encoding,
  or UTF-8 by default."
  [^String encoded & [encoding]]
  (try
    (URLDecoder/decode encoded (or encoding "UTF-8"))
    (catch Exception _ nil)))

(defn form-decode
  "Decode the supplied www-form-urlencoded string using the specified encoding,
  or UTF-8 by default. If the encoded value is a string, a string is returned.
  If the encoded value is a map of parameters, a map is returned."
  [^String encoded & [encoding]]
  (if-not (.contains encoded "=")
    (form-decode-str encoded encoding)
    (reduce
     (fn [m param]
       (if-let [[k v] (str/split param #"=" 2)]
         (assoc-conj m (form-decode-str k encoding) (form-decode-str v encoding))
         m))
     {}
     (str/split encoded #"&"))))
```