### PR TITLE
Stores token source metadata in the service description

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -334,7 +334,7 @@
 
       (testing "should provide effective service description when requested"
         (let [service (service waiter-url service-id {"effective-parameters" "true"})]
-          (is (= sd/service-description-keys (set (keys (get service "effective-parameters")))))))
+          (is (= sd/service-parameter-keys (set (keys (get service "effective-parameters")))))))
 
       (delete-service waiter-url service-id))
 

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -89,8 +89,8 @@
       :headers
       (get "etag")))
 
-(defn- make-token->etag-map [waiter-url & tokens]
-  (pc/map-from-keys (fn [token] (token->etag waiter-url token)) tokens))
+(defn- make-source-tokens-entries [waiter-url & tokens]
+  (mapv (fn [token] {"token" token "version" (token->etag waiter-url token)}) tokens))
 
 (defn- create-token-name
   [waiter-url service-id-prefix]
@@ -317,7 +317,7 @@
                     service-id (retrieve-service-id waiter-url (:request-headers response))]
                 (assert-response-status response 200)
                 (is (= (name-from-service-description waiter-url service-id) service-id-prefix))
-                (is (= (make-token->etag-map waiter-url token)
+                (is (= (make-source-tokens-entries waiter-url token)
                        (source-tokens-from-service-description waiter-url service-id))))
 
               (log/info "request with hostname token" token "along with x-waiter headers except permitted-user")
@@ -327,7 +327,7 @@
                     service-id (retrieve-service-id waiter-url (:request-headers response))]
                 (assert-response-status response 200)
                 (is (= (name-from-service-description waiter-url service-id) service-id-prefix))
-                (is (= (make-token->etag-map waiter-url token)
+                (is (= (make-source-tokens-entries waiter-url token)
                        (source-tokens-from-service-description waiter-url service-id)))
                 ;; the above request hashes to a different service-id than the rest of the test, so we need to cleanup
                 (delete-service waiter-url service-id))
@@ -339,7 +339,7 @@
                     service-id (retrieve-service-id waiter-url (:request-headers response))]
                 (assert-response-status response 200)
                 (is (= (name-from-service-description waiter-url service-id) service-id-prefix))
-                (is (= (make-token->etag-map waiter-url token)
+                (is (= (make-source-tokens-entries waiter-url token)
                        (source-tokens-from-service-description waiter-url service-id)))
 
                 (testing "backend request headers"
@@ -372,7 +372,7 @@
                     service-id (retrieve-service-id waiter-url request-headers)]
                 (assert-response-status response 200)
                 (is (= (name-from-service-description waiter-url service-id) service-id-prefix))
-                (is (= (make-token->etag-map waiter-url token)
+                (is (= (make-source-tokens-entries waiter-url token)
                        (source-tokens-from-service-description waiter-url service-id)))
                 (is (every? #(not (str/blank? (get headers %)))
                             (concat required-response-headers (retrieve-debug-response-headers waiter-url)))
@@ -550,7 +550,7 @@
               service-id (retrieve-service-id waiter-url (:request-headers response))]
           (assert-response-status response 200)
           (is (= (name-from-service-description waiter-url service-id) service-id-prefix))
-          (is (= (make-token->etag-map waiter-url token)
+          (is (= (make-source-tokens-entries waiter-url token)
                  (source-tokens-from-service-description waiter-url service-id))))
 
         (log/info "making Waiter request with token and x-waiter-debug token" token "in header")
@@ -560,7 +560,7 @@
               service-id (retrieve-service-id waiter-url request-headers)]
           (assert-response-status response 200)
           (is (= (name-from-service-description waiter-url service-id) service-id-prefix))
-          (is (= (make-token->etag-map waiter-url token)
+          (is (= (make-source-tokens-entries waiter-url token)
                  (source-tokens-from-service-description waiter-url service-id)))
           (is (every? #(not (str/blank? (get headers %)))
                       (concat required-response-headers (retrieve-debug-response-headers waiter-url)))
@@ -611,7 +611,7 @@
               service-id (retrieve-service-id waiter-url (:request-headers response))]
           (assert-response-status response 200)
           (is (= (name-from-service-description waiter-url service-id) service-id-prefix))
-          (is (= (make-token->etag-map waiter-url token)
+          (is (= (make-source-tokens-entries waiter-url token)
                  (source-tokens-from-service-description waiter-url service-id)))
           (is (= (retrieve-username) (:run-as-user (service-id->service-description waiter-url service-id)))))
 
@@ -622,7 +622,7 @@
               service-id (retrieve-service-id waiter-url request-headers)]
           (assert-response-status response 200)
           (is (= (name-from-service-description waiter-url service-id) service-id-prefix))
-          (is (= (make-token->etag-map waiter-url token)
+          (is (= (make-source-tokens-entries waiter-url token)
                  (source-tokens-from-service-description waiter-url service-id)))
           (is (every? #(not (str/blank? (get headers %)))
                       (concat required-response-headers (retrieve-debug-response-headers waiter-url)))
@@ -648,7 +648,7 @@
             (assert-response-status response 200)
             (is service-id-2)
             (is (not= service-id-1 service-id-2))
-            (is (= (make-token->etag-map waiter-url token)
+            (is (= (make-source-tokens-entries waiter-url token)
                    (source-tokens-from-service-description waiter-url service-id-2)))))))))
 
 (deftest ^:parallel ^:integration-fast test-bad-token

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -79,6 +79,19 @@
 (defn- name-from-service-description [waiter-url service-id]
   (get-in (service-settings waiter-url service-id) [:service-description :name]))
 
+(defn- source-tokens-from-service-description [waiter-url service-id]
+  (-> (service-settings waiter-url service-id)
+      (get-in [:service-description :source-tokens])
+      walk/stringify-keys))
+
+(defn- token->etag [waiter-url token]
+  (-> (get-token waiter-url token :query-params {"token" token})
+      :headers
+      (get "etag")))
+
+(defn- make-token->etag-map [waiter-url & tokens]
+  (pc/map-from-keys (fn [token] (token->etag waiter-url token)) tokens))
+
 (defn- create-token-name
   [waiter-url service-id-prefix]
   (str service-id-prefix "." (subs waiter-url 0 (str/index-of waiter-url ":"))))
@@ -166,9 +179,9 @@
               (assert-response-status response 200)
               (let [token-description (-> response :body json/read-str)]
                 (is (= {"health-check-url" "/check", "name" service-id-prefix}
-                       (-> token-description (get-in (repeat 2 "previous")) (select-keys sd/service-description-keys))))
+                       (-> token-description (get-in (repeat 2 "previous")) (select-keys sd/service-parameter-keys))))
                 (is (= {"health-check-url" "/health", "name" service-id-prefix}
-                       (-> token-description (get-in (repeat 1 "previous")) (select-keys sd/service-description-keys)))))
+                       (-> token-description (get-in (repeat 1 "previous")) (select-keys sd/service-parameter-keys)))))
               (is actual-etag)))
           (testing "via x-waiter-token header"
             (let [{:keys [body headers] :as response} (get-token waiter-url token :cookies cookies)
@@ -303,7 +316,9 @@
                     response (make-request waiter-url path :headers request-headers)
                     service-id (retrieve-service-id waiter-url (:request-headers response))]
                 (assert-response-status response 200)
-                (is (= (name-from-service-description waiter-url service-id) service-id-prefix)))
+                (is (= (name-from-service-description waiter-url service-id) service-id-prefix))
+                (is (= (make-token->etag-map waiter-url token)
+                       (source-tokens-from-service-description waiter-url service-id))))
 
               (log/info "request with hostname token" token "along with x-waiter headers except permitted-user")
               (let [request-headers (merge (dissoc service-description :x-waiter-permitted-user) {"host" token})
@@ -312,6 +327,8 @@
                     service-id (retrieve-service-id waiter-url (:request-headers response))]
                 (assert-response-status response 200)
                 (is (= (name-from-service-description waiter-url service-id) service-id-prefix))
+                (is (= (make-token->etag-map waiter-url token)
+                       (source-tokens-from-service-description waiter-url service-id)))
                 ;; the above request hashes to a different service-id than the rest of the test, so we need to cleanup
                 (delete-service waiter-url service-id))
 
@@ -322,6 +339,8 @@
                     service-id (retrieve-service-id waiter-url (:request-headers response))]
                 (assert-response-status response 200)
                 (is (= (name-from-service-description waiter-url service-id) service-id-prefix))
+                (is (= (make-token->etag-map waiter-url token)
+                       (source-tokens-from-service-description waiter-url service-id)))
 
                 (testing "backend request headers"
                   (let [{:keys [body] :as response} (make-request waiter-url "/request-info" :headers request-headers)
@@ -353,6 +372,8 @@
                     service-id (retrieve-service-id waiter-url request-headers)]
                 (assert-response-status response 200)
                 (is (= (name-from-service-description waiter-url service-id) service-id-prefix))
+                (is (= (make-token->etag-map waiter-url token)
+                       (source-tokens-from-service-description waiter-url service-id)))
                 (is (every? #(not (str/blank? (get headers %)))
                             (concat required-response-headers (retrieve-debug-response-headers waiter-url)))
                     (str headers))
@@ -528,7 +549,9 @@
               response (make-request waiter-url path :headers request-headers)
               service-id (retrieve-service-id waiter-url (:request-headers response))]
           (assert-response-status response 200)
-          (is (= (name-from-service-description waiter-url service-id) service-id-prefix)))
+          (is (= (name-from-service-description waiter-url service-id) service-id-prefix))
+          (is (= (make-token->etag-map waiter-url token)
+                 (source-tokens-from-service-description waiter-url service-id))))
 
         (log/info "making Waiter request with token and x-waiter-debug token" token "in header")
         (let [request-headers {:x-waiter-debug "true", :x-waiter-token token}
@@ -537,6 +560,8 @@
               service-id (retrieve-service-id waiter-url request-headers)]
           (assert-response-status response 200)
           (is (= (name-from-service-description waiter-url service-id) service-id-prefix))
+          (is (= (make-token->etag-map waiter-url token)
+                 (source-tokens-from-service-description waiter-url service-id)))
           (is (every? #(not (str/blank? (get headers %)))
                       (concat required-response-headers (retrieve-debug-response-headers waiter-url)))
               (str headers))
@@ -586,6 +611,8 @@
               service-id (retrieve-service-id waiter-url (:request-headers response))]
           (assert-response-status response 200)
           (is (= (name-from-service-description waiter-url service-id) service-id-prefix))
+          (is (= (make-token->etag-map waiter-url token)
+                 (source-tokens-from-service-description waiter-url service-id)))
           (is (= (retrieve-username) (:run-as-user (service-id->service-description waiter-url service-id)))))
 
         (log/info "making Waiter request with token and x-waiter-debug token" token "in header")
@@ -595,6 +622,8 @@
               service-id (retrieve-service-id waiter-url request-headers)]
           (assert-response-status response 200)
           (is (= (name-from-service-description waiter-url service-id) service-id-prefix))
+          (is (= (make-token->etag-map waiter-url token)
+                 (source-tokens-from-service-description waiter-url service-id)))
           (is (every? #(not (str/blank? (get headers %)))
                       (concat required-response-headers (retrieve-debug-response-headers waiter-url)))
               (str headers))
