### PR TITLE
removes streaming-timeout integration tests and adds unit tests

### DIFF
--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -62,7 +62,7 @@
             (error-callback e))
           (throw e))))))
 
-(defn- set-idle-timeout!
+(defn set-idle-timeout!
   "Configures the idle timeout in the response output stream (HttpOutput) to `idle-timeout-ms` ms."
   [^HttpOutput output-stream idle-timeout-ms]
   (try


### PR DESCRIPTION

## Changes proposed in this PR

- removes test-streaming-timeout-on-default-settings and test-streaming-timeout-with-custom-settings in favor of unit test test-stream-http-response-configure-idle-timeout

## Why are we making these changes?

We would like all our tests to run and catch regressions.

