### PR TITLE
Rename waiter.mesos.utils to waiter.utils.http-utils

### DIFF
--- a/waiter/src/waiter/mesos/marathon.clj
+++ b/waiter/src/waiter/mesos/marathon.clj
@@ -10,7 +10,7 @@
 ;;
 (ns waiter.mesos.marathon
   (:require [clojure.data.json :as json]
-            [waiter.mesos.utils :as mesos-utils])
+            [waiter.util.http-utils :as http-utils])
   (:import org.eclipse.jetty.client.HttpClient))
 
 (defrecord MarathonApi [^HttpClient http-client ^String marathon-url spnego-auth])
@@ -23,7 +23,7 @@
 (defn create-app
   "Create and start a new app specified by the descriptor."
   [{:keys [http-client marathon-url spnego-auth]} descriptor]
-  (mesos-utils/http-request http-client (str marathon-url "/v2/apps")
+  (http-utils/http-request http-client (str marathon-url "/v2/apps")
                             :body (json/write-str descriptor)
                             :content-type "application/json"
                             :spnego-auth spnego-auth
@@ -32,7 +32,7 @@
 (defn delete-app
   "Delete the app specified by the app-id."
   [{:keys [http-client marathon-url spnego-auth]} app-id]
-  (mesos-utils/http-request http-client (str marathon-url "/v2/apps/" app-id)
+  (http-utils/http-request http-client (str marathon-url "/v2/apps/" app-id)
                             :content-type "application/json"
                             :request-method :delete
                             :spnego-auth spnego-auth))
@@ -40,14 +40,14 @@
 (defn get-app
   "List the app specified by app-id."
   [{:keys [http-client marathon-url spnego-auth]} app-id]
-  (mesos-utils/http-request http-client (str marathon-url "/v2/apps/" app-id)
+  (http-utils/http-request http-client (str marathon-url "/v2/apps/" app-id)
                             :request-method :get
                             :spnego-auth spnego-auth))
 
 (defn get-apps
   "List all running apps including running and failed tasks."
   [{:keys [http-client marathon-url spnego-auth]}]
-  (mesos-utils/http-request http-client (str marathon-url "/v2/apps")
+  (http-utils/http-request http-client (str marathon-url "/v2/apps")
                             :query-string {"embed" ["apps.lastTaskFailure" "apps.tasks"]}
                             :request-method :get
                             :spnego-auth spnego-auth))
@@ -55,21 +55,21 @@
 (defn get-deployments
   "List all running deployments."
   [{:keys [http-client marathon-url spnego-auth]}]
-  (mesos-utils/http-request http-client (str marathon-url "/v2/deployments")
+  (http-utils/http-request http-client (str marathon-url "/v2/deployments")
                             :request-method :get
                             :spnego-auth spnego-auth))
 
 (defn get-info
   "Get info about the Marathon instance."
   [{:keys [http-client marathon-url spnego-auth]}]
-  (mesos-utils/http-request http-client (str marathon-url "/v2/info")
+  (http-utils/http-request http-client (str marathon-url "/v2/info")
                             :request-method :get
                             :spnego-auth spnego-auth))
 
 (defn kill-task
   "Kill the task task-id that belongs to the application app-id."
   [{:keys [http-client marathon-url spnego-auth]} app-id task-id scale force]
-  (mesos-utils/http-request http-client (str marathon-url "/v2/apps/" app-id "/tasks/" task-id)
+  (http-utils/http-request http-client (str marathon-url "/v2/apps/" app-id "/tasks/" task-id)
                             :query-string {"force" force, "scale" scale}
                             :request-method :delete
                             :spnego-auth spnego-auth))
@@ -77,7 +77,7 @@
 (defn update-app
   "Update the descriptor of an existing app specified by the app-id."
   [{:keys [http-client marathon-url spnego-auth]} app-id descriptor]
-  (mesos-utils/http-request http-client (str marathon-url "/v2/apps/" app-id)
+  (http-utils/http-request http-client (str marathon-url "/v2/apps/" app-id)
                             :body (json/write-str descriptor)
                             :content-type "application/json"
                             :query-string {"force" true}

--- a/waiter/src/waiter/mesos/mesos.clj
+++ b/waiter/src/waiter/mesos/mesos.clj
@@ -9,7 +9,7 @@
 ;;       actual or intended publication of such source code.
 ;;
 (ns waiter.mesos.mesos
-  (:require [waiter.mesos.utils :as mesos-utils])
+  (:require [waiter.util.http-utils :as http-utils])
   (:import org.eclipse.jetty.client.HttpClient))
 
 (defrecord MesosApi [^HttpClient http-client spnego-auth slave-port slave-directory])
@@ -29,7 +29,7 @@
 (defn list-directory-content
   "Lists files and directories contained in the path."
   [{:keys [http-client slave-port spnego-auth]} host directory]
-  (mesos-utils/http-request http-client (str "http://" host ":" slave-port "/files/browse")
+  (http-utils/http-request http-client (str "http://" host ":" slave-port "/files/browse")
                             :query-string {"path" directory}
                             :request-method :get
                             :spnego-auth spnego-auth
@@ -45,7 +45,7 @@
   "Returns information about the frameworks, executors and the agent’s master."
   [{:keys [http-client slave-port spnego-auth]} host]
   (when (and slave-port host)
-    (mesos-utils/http-request http-client (str "http://" host ":" slave-port "/state.json")
+    (http-utils/http-request http-client (str "http://" host ":" slave-port "/state.json")
                               :request-method :get
                               :spnego-auth spnego-auth
                               :throw-exceptions false)))

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -19,7 +19,7 @@
             [slingshot.slingshot :as ss]
             [waiter.mesos.marathon :as marathon]
             [waiter.mesos.mesos :as mesos]
-            [waiter.mesos.utils :as mesos-utils]
+            [waiter.util.http-utils :as http-utils]
             [waiter.metrics :as metrics]
             [waiter.scheduler :as scheduler]
             [waiter.service-description :as sd]
@@ -418,7 +418,7 @@
          (not (str/blank? home-path-prefix))]}
   (when (or (not slave-directory) (not mesos-slave-port))
     (log/info "scheduler mesos-slave-port or slave-directory is missing, log directory and url support will be disabled"))
-  (let [http-client (mesos-utils/http-client-factory http-options)
+  (let [http-client (http-utils/http-client-factory http-options)
         marathon-api (marathon/api-factory http-client http-options url)
         mesos-api (mesos/api-factory http-client http-options mesos-slave-port slave-directory)
         service-id->failed-instances-transient-store (atom {})

--- a/waiter/src/waiter/util/http_utils.clj
+++ b/waiter/src/waiter/util/http_utils.clj
@@ -8,7 +8,7 @@
 ;;       The copyright notice above does not evidence any
 ;;       actual or intended publication of such source code.
 ;;
-(ns waiter.mesos.utils
+(ns waiter.util.http-utils
   (:require [clojure.core.async :as async]
             [clojure.data.json :as json]
             [clojure.walk :as walk]

--- a/waiter/test/waiter/mesos/marathon_test.clj
+++ b/waiter/test/waiter/mesos/marathon_test.clj
@@ -12,7 +12,7 @@
   (:require [clojure.string :as str]
             [clojure.test :refer :all]
             [waiter.mesos.marathon :refer :all]
-            [waiter.mesos.utils :as mesos-utils]))
+            [waiter.util.http-utils :as http-utils]))
 
 (deftest test-marathon-rest-api-endpoints
   (let [http-client (Object.)
@@ -30,29 +30,29 @@
                                              (is (= expected-absolute-url in-request-url)))))]
 
     (testing "create-app"
-      (with-redefs [mesos-utils/http-request (assert-endpoint-request-method :post "/v2/apps")]
+      (with-redefs [http-utils/http-request (assert-endpoint-request-method :post "/v2/apps")]
         (create-app marathon-api {})))
 
     (testing "delete-app"
-      (with-redefs [mesos-utils/http-request (assert-endpoint-request-method :delete (str "/v2/apps/" app-id))]
+      (with-redefs [http-utils/http-request (assert-endpoint-request-method :delete (str "/v2/apps/" app-id))]
         (delete-app marathon-api app-id)))
 
     (testing "get-apps"
-      (with-redefs [mesos-utils/http-request (assert-endpoint-request-method :get "/v2/apps")]
+      (with-redefs [http-utils/http-request (assert-endpoint-request-method :get "/v2/apps")]
         (get-apps marathon-api)))
 
     (testing "get-deployments"
-      (with-redefs [mesos-utils/http-request (assert-endpoint-request-method :get "/v2/deployments")]
+      (with-redefs [http-utils/http-request (assert-endpoint-request-method :get "/v2/deployments")]
         (get-deployments marathon-api)))
 
     (testing "get-info"
-      (with-redefs [mesos-utils/http-request (assert-endpoint-request-method :get "/v2/info")]
+      (with-redefs [http-utils/http-request (assert-endpoint-request-method :get "/v2/info")]
         (get-info marathon-api)))
 
     (testing "kill-task"
-      (with-redefs [mesos-utils/http-request (assert-endpoint-request-method :delete (str "/v2/apps/" app-id "/tasks/" task-id))]
+      (with-redefs [http-utils/http-request (assert-endpoint-request-method :delete (str "/v2/apps/" app-id "/tasks/" task-id))]
         (kill-task marathon-api app-id task-id false true)))
 
     (testing "update-app"
-      (with-redefs [mesos-utils/http-request (assert-endpoint-request-method :put (str "/v2/apps/" app-id))]
+      (with-redefs [http-utils/http-request (assert-endpoint-request-method :put (str "/v2/apps/" app-id))]
         (update-app marathon-api app-id {})))))

--- a/waiter/test/waiter/mesos/mesos_test.clj
+++ b/waiter/test/waiter/mesos/mesos_test.clj
@@ -12,7 +12,7 @@
   (:require [clojure.string :as str]
             [clojure.test :refer :all]
             [waiter.mesos.mesos :refer :all]
-            [waiter.mesos.utils :as mesos-utils]))
+            [waiter.util.http-utils :as http-utils]))
 
 (deftest test-mesos-api
   (let [http-client (Object.)
@@ -41,7 +41,7 @@
 
     (testing "list-directory-content"
       (let [host "www.host.com"]
-        (with-redefs [mesos-utils/http-request
+        (with-redefs [http-utils/http-request
                       (assert-endpoint-request-method :get (str "http://" host ":" slave-port "/files/browse"))]
           (list-directory-content mesos-api host "/some/directory"))))
 
@@ -55,6 +55,6 @@
 
     (testing "get-agent-state"
       (let [host "www.host.com"]
-        (with-redefs [mesos-utils/http-request
+        (with-redefs [http-utils/http-request
                       (assert-endpoint-request-method :get (str "http://" host ":" slave-port "/state.json"))]
           (get-agent-state mesos-api host))))))

--- a/waiter/test/waiter/util/http_utils_test.clj
+++ b/waiter/test/waiter/util/http_utils_test.clj
@@ -8,12 +8,12 @@
 ;;       The copyright notice above does not evidence any
 ;;       actual or intended publication of such source code.
 ;;
-(ns waiter.mesos.utils-test
+(ns waiter.util.http-utils-test
   (:require [clojure.core.async :as async]
             [clojure.data.json :as json]
             [clojure.test :refer :all]
             [qbits.jet.client.http :as http]
-            [waiter.mesos.utils :refer :all])
+            [waiter.util.http-utils :refer :all])
   (:import clojure.lang.ExceptionInfo))
 
 (deftest test-http-request


### PR DESCRIPTION
## Changes proposed in this PR

Rename `waiter.mesos.utils` to `waiter.utils.http-utils`.

## Why are we making these changes?

The functions in this namespace aren't Mesos-specific. I'm also using them in the Kubernetes Scheduler implementation (#285).