### PR TITLE
deflakes test-simple-async-request and test-multiple-async-requests

### DIFF
--- a/waiter/integration/waiter/async_request_integration_test.clj
+++ b/waiter/integration/waiter/async_request_integration_test.clj
@@ -14,7 +14,8 @@
 ;; limitations under the License.
 ;;
 (ns waiter.async-request-integration-test
-  (:require [clojure.string :as str]
+  (:require [clj-time.core :as t]
+            [clojure.string :as str]
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [plumbing.core :as pc]
@@ -22,9 +23,9 @@
 
 (deftest ^:parallel ^:integration-fast test-202-response-without-location-header
   (testing-using-waiter-url
-    (let [request-processing-time-ms 15000
+    (let [processing-time-ms 15000
           async-request-headers {:x-waiter-name (rand-name)
-                                 :x-kitchen-delay-ms request-processing-time-ms
+                                 :x-kitchen-delay-ms processing-time-ms
                                  :x-kitchen-exclude-headers "location"
                                  :x-kitchen-store-async-response-ms 40000}
           {:keys [headers service-id] :as response}
@@ -44,14 +45,15 @@
       (delete-service waiter-url service-id))))
 
 (defn- make-async-request
-  [waiter-url request-processing-time-ms]
+  [waiter-url processing-time-ms]
   (let [headers {:x-waiter-name (rand-name)
                  :x-waiter-max-instances 1
                  :x-waiter-concurrency-level 100}
         {:keys [request-headers service-id cookies]}
         (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))
-        async-request-headers
-        (assoc request-headers :x-kitchen-delay-ms request-processing-time-ms :x-kitchen-store-async-response-ms 40000)
+        async-request-headers (-> request-headers
+                                  (dissoc "x-cid")
+                                  (assoc :x-kitchen-delay-ms processing-time-ms :x-kitchen-store-async-response-ms 40000))
         {:keys [headers] :as response}
         (make-kitchen-request waiter-url async-request-headers :body "" :method :get :path "/async/request")
         status-location (get (pc/map-keys str/lower-case headers) "location")]
@@ -62,9 +64,9 @@
      :status-location status-location}))
 
 (defn- async-status
-  [[router-id endpoint-url] status-location cookies]
-  (log/info "Retrieving async status from router" router-id "at" endpoint-url)
-  (let [{:keys [headers] :as response} (make-request endpoint-url status-location :cookies cookies)
+  [[router-id router-url] status-location cookies]
+  (log/info "Retrieving async status from router" router-id "at" router-url)
+  (let [{:keys [headers] :as response} (make-request router-url status-location :cookies cookies)
         result-location (get (pc/map-keys str/lower-case headers) "location")]
     {:response response
      :result-location result-location}))
@@ -76,83 +78,88 @@
                 :headers {:x-kitchen-allow-async-cancel allow-cancel}
                 :method :delete))
 
-; Marked explicit due to:
-; FAIL in (test-simple-async-request)
-; test-simple-async-request validate-completed-request-counters
-; {:async 1
-;  :async-status 3
-;  :successful 1
-;  :async-monitor 5
-;  :waiting-for-available-instance 0
-;  :total 2
-;  :async-result 1
-;  :waiting-to-stream 0
-;  :outstanding 1
-;  :streaming 0}
-; expected: (zero? (get request-counts :async))
-;   actual: (not (zero? 1))
-(deftest ^:parallel ^:integration-fast ^:explicit test-simple-async-request
+(deftest ^:parallel ^:integration-fast test-simple-async-request
+  ;; tests the metrics and state flow associated with a single async request.
   (testing-using-waiter-url
-    (let [request-processing-time-ms 15000
+    (let [processing-time-secs 12
+          _ (log/info "making initial request with processing time of" processing-time-secs "seconds")
           {:keys [cookies request-headers response service-id status-location]}
-          (make-async-request waiter-url request-processing-time-ms)
+          (make-async-request waiter-url (-> processing-time-secs t/seconds t/in-millis))
           async-request-cid (get-in response [:headers "x-cid"] "")]
       (assert-response-status response 202)
       (is (not (str/blank? status-location)))
       (is (str/starts-with? (str status-location) "/waiter-async/status/") (str status-location))
+      (log/info async-request-cid "status-location:" status-location)
 
-      (testing "validate-in-flight-request-counters"
-        (let [service-data (service-settings waiter-url service-id)
-              request-counts (get-in service-data [:metrics :aggregate :counters :request-counts])]
-          (is (= 1 (get request-counts :async)) (str request-counts))
-          (is (= 1 (get request-counts :outstanding)) (str request-counts))))
+      (with-service-cleanup
+        service-id
+        (testing "validate-in-flight-request-counters"
+          (log/info "validate in-flight request counters")
+          (is (wait-for
+                #(let [service-data (service-settings waiter-url service-id)
+                       request-counts (get-in service-data [:metrics :aggregate :counters :request-counts])]
+                   (log/info "request counts" service-id request-counts)
+                   (and (= 1 (get request-counts :async))
+                        (= 1 (get request-counts :outstanding))))
+                :interval 1 :timeout 5)))
 
-      (let [routers (routers waiter-url)]
+        (let [routers (routers waiter-url)]
 
-        (testing "validating-status"
-          (doseq [router (seq routers)]
-            (let [{:keys [response]} (async-status router status-location cookies)]
-              (assert-response-status response 200))))
+          (testing "validating-status"
+            (doseq [router (seq routers)]
+              (let [{:keys [response result-location]} (async-status router status-location cookies)]
+                (assert-response-status response 200)
+                (is (nil? result-location)))))
 
-        ;; wait for async request to complete processing
-        (Thread/sleep (+ request-processing-time-ms 1000))
+          ;; wait for async request to complete processing
+          (wait-for
+            #(let [router-entry (rand-nth (seq routers))
+                   {:keys [response result-location]} (async-status router-entry status-location cookies)]
+               (and result-location (= 303 (:status response))))
+            :interval 1 :timeout (inc processing-time-secs))
 
-        (testing "validate-complete-status"
-          (doseq [router (seq routers)]
-            (let [{:keys [response result-location]} (async-status router status-location cookies)]
-              (assert-response-status response 303)
-              (is result-location))))
+          (testing "validate-complete-status"
+            (doseq [router-entry (seq routers)]
+              (let [{:keys [response result-location]} (async-status router-entry status-location cookies)]
+                (assert-response-status response 303)
+                (is result-location))))
 
-        (testing "validate-303-does-not-reset-in-flight-request-counters"
-          (let [service-data (service-settings waiter-url service-id)
-                request-counts (get-in service-data [:metrics :aggregate :counters :request-counts])]
-            (is (= 1 (get request-counts :async)) (str request-counts))
-            (is (= 1 (get request-counts :outstanding)) (str request-counts))))
+          (testing "validate-303-does-not-reset-in-flight-request-counters"
+            (log/info "validating 303 status does not reset in-flight request counters")
+            (is (wait-for
+                  #(let [service-data (service-settings waiter-url service-id)
+                         request-counts (get-in service-data [:metrics :aggregate :counters :request-counts])]
+                     (log/info "request counts" service-id request-counts)
+                     (and (= 1 (get request-counts :async))
+                          (= 1 (get request-counts :outstanding))))
+                  :interval 1 :timeout 5)))
 
-        (testing "validate-async-result"
-          (let [[router-id endpoint-url] (first (seq routers))
-                {:keys [result-location]} (async-status [router-id endpoint-url] status-location cookies)]
-            (is (str/starts-with? (str result-location) "/waiter-async/result/") (str result-location))
-            (is (str/includes? (str result-location) service-id) (str result-location))
-            (log/info "validating async result from router" router-id "at" endpoint-url)
-            (let [{:keys [body] :as response} (make-request endpoint-url result-location :headers request-headers :cookies cookies)]
-              (assert-response-status response 200)
-              ;; kitchen response includes the original CID
-              (is (str/includes? (str body) async-request-cid) (str body))))))
+          (testing "validate-async-result"
+            (let [[router-id endpoint-url] (first (seq routers))
+                  {:keys [result-location]} (async-status [router-id endpoint-url] status-location cookies)]
+              (is (str/starts-with? (str result-location) "/waiter-async/result/") (str result-location))
+              (is (str/includes? (str result-location) service-id) (str result-location))
+              (log/info "validating async result from router" router-id "at" endpoint-url)
+              (let [{:keys [body] :as response} (make-request endpoint-url result-location :headers request-headers :cookies cookies)]
+                (assert-response-status response 200)
+                ;; kitchen response includes the original CID
+                (is (str/includes? (str body) async-request-cid) (str body))))))
 
-      (testing "validate-completed-request-counters"
-        (let [service-data (service-settings waiter-url service-id)
-              request-counts (get-in service-data [:metrics :aggregate :counters :request-counts])]
-          (is (zero? (get request-counts :async)) (str request-counts))
-          (is (zero? (get request-counts :outstanding)) (str request-counts))))
-
-      (delete-service waiter-url service-id))))
+        (testing "validate-completed-request-counters"
+          (log/info "validate completed request counters")
+          (is (wait-for
+                #(let [service-data (service-settings waiter-url service-id)
+                       request-counts (get-in service-data [:metrics :aggregate :counters :request-counts])]
+                   (log/info "request counts" service-id request-counts)
+                   (and (zero? (get request-counts :async))
+                        (zero? (get request-counts :outstanding))))
+                :interval 1 :timeout 5)))))))
 
 (deftest ^:parallel ^:integration-fast test-cancel-supported-async-request
   (testing-using-waiter-url
-    (let [request-processing-time-ms 15000
+    (let [processing-time-ms 15000
           {:keys [cookies response service-id status-location]}
-          (make-async-request waiter-url request-processing-time-ms)]
+          (make-async-request waiter-url processing-time-ms)]
       (assert-response-status response 202)
       (is (not (str/blank? status-location)))
       (is (str/starts-with? (str status-location) "/waiter-async/status/") (str status-location))
@@ -167,9 +174,9 @@
 
 (deftest ^:parallel ^:integration-fast test-cancel-unsupported-async-request
   (testing-using-waiter-url
-    (let [request-processing-time-ms 15000
+    (let [processing-time-ms 15000
           {:keys [cookies response service-id status-location]}
-          (make-async-request waiter-url request-processing-time-ms)]
+          (make-async-request waiter-url processing-time-ms)]
       (assert-response-status response 202)
       (is (not (str/blank? status-location)))
       (let [routers (routers waiter-url)]
@@ -180,28 +187,16 @@
             (assert-response-status response 200))))
       (delete-service waiter-url service-id))))
 
-; Marked explicit due to:
-; FAIL in (test-multiple-async-requests)
-; test-multiple-async-requests validate-pending-request-counters
-; {:async 20
-;  :async-monitor 93
-;  :outstanding 19
-;  :streaming 0
-;  :successful 2
-;  :total 21
-;  :waiting-for-available-instance 0
-;  :waiting-to-stream 0}
-; expected: (= expected-total (+ async successful))
-; actual: (not (= 21 22))
-(deftest ^:parallel ^:integration-slow ^:explicit test-multiple-async-requests
+(deftest ^:parallel ^:integration-slow test-multiple-async-requests
+  ;; tests the metrics and state flow associated with a multiple concurrent async requests.
   (testing-using-waiter-url
-    (let [waiter-settings (waiter-settings waiter-url)
-          metrics-sync-interval-ms (get-in waiter-settings [:metrics-config :metrics-sync-interval-ms])
+    (let [metrics-sync-interval-ms (-> (waiter-settings waiter-url)
+                                       (get-in [:metrics-config :metrics-sync-interval-ms]))
           inter-router-metrics-interval-ms (max (int 2000) (int (* 3 metrics-sync-interval-ms)))
           headers {:x-waiter-name (rand-name)
                    :x-waiter-concurrency-level 5}
           {:keys [request-headers service-id cookies]} (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))
-          request-processing-time-ms 30000
+          processing-time-ms 30000
           num-threads 20
           num-requests-to-delete 10
           async-responses (parallelize-requests
@@ -209,9 +204,13 @@
                             (fn []
                               (log/info "making kitchen request")
                               (let [async-request-headers
-                                    (assoc request-headers :x-kitchen-delay-ms (int (* (max 0.5 (double (rand))) request-processing-time-ms))
-                                                           :x-kitchen-store-async-response-ms 600000)]
-                                (make-kitchen-request waiter-url async-request-headers :body "" :method :get :path "/async/request")))
+                                    (assoc request-headers
+                                      :x-kitchen-delay-ms (int (* (max 0.5 (double (rand))) processing-time-ms))
+                                      :x-kitchen-store-async-response-ms 600000)]
+                                (make-kitchen-request waiter-url async-request-headers
+                                                      :body ""
+                                                      :method :get
+                                                      :path "/async/request")))
                             :verbose true)
           status-locations (for [{:keys [headers] :as response} async-responses]
                              (let [status-location (get (pc/map-keys str/lower-case headers) "location")]
@@ -219,62 +218,62 @@
                                (is (not (str/blank? status-location)))
                                status-location))]
 
-      (testing "validate-pending-request-counters"
-        (Thread/sleep inter-router-metrics-interval-ms) ;; allow routers to sync metrics
-        (let [expected-total (inc num-threads)
-              service-data (service-settings waiter-url service-id)
-              {:keys [async outstanding successful total] :as request-counts}
-              (get-in service-data [:metrics :aggregate :counters :request-counts])]
-          (is (= expected-total total) (str request-counts))
-          (is (= expected-total (+ async successful)) (str request-counts))
-          (is (= expected-total (+ outstanding successful)) (str request-counts))))
-
-      (testing "delete-arbitrary-requests"
-        (let [kitchen-delete-headers {:x-kitchen-allow-async-cancel true, :x-kitchen-204-on-async-cancel false}]
-          (doseq [status-location (take num-requests-to-delete status-locations)]
-            (let [{:keys [body] :as response} (make-request waiter-url status-location
-                                                            :cookies cookies
-                                                            :headers kitchen-delete-headers
-                                                            :method :delete)]
-              (assert-response-status response 200)
-              (is (str/includes? body "Deleted request-id")))))
-        (Thread/sleep inter-router-metrics-interval-ms) ;; allow routers to sync metrics
-        (let [service-data (service-settings waiter-url service-id)
-              {:keys [async outstanding] :as request-counts}
-              (get-in service-data [:metrics :aggregate :counters :request-counts])
-              undeleted-requests (- num-threads num-requests-to-delete)]
-          (is (<= 0 async undeleted-requests) (str request-counts))
-          (is (<= 0 outstanding undeleted-requests) (str request-counts))))
-
-      (wait-for
-        (fn []
-          (every? (fn [status-location]
-                    (let [{:keys [status]} (make-request waiter-url status-location :cookies cookies)]
-                      (not= 200 status)))
-                  status-locations))
-        :interval 10, :timeout 70)
-
-      (testing "validate-async-results"
-        (let [routers (routers waiter-url)]
-          (doseq [status-location status-locations]
-            (let [[router-id endpoint-url] (rand-nth (seq routers))
-                  {:keys [result-location response]} (async-status [router-id endpoint-url] status-location cookies)]
-              (when (not= 410 (:status response))
-                (is (str/starts-with? (str result-location) "/waiter-async/result/") (str result-location))
-                (is (str/includes? (str result-location) service-id) (str result-location))
-                (log/info "validating async result via router" router-id "at" endpoint-url)
-                (let [response (make-request endpoint-url result-location :cookies cookies :method :get)]
-                  (assert-response-status response 200))))))
-
-        (testing "validate-completed-request-counters"
+      (with-service-cleanup
+        service-id
+        (testing "validate-pending-request-counters"
           (Thread/sleep inter-router-metrics-interval-ms) ;; allow routers to sync metrics
           (let [expected-total (inc num-threads)
-                service-data (service-settings waiter-url service-id)
                 {:keys [async outstanding successful total] :as request-counts}
-                (get-in service-data [:metrics :aggregate :counters :request-counts])]
+                (-> (service-settings waiter-url service-id)
+                    (get-in [:metrics :aggregate :counters :request-counts]))]
             (is (= expected-total total) (str request-counts))
-            (is (= expected-total successful) (str request-counts))
-            (is (zero? async) (str request-counts))
-            (is (zero? outstanding) (str request-counts)))))
+            (is (= expected-total (+ async successful)) (str request-counts))
+            (is (= expected-total (+ outstanding successful)) (str request-counts))))
 
-      (delete-service waiter-url service-id))))
+        (testing "delete-arbitrary-requests"
+          (let [kitchen-delete-headers {:x-kitchen-allow-async-cancel true, :x-kitchen-204-on-async-cancel false}]
+            (doseq [status-location (take num-requests-to-delete status-locations)]
+              (let [{:keys [body] :as response} (make-request waiter-url status-location
+                                                              :cookies cookies
+                                                              :headers kitchen-delete-headers
+                                                              :method :delete)]
+                (assert-response-status response 200)
+                (is (str/includes? body "Deleted request-id")))))
+          (Thread/sleep inter-router-metrics-interval-ms) ;; allow routers to sync metrics
+          (let [{:keys [async outstanding] :as request-counts}
+                (-> (service-settings waiter-url service-id)
+                    (get-in [:metrics :aggregate :counters :request-counts]))
+                num-requests-alive (- num-threads num-requests-to-delete)]
+            (is (<= 0 async num-requests-alive) (str request-counts))
+            (is (<= 0 outstanding num-requests-alive) (str request-counts))))
+
+        (wait-for
+          (fn []
+            (every? (fn [status-location]
+                      (let [{:keys [status]} (make-request waiter-url status-location :cookies cookies)]
+                        (not= 200 status)))
+                    status-locations))
+          :interval 5, :timeout 70)
+
+        (testing "validate-async-results"
+          (let [routers (routers waiter-url)]
+            (doseq [status-location status-locations]
+              (let [[router-id endpoint-url] (rand-nth (seq routers))
+                    {:keys [result-location response]} (async-status [router-id endpoint-url] status-location cookies)]
+                (when (not= 410 (:status response))
+                  (is (str/starts-with? (str result-location) "/waiter-async/result/") (str result-location))
+                  (is (str/includes? (str result-location) service-id) (str result-location))
+                  (log/info "validating async result via router" router-id "at" endpoint-url)
+                  (let [response (make-request endpoint-url result-location :cookies cookies :method :get)]
+                    (assert-response-status response 200))))))
+
+          (testing "validate-completed-request-counters"
+            (Thread/sleep inter-router-metrics-interval-ms) ;; allow routers to sync metrics
+            (let [expected-total (inc num-threads)
+                  {:keys [async outstanding successful total] :as request-counts}
+                  (-> (service-settings waiter-url service-id)
+                      (get-in [:metrics :aggregate :counters :request-counts]))]
+              (is (= expected-total total) (str request-counts))
+              (is (= expected-total successful) (str request-counts))
+              (is (zero? async) (str request-counts))
+              (is (zero? outstanding) (str request-counts)))))))))

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -248,87 +248,62 @@
         (is (= 10000000 (reduce + bytes-reported)))
         (is (= [1000448 1000448 1000448 1000448 1000448 1000448 1000448 1000448 1000448 995968] bytes-reported))))))
 
