### PR TITLE
reduces flakiness in test-service-fallback-support

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -92,6 +92,7 @@
                      "settings" :display-settings-handler-fn
                      "sim" :sim-request-handler
                      "state" [["" :state-all-handler-fn]
+                              ["/fallback" :state-fallback-handler-fn]
                               ["/interstitial" :state-interstitial-handler-fn]
                               ["/kv-store" :state-kv-store-handler-fn]
                               ["/leader" :state-leader-handler-fn]
@@ -1140,6 +1141,13 @@
                                (fn state-all-handler-fn [request]
                                  (handler/get-router-state state-chan scheduler-query-chan router-metrics-state-fn
                                                            kv-store leader?-fn local-usage-agent request)))))
+   :state-fallback-handler-fn (pc/fnk [[:daemons fallback-maintainer]
+                                       [:state router-id]
+                                       wrap-secure-request-fn]
+                                (let [fallback-query-chan (:query-chan fallback-maintainer)]
+                                  (wrap-secure-request-fn
+                                    (fn state-fallback-handler-fn [request]
+                                      (handler/get-fallback-state router-id fallback-query-chan request)))))
    :state-interstitial-handler-fn (pc/fnk [[:daemons interstitial-maintainer]
                                            [:state router-id]
                                            wrap-secure-request-fn]

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -399,6 +399,11 @@
     (log/debug endpoint "body:" state-body)
     (try-parse-json state-body)))
 
+(defn fallback-state
+  "Fetches and returns the statsd state."
+  [waiter-url & {:keys [cookies] :or {cookies {}}}]
+  (retrieve-state-helper waiter-url "/state/fallback" :cookies cookies))
+
 (defn interstitial-state
   "Fetches and returns the interstitial state."
   [waiter-url & {:keys [cookies] :or {cookies {}}}]


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for fallback state display
- reduces flakiness in test-service-fallback-support

## Why are we making these changes?

We would like our tests to not be flaky.