### PR TITLE
Updates jetty version to 9.4.9.v20180320

### DIFF
--- a/kitchen/project.clj
+++ b/kitchen/project.clj
@@ -10,7 +10,7 @@
 ;;
 (defproject kitchen "0.1.0-SNAPSHOT"
   :dependencies [^{:voom {:repo "https://github.com/twosigma/jet.git" :branch "waiter-patch"}}
-                 [cc.qbits/jet "0.7.10-20180124_201515-g857338f"]
+                 [cc.qbits/jet "0.7.10-20180504_143513-g8f00b45"]
                  [log4j/log4j "1.2.17" :exclusions [javax.mail/mail
                                                     javax.jms/jms
                                                     com.sun.jmdk/jmxtools

--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -86,7 +86,7 @@
               ;; ASSERT
               (let [waiter-sync-result (constantly
                                          {:code :success/hard-delete
-                                          :details {:etag token-etag
+                                          :details {:etag (str token-etag)
                                                     :status 200}})
                     expected-result {:details {token-name {:latest {:cluster-url (first waiter-urls)
                                                                     :description token-description

--- a/token-syncer/project.clj
+++ b/token-syncer/project.clj
@@ -10,7 +10,7 @@
 ;;
 (defproject token-syncer "0.1.0-SNAPSHOT"
   :dependencies [^{:voom {:repo "https://github.com/twosigma/jet.git" :branch "waiter-patch"}}
-                 [cc.qbits/jet "0.7.10-20180410_173552-gb29616d"]
+                 [cc.qbits/jet "0.7.10-20180504_143513-g8f00b45"]
                  [clj-time "0.12.0"]
                  [commons-codec/commons-codec "1.10"]
                  [org.clojure/clojure "1.8.0"]

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -48,7 +48,7 @@
           (is (get-in body-json ["headers" "authorization"]) (str body))
           (is (get-in body-json ["headers" "x-waiter-auth-principal"]) (str body))
           (is (get-in body-json ["headers" "x-cid"]) (str body))
-          (is (nil? (get-in body-json ["headers" "content-type"])) (str body))
+          (is (str/blank? (get-in body-json ["headers" "content-type"])) (str body))
           (is (= "0" (get-in body-json ["headers" "content-length"])) (str body))
           (is (= "text/plain" (get-in body-json ["headers" "accept"])) (str body))))
 

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -26,7 +26,7 @@
   :dependencies [[bidi "2.0.16"
                   :exclusions [prismatic/schema ring/ring-core]]
                  ^{:voom {:repo "https://github.com/twosigma/jet.git" :branch "waiter-patch"}}
-                 [cc.qbits/jet "0.7.10-20180410_173552-gb29616d"]
+                 [cc.qbits/jet "0.7.10-20180504_143513-g8f00b45"]
                  ^{:voom {:repo "https://github.com/twosigma/clj-http.git" :branch "waiter-patch"}}
                  [clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-io org.clojure/tools.reader potemkin slingshot]]

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -47,7 +47,7 @@
   "Validates whether the token modification should be allowed on based on the provided token version-hash."
   [{:keys [token-metadata] :as token-description} version-hash]
   (when version-hash
-    (when (not= (token-description->token-hash token-description) (str version-hash))
+    (when (not= (str (token-description->token-hash token-description)) (str version-hash))
       (throw (ex-info "Cannot modify stale token"
                       {:provided-version version-hash
                        :status 412

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -257,7 +257,7 @@
                                   multipart (assoc :multipart multipart)
                                   add-spnego-auth (assoc :auth (spnego/spnego-authentication (URI. request-url)))
                                   form-params (assoc :form-params form-params)
-                                  content-type (assoc :content-type content-type)
+                                  (not (str/blank? content-type)) (assoc :content-type content-type)
                                   cookies (assoc :cookies (map (fn [c] [(:name c) (:value c)]) cookies)))))
              response-body (if body (async/<!! body) nil)]
          (when verbose

--- a/waiter/src/waiter/util/http_utils.clj
+++ b/waiter/src/waiter/util/http_utils.clj
@@ -11,6 +11,7 @@
 (ns waiter.util.http-utils
   (:require [clojure.core.async :as async]
             [clojure.data.json :as json]
+            [clojure.string :as str]
             [clojure.walk :as walk]
             [qbits.jet.client.http :as http]
             [slingshot.slingshot :as ss]
@@ -33,7 +34,7 @@
                             spnego-auth (assoc :auth (spnego/spnego-authentication (URI. request-url)))
                             accept (assoc :accept accept)
                             body (assoc :body body)
-                            content-type (assoc :content-type content-type)
+                            (not (str/blank? content-type)) (assoc :content-type content-type)
                             (seq headers) (assoc :headers headers)
                             query-string (assoc :query-string query-string))
         raw-response (http/request http-client request-map)


### PR DESCRIPTION
## Changes proposed in this PR

- updates jetty version to 9.4.9.v20180320

## Why are we making these changes?

The new version of Jetty is better about error handling in the presence of invalid query strings in websocket requests.

<img width="736" alt="screen shot 2018-05-08 at 2 48 53 pm" src="https://user-images.githubusercontent.com/6611249/39779496-f98418e0-52ce-11e8-84bf-917b757a987b.png">


### Note

Jetty 9.4.9 has the bug fix reported by @pschorf https://github.com/eclipse/jetty.project/issues/1116