### PR TITLE
defaults fallback-period-secs to 5 minutes

### DIFF
--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -317,7 +317,7 @@
                    :link {:type :url
                           :value "http://github.com/twosigma/waiter"}}]
    :token-config {:history-length 5
-                  :token-defaults {"fallback-period-secs" (-> 4 t/hours t/in-seconds)}}
+                  :token-defaults {"fallback-period-secs" (-> 5 t/minutes t/in-seconds)}}
    :websocket-config {:ws-max-binary-message-size (* 1024 1024 40)
                       :ws-max-text-message-size (* 1024 1024 40)}
    :work-stealing {:offer-help-interval-ms 100


### PR DESCRIPTION
## Changes proposed in this PR

- defaults fallback-period-secs to 5 minutes

## Why are we making these changes?

We don't want to wait 4 hours for a service upgrade, esp when the max value is supposed to be 1 hour.