-(deftest test-inspect-for-202-async-request-response
-  (letfn [(execute-inspect-for-202-async-request-response
-            [endpoint request response]
-            (let [post-process-data (atom {:result :not-async})
-                  post-process-async-request-response-fn
-                  (fn [_ _ _ _ auth-user _ _ location query-string]
-                    (reset! post-process-data
-                            {:auth-user (:username auth-user)
-                             :location location
-                             :query-string query-string
-                             :result :success-async}))]
-              (inspect-for-202-async-request-response
-                response post-process-async-request-response-fn {} "service-id" "metric-group" {}
-                endpoint request {})
-              @post-process-data))]
-    (testing "202-missing-location-header"
-      (is (= {:result :not-async}
-             (execute-inspect-for-202-async-request-response
-               "http://www.example.com:1234/query/for/status"
-               {:authorization/user "test-user"}
-               {:status 202 :headers {}}))))
-    (testing "200-not-async"
-      (is (= {:result :not-async}
-             (execute-inspect-for-202-async-request-response
-               "http://www.example.com:1234/query/for/status"
-               {:authorization/user "test-user"}
-               {:status 200, :headers {"location" "/result/location"}}))))
-    (testing "303-not-async"
-      (is (= {:result :not-async}
-             (execute-inspect-for-202-async-request-response
-               "http://www.example.com:1234/query/for/status"
-               {:authorization/user "test-user"}
-               {:status 303, :headers {"location" "/result/location"}}))))
-    (testing "404-not-async"
-      (is (= {:result :not-async}
-             (execute-inspect-for-202-async-request-response
-               "http://www.example.com:1234/query/for/status"
-               {:authorization/user "test-user"}
-               {:status 404, :headers {"location" "/result/location"}}))))
-    (testing "202-absolute-location"
-      (is (= {:auth-user "test-user" :location "/result/location" :query-string nil :result :success-async}
-             (execute-inspect-for-202-async-request-response
-               "http://www.example.com:1234/query/for/status"
-               {:authorization/user "test-user"}
-               {:status 202 :headers {"location" "/result/location"}}))))
-    (testing "202-relative-location-1"
-      (is (= {:auth-user "test-user" :location "/query/result/location" :query-string nil :result :success-async}
-             (execute-inspect-for-202-async-request-response
-               "http://www.example.com:1234/query/for/status"
-               {:authorization/user "test-user"}
-               {:status 202 :headers {"location" "../result/location"}}))))
-    (testing "202-relative-location-2"
-      (is (= {:auth-user "test-user" :location "/query/for/result/location" :query-string nil :result :success-async}
-             (execute-inspect-for-202-async-request-response
-               "http://www.example.com:1234/query/for/status"
-               {:authorization/user "test-user"}
-               {:status 202 :headers {"location" "result/location"}}))))
-    (testing "202-relative-location-two-levels"
-      (is (= {:auth-user "test-user" :location "/result/location" :query-string "p=q&r=s|t" :result :success-async}
-             (execute-inspect-for-202-async-request-response
-               "http://www.example.com:1234/query/for/status?u=v&w=x|y|z"
-               {:authorization/user "test-user" :query-string "a=b&c=d|e"}
-               {:status 202 :headers {"location" "../../result/location?p=q&r=s|t"}}))))
-    (testing "202-absolute-url-same-host-port"
-      (is (= {:auth-user "test-user" :location "/retrieve/result/location" :query-string nil :result :success-async}
-             (execute-inspect-for-202-async-request-response
-               "http://www.example.com:1234/query/for/status"
-               {:authorization/user "test-user"}
-               {:status 202 :headers {"location" "http://www.example.com:1234/retrieve/result/location"}}))))
-    (testing "202-absolute-url-different-host"
-      (is (= {:result :not-async}
-             (execute-inspect-for-202-async-request-response
-               "http://www.example.com:1234/query/for/status"
-               {:authorization/user "test-user"}
-               {:status 202 :headers {"location" "http://www.example2.com:1234/retrieve/result/location"}}))))
-    (testing "202-absolute-url-different-port"
-      (is (= {:result :not-async}
-             (execute-inspect-for-202-async-request-response
-               "http://www.example.com:1234/query/for/status"
-               {:authorization/user "test-user"}
-               {:status 202 :headers {"location" "http://www.example.com:5678/retrieve/result/location"}}))))))
+(deftest test-extract-async-request-response-data
+  (testing "202-missing-location-header"
+    (is (nil?
+          (extract-async-request-response-data
+            {:status 202 :headers {}}
+            "http://www.example.com:1234/query/for/status"))))
+  (testing "200-not-async"
+    (is (nil?
+          (extract-async-request-response-data
+            {:status 200, :headers {"location" "/result/location"}}
+            "http://www.example.com:1234/query/for/status"))))
+  (testing "303-not-async"
+    (is (nil?
+          (extract-async-request-response-data
+            {:status 303, :headers {"location" "/result/location"}}
+            "http://www.example.com:1234/query/for/status"))))
+  (testing "404-not-async"
+    (is (nil?
+          (extract-async-request-response-data
+            {:status 404, :headers {"location" "/result/location"}}
+            "http://www.example.com:1234/query/for/status"))))
+  (testing "202-absolute-location"
+    (is (= {:location "/result/location" :query-string nil}
+           (extract-async-request-response-data
+             {:status 202 :headers {"location" "/result/location"}}
+             "http://www.example.com:1234/query/for/status"))))
+  (testing "202-relative-location-1"
+    (is (= {:location "/query/result/location" :query-string nil}
+           (extract-async-request-response-data
+             {:status 202 :headers {"location" "../result/location"}}
+             "http://www.example.com:1234/query/for/status"))))
+  (testing "202-relative-location-2"
+    (is (= {:location "/query/for/result/location" :query-string nil}
+           (extract-async-request-response-data
+             {:status 202 :headers {"location" "result/location"}}
+             "http://www.example.com:1234/query/for/status"))))
+  (testing "202-relative-location-two-levels"
+    (is (= {:location "/result/location" :query-string "p=q&r=s|t"}
+           (extract-async-request-response-data
+             {:status 202 :headers {"location" "../../result/location?p=q&r=s|t"}}
+             "http://www.example.com:1234/query/for/status?u=v&w=x|y|z"))))
+  (testing "202-absolute-url-same-host-port"
+    (is (= {:location "/retrieve/result/location" :query-string nil}
+           (extract-async-request-response-data
+             {:status 202 :headers {"location" "http://www.example.com:1234/retrieve/result/location"}}
+             "http://www.example.com:1234/query/for/status"))))
+  (testing "202-absolute-url-different-host"
+    (is (nil?
+          (extract-async-request-response-data
+            {:status 202 :headers {"location" "http://www.example2.com:1234/retrieve/result/location"}}
+            "http://www.example.com:1234/query/for/status"))))
+  (testing "202-absolute-url-different-port"
+    (is (nil?
+          (extract-async-request-response-data
+            {:status 202 :headers {"location" "http://www.example.com:5678/retrieve/result/location"}}
+            "http://www.example.com:1234/query/for/status")))))
 
 (deftest test-make-request
   (let [instance {:service-id "test-service-id", :host "example.com", :port 8080, :protocol "proto"}

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -251,17 +251,18 @@
 (deftest test-inspect-for-202-async-request-response
   (letfn [(execute-inspect-for-202-async-request-response
             [endpoint request response]
-            (let [reservation-status-promise (promise)
-                  post-process-data (atom {})
+            (let [post-process-data (atom {:result :not-async})
                   post-process-async-request-response-fn
                   (fn [_ _ _ _ auth-user _ _ location query-string]
                     (reset! post-process-data
-                            {:auth-user (:username auth-user) :location location :query-string query-string}))]
+                            {:auth-user (:username auth-user)
+                             :location location
+                             :query-string query-string
+                             :result :success-async}))]
               (inspect-for-202-async-request-response
                 response post-process-async-request-response-fn {} "service-id" "metric-group" {}
-                endpoint request {} reservation-status-promise)
-              (deliver reservation-status-promise :not-async)
-              (assoc @post-process-data :result @reservation-status-promise)))]
+                endpoint request {})
+              @post-process-data))]
     (testing "202-missing-location-header"
       (is (= {:result :not-async}
              (execute-inspect-for-202-async-request-response


### PR DESCRIPTION
## Changes proposed in this PR

- deflakes test-simple-async-request and test-multiple-async-requests

## Why are we making these changes?

We would like all our tests to run and catch regressions.
