### PR TITLE
fixes token create/update messaging in responses

### DIFF
--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -425,11 +425,15 @@
       (make-peer-requests-fn "tokens/refresh"
                              :method :post
                              :body (json/write-str {:token token, :owner owner}))
-      (utils/map->json-response {:message (str "Successfully created " token)
-                                 :service-description new-service-description-template}
-                                :headers {"etag" (-> {:service-description-template new-service-description-template
-                                                      :token-metadata new-token-metadata}
-                                                     token-description->token-hash)}))))
+      (let [creation-mode (if (and (seq existing-token-metadata)
+                                   (not (get existing-token-metadata "deleted")))
+                            "updated "
+                            "created ")]
+        (utils/map->json-response {:message (str "Successfully " creation-mode token)
+                                   :service-description new-service-description-template}
+                                  :headers {"etag" (-> {:service-description-template new-service-description-template
+                                                        :token-metadata new-token-metadata}
+                                                       token-description->token-hash)})))))
 
 (defn handle-token-request
   "Ring handler for dealing with tokens.

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -381,7 +381,7 @@
                  :headers {}
                  :request-method :post})]
           (is (= 200 status))
-          (is (str/includes? body (str "Successfully created " token)))
+          (is (str/includes? body (str "Successfully updated " token)))
           (is (= (select-keys service-description-2 sd/token-data-keys)
                  (sd/token->service-description-template kv-store token)))
           (let [{:keys [service-description-template token-metadata]} (sd/token->token-description kv-store token)]
@@ -405,7 +405,7 @@
                  :headers {}
                  :request-method :post})]
           (is (= 200 status))
-          (is (str/includes? body (str "Successfully created " token)))
+          (is (str/includes? body (str "Successfully updated " token)))
           (is (= (select-keys service-description-2 sd/token-data-keys)
                  (sd/token->service-description-template kv-store token)))
           (let [{:keys [service-description-template token-metadata]} (sd/token->token-description kv-store token)]
@@ -430,7 +430,7 @@
                  :request-method :post})]
           (is (= 200 status))
           (is (= "application/json" (get headers "content-type")))
-          (is (str/includes? body (str "Successfully created " token)))
+          (is (str/includes? body (str "Successfully updated " token)))
           (is (= (select-keys service-description-2 sd/token-data-keys)
                  (sd/token->service-description-template kv-store token)))
           (let [{:keys [service-description-template token-metadata]} (sd/token->token-description kv-store token)]
@@ -639,7 +639,7 @@
                  :headers {}
                  :request-method :post})]
           (is (= 200 status))
-          (is (str/includes? body (str "Successfully created " token)))
+          (is (str/includes? body (str "Successfully updated " token)))
           (is (= (-> service-description-2 (select-keys sd/service-description-keys) sd/transform-allowed-params-token-entry)
                  (-> body json/read-str (get "service-description") sd/transform-allowed-params-token-entry)))
           (is (= (-> service-description-2
@@ -667,7 +667,7 @@
                  :headers {"x-waiter-token" token}
                  :request-method :post})]
           (is (= 200 status))
-          (is (str/includes? body "Successfully created test-token"))
+          (is (str/includes? body "Successfully updated test-token"))
           (is (= (-> service-description
                      (dissoc "token")
                      (assoc "last-update-time" (clock-millis)
@@ -692,7 +692,7 @@
                  :headers {"x-waiter-token" token}
                  :request-method :post})]
           (is (= 200 status))
-          (is (str/includes? body "Successfully created test-token"))
+          (is (str/includes? body "Successfully updated test-token"))
           (is (= (-> service-description
                      (dissoc "token")
                      (assoc "last-update-time" (clock-millis)
@@ -777,7 +777,7 @@
                      :headers {"x-waiter-token" token}
                      :request-method :post})]
               (is (= 200 status))
-              (is (str/includes? body "Successfully created test-token"))
+              (is (str/includes? body "Successfully updated test-token"))
               (is (= (-> service-description
                          (dissoc "token")
                          (assoc "cpus" iteration


### PR DESCRIPTION
## Changes proposed in this PR

-  fixes token create/update messaging in responses

## Why are we making these changes?

Helps the end user distinguish between when a new token was created versus an existing one being updated.
