### PR TITLE
simplify /state endpoint

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1130,18 +1130,13 @@
                                      (fn service-view-logs-handler-fn [{:as request {:keys [service-id]} :route-params}]
                                        (handler/service-view-logs-handler scheduler service-id generate-log-url-fn request))))
    :sim-request-handler (pc/fnk [] simulator/handle-sim-request)
-   :state-all-handler-fn (pc/fnk [[:curator leader?-fn kv-store]
-                                  [:daemons router-state-maintainer scheduler-maintainer]
-                                  [:routines router-metrics-helpers]
-                                  [:state local-usage-agent]
+   :state-all-handler-fn (pc/fnk [[:daemons router-state-maintainer]
+                                  [:state router-id]
                                   wrap-secure-request-fn]
-                           (let [state-chan (get-in router-state-maintainer [:maintainer-chans :state-chan])
-                                 scheduler-query-chan (:query-chan scheduler-maintainer)
-                                 router-metrics-state-fn (:router-metrics-state-fn router-metrics-helpers)]
+                           (let [state-chan (get-in router-state-maintainer [:maintainer-chans :state-chan])]
                              (wrap-secure-request-fn
                                (fn state-all-handler-fn [request]
-                                 (handler/get-router-state state-chan scheduler-query-chan router-metrics-state-fn
-                                                           kv-store leader?-fn local-usage-agent request)))))
+                                 (handler/get-router-state router-id state-chan request)))))
    :state-fallback-handler-fn (pc/fnk [[:daemons fallback-maintainer]
                                        [:state router-id]
                                        wrap-secure-request-fn]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1148,14 +1148,14 @@
                                 (let [fallback-query-chan (:query-chan fallback-maintainer)]
                                   (wrap-secure-request-fn
                                     (fn state-fallback-handler-fn [request]
-                                      (handler/get-fallback-state router-id fallback-query-chan request)))))
+                                      (handler/get-query-chan-state-handler router-id fallback-query-chan request)))))
    :state-interstitial-handler-fn (pc/fnk [[:daemons interstitial-maintainer]
                                            [:state router-id]
                                            wrap-secure-request-fn]
                                     (let [interstitial-query-chan (:query-chan interstitial-maintainer)]
                                       (wrap-secure-request-fn
                                         (fn state-interstitial-handler-fn [request]
-                                          (handler/get-interstitial-state router-id interstitial-query-chan request)))))
+                                          (handler/get-query-chan-state-handler router-id interstitial-query-chan request)))))
    :state-kv-store-handler-fn (pc/fnk [[:curator kv-store]
                                        [:state router-id]
                                        wrap-secure-request-fn]
@@ -1179,7 +1179,7 @@
                                   (let [state-chan (get-in router-state-maintainer [:maintainer-chans :state-chan])]
                                     (wrap-secure-request-fn
                                       (fn maintainer-state-handler-fn [request]
-                                        (handler/get-maintainer-state router-id state-chan request)))))
+                                        (handler/get-chan-latest-state-handler router-id state-chan request)))))
    :state-router-metrics-handler-fn (pc/fnk [[:routines router-metrics-helpers]
                                              [:state router-id]
                                              wrap-secure-request-fn]
@@ -1193,7 +1193,7 @@
                                  (let [scheduler-query-chan (:query-chan scheduler-maintainer)]
                                    (wrap-secure-request-fn
                                      (fn scheduler-state-handler-fn [request]
-                                       (handler/get-scheduler-state router-id scheduler-query-chan request)))))
+                                       (handler/get-query-chan-state-handler router-id scheduler-query-chan request)))))
    :state-service-handler-fn (pc/fnk [[:daemons state-query-chans]
                                       [:state instance-rpc-chan local-usage-agent router-id]
                                       wrap-secure-request-fn]

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -554,16 +554,6 @@
       (catch Exception ex
         (utils/exception->response ex request)))))
 
-(defn get-kv-store-state
-  "Outputs the kv-store state."
-  [router-id kv-store request]
-  (try
-    (-> {:router-id router-id
-         :state (kv/state kv-store)}
-        (utils/map->streaming-json-response))
-    (catch Exception ex
-      (utils/exception->response ex request))))
-
 (defn- get-function-state
   "Outputs the state obtained by invoking `retrieve-state-fn`."
   [retrieve-state-fn router-id request]
@@ -574,12 +564,15 @@
     (catch Exception ex
       (utils/exception->response ex request))))
 
+(defn get-kv-store-state
+  "Outputs the kv-store state."
+  [router-id kv-store request]
+  (get-function-state #(kv/state kv-store) router-id request))
+
 (defn get-local-usage-state
   "Outputs the local metrics agent state."
   [router-id local-usage-agent request]
-  (-> (fn local-usage-state-fn []
-        @local-usage-agent)
-      (get-function-state router-id request)))
+  (get-function-state #(identity @local-usage-agent) router-id request))
 
 (defn get-leader-state
   "Outputs the leader state."

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -246,7 +246,7 @@
 
 (defn exception->response
   "Converts an exception into a ring response."
-  [^Exception ex {:keys [] :as request}]
+  [^Exception ex request]
   (let [wrapped-ex (wrap-unhandled-exception ex)
         {:keys [friendly-error-message headers message status suppress-logging] :as data} (ex-data wrapped-ex)
         response-msg (or friendly-error-message message (.getMessage wrapped-ex))

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -750,9 +750,9 @@
         (is (= 500 status))
         (is (str/includes? body "Waiter Error 500"))))))
 
-(deftest test-get-maintainer-state
+(deftest test-get-chan-latest-state-handler
   (let [router-id "test-router-id"
-        test-fn (wrap-async-handler-json-response get-maintainer-state)]
+        test-fn (wrap-async-handler-json-response get-chan-latest-state-handler)]
     (testing "successful response"
       (let [state-chan (async/promise-chan)
             state {"foo" "bar"}
@@ -769,7 +769,8 @@
             router-metrics-state-fn (constantly state)
             {:keys [body status]} (test-fn router-id router-metrics-state-fn {})]
         (is (= 200 status))
-        (is (= (-> body json/read-str) {"router-id" router-id, "state" state}))))
+        (is (= {"router-id" router-id "state" state}
+               (-> body json/read-str)))))
 
     (testing "exception response"
       (let [router-metrics-state-fn (fn [] (throw (Exception. "Test Exception")))
@@ -777,9 +778,9 @@
         (is (= 500 status))
         (is (str/includes? body "Waiter Error 500"))))))
 
-(deftest test-get-scheduler-state
+(deftest test-get-query-chan-state-handler
   (let [router-id "test-router-id"
-        test-fn (wrap-async-handler-json-response get-scheduler-state)]
+        test-fn (wrap-async-handler-json-response get-query-chan-state-handler)]
     (testing "successful response"
       (let [scheduler-chan (async/promise-chan)
             state {"foo" "bar"}


### PR DESCRIPTION
## Changes proposed in this PR

- introduces helper functions to simplify retrieving state
- deletes unused destructuring clauses

## Why are we making these changes?

Make it simpler to read the current code and to add future extensions to the state endpoint.

### Before

<img width="627" alt="old-state" src="https://user-images.githubusercontent.com/6611249/39738596-bcb31f1a-5251-11e8-9948-816dbad11e3c.png">

### After

<img width="630" alt="new-state" src="https://user-images.githubusercontent.com/6611249/39738560-7f7d4422-5251-11e8-8f78-68926cbd444f.png">

#### Note: For backwards compatibility I have kept `routers` in the output of `/state`.
