### PR TITLE
removes logging of request-time

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -156,7 +156,8 @@
       (cid/with-correlation-id
         request-cid
         (log/info "request received:"
-                  (-> (dissoc request :body :ctrl :server-name :server-port :servlet-request :ssl-client-cert :support-info)
+                  (-> (dissoc request :body :ctrl :request-time :server-name :server-port :servlet-request
+                              :ssl-client-cert :support-info)
                       (update-in [:headers] headers/truncate-header-values)))
         (let [response (handler request)
               get-request-cid (fn get-request-cid [] request-cid)]


### PR DESCRIPTION
## Changes proposed in this PR

- removes logging of request-time

## Why are we making these changes?

Reduces redundant information in and the size of our logs.

