### PR TITLE
displays count of running tests

### DIFF
--- a/waiter/test/waiter/test_helpers.clj
+++ b/waiter/test/waiter/test_helpers.clj
@@ -75,10 +75,11 @@
   (defmethod report :end-test-var [m]
     (let [test-name (full-test-name m)
           elapsed-millis (- (System/currentTimeMillis) (get @start-millis test-name))]
-      (with-test-out
-        (println \tab (blue "FINISH:") test-name (cyan (format-duration elapsed-millis)) @*report-counters*))
       (swap! test-durations #(assoc % test-name elapsed-millis))
       (swap! running-tests #(dissoc % test-name))
+      (with-test-out
+        (println \tab (blue "FINISH:") test-name (cyan (format-duration elapsed-millis))
+                 (assoc @*report-counters* :running (count @running-tests))))
       (log-running-tests)))
 
   (defmethod report :summary [m]


### PR DESCRIPTION
## Changes proposed in this PR

- displays count of running tests

## Why are we making these changes?

We would like to know, for long running tests, how many are currently active.

### Before:

```
START:  namespace/test-function
FINISH: namespace/test-function 11ms {:test 10, :pass 126, :fail 0, :error 0}
```

### After:

```
START:  namespace/test-function
FINISH: namespace/test-function 11ms {:test 10, :pass 126, :fail 0, :error 0, :running 0}
```