@@ -606,10 +635,21 @@
   (testing-using-waiter-url
     (let [name-string (rand-name)
           canary-response (make-kitchen-request waiter-url {:x-waiter-name name-string})
-          service-id (retrieve-service-id waiter-url (:request-headers canary-response))]
-      (is (str/includes? service-id name-string) (str "ERROR: App-name is missing " name-string))
-      (is (= 200 (:status (make-request waiter-url "" :headers {:x-waiter-token (str "^SERVICE-ID#" service-id)}))))
-      (delete-service waiter-url service-id))))
+          service-id-1 (retrieve-service-id waiter-url (:request-headers canary-response))]
+      (with-service-cleanup
+        service-id-1
+        (is (str/includes? service-id-1 name-string) (str "ERROR: App-name is missing " name-string))
+        (is (nil? (source-tokens-from-service-description waiter-url service-id-1)))
+        (let [token (str "^SERVICE-ID#" service-id-1)
+              response (make-request-with-debug-info {:x-waiter-token token} #(make-request waiter-url "" :headers %))
+              service-id-2 (:service-id response)]
+          (with-service-cleanup
+            service-id-2
+            (assert-response-status response 200)
+            (is service-id-2)
+            (is (not= service-id-1 service-id-2))
+            (is (= (make-token->etag-map waiter-url token)
+                   (source-tokens-from-service-description waiter-url service-id-2)))))))))
 
 (deftest ^:parallel ^:integration-fast test-bad-token
   (testing-using-waiter-url

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -641,7 +641,7 @@
 (defn acknowledge-consent-handler
   "Processes the acknowledgment to launch a service as the auth-user.
    It triggers storing of the x-waiter-consent cookie on the client."
-  [token->service-description-template token->token-metadata service-description->service-id
+  [token->service-description-template token->token-metadata token->token-hash service-description->service-id
    consent-cookie-value add-encoded-cookie consent-expiry-days {:keys [request-method] :as request}]
   (try
     (when-not (= :post request-method)
@@ -672,7 +672,8 @@
         (when-not service-id
           (throw (ex-info "Missing service-id" (assoc params :status 400)))))
       (let [token (utils/authority->host host)
-            service-description-template (token->service-description-template token)]
+            service-description-template (some-> (token->service-description-template token)
+                                                 (assoc "source-tokens" {token (token->token-hash token)}))]
         (when-not (seq service-description-template)
           (throw (ex-info "Unable to load description for token" {:token token :status 400})))
         (when (= "service" mode)
@@ -707,7 +708,7 @@
 (defn request-consent-handler
   "Displays the consent form and requests approval from user. The content is rendered from consent.html.
    Approval form is submitted using AJAX and the user is then redirected to the target url that triggered a redirect to this form."
-  [token->service-description-template service-description->service-id consent-expiry-days
+  [token->service-description-template token->token-hash service-description->service-id consent-expiry-days
    {:keys [headers query-string request-method request-time route-params] :as request}]
   (try
     (when-not (= :get request-method)
@@ -715,7 +716,9 @@
     (let [host-header (get headers "host")
           token (utils/authority->host host-header)
           {:keys [path]} route-params
-          {:strs [interstitial-secs] :as service-description-template} (token->service-description-template token)]
+          {:strs [interstitial-secs] :as service-description-template}
+          (some-> (token->service-description-template token)
+                  (assoc "source-tokens" {token (token->token-hash token)}))]
       (when-not (seq service-description-template)
         (throw (ex-info "Unable to load description for token" {:token token :status 404})))
       (let [auth-user (:authorization/user request)

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -103,23 +103,30 @@
                                         (map :k)
                                         (set)))
 
-; keys used in computing the service-id from the service description
 (def ^:const service-override-keys
   #{"authentication" "blacklist-on-503" "concurrency-level" "distribution-scheme" "expired-instance-restart-rate"
     "grace-period-secs" "health-check-interval-secs" "health-check-max-consecutive-failures"
     "idle-timeout-mins" "instance-expiry-mins" "interstitial-secs" "jitter-threshold" "max-queue-length" "min-instances"
     "max-instances" "restart-backoff-factor" "scale-down-factor" "scale-factor" "scale-up-factor"})
 
-; keys stored in the service description
-(def ^:const service-description-keys
-  (set/union service-override-keys
-             #{"allowed-params" "backend-proto" "cmd" "cmd-type" "cpus" "env" "health-check-url" "mem" "metadata"
-               "metric-group" "name" "permitted-user" "ports" "run-as-user" "version"}))
+(def ^:const service-non-override-keys
+  #{"allowed-params" "backend-proto" "cmd" "cmd-type" "cpus" "env" "health-check-url" "mem" "metadata"
+    "metric-group" "name" "permitted-user" "ports" "run-as-user" "version"})
 
-(def ^:const service-description-from-header-keys (set/union service-description-keys #{"param"}))
+; keys used as parameters in the service description
+(def ^:const service-parameter-keys
+  (set/union service-override-keys service-non-override-keys))
+
+; keys allowed in service description metadata, these need to be distinct from service parameter keys
+(def ^:const service-metadata-keys #{"source-tokens"})
+
+; keys used in computing the service-id from the service description
+(def ^:const service-description-keys (set/union service-parameter-keys service-metadata-keys))
+
+(def ^:const service-description-from-header-keys (set/union service-parameter-keys #{"param"}))
 
 ; keys allowed in a service description for on-the-fly requests
-(def ^:const on-the-fly-service-description-keys (set/union service-description-keys #{"token"}))
+(def ^:const on-the-fly-service-description-keys (set/union service-parameter-keys #{"token"}))
 
 ; keys allowed in system metadata for tokens, these need to be distinct from service description keys
 (def ^:const system-metadata-keys #{"deleted" "last-update-time" "last-update-user" "owner" "previous" "root"})
@@ -131,7 +138,7 @@
 (def ^:const token-metadata-keys (set/union system-metadata-keys user-metadata-keys))
 
 ; keys allowed in the token data
-(def ^:const token-data-keys (set/union service-description-keys token-metadata-keys))
+(def ^:const token-data-keys (set/union service-parameter-keys token-metadata-keys))
 
 (defn transform-allowed-params-header
   "Converts allowed-params comma-separated string in the service-description to a set."
@@ -421,7 +428,8 @@
 (defrecord DefaultServiceDescriptionBuilder [max-constraints-schema]
   ServiceDescriptionBuilder
 
-  (build [_ user-service-description {:keys [service-id-prefix metric-group-mappings kv-store defaults assoc-run-as-user-approved? username]}]
+  (build [_ user-service-description
+          {:keys [assoc-run-as-user-approved? defaults kv-store metric-group-mappings service-id-prefix username]}]
     (let [core-service-description (if (get user-service-description "run-as-user")
                                      user-service-description
                                      (let [candidate-service-description (assoc-run-as-requester-fields user-service-description username)
@@ -489,12 +497,18 @@
     (when (or (not deleted) include-deleted)
       (select-keys token-data allowed-keys))))
 
+(defn token->token-hash
+  "Retrieves the token-data and converts it into a hash."
+  [kv-store ^String token & {:keys [error-on-missing] :or {error-on-missing true}}]
+  (-> (token->token-data kv-store token token-data-keys error-on-missing false)
+      token-data->token-hash))
+
 (defn token-data->token-description
   "Retrieves the token description for the given token when the raw kv data (merged value of service
    parameters and metadata) is provided.
    The token-description consists of the following keys: :service-description-template and :token-metadata"
   [config]
-  {:service-description-template (select-keys config service-description-keys)
+  {:service-description-template (select-keys config service-parameter-keys)
    :token-metadata (select-keys config token-metadata-keys)})
 
 (defn token->token-description
@@ -506,7 +520,7 @@
 (defn token->service-description-template
   "Retrieves the service description template for the given token."
   [kv-store ^String token & {:keys [error-on-missing] :or {error-on-missing true}}]
-  (token->token-data kv-store token service-description-keys error-on-missing false))
+  (token->token-data kv-store token service-parameter-keys error-on-missing false))
 
 (defn token->token-metadata
   "Retrieves the token metadata for the given token."
@@ -559,7 +573,10 @@
   [token-defaults token-sequence token->token-data]
   (let [merged-token-data (->> (token-sequence->merged-data token->token-data token-sequence)
                                (merge token-defaults))
-        service-description-template (select-keys merged-token-data service-description-keys)]
+        service-description-from-token-sequence (select-keys merged-token-data service-parameter-keys)
+        service-description-template (cond-> service-description-from-token-sequence
+                                             (seq service-description-from-token-sequence)
+                                             (assoc "source-tokens" (pc/map-vals token-data->token-hash token->token-data)))]
     {:fallback-period-secs (get merged-token-data "fallback-period-secs")
      :service-description-template service-description-template
      :token->token-data token->token-data
@@ -739,7 +756,7 @@
           ; run-as-user will not be set if description-from-headers or the token description contains it.
           ; else rely on presence of x-waiter headers to set the run-as-user
           contains-waiter-header? (headers/contains-waiter-header waiter-headers on-the-fly-service-description-keys)
-          contains-service-parameter-header? (headers/contains-waiter-header waiter-headers service-description-keys)
+          contains-service-parameter-header? (headers/contains-waiter-header waiter-headers service-parameter-keys)
           user-service-description (cond-> sanitized-metadata-description
                                            (and (not (contains? sanitized-metadata-description "run-as-user")) contains-waiter-header?)
                                            ; can only set the run-as-user if some on-the-fly-service-description-keys waiter header was provided

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -319,7 +319,7 @@
         new-token-metadata (select-keys new-token-data sd/token-metadata-keys)
         new-user-metadata (select-keys new-token-metadata sd/user-metadata-keys)
         {:strs [authentication interstitial-secs permitted-user run-as-user] :as new-service-description-template}
-        (select-keys new-token-data sd/service-description-keys)
+        (select-keys new-token-data sd/service-parameter-keys)
         existing-token-metadata (sd/token->token-metadata kv-store token :error-on-missing false)
         owner (or (get new-token-metadata "owner")
                   (get existing-token-metadata "owner")
@@ -434,11 +434,12 @@
                                    (not (get existing-token-metadata "deleted")))
                             "updated "
                             "created ")]
-        (utils/map->json-response {:message (str "Successfully " creation-mode token)
-                                   :service-description new-service-description-template}
-                                  :headers {"etag" (-> {:service-description-template new-service-description-template
-                                                        :token-metadata new-token-metadata}
-                                                       token-description->token-hash)})))))
+        (utils/map->json-response
+          {:message (str "Successfully " creation-mode token)
+           :service-description new-service-description-template}
+          :headers {"etag" (token-description->token-hash
+                             {:service-description-template new-service-description-template
+                              :token-metadata new-token-metadata})})))))
 
 (defn handle-token-request
   "Ring handler for dealing with tokens.

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -44,8 +44,8 @@
 
 (defn- token-description->token-hash
   "Converts the token metadata to a hash."
-  [{:keys [service-description-template token-metadata]}]
-  (-> (merge service-description-template token-metadata)
+  [{:keys [service-parameter-template token-metadata]}]
+  (-> (merge service-parameter-template token-metadata)
       sd/token-data->token-hash))
 
 (defn- validate-token-modification-based-on-hash
@@ -86,13 +86,13 @@
 
   (defn store-service-description-for-token
     "Store the token mapping of the service description template in the key-value store."
-    [synchronize-fn kv-store history-length ^String token service-description-template token-metadata &
+    [synchronize-fn kv-store history-length ^String token service-parameter-template token-metadata &
      {:keys [version-hash]}]
     (synchronize-fn
       token-lock
       (fn inner-store-service-description-for-token []
         (log/info "storing service description for token:" token)
-        (let [token-data (-> (merge service-description-template token-metadata)
+        (let [token-data (-> (merge service-parameter-template token-metadata)
                              (select-keys sd/token-data-keys))
               {:strs [deleted owner] :as new-token-data} (sd/sanitize-service-description token-data sd/token-data-keys)
               existing-token-data (kv/fetch kv-store token :refresh true)
@@ -239,8 +239,8 @@
         hard-delete (utils/request-flag request-params "hard-delete")]
     (if token
       (let [token-description (sd/token->token-description kv-store token :include-deleted hard-delete)
-            {:keys [service-description-template token-metadata]} token-description]
-        (if (and service-description-template (not-empty service-description-template))
+            {:keys [service-parameter-template token-metadata]} token-description]
+        (if (and service-parameter-template (not-empty service-parameter-template))
           (let [token-owner (get token-metadata "owner")
                 version-hash (get headers "if-match")]
             (if hard-delete
@@ -281,14 +281,14 @@
         token (or (get request-params "token")
                   (:token (sd/retrieve-token-from-service-description-or-hostname headers headers waiter-hostnames)))
         token-description (sd/token->token-description kv-store token :include-deleted include-deleted)
-        {:keys [service-description-template token-metadata]} token-description
+        {:keys [service-parameter-template token-metadata]} token-description
         token-hash (token-description->token-hash token-description)]
-    (if (seq service-description-template)
+    (if (seq service-parameter-template)
       ;;NB do not ever return the password to the user
       (let [epoch-time->date-time (fn [epoch-time] (DateTime. epoch-time))]
         (log/info "successfully retrieved token " token)
         (utils/map->json-response
-          (cond-> service-description-template
+          (cond-> service-parameter-template
                   show-metadata
                   (merge (cond-> (loop [loop-token-metadata token-metadata
                                         nested-last-update-time-path ["last-update-time"]]
@@ -318,7 +318,7 @@
                                                sd/transform-allowed-params-token-entry)
         new-token-metadata (select-keys new-token-data sd/token-metadata-keys)
         new-user-metadata (select-keys new-token-metadata sd/user-metadata-keys)
-        {:strs [authentication interstitial-secs permitted-user run-as-user] :as new-service-description-template}
+        {:strs [authentication interstitial-secs permitted-user run-as-user] :as new-service-parameter-template}
         (select-keys new-token-data sd/service-parameter-keys)
         existing-token-metadata (sd/token->token-metadata kv-store token :error-on-missing false)
         owner (or (get new-token-metadata "owner")
@@ -332,7 +332,7 @@
     (when-not (re-matches valid-token-re token)
       (throw (ex-info "Token must match pattern"
                       {:status 400 :token token :pattern (str valid-token-re)})))
-    (validate-service-description-fn new-service-description-template)
+    (validate-service-description-fn new-service-parameter-template)
     (when-let [user-metadata-check (s/check sd/user-metadata-schema new-user-metadata)]
       (throw (ex-info "User metadata validation failed"
                       {:failed-check user-metadata-check :status 400 :token token})))
@@ -350,13 +350,13 @@
                              " permitted-user as *, instead provided " permitted-user)
                         {:status 400 :token token})))
       ;; partial tokens not supported when authentication is disabled
-      (when-not (sd/required-keys-present? new-service-description-template)
+      (when-not (sd/required-keys-present? new-service-parameter-template)
         (throw (ex-info "Tokens with authentication disabled must specify all required parameters"
                         {:missing-parameters (->> sd/service-required-keys
-                                                  (remove #(contains? new-service-description-template %1)) seq)
-                         :service-description new-service-description-template
+                                                  (remove #(contains? new-service-parameter-template %1)) seq)
+                         :service-description new-service-parameter-template
                          :status 400}))))
-    (when (and interstitial-secs (not (sd/required-keys-present? new-service-description-template)))
+    (when (and interstitial-secs (not (sd/required-keys-present? new-service-parameter-template)))
       (throw (ex-info (str "Tokens with missing required parameters cannot use interstitial support")
                       {:status 400 :token token})))
     (case (get request-params "update-mode")
@@ -424,7 +424,7 @@
                                      "root" (or (get existing-token-metadata "root") token-root)}
                                     new-token-metadata)]
       (store-service-description-for-token
-        synchronize-fn kv-store history-length token new-service-description-template new-token-metadata
+        synchronize-fn kv-store history-length token new-service-parameter-template new-token-metadata
         :version-hash version-hash)
       ; notify peers of token update
       (make-peer-requests-fn "tokens/refresh"
@@ -436,9 +436,9 @@
                             "created ")]
         (utils/map->json-response
           {:message (str "Successfully " creation-mode token)
-           :service-description new-service-description-template}
+           :service-description new-service-parameter-template}
           :headers {"etag" (token-description->token-hash
-                             {:service-description-template new-service-description-template
+                             {:service-parameter-template new-service-parameter-template
                               :token-metadata new-token-metadata})})))))
 
 (defn handle-token-request

--- a/waiter/test/waiter/descriptor_test.clj
+++ b/waiter/test/waiter/descriptor_test.clj
@@ -499,16 +499,18 @@
                      :waiter-headers waiter-headers})))))
 
     (testing "single token with previous"
-      (let [service-description-1 {"cmd" "ls" "cpus" 1 "mem" 32 "run-as-user" "ru1" "version" "foo1"}
-            service-description-2 {"cmd" "ls" "cpus" 1 "mem" 32 "run-as-user" "ru2" "version" "foo2"}
+      (let [test-token "test-token"
+            token-data-1 {"cmd" "ls" "cpus" 1 "mem" 32 "run-as-user" "ru" "version" "foo1"}
+            service-description-1 (assoc token-data-1 "source-tokens" {test-token (sd/token-data->token-hash token-data-1)})
+            token-data-2 {"cmd" "ls" "cpus" 2 "mem" 64 "previous" token-data-1 "run-as-user" "ru" "version" "foo2"}
+            service-description-2 (assoc token-data-2 "source-tokens" {test-token (sd/token-data->token-hash token-data-2)})
             sources {:defaults {"metric-group" "other" "permitted-user" "*"}
                      :headers {}
-                     :service-description-template service-description-1
-                     :token->token-data {"token-1" {"cmd" "ls" "cpus" 1 "mem" 32 "run-as-user" "ru" "version" "foo"
-                                                    "previous" service-description-2}}
+                     :service-description-template service-description-2
+                     :token->token-data {test-token token-data-2}
                      :token-authentication-disabled false
                      :token-preauthorized false
-                     :token-sequence ["token-1"]}
+                     :token-sequence [test-token]}
             passthrough-headers {}
             waiter-headers {}
             previous-descriptor (descriptor->previous-descriptor
@@ -516,17 +518,17 @@
                                   {:passthrough-headers passthrough-headers
                                    :sources sources
                                    :waiter-headers waiter-headers})]
-        (is (= {:core-service-description service-description-2
+        (is (= {:core-service-description service-description-1
                 :on-the-fly? nil
                 :passthrough-headers passthrough-headers
                 :service-authentication-disabled false
-                :service-description (merge (:defaults sources) service-description-2)
-                :service-id (sd/service-description->service-id service-id-prefix service-description-2)
+                :service-description (merge (:defaults sources) service-description-1)
+                :service-id (sd/service-description->service-id service-id-prefix service-description-1)
                 :service-preauthorized false
-                :sources (-> sources
-                             (assoc :fallback-period-secs 300
-                                    :service-description-template service-description-2)
-                             (update :token->token-data assoc "token-1" service-description-2))
+                :sources (assoc sources
+                           :fallback-period-secs 300
+                           :service-description-template service-description-1
+                           :token->token-data {test-token token-data-1})
                 :waiter-headers waiter-headers}
                previous-descriptor))
         (is (nil? (descriptor->previous-descriptor
@@ -534,17 +536,19 @@
                     previous-descriptor)))))
 
     (testing "single on-the-fly+token with previous"
-      (let [service-description-1 {"cmd" "ls" "cpus" 1 "mem" 32 "run-as-user" "ru1" "version" "foo1"}
-            service-description-2 {"cmd" "ls" "cpus" 1 "mem" 32 "run-as-user" "ru2" "version" "foo2"}
+      (let [test-token "test-token"
+            token-data-1 {"cmd" "ls" "cpus" 1 "mem" 32 "run-as-user" "ru1" "version" "foo1"}
+            service-description-1 (assoc token-data-1 "source-tokens" {test-token (sd/token-data->token-hash token-data-1)})
+            token-data-2 {"cmd" "ls" "cpus" 2 "mem" 64 "previous" token-data-1 "run-as-user" "ru2" "version" "foo2"}
+            service-description-2 (assoc token-data-1 "source-tokens" {test-token (sd/token-data->token-hash token-data-2)})
             sources {:defaults {"metric-group" "other" "permitted-user" "*"}
                      :headers {"cpus" 20}
                      :on-the-fly? nil ;; invalid value to check if it is ignored and generated in the fallback
-                     :service-description-template service-description-1
-                     :token->token-data {"token-1" {"cmd" "ls" "cpus" 1 "mem" 32 "run-as-user" "ru" "version" "foo"
-                                                    "previous" service-description-2}}
+                     :service-description-template service-description-2
+                     :token->token-data {test-token token-data-2}
                      :token-authentication-disabled false
                      :token-preauthorized false
-                     :token-sequence ["token-1"]}
+                     :token-sequence [test-token]}
             passthrough-headers {}
             waiter-headers {"x-waiter-cpus" 20}
             previous-descriptor (descriptor->previous-descriptor
@@ -552,37 +556,33 @@
                                   {:passthrough-headers passthrough-headers
                                    :sources sources
                                    :waiter-headers waiter-headers})]
-        (is (= {:core-service-description (merge service-description-2
-                                                 {"cpus" 20 "permitted-user" username "run-as-user" username})
-                :on-the-fly? true
-                :passthrough-headers passthrough-headers
-                :service-authentication-disabled false
-                :service-description (merge (:defaults sources)
-                                            service-description-2
-                                            {"cpus" 20 "permitted-user" username "run-as-user" username})
-                :service-id (sd/service-description->service-id
-                              service-id-prefix
-                              (merge service-description-2
-                                     {"cpus" 20 "permitted-user" username "run-as-user" username}))
-                :service-preauthorized false
-                :sources (-> sources
-                             (assoc :fallback-period-secs 300
-                                    :service-description-template service-description-2)
-                             (update :token->token-data assoc "token-1" service-description-2))
-                :waiter-headers waiter-headers}
-               previous-descriptor))))
+        (let [expected-core-service-description (assoc service-description-1 "cpus" 20 "permitted-user" username "run-as-user" username)]
+          (is (= {:core-service-description expected-core-service-description
+                  :on-the-fly? true
+                  :passthrough-headers passthrough-headers
+                  :service-authentication-disabled false
+                  :service-description (merge (:defaults sources) expected-core-service-description)
+                  :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)
+                  :service-preauthorized false
+                  :sources (assoc sources
+                             :fallback-period-secs 300
+                             :service-description-template service-description-1
+                             :token->token-data {test-token token-data-1})
+                  :waiter-headers waiter-headers}
+                 previous-descriptor)))))
 
     (testing "multiple tokens without previous"
-      (let [service-description-1 {"cmd" "ls" "cpus" 1 "mem" 32}
+      (let [test-token "test-token"
+            service-description-1 {"cmd" "ls" "cpus" 1 "mem" 32}
             service-description-2 {"run-as-user" "ru" "version" "foo"}
             sources {:defaults {"permitted-user" "*"}
                      :headers {}
                      :service-description-template (merge service-description-1 service-description-2)
-                     :token->token-data {"token-1" service-description-1
+                     :token->token-data {test-token service-description-1
                                          "token-2" service-description-2}
                      :token-authentication-disabled false
                      :token-preauthorized false
-                     :token-sequence ["token-1" "token-2"]}
+                     :token-sequence [test-token "token-2"]}
             passthrough-headers {}
             waiter-headers {}]
         (is (nil? (descriptor->previous-descriptor
@@ -592,18 +592,29 @@
                      :waiter-headers waiter-headers})))))
 
     (testing "multiple tokens with previous"
-      (let [service-description-1p {"cmd" "lsp" "cpus" 1 "last-update-time" 1000 "mem" 32}
-            service-description-1 {"cmd" "ls" "cpus" 1 "mem" 32 "previous" service-description-1p}
-            service-description-2p {"last-update-time" 2000 "run-as-user" "rup" "version" "foo"}
-            service-description-2 {"previous" service-description-2p "run-as-user" "ru" "version" "foo"}
+      (let [test-token-1 "test-token-1"
+            token-data-1p {"cmd" "lsp" "cpus" 1 "last-update-time" 1000 "mem" 32}
+            token-hash-1p (sd/token-data->token-hash token-data-1p)
+            service-description-1p (assoc token-data-1p "source-tokens" {test-token-1 token-hash-1p})
+            token-data-1 {"cmd" "ls" "cpus" 1 "mem" 32 "previous" token-data-1p}
+            token-hash-1 (sd/token-data->token-hash token-data-1)
+            service-description-1 (assoc token-data-1 "source-tokens" {test-token-1 token-hash-1})
+            test-token-2 "test-token-2"
+            token-data-2p {"last-update-time" 2000 "run-as-user" "rup" "version" "foo"}
+            token-hash-2p (sd/token-data->token-hash token-data-2p)
+            service-description-2p (assoc token-data-2p "source-tokens" {test-token-2 token-hash-2p})
+            token-data-2 {"previous" token-data-2p "run-as-user" "ru" "version" "foo"}
+            token-hash-2 (sd/token-data->token-hash token-data-2)
             sources {:defaults {"metric-group" "other" "permitted-user" "*"}
                      :headers {}
-                     :service-description-template (merge service-description-1 service-description-2)
-                     :token->token-data {"token-1" service-description-1
-                                         "token-2" service-description-2}
+                     :service-description-template (-> (merge service-description-1 service-description-2p)
+                                                       (assoc "source-tokens" {test-token-1 token-hash-1
+                                                                               test-token-2 token-hash-2}))
+                     :token->token-data {test-token-1 token-data-1
+                                         test-token-2 token-data-2}
                      :token-authentication-disabled false
                      :token-preauthorized false
-                     :token-sequence ["token-1" "token-2"]}
+                     :token-sequence [test-token-1 test-token-2]}
             passthrough-headers {}
             waiter-headers {}
             previous-descriptor (descriptor->previous-descriptor
@@ -611,46 +622,45 @@
                                   {:passthrough-headers passthrough-headers
                                    :sources sources
                                    :waiter-headers waiter-headers})]
-        (is (= {:core-service-description (-> (merge service-description-1 service-description-2p)
-                                              (select-keys sd/service-description-keys))
-                :on-the-fly? nil
-                :passthrough-headers passthrough-headers
-                :service-authentication-disabled false
-                :service-description (-> (merge (:defaults sources) service-description-1 service-description-2p)
-                                         (select-keys sd/service-description-keys))
-                :service-id (->> (dissoc (merge service-description-1 service-description-2p) "previous")
-                                 (sd/service-description->service-id service-id-prefix))
-                :service-preauthorized false
-                :sources (-> sources
-                             (assoc :fallback-period-secs 300
-                                    :service-description-template
-                                    (-> (merge service-description-1 service-description-2p)
-                                        (select-keys sd/service-description-keys)))
-                             (update :token->token-data assoc "token-2" service-description-2p))
-                :waiter-headers waiter-headers}
-               previous-descriptor))
-        (let [prev-descriptor-2 (descriptor->previous-descriptor
-                                  kv-store service-id-prefix token-defaults metric-group-mappings builder assoc-run-as-user-approved? username
-                                  previous-descriptor)]
-          (is (= {:core-service-description (-> (merge service-description-1p service-description-2p)
-                                                (select-keys sd/service-description-keys))
+        (let [expected-core-service-description (-> (merge service-description-1 service-description-2p)
+                                                    (select-keys sd/service-parameter-keys)
+                                                    (assoc "source-tokens" {test-token-1 token-hash-1
+                                                                            test-token-2 token-hash-2p}))]
+          (is (= {:core-service-description expected-core-service-description
                   :on-the-fly? nil
                   :passthrough-headers passthrough-headers
                   :service-authentication-disabled false
-                  :service-description (-> (merge (:defaults sources) service-description-1p service-description-2p)
-                                           (select-keys sd/service-description-keys))
-                  :service-id (->> (dissoc (merge service-description-1p service-description-2p) "previous")
-                                   (sd/service-description->service-id service-id-prefix))
+                  :service-description (merge (:defaults sources) expected-core-service-description)
+                  :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)
                   :service-preauthorized false
                   :sources (-> sources
                                (assoc :fallback-period-secs 300
-                                      :service-description-template
-                                      (-> (merge service-description-1p service-description-2p)
-                                          (select-keys sd/service-description-keys)))
-                               (update :token->token-data assoc "token-2" service-description-2p)
-                               (update :token->token-data assoc "token-1" service-description-1p))
+                                      :service-description-template expected-core-service-description
+                                      :token->token-data {test-token-1 token-data-1
+                                                          test-token-2 token-data-2p}))
                   :waiter-headers waiter-headers}
-                 (dissoc prev-descriptor-2 :retrieve-fallback-service-description)))
+                 previous-descriptor)))
+        (let [prev-descriptor-2 (descriptor->previous-descriptor
+                                  kv-store service-id-prefix token-defaults metric-group-mappings builder assoc-run-as-user-approved? username
+                                  previous-descriptor)]
+          (let [expected-core-service-description (-> (merge service-description-1p service-description-2p)
+                                                      (select-keys sd/service-parameter-keys)
+                                                      (assoc "source-tokens" {test-token-1 token-hash-1p
+                                                                              test-token-2 token-hash-2p}))]
+            (is (= {:core-service-description expected-core-service-description
+                    :on-the-fly? nil
+                    :passthrough-headers passthrough-headers
+                    :service-authentication-disabled false
+                    :service-description (merge (:defaults sources) expected-core-service-description)
+                    :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)
+                    :service-preauthorized false
+                    :sources (assoc sources
+                               :fallback-period-secs 300
+                               :service-description-template expected-core-service-description
+                               :token->token-data {test-token-1 token-data-1p
+                                                   test-token-2 token-data-2p})
+                    :waiter-headers waiter-headers}
+                   (dissoc prev-descriptor-2 :retrieve-fallback-service-description))))
           (is (nil? (descriptor->previous-descriptor
                       kv-store service-id-prefix token-defaults metric-group-mappings builder assoc-run-as-user-approved? username
                       prev-descriptor-2))))))))

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -841,12 +841,14 @@
         test-service-description {"cmd" "some-cmd", "cpus" 1, "mem" 1024}
         token->service-description-template (fn [token] (when (= token test-token) test-service-description))
         token->token-metadata (fn [token] (when (= token test-token) {"owner" "user"}))
+        token->token-hash (fn [token] (when (= token test-token) (hash test-service-description)))
         service-description->service-id (fn [service-description]
                                           (str "service-" (count service-description) "." (count (str service-description))))
         test-user "test-user"
         test-service-id (-> test-service-description
                             (assoc "permitted-user" test-user
-                                   "run-as-user" test-user)
+                                   "run-as-user" test-user
+                                   "source-tokens" {test-token (token->token-hash test-token)})
                             service-description->service-id)
         add-encoded-cookie (fn [response cookie-name cookie-value consent-expiry-days]
                              (assoc-in response [:cookie cookie-name] {:value cookie-value, :age consent-expiry-days}))
@@ -865,7 +867,7 @@
                                                             (update :request-method #(or %1 :post))
                                                             (update :scheme #(or %1 :http)))]
                                            (acknowledge-consent-handler
-                                             token->service-description-template token->token-metadata
+                                             token->service-description-template token->token-metadata token->token-hash
                                              service-description->service-id consent-cookie-value add-encoded-cookie
                                              consent-expiry-days request')))]
     (testing "unsupported request method"
@@ -1040,6 +1042,7 @@
                                                 "www.example-i0.com" (assoc basic-service-description "interstitial-secs" 0)
                                                 "www.example-i10.com" (assoc basic-service-description "interstitial-secs" 10)
                                                 nil))
+        token->token-hash (fn [token] (hash (token->service-description-template token)))
         service-description->service-id (fn [service-description]
                                           (str "service-" (count service-description) "." (count (str service-description))))
         consent-expiry-days 1
@@ -1048,19 +1051,21 @@
                                      (let [request' (-> request
                                                         (update :authorization/user #(or %1 test-user))
                                                         (update :request-method #(or %1 :get)))]
-                                       (request-consent-handler
-                                         token->service-description-template service-description->service-id
-                                         consent-expiry-days request')))
+                                       (request-consent-handler token->service-description-template token->token-hash
+                                                                service-description->service-id consent-expiry-days request')))
         io-resource-fn (fn [file-path]
                          (is (= "web/consent.html" file-path))
                          (StringReader. "some-content"))
         expected-service-id (fn [token]
                               (-> (token->service-description-template token)
-                                  (assoc "permitted-user" test-user "run-as-user" test-user)
+                                  (assoc "permitted-user" test-user
+                                         "run-as-user" test-user
+                                         "source-tokens" {token (token->token-hash token)})
                                   service-description->service-id))
         template-eval-factory (fn [scheme]
                                 (fn [{:keys [token] :as data}]
-                                  (let [service-description-template (token->service-description-template token)]
+                                  (let [service-description-template (-> (token->service-description-template token)
+                                                                         (assoc "source-tokens" {token (token->token-hash token)}))]
                                     (is (= {:auth-user test-user
                                             :consent-expiry-days 1
                                             :service-description-template service-description-template

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -1068,8 +1068,7 @@
                          (StringReader. "some-content"))
         expected-service-id (fn [token]
                               (-> (token->service-description-template token)
-                                  (assoc "permitted-user" test-user
-                                         "run-as-user" test-user)
+                                  (assoc "permitted-user" test-user "run-as-user" test-user)
                                   service-description->service-id))
         template-eval-factory (fn [scheme]
                                 (fn [{:keys [token] :as data}]
@@ -1133,56 +1132,56 @@
           (is (= body "template:some-content")))))
 
     (with-redefs [io/resource io-resource-fn
-                          render-consent-template (template-eval-factory "https")]
-             (testing "token without service description - https x-forwarded-proto"
-               (let [request {:authorization/user test-user
-                              :headers {"host" "www.example.com:6789", "x-forwarded-proto" "https"}
-                              :request-time request-time
-                              :route-params {:path "some-path"}
-                              :scheme :http}
-                     {:keys [body headers status]} (request-consent-handler-fn request)]
-                 (is (= 200 status))
-                 (is (= {"content-type" "text/html"} headers))
-                 (is (= body "template:some-content")))))
+                  render-consent-template (template-eval-factory "https")]
+      (testing "token without service description - https x-forwarded-proto"
+        (let [request {:authorization/user test-user
+                       :headers {"host" "www.example.com:6789", "x-forwarded-proto" "https"}
+                       :request-time request-time
+                       :route-params {:path "some-path"}
+                       :scheme :http}
+              {:keys [body headers status]} (request-consent-handler-fn request)]
+          (is (= 200 status))
+          (is (= {"content-type" "text/html"} headers))
+          (is (= body "template:some-content")))))
 
     (with-redefs [io/resource io-resource-fn
-                          render-consent-template (template-eval-factory "https")]
-             (testing "token without service description - https x-forwarded-proto"
-               (let [request {:authorization/user test-user
-                              :headers {"host" "www.example-i0.com:6789", "x-forwarded-proto" "https"}
-                              :request-time request-time
-                              :route-params {:path "some-path"}
-                              :scheme :http}
-                     {:keys [body headers status]} (request-consent-handler-fn request)]
-                 (is (= 200 status))
-                 (is (= {"content-type" "text/html"} headers))
-                 (is (= body "template:some-content")))))
+                  render-consent-template (template-eval-factory "https")]
+      (testing "token without service description - https x-forwarded-proto"
+        (let [request {:authorization/user test-user
+                       :headers {"host" "www.example-i0.com:6789", "x-forwarded-proto" "https"}
+                       :request-time request-time
+                       :route-params {:path "some-path"}
+                       :scheme :http}
+              {:keys [body headers status]} (request-consent-handler-fn request)]
+          (is (= 200 status))
+          (is (= {"content-type" "text/html"} headers))
+          (is (= body "template:some-content")))))
 
     (with-redefs [io/resource io-resource-fn
-                          render-consent-template (template-eval-factory "https")]
-             (testing "token without service description - https x-forwarded-proto"
-               (let [request {:authorization/user test-user
-                              :headers {"host" "www.example-i10.com:6789", "x-forwarded-proto" "https"}
-                              :request-time request-time
-                              :route-params {:path "some-path"}
-                              :scheme :http}
-                     {:keys [body headers status]} (request-consent-handler-fn request)]
-                 (is (= 200 status))
-                 (is (= {"content-type" "text/html"} headers))
-                 (is (= body "template:some-content")))))
+                  render-consent-template (template-eval-factory "https")]
+      (testing "token without service description - https x-forwarded-proto"
+        (let [request {:authorization/user test-user
+                       :headers {"host" "www.example-i10.com:6789", "x-forwarded-proto" "https"}
+                       :request-time request-time
+                       :route-params {:path "some-path"}
+                       :scheme :http}
+              {:keys [body headers status]} (request-consent-handler-fn request)]
+          (is (= 200 status))
+          (is (= {"content-type" "text/html"} headers))
+          (is (= body "template:some-content")))))
 
     (with-redefs [io/resource io-resource-fn
-                          render-consent-template (template-eval-factory "https")]
-             (testing "token without service description - https x-forwarded-proto"
-               (let [request {:authorization/user test-user
-                              :headers {"host" "www.example.com:6789", "x-forwarded-proto" "https"}
-                              :request-time request-time
-                              :route-params {:path "some-path"}
-                              :scheme :http}
-                     {:keys [body headers status]} (request-consent-handler-fn request)]
-                 (is (= 200 status))
-                 (is (= {"content-type" "text/html"} headers))
-                 (is (= body "template:some-content")))))))
+                  render-consent-template (template-eval-factory "https")]
+      (testing "token without service description - https x-forwarded-proto"
+        (let [request {:authorization/user test-user
+                       :headers {"host" "www.example.com:6789", "x-forwarded-proto" "https"}
+                       :request-time request-time
+                       :route-params {:path "some-path"}
+                       :scheme :http}
+              {:keys [body headers status]} (request-consent-handler-fn request)]
+          (is (= 200 status))
+          (is (= {"content-type" "text/html"} headers))
+          (is (= body "template:some-content")))))))
 
 (deftest test-blacklist-instance-cannot-find-channel
   (let [instance-rpc-chan (async/chan)

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -29,6 +29,7 @@
             [waiter.interstitial :as interstitial]
             [waiter.kv :as kv]
             [waiter.scheduler :as scheduler]
+            [waiter.service-description :as sd]
             [waiter.statsd :as statsd]
             [waiter.test-helpers :refer :all]
             [waiter.util.async-utils :as au])
@@ -842,7 +843,7 @@
         token->service-description-template (fn [token]
                                               (when (= token test-token)
                                                 (assoc test-service-description
-                                                  "source-tokens" {token (hash test-service-description)})))
+                                                  "source-tokens" [(sd/source-tokens-entry test-token test-service-description)])))
         token->token-metadata (fn [token] (when (= token test-token) {"owner" "user"}))
         service-description->service-id (fn [service-description]
                                           (str "service-" (count service-description) "." (count (str service-description))))
@@ -850,7 +851,7 @@
         test-service-id (-> test-service-description
                             (assoc "permitted-user" test-user
                                    "run-as-user" test-user
-                                   "source-tokens" {test-token (hash test-service-description)})
+                                   "source-tokens" [(sd/source-tokens-entry test-token test-service-description)])
                             service-description->service-id)
         add-encoded-cookie (fn [response cookie-name cookie-value consent-expiry-days]
                              (assoc-in response [:cookie cookie-name] {:value cookie-value, :age consent-expiry-days}))
@@ -1049,9 +1050,8 @@
                                       nil)]
             (cond-> service-description
                     (seq service-description)
-                    (assoc "source-tokens" {token (hash service-description)}))
+                    (assoc "source-tokens" [(sd/source-tokens-entry token service-description)]))
             service-description))
-        token->token-hash (fn [token] (hash (token->service-description-template token)))
         service-description->service-id (fn [service-description]
                                           (str "service-" (count service-description) "." (count (str service-description))))
         consent-expiry-days 1

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -1722,15 +1722,15 @@
 
       ; test
       (testing "retrieve-invalid-token"
-        (is (= {} (token->service-description-template kv-store "invalid-token" :error-on-missing false)))
-        (is (thrown? ExceptionInfo (token->service-description-template kv-store "invalid-token")))
+        (is (= {} (token->service-parameter-template kv-store "invalid-token" :error-on-missing false)))
+        (is (thrown? ExceptionInfo (token->service-parameter-template kv-store "invalid-token")))
         (is (nil? (kv/fetch kv-store service-id))))
 
       (testing "test:token->service-description-2"
-        (let [{:keys [service-description-template token-metadata]} (token->token-description kv-store token)
-              service-description-template-2 (token->service-description-template kv-store token)]
-          (is (= service-description-template service-description-template-2))
-          (is (= (select-keys in-service-description service-description-keys) service-description-template))
+        (let [{:keys [service-parameter-template token-metadata]} (token->token-description kv-store token)
+              service-description-template-2 (token->service-parameter-template kv-store token)]
+          (is (= service-parameter-template service-description-template-2))
+          (is (= (select-keys in-service-description service-description-keys) service-parameter-template))
           (is (= (-> in-service-description
                      (assoc "previous" {})
                      (select-keys token-metadata-keys))
@@ -1738,15 +1738,15 @@
 
       (testing "test:deleted:token->service-description-2"
         (kv/store kv-store token (assoc in-service-description "deleted" true))
-        (let [{:keys [service-description-template token-metadata]} (token->token-description kv-store token)
-              service-description-template-2 (token->service-description-template kv-store token)]
+        (let [{:keys [service-parameter-template token-metadata]} (token->token-description kv-store token)
+              service-description-template-2 (token->service-parameter-template kv-store token)]
           (is (empty? service-description-template-2))
-          (is (empty? service-description-template))
+          (is (empty? service-parameter-template))
           (is (empty? token-metadata)))
-        (let [{:keys [service-description-template token-metadata]} (token->token-description kv-store token :include-deleted true)
-              service-description-template-2 (token->service-description-template kv-store token)]
+        (let [{:keys [service-parameter-template token-metadata]} (token->token-description kv-store token :include-deleted true)
+              service-description-template-2 (token->service-parameter-template kv-store token)]
           (is (empty? service-description-template-2))
-          (is (= (select-keys in-service-description service-description-keys) service-description-template))
+          (is (= (select-keys in-service-description service-description-keys) service-parameter-template))
           (is (= {"deleted" true, "owner" "tu3", "previous" {}} token-metadata)))))))
 
 (deftest test-service-suspend-resume

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -19,6 +19,7 @@
             [clojure.string :as str]
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
+            [plumbing.core :as pc]
             [schema.core :as s]
             [waiter.authorization :as authz]
             [waiter.kv :as kv]
@@ -395,7 +396,9 @@
                                       (str/includes? token "mem") (assoc "mem" "2")
                                       (str/includes? token "per") (assoc "permitted-user" "puser")
                                       (str/includes? token "run") (assoc "run-as-user" "ruser"))
-                              {}))]
+                              {}))
+        build-source-tokens (fn [& tokens]
+                              (pc/map-from-keys #(-> % create-token-data token-data->token-hash) tokens))]
     (with-redefs [kv/fetch (fn [in-kv-store token]
                              (is (= kv-store in-kv-store))
                              (create-token-data token))]
@@ -420,8 +423,9 @@
                                                "cmd" "test-cmd"
                                                "version" "test-version"
                                                "run-as-user" test-user}
-                                     :service-description-template {"name" "test-host"
-                                                                    "cmd" "token-user"
+                                     :service-description-template {"cmd" "token-user"
+                                                                    "name" "test-host"
+                                                                    "source-tokens" (build-source-tokens "test-host")
                                                                     "version" "token"}
                                      :token->token-data {"test-host" (create-token-data "test-host")}
                                      :token-authentication-disabled false
@@ -468,8 +472,9 @@
                                                "cmd" "test-cmd"
                                                "version" "test-version"
                                                "run-as-user" test-user}
-                                     :service-description-template {"name" "test-host"
-                                                                    "cmd" "token-user"
+                                     :service-description-template {"cmd" "token-user"
+                                                                    "name" "test-host"
+                                                                    "source-tokens" (build-source-tokens "test-host")
                                                                     "version" "token"}
                                      :token->token-data {"test-host" (create-token-data "test-host")}
                                      :token-authentication-disabled false
@@ -506,8 +511,9 @@
                                                 "health-check-url" "/ping"}
                                      :fallback-period-secs 300
                                      :headers {}
-                                     :service-description-template {"name" "test-host"
-                                                                    "cmd" "token-user"
+                                     :service-description-template {"cmd" "token-user"
+                                                                    "name" "test-host"
+                                                                    "source-tokens" (build-source-tokens "test-host")
                                                                     "version" "token"}
                                      :token->token-data {"test-host" (create-token-data "test-host")}
                                      :token-authentication-disabled false
@@ -522,8 +528,9 @@
                                                 "health-check-url" "/ping"}
                                      :fallback-period-secs 300
                                      :headers {}
-                                     :service-description-template {"name" "test-token"
-                                                                    "cmd" "token-user"
+                                     :service-description-template {"cmd" "token-user"
+                                                                    "name" "test-token"
+                                                                    "source-tokens" (build-source-tokens "test-token")
                                                                     "version" "token"}
                                      :token->token-data {"test-token" (create-token-data "test-token")}
                                      :token-authentication-disabled false
@@ -539,8 +546,9 @@
                                                 "health-check-url" "/ping"}
                                      :fallback-period-secs 300
                                      :headers {}
-                                     :service-description-template {"name" "test-token2"
-                                                                    "cmd" "token-user"
+                                     :service-description-template {"cmd" "token-user"
+                                                                    "name" "test-token2"
+                                                                    "source-tokens" (build-source-tokens "test-token" "test-token2")
                                                                     "version" "token"}
                                      :token->token-data {"test-token" (create-token-data "test-token")
                                                          "test-token2" (create-token-data "test-token2")}
@@ -555,10 +563,11 @@
                           :expected {:defaults {"name" "default-name" "health-check-url" "/ping"}
                                      :fallback-period-secs 300
                                      :headers {}
-                                     :service-description-template {"name" "test-mem-token"
-                                                                    "cmd" "token-user"
+                                     :service-description-template {"cmd" "token-user"
                                                                     "cpus" "1"
                                                                     "mem" "2"
+                                                                    "name" "test-mem-token"
+                                                                    "source-tokens" (build-source-tokens "test-token" "test-token2" "test-cpus-token" "test-mem-token")
                                                                     "version" "token"}
                                      :token->token-data {"test-cpus-token" (create-token-data "test-cpus-token")
                                                          "test-mem-token" (create-token-data "test-mem-token")
@@ -575,8 +584,9 @@
                                                 "health-check-url" "/ping"}
                                      :fallback-period-secs 300
                                      :headers {}
-                                     :service-description-template {"name" "test-host"
-                                                                    "cmd" "token-user"
+                                     :service-description-template {"cmd" "token-user"
+                                                                    "name" "test-host"
+                                                                    "source-tokens" (build-source-tokens "test-host")
                                                                     "version" "token"}
                                      :token->token-data {"test-host" (create-token-data "test-host")}
                                      :token-authentication-disabled false
@@ -590,8 +600,9 @@
                                                 "health-check-url" "/ping"}
                                      :fallback-period-secs 300
                                      :headers {}
-                                     :service-description-template {"name" "test-host"
-                                                                    "cmd" "token-user"
+                                     :service-description-template {"cmd" "token-user"
+                                                                    "name" "test-host"
+                                                                    "source-tokens" (build-source-tokens "test-host")
                                                                     "version" "token"}
                                      :token->token-data {"test-host" (create-token-data "test-host")}
                                      :token-authentication-disabled false,
@@ -605,10 +616,11 @@
                                                 "health-check-url" "/ping"}
                                      :fallback-period-secs 300
                                      :headers {}
-                                     :service-description-template {"name" "test-token-run"
-                                                                    "cmd" "token-user"
-                                                                    "version" "token"
-                                                                    "run-as-user" "ruser"}
+                                     :service-description-template {"cmd" "token-user"
+                                                                    "name" "test-token-run"
+                                                                    "run-as-user" "ruser"
+                                                                    "source-tokens" (build-source-tokens "test-token-run")
+                                                                    "version" "token"}
                                      :token->token-data {"test-token-run" (create-token-data "test-token-run")}
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
@@ -621,8 +633,9 @@
                                                 "health-check-url" "/ping"}
                                      :fallback-period-secs 600
                                      :headers {}
-                                     :service-description-template {"name" "test-token-per-fall"
-                                                                    "cmd" "token-user"
+                                     :service-description-template {"cmd" "token-user"
+                                                                    "name" "test-token-per-fall"
+                                                                    "source-tokens" (build-source-tokens "test-token-per-fall")
                                                                     "version" "token" "permitted-user" "puser"}
                                      :token->token-data {"test-token-per-fall" (create-token-data "test-token-per-fall")}
                                      :token-authentication-disabled false,
@@ -636,11 +649,12 @@
                                                 "health-check-url" "/ping"}
                                      :fallback-period-secs 300
                                      :headers {}
-                                     :service-description-template {"name" "test-token-per-run"
-                                                                    "cmd" "token-user"
-                                                                    "version" "token"
+                                     :service-description-template {"cmd" "token-user"
+                                                                    "name" "test-token-per-run"
+                                                                    "permitted-user" "puser"
                                                                     "run-as-user" "ruser"
-                                                                    "permitted-user" "puser"}
+                                                                    "source-tokens" (build-source-tokens "test-token-per-run")
+                                                                    "version" "token"}
                                      :token->token-data {"test-token-per-run" (create-token-data "test-token-per-run")}
                                      :token-authentication-disabled false
                                      :token-preauthorized true
@@ -653,12 +667,13 @@
                                                 "health-check-url" "/ping"}
                                      :fallback-period-secs 300
                                      :headers {}
-                                     :service-description-template {"name" "test-cpus-token"
-                                                                    "cmd" "token-user"
-                                                                    "version" "token"
+                                     :service-description-template {"cmd" "token-user"
                                                                     "cpus" "1"
+                                                                    "name" "test-cpus-token"
+                                                                    "permitted-user" "puser"
                                                                     "run-as-user" "ruser"
-                                                                    "permitted-user" "puser"}
+                                                                    "source-tokens" (build-source-tokens "test-token-per-run" "test-cpus-token")
+                                                                    "version" "token"}
                                      :token->token-data {"test-cpus-token" (create-token-data "test-cpus-token")
                                                          "test-token-per-run" (create-token-data "test-token-per-run")}
                                      :token-authentication-disabled false
@@ -712,6 +727,7 @@
                                                                     "name" "test-host-allowed-cpus-mem-per-run"
                                                                     "permitted-user" "puser"
                                                                     "run-as-user" "ruser"
+                                                                    "source-tokens" (build-source-tokens "test-host-allowed-cpus-mem-per-run")
                                                                     "version" "token"}
                                      :token->token-data {"test-host-allowed-cpus-mem-per-run" (create-token-data "test-host-allowed-cpus-mem-per-run")}
                                      :token-authentication-disabled false
@@ -735,6 +751,7 @@
                                                                     "name" "test-host-allowed-cpus-mem-per-run"
                                                                     "permitted-user" "puser"
                                                                     "run-as-user" "ruser"
+                                                                    "source-tokens" (build-source-tokens "test-host-allowed-cpus-mem-per-run")
                                                                     "version" "token"}
                                      :token->token-data {"test-host-allowed-cpus-mem-per-run" (create-token-data "test-host-allowed-cpus-mem-per-run")}
                                      :token-authentication-disabled false
@@ -757,6 +774,7 @@
                                                                     "name" "test-host-allowed-cpus-mem-per-run"
                                                                     "permitted-user" "puser"
                                                                     "run-as-user" "ruser"
+                                                                    "source-tokens" (build-source-tokens "test-host-allowed-cpus-mem-per-run")
                                                                     "version" "token"}
                                      :token->token-data {"test-host-allowed-cpus-mem-per-run" (create-token-data "test-host-allowed-cpus-mem-per-run")}
                                      :token-authentication-disabled false
@@ -854,12 +872,20 @@
         service-description-defaults {"name" "default-name" "health-check-url" "/ping"}
         token-defaults {"fallback-period-secs" 300}]
     (testing "authentication-disabled token"
-      (let [token-description {"authentication" "disabled", "cmd" "a-command", "cpus" "1", "mem" "2", "name" test-token
-                               "owner" "token-owner", "permitted-user" "*", "previous" {}, "run-as-user" "ruser", "version" "token"}]
+      (let [token-data {"authentication" "disabled"
+                        "cmd" "a-command"
+                        "cpus" "1"
+                        "mem" "2"
+                        "name" test-token
+                        "owner" "token-owner"
+                        "permitted-user" "*"
+                        "previous" {}
+                        "run-as-user" "ruser"
+                        "version" "token"}]
         (with-redefs [kv/fetch (fn [in-kv-store token]
                                  (is (= kv-store in-kv-store))
                                  (is (= test-token token))
-                                 token-description)]
+                                 token-data)]
           (let [waiter-headers {"x-waiter-token" test-token}
                 passthrough-headers {"host" "test-host:1234", "fee" "foe"}
                 actual (prepare-service-description-sources
@@ -869,20 +895,30 @@
                 expected {:defaults service-description-defaults
                           :fallback-period-secs 300
                           :headers {}
-                          :service-description-template (select-keys token-description service-description-keys)
-                          :token->token-data {test-token token-description}
+                          :service-description-template (-> token-data
+                                                            (select-keys service-parameter-keys)
+                                                            (assoc "source-tokens" {test-token (token-data->token-hash token-data)}))
+                          :token->token-data {test-token token-data}
                           :token-authentication-disabled true
                           :token-preauthorized true
                           :token-sequence [test-token]}]
             (is (= expected actual))))))
 
     (testing "limited-access token"
-      (let [token-description {"authentication" "standard", "cmd" "a-command", "cpus" "1", "mem" "2", "name" test-token
-                               "owner" "token-owner", "permitted-user" "*", "previous" {}, "run-as-user" "ruser", "version" "token"}]
+      (let [token-data {"authentication" "standard"
+                        "cmd" "a-command"
+                        "cpus" "1"
+                        "mem" "2"
+                        "name" test-token
+                        "owner" "token-owner"
+                        "permitted-user" "*"
+                        "previous" {}
+                        "run-as-user" "ruser"
+                        "version" "token"}]
         (with-redefs [kv/fetch (fn [in-kv-store token]
                                  (is (= kv-store in-kv-store))
                                  (is (= test-token token))
-                                 token-description)]
+                                 token-data)]
           (let [waiter-headers {"x-waiter-token" test-token}
                 passthrough-headers {"host" "test-host:1234", "fee" "foe"}
                 actual (prepare-service-description-sources
@@ -892,8 +928,10 @@
                 expected {:defaults service-description-defaults
                           :fallback-period-secs 300
                           :headers {}
-                          :service-description-template (select-keys token-description service-description-keys)
-                          :token->token-data {test-token token-description}
+                          :service-description-template (-> token-data
+                                                            (select-keys service-parameter-keys)
+                                                            (assoc "source-tokens" {test-token (token-data->token-hash token-data)}))
+                          :token->token-data {test-token token-data}
                           :token-authentication-disabled false
                           :token-preauthorized true
                           :token-sequence [test-token]}]
@@ -1372,50 +1410,41 @@
                                                                   "cmd" "token-cmd"}}
                                   :waiter-headers {"x-waiter-run-as-user" "header-user"}))))
 
-    (testing "active overrides"
-      (let [kv-store (kv/->LocalKeyValueStore (atom {}))]
-        (store-service-description-overrides
-          kv-store
-          "test-service-activeoverride-00de822338af921fbefacd263d092c8a"
-          "current-request-user"
-          {"scale-factor" 0.3})
-        (is (= {"cmd" "on-the-fly-cmd"
-                "health-check-url" "/ping"
-                "permitted-user" "bob"
-                "run-as-user" "on-the-fly-ru"
-                "name" "active-override"
-                "scale-factor" 0.3}
-               (service-description {:defaults {"health-check-url" "/ping"
-                                                "permitted-user" "bob"}
-                                     :headers {"cmd" "on-the-fly-cmd"
-                                               "run-as-user" "on-the-fly-ru"
-                                               "name" "active-override"}}
-                                    :kv-store kv-store)))))
+    (testing "overrides"
+      (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+            basic-service-description {"cmd" "on-the-fly-cmd"
+                                       "run-as-user" "on-the-fly-ru"}
+            basic-service-id (service-description->service-id "test-service-" basic-service-description)]
 
-    (testing "inactive overrides"
-      (let [kv-store (kv/->LocalKeyValueStore (atom {}))]
-        (store-service-description-overrides
-          kv-store
-          "test-service-inactiveoverride-b72d04dd1527e9730d1e8f5bc6bcf341"
-          "current-request-user"
-          {"scale-factor" 0.3})
-        (clear-service-description-overrides
-          kv-store
-          "test-service-inactiveoverride-b72d04dd1527e9730d1e8f5bc6bcf341"
-          "current-request-user")
-        (is (= {"cmd" "on-the-fly-cmd"
-                "health-check-url" "/ping"
-                "permitted-user" "bob"
-                "run-as-user" "on-the-fly-ru"
-                "name" "inactive-override"
-                "scale-factor" 1}
-               (service-description {:defaults {"health-check-url" "/ping"
-                                                "permitted-user" "bob"
-                                                "scale-factor" 1}
-                                     :headers {"cmd" "on-the-fly-cmd"
-                                               "run-as-user" "on-the-fly-ru"
-                                               "name" "inactive-override"}}
-                                    :kv-store kv-store)))))
+        (testing "active"
+          (store-service-description-overrides
+            kv-store
+            basic-service-id
+            "current-request-user"
+            {"scale-factor" 0.3})
+          (is (= (-> basic-service-description
+                     (dissoc "source-tokens")
+                     (assoc "health-check-url" "/ping" "permitted-user" "bob" "scale-factor" 0.3))
+                 (service-description {:defaults {"health-check-url" "/ping"
+                                                  "permitted-user" "bob"
+                                                  "scale-factor" 1}
+                                       :headers {"cmd" "on-the-fly-cmd"
+                                                 "run-as-user" "on-the-fly-ru"}}
+                                      :kv-store kv-store))))
+
+        (testing "inactive"
+          (clear-service-description-overrides
+            kv-store
+            basic-service-id
+            "current-request-user")
+          (is (= (-> basic-service-description
+                     (dissoc "source-tokens")
+                     (assoc "health-check-url" "/ping" "permitted-user" "bob"))
+                 (service-description {:defaults {"health-check-url" "/ping"
+                                                  "permitted-user" "bob"}
+                                       :headers {"cmd" "on-the-fly-cmd"
+                                                 "run-as-user" "on-the-fly-ru"}}
+                                      :kv-store kv-store))))))
 
     (testing "override token metadata from headers"
       (is (= {"cmd" "token-cmd"
@@ -1987,6 +2016,10 @@
   (is (token-authentication-disabled? {"authentication" "disabled", "cpus" 1, "mem" 1, "cmd" "default-cmd", "version" "default-version", "permitted-user" "*", "run-as-user" "ru"})))
 
 (deftest test-no-intersection-in-token-request-scope-and-service-description-and-metadata
+  (is (empty? (set/intersection service-override-keys service-non-override-keys))
+      "We found common elements in service-override-keys and service-non-override-keys!")
+  (is (empty? (set/intersection service-parameter-keys service-metadata-keys))
+      "We found common elements in service-description-without-metadata-keys and service-metadata-keys!")
   (is (empty? (set/intersection system-metadata-keys user-metadata-keys))
       "We found common elements in system-metadata-keys and user-metadata-keys!")
   (is (empty? (set/intersection service-description-keys token-metadata-keys))

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -19,7 +19,6 @@
             [clojure.string :as str]
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
-            [plumbing.core :as pc]
             [schema.core :as s]
             [waiter.authorization :as authz]
             [waiter.kv :as kv]
@@ -398,7 +397,7 @@
                                       (str/includes? token "run") (assoc "run-as-user" "ruser"))
                               {}))
         build-source-tokens (fn [& tokens]
-                              (pc/map-from-keys #(-> % create-token-data token-data->token-hash) tokens))]
+                              (mapv (fn [token] (source-tokens-entry token (create-token-data token))) tokens))]
     (with-redefs [kv/fetch (fn [in-kv-store token]
                              (is (= kv-store in-kv-store))
                              (create-token-data token))]
@@ -897,7 +896,7 @@
                           :headers {}
                           :service-description-template (-> token-data
                                                             (select-keys service-parameter-keys)
-                                                            (assoc "source-tokens" {test-token (token-data->token-hash token-data)}))
+                                                            (assoc "source-tokens" [(source-tokens-entry test-token token-data)]))
                           :token->token-data {test-token token-data}
                           :token-authentication-disabled true
                           :token-preauthorized true
@@ -930,7 +929,7 @@
                           :headers {}
                           :service-description-template (-> token-data
                                                             (select-keys service-parameter-keys)
-                                                            (assoc "source-tokens" {test-token (token-data->token-hash token-data)}))
+                                                            (assoc "source-tokens" [(source-tokens-entry test-token token-data)]))
                           :token->token-data {test-token token-data}
                           :token-authentication-disabled false
                           :token-preauthorized true

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -56,7 +56,7 @@
                         make-peer-requests-fn validate-service-description-fn request))
 
 (deftest test-handle-token-request
-  (with-redefs [sd/service-description->service-id (fn [prefix sd] (str prefix (hash (select-keys sd sd/service-description-keys))))]
+  (with-redefs [sd/service-description->service-id (fn [prefix sd] (str prefix (hash (select-keys sd sd/service-parameter-keys))))]
     (let [kv-store (kv/->LocalKeyValueStore (atom {}))
           service-id-prefix "test#"
           entitlement-manager (authz/->SimpleEntitlementManager nil)
@@ -296,7 +296,9 @@
           (is (= 200 status))
           (is (= (get headers "etag") (sd/token-data->token-hash (kv/fetch kv-store token))))
           (is (str/includes? body (str "Successfully created " token)))
-          (is (= (select-keys service-description-1 sd/token-data-keys)
+          (is (= (-> service-description-1
+                     (assoc "source-tokens" [token])
+                     (select-keys sd/token-data-keys))
                  (sd/token->service-description-template kv-store token)))
           (let [{:keys [service-description-template token-metadata]} (sd/token->token-description kv-store token)]
             (is (= (dissoc service-description-1 "token") service-description-template))
@@ -333,7 +335,9 @@
                  :request-method :post})]
           (is (= 200 status))
           (is (str/includes? body (str "Successfully created " token)))
-          (is (= (select-keys service-description-1 sd/token-data-keys)
+          (is (= (-> service-description-1
+                     (assoc "source-tokens" [token])
+                     (select-keys sd/token-data-keys))
                  (sd/token->service-description-template kv-store token)))
           (let [{:keys [service-description-template token-metadata]} (sd/token->token-description kv-store token)]
             (is (= (dissoc service-description-1 "token") service-description-template))
@@ -355,7 +359,7 @@
           (is (= 200 status))
           (is (= "application/json" (get headers "content-type")))
           (is (not (str/includes? body "last-update-time")))
-          (doseq [key (keys (apply dissoc (select-keys service-description-1 sd/service-description-keys) json-keys))]
+          (doseq [key (keys (apply dissoc (select-keys service-description-1 sd/service-parameter-keys) json-keys))]
             (is (str/includes? body (str (get service-description-1 key)))))
           (doseq [key json-keys]
             (is (str/includes? body (json/write-str (get service-description-1 key)))))))
@@ -371,7 +375,7 @@
           (is (= 200 status))
           (is (= "application/json" (get headers "content-type")))
           (is (not (str/includes? body "last-update-time")))
-          (doseq [key (keys (apply dissoc (select-keys service-description-1 sd/service-description-keys) json-keys))]
+          (doseq [key (keys (apply dissoc (select-keys service-description-1 sd/service-parameter-keys) json-keys))]
             (is (str/includes? body (str (get service-description-1 key)))))
           (doseq [key json-keys]
             (is (str/includes? body (json/write-str (get service-description-1 key)))))))
@@ -387,7 +391,9 @@
                  :request-method :post})]
           (is (= 200 status))
           (is (str/includes? body (str "Successfully updated " token)))
-          (is (= (select-keys service-description-2 sd/token-data-keys)
+          (is (= (-> service-description-2
+                     (assoc "source-tokens" [token])
+                     (select-keys sd/token-data-keys))
                  (sd/token->service-description-template kv-store token)))
           (let [{:keys [service-description-template token-metadata]} (sd/token->token-description kv-store token)]
             (is (= (dissoc service-description-2 "token") service-description-template))
@@ -411,7 +417,9 @@
                  :request-method :post})]
           (is (= 200 status))
           (is (str/includes? body (str "Successfully updated " token)))
-          (is (= (select-keys service-description-2 sd/token-data-keys)
+          (is (= (-> service-description-2
+                     (assoc "source-tokens" [token])
+                     (select-keys sd/token-data-keys))
                  (sd/token->service-description-template kv-store token)))
           (let [{:keys [service-description-template token-metadata]} (sd/token->token-description kv-store token)]
             (is (= (dissoc service-description-2 "token") service-description-template))
@@ -436,7 +444,9 @@
           (is (= 200 status))
           (is (= "application/json" (get headers "content-type")))
           (is (str/includes? body (str "Successfully updated " token)))
-          (is (= (select-keys service-description-2 sd/token-data-keys)
+          (is (= (-> service-description-2
+                     (assoc "source-tokens" [token])
+                     (select-keys sd/token-data-keys))
                  (sd/token->service-description-template kv-store token)))
           (let [{:keys [service-description-template token-metadata]} (sd/token->token-description kv-store token)]
             (is (= (dissoc service-description-2 "token") service-description-template))
@@ -460,7 +470,7 @@
           (is (= "application/json" (get headers "content-type")))
           (is (-> body json/read-str (get "last-update-time") du/str-to-date))
           (let [body-map (-> body str json/read-str)]
-            (doseq [key sd/service-description-keys]
+            (doseq [key sd/service-parameter-keys]
               (is (= (get service-description-2 key) (get body-map key))))
             (doseq [key (disj sd/system-metadata-keys "deleted")]
               (is (contains? body-map key) (str "Missing entry for " key)))
@@ -479,7 +489,7 @@
           (is (= "application/json" (get headers "content-type")))
           (is (not (str/includes? body "last-update-time")))
           (let [body-map (-> body str json/read-str)]
-            (doseq [key sd/service-description-keys]
+            (doseq [key sd/service-parameter-keys]
               (is (= (get service-description-2 key) (get body-map key))))
             (doseq [key sd/token-metadata-keys]
               (is (not (contains? body-map key)))))))
@@ -495,7 +505,7 @@
           (is (= "application/json" (get headers "content-type")))
           (is (-> body json/read-str (get "last-update-time") du/str-to-date))
           (let [body-map (-> body str json/read-str)]
-            (doseq [key sd/service-description-keys]
+            (doseq [key sd/service-parameter-keys]
               (is (= (get service-description-2 key) (get body-map key))))
             (doseq [key (disj sd/system-metadata-keys "deleted")]
               (is (contains? body-map key) (str "Missing entry for " key)))
@@ -513,7 +523,7 @@
           (is (= "application/json" (get headers "content-type")))
           (is (not (str/includes? body "last-update-time")))
           (let [body-map (-> body str json/read-str)]
-            (doseq [key sd/service-description-keys]
+            (doseq [key sd/service-parameter-keys]
               (is (= (get service-description-2 key) (get body-map key))))
             (doseq [key sd/token-metadata-keys]
               (is (not (contains? body-map key)))))))
@@ -613,7 +623,7 @@
                  :request-method :post})]
           (is (= 200 status))
           (is (str/includes? body (str "Successfully created " token)))
-          (is (= (-> service-description (select-keys sd/service-description-keys) sd/transform-allowed-params-token-entry)
+          (is (= (-> service-description (select-keys sd/service-parameter-keys) sd/transform-allowed-params-token-entry)
                  (-> body json/read-str (get "service-description") sd/transform-allowed-params-token-entry)))
           (is (= (-> service-description
                      sd/transform-allowed-params-token-entry
@@ -645,7 +655,7 @@
                  :request-method :post})]
           (is (= 200 status))
           (is (str/includes? body (str "Successfully updated " token)))
-          (is (= (-> service-description-2 (select-keys sd/service-description-keys) sd/transform-allowed-params-token-entry)
+          (is (= (-> service-description-2 (select-keys sd/service-parameter-keys) sd/transform-allowed-params-token-entry)
                  (-> body json/read-str (get "service-description") sd/transform-allowed-params-token-entry)))
           (is (= (-> service-description-2
                      sd/transform-allowed-params-token-entry
@@ -794,7 +804,7 @@
                      (kv/fetch kv-store token))))))))))
 
 (deftest test-post-failure-in-handle-token-request
-  (with-redefs [sd/service-description->service-id (fn [prefix sd] (str prefix (hash (select-keys sd sd/service-description-keys))))]
+  (with-redefs [sd/service-description->service-id (fn [prefix sd] (str prefix (hash (select-keys sd sd/service-parameter-keys))))]
     (let [entitlement-manager (authz/->SimpleEntitlementManager nil)
           make-peer-requests-fn (fn [endpoint & _]
                                   (and (str/starts-with? endpoint "token/")
@@ -1308,7 +1318,7 @@
     (testing "basic creation"
       (store-service-description-for-token synchronize-fn kv-store history-length token service-description-1 token-metadata-1)
       (let [token-description (kv/fetch kv-store token)]
-        (is (= service-description-1 (select-keys token-description sd/service-description-keys)))
+        (is (= service-description-1 (select-keys token-description sd/service-parameter-keys)))
         (is (= token-metadata-1 (select-keys token-description sd/token-metadata-keys)))
         (is (= (merge service-description-1 token-metadata-1) token-description))))
 
@@ -1321,7 +1331,7 @@
           (store-service-description-for-token synchronize-fn kv-store history-length token service-description-2 token-metadata-2
                                                :version-hash token-hash)
           (let [token-description (kv/fetch kv-store token)]
-            (is (= service-description-2 (select-keys token-description sd/service-description-keys)))
+            (is (= service-description-2 (select-keys token-description sd/service-parameter-keys)))
             (is (= token-metadata-2 (select-keys token-description sd/token-metadata-keys)))
             (is (= (merge service-description-2 token-metadata-2) token-description)))))
 
@@ -1332,7 +1342,7 @@
                 (store-service-description-for-token synchronize-fn kv-store history-length token service-description-3 token-metadata-1
                                                      :version-hash (- last-update-time 1000))))
           (let [token-description (kv/fetch kv-store token)]
-            (is (= service-description-2 (select-keys token-description sd/service-description-keys)))
+            (is (= service-description-2 (select-keys token-description sd/service-parameter-keys)))
             (is (= token-metadata-2 (select-keys token-description sd/token-metadata-keys)))
             (is (= (merge service-description-2 token-metadata-2) token-description))))))))
 

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -296,12 +296,10 @@
           (is (= 200 status))
           (is (= (get headers "etag") (sd/token-data->token-hash (kv/fetch kv-store token))))
           (is (str/includes? body (str "Successfully created " token)))
-          (is (= (-> service-description-1
-                     (assoc "source-tokens" [token])
-                     (select-keys sd/token-data-keys))
-                 (sd/token->service-description-template kv-store token)))
-          (let [{:keys [service-description-template token-metadata]} (sd/token->token-description kv-store token)]
-            (is (= (dissoc service-description-1 "token") service-description-template))
+          (is (= (select-keys service-description-1 sd/token-data-keys)
+                 (sd/token->service-parameter-template kv-store token)))
+          (let [{:keys [service-parameter-template token-metadata]} (sd/token->token-description kv-store token)]
+            (is (= (dissoc service-description-1 "token") service-parameter-template))
             (is (= {"last-update-time" (clock-millis)
                     "last-update-user" "tu1"
                     "owner" "tu1"
@@ -335,12 +333,10 @@
                  :request-method :post})]
           (is (= 200 status))
           (is (str/includes? body (str "Successfully created " token)))
-          (is (= (-> service-description-1
-                     (assoc "source-tokens" [token])
-                     (select-keys sd/token-data-keys))
-                 (sd/token->service-description-template kv-store token)))
-          (let [{:keys [service-description-template token-metadata]} (sd/token->token-description kv-store token)]
-            (is (= (dissoc service-description-1 "token") service-description-template))
+          (is (= (select-keys service-description-1 sd/token-data-keys)
+                 (sd/token->service-parameter-template kv-store token)))
+          (let [{:keys [service-parameter-template token-metadata]} (sd/token->token-description kv-store token)]
+            (is (= (dissoc service-description-1 "token") service-parameter-template))
             (is (= {"last-update-time" (clock-millis)
                     "last-update-user" "tu1"
                     "owner" "tu2"
@@ -391,12 +387,10 @@
                  :request-method :post})]
           (is (= 200 status))
           (is (str/includes? body (str "Successfully updated " token)))
-          (is (= (-> service-description-2
-                     (assoc "source-tokens" [token])
-                     (select-keys sd/token-data-keys))
-                 (sd/token->service-description-template kv-store token)))
-          (let [{:keys [service-description-template token-metadata]} (sd/token->token-description kv-store token)]
-            (is (= (dissoc service-description-2 "token") service-description-template))
+          (is (= (select-keys service-description-2 sd/token-data-keys)
+                 (sd/token->service-parameter-template kv-store token)))
+          (let [{:keys [service-parameter-template token-metadata]} (sd/token->token-description kv-store token)]
+            (is (= (dissoc service-description-2 "token") service-parameter-template))
             (is (= {"last-update-time" (clock-millis)
                     "last-update-user" "tu1"
                     "owner" "tu1"
@@ -417,12 +411,10 @@
                  :request-method :post})]
           (is (= 200 status))
           (is (str/includes? body (str "Successfully updated " token)))
-          (is (= (-> service-description-2
-                     (assoc "source-tokens" [token])
-                     (select-keys sd/token-data-keys))
-                 (sd/token->service-description-template kv-store token)))
-          (let [{:keys [service-description-template token-metadata]} (sd/token->token-description kv-store token)]
-            (is (= (dissoc service-description-2 "token") service-description-template))
+          (is (= (select-keys service-description-2 sd/token-data-keys)
+                 (sd/token->service-parameter-template kv-store token)))
+          (let [{:keys [service-parameter-template token-metadata]} (sd/token->token-description kv-store token)]
+            (is (= (dissoc service-description-2 "token") service-parameter-template))
             (is (= {"last-update-time" (clock-millis)
                     "last-update-user" "tu1"
                     "owner" "tu2"
@@ -444,12 +436,10 @@
           (is (= 200 status))
           (is (= "application/json" (get headers "content-type")))
           (is (str/includes? body (str "Successfully updated " token)))
-          (is (= (-> service-description-2
-                     (assoc "source-tokens" [token])
-                     (select-keys sd/token-data-keys))
-                 (sd/token->service-description-template kv-store token)))
-          (let [{:keys [service-description-template token-metadata]} (sd/token->token-description kv-store token)]
-            (is (= (dissoc service-description-2 "token") service-description-template))
+          (is (= (select-keys service-description-2 sd/token-data-keys)
+                 (sd/token->service-parameter-template kv-store token)))
+          (let [{:keys [service-parameter-template token-metadata]} (sd/token->token-description kv-store token)]
+            (is (= (dissoc service-description-2 "token") service-parameter-template))
             (is (= {"last-update-time" (clock-millis)
                     "last-update-user" "tu1"
                     "owner" "tu2"


### PR DESCRIPTION
## Changes proposed in this PR

We are adding support for the tokens (and their versions) used to create a service description in this PR. The field is stored as the `source-tokens` metadata field in the service description. While computing the service description, we auto-populate this new metadata field. The metadata field also needs to be populated during the waiter consent workflow.

<img width="562" alt="source-tokens" src="https://user-images.githubusercontent.com/6611249/40184979-2a9b1386-59b7-11e8-9a8a-a8d58f0828d0.png">

As a result, we now have a distinction between service parameters and service description (includes service parameters and service metadata). This distinction also carries forward to tokens which only specify service parameter values.

### Summary of changes
- introduces `service-parameter-keys`, `service-non-override-keys` and `service-metadata-keys`
- distinguishes between token `service-description-template` and `service-parameter-template`

**Note**: A result of these changes is the refactoring to rename `service-description-keys` to `service-parameter-keys` and (in the context of tokens) `service-description-template` to `service-parameter-template`. Let me know if you prefer these renames to be provided in two separate PRs to minify the diff of this PR.

## Why are we making these changes?

Our long-term goal is to be able to GC outdated services quicker. This PR enables that feature by providing the token information used to create a service. As a result of this change, on-the-fly services with the same service parameters as a tokenized service will be treated as two different services.
