### PR TITLE
removes use of http-method-fn in favor of simpler method parameter

### DIFF
--- a/waiter/integration/waiter/request_method_test.clj
+++ b/waiter/integration/waiter/request_method_test.clj
@@ -10,7 +10,6 @@
 ;;
 (ns waiter.request-method-test
   (:require [clojure.test :refer :all]
-            [qbits.jet.client.http :as http]
             [waiter.util.client-tools :refer :all]))
 
 (deftest ^:parallel ^:integration-fast test-request-method
@@ -19,7 +18,7 @@
           headers {:x-waiter-name service-name, :x-kitchen-echo "true"}
           canary-response (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))
           lorem-ipsum "Lorem ipsum dolor sit amet, consectetur adipiscing elit."]
-      (is (= lorem-ipsum (:body (make-kitchen-request waiter-url headers :http-method-fn http/post :body lorem-ipsum))))
-      (is (= lorem-ipsum (:body (make-kitchen-request waiter-url headers :http-method-fn http/put :body lorem-ipsum))))
-      (is (= lorem-ipsum (:body (make-kitchen-request waiter-url headers :http-method-fn http/get :body lorem-ipsum))))
+      (is (= lorem-ipsum (:body (make-kitchen-request waiter-url headers :body lorem-ipsum :method :get))))
+      (is (= lorem-ipsum (:body (make-kitchen-request waiter-url headers :body lorem-ipsum :method :post))))
+      (is (= lorem-ipsum (:body (make-kitchen-request waiter-url headers :body lorem-ipsum :method :put))))
       (delete-service waiter-url (:service-id canary-response)))))

--- a/waiter/integration/waiter/request_timeout_test.clj
+++ b/waiter/integration/waiter/request_timeout_test.clj
@@ -15,7 +15,6 @@
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [clojure.walk :as walk]
-            [qbits.jet.client.http :as http]
             [waiter.util.client-tools :refer :all])
   (:import java.util.concurrent.CountDownLatch))
 
@@ -37,9 +36,9 @@
   "Makes a request with the provided headers and cookies, and with verbose logging"
   [waiter-url request-headers cookies]
   (let [response (make-request waiter-url "/secrun"
-                               :http-method-fn http/post
-                               :headers request-headers
                                :cookies cookies
+                               :headers request-headers
+                               :method :post
                                :verbose true)
         service-name (str (get-in response [:request-headers :x-waiter-name]))]
     (log/info "response:" (:body response))
@@ -56,9 +55,9 @@
   (let [response (make-request-with-debug-info
                    request-headers
                    #(make-request waiter-url endpoint
-                                  :http-method-fn http/post
-                                  :headers %
                                   :cookies cookies
+                                  :headers %
+                                  :method :post
                                   :verbose true))]
     (log/info "response: " (:body response))
     response))

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -16,7 +16,6 @@
             [clojure.tools.logging :as log]
             [clojure.walk :as walk]
             [plumbing.core :as pc]
-            [qbits.jet.client.http :as http]
             [waiter.service-description :as sd]
             [waiter.util.client-tools :refer :all]
             [waiter.util.date-utils :as du])
@@ -431,7 +430,7 @@
               (testing "hard-delete without etag"
                 (let [{:keys [body] :as response} (make-request waiter-url "/token"
                                                                 :headers {"host" token}
-                                                                :http-method-fn http/delete
+                                                                :method :delete
                                                                 :query-params {"hard-delete" true})]
                   (assert-response-status response 400)
                   (is (str/includes? (str body) "Must specify if-match header for token hard deletes"))))
@@ -440,7 +439,7 @@
                 (let [{:keys [body] :as response} (make-request waiter-url "/token"
                                                                 :headers {"host" token
                                                                           "if-match" "1010"}
-                                                                :http-method-fn http/delete
+                                                                :method :delete
                                                                 :query-params {"hard-delete" true})]
                   (assert-response-status response 412)
                   (is (str/includes? (str body) "Cannot modify stale token"))))
@@ -669,7 +668,7 @@
     (let [{:keys [status]} (make-request waiter-url "/token"
                                          :body "i'm bad at json"
                                          :headers {"host" "test-token"}
-                                         :http-method-fn http/post)]
+                                         :method :post)]
       (is (= 400 status)))))
 
 (deftest ^:parallel ^:integration-fast test-token-environment-variables
@@ -846,7 +845,7 @@
                                               "referer" (str "http://" host-header)
                                               "origin" (str "http://" host-header)
                                               "x-requested-with" "XMLHttpRequest"}
-                                    :http-method-fn http/post
+                                    :method :post
                                     :multipart {"mode" "service"
                                                 "service-id" service-id})]
                   (reset! cookies-atom cookies)
@@ -898,7 +897,7 @@
                                               "referer" (str "http://" host-header)
                                               "origin" (str "http://" host-header)
                                               "x-requested-with" "XMLHttpRequest"}
-                                    :http-method-fn http/post
+                                    :method :post
                                     :multipart {"mode" "token"})]
                   (reset! cookies-atom cookies)
                   (is (= "Added cookie x-waiter-consent" body))

--- a/waiter/integration/waiter/websocket_integration_test.clj
+++ b/waiter/integration/waiter/websocket_integration_test.clj
@@ -16,7 +16,6 @@
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [clojure.walk :as walk]
-            [qbits.jet.client.http :as http]
             [qbits.jet.client.websocket :as ws-client]
             [waiter.util.client-tools :refer :all]
             [waiter.util.date-utils :as du]
@@ -99,9 +98,9 @@
           waiter-headers (assoc (kitchen-request-headers)
                            :x-waiter-metric-group "test-ws-support"
                            :x-waiter-name (rand-name))
-          _ (make-kitchen-request waiter-url waiter-headers :http-method-fn http/get)
+          _ (make-kitchen-request waiter-url waiter-headers :method :get)
           {:keys [headers service-id] :as canary-response}
-          (make-request-with-debug-info waiter-headers #(make-kitchen-request waiter-url % :http-method-fn http/get))
+          (make-request-with-debug-info waiter-headers #(make-kitchen-request waiter-url % :method :get))
           _ (assert-response-status canary-response 200)
           first-request-time-header (-> (get headers "x-waiter-request-date")
                                         (du/str-to-date du/formatter-rfc822))


### PR DESCRIPTION
## Changes proposed in this PR

- removes use of `http-method-fn` in favor of simpler `method` parameter

## Why are we making these changes?

Simpler code is easier to maintain.
