### PR TITLE
refactors store-service-description-fn to accept the descriptor as the parameter

### DIFF
--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -218,7 +218,7 @@
     (let [{:keys [service-id core-service-description]} descriptor]
       (when (not= core-service-description (sd/fetch-core kv-store service-id))
         ; eagerly store the service description for this service-id
-        (store-service-description-fn service-id core-service-description))
+        (store-service-description-fn descriptor))
       {:body service-id
        :status 200})
     (catch Exception ex


### PR DESCRIPTION
## Changes proposed in this PR

- refactors store-service-description-fn to accept the descriptor as the parameter

## Why are we making these changes?

Simplifies the invocation of `store-service-description-fn`
