### PR TITLE
WIP: extends can-run-as support for permitted-user checks

### DIFF
--- a/waiter/src/waiter/authorization.clj
+++ b/waiter/src/waiter/authorization.clj
@@ -61,3 +61,9 @@
   [entitlement-manager auth-user run-as-user]
   (and auth-user run-as-user
        (authorized? entitlement-manager auth-user :run-as {:resource-type :credential, :user run-as-user})))
+
+(defn member-of?
+  "Helper function that checks the whether the auth-user is a member of the provided group."
+  [entitlement-manager auth-user group]
+  (and auth-user group
+       (authorized? entitlement-manager auth-user :member-of {:resource-type :group, :user group})))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -712,6 +712,9 @@
                                                    (make-request-sync http-client initial-socket-timeout-ms method endpoint-url auth body config))]
                                            (fn make-inter-router-requests-sync-fn [endpoint & args]
                                              (apply make-inter-router-requests make-request-sync-fn make-basic-auth-fn router-id discovery passwords endpoint args))))
+   :member-of?-fn (pc/fnk [[:state entitlement-manager]]
+                    (fn member-of [auth-user user-group]
+                      (authz/member-of? entitlement-manager auth-user user-group)))
    :peers-acknowledged-blacklist-requests-fn (pc/fnk [[:curator discovery]
                                                       [:state router-id]
                                                       make-inter-router-requests-sync-fn]
@@ -739,10 +742,10 @@
    :request->descriptor-fn (pc/fnk [[:curator kv-store]
                                     [:settings [:token-config history-length token-defaults] metric-group-mappings service-description-defaults]
                                     [:state fallback-state-atom service-description-builder service-id-prefix waiter-hostnames]
-                                    assoc-run-as-user-approved? can-run-as?-fn]
+                                    assoc-run-as-user-approved? can-run-as?-fn member-of?-fn]
                              (fn request->descriptor-fn [request]
                                (descriptor/request->descriptor
-                                 assoc-run-as-user-approved? can-run-as?-fn fallback-state-atom kv-store metric-group-mappings
+                                 assoc-run-as-user-approved? can-run-as?-fn member-of?-fn fallback-state-atom kv-store metric-group-mappings
                                  history-length service-description-builder service-description-defaults service-id-prefix
                                  token-defaults waiter-hostnames request)))
    :router-metrics-helpers (pc/fnk [[:state passwords router-metrics-agent]]

--- a/waiter/test/waiter/authorization_test.clj
+++ b/waiter/test/waiter/authorization_test.clj
@@ -89,3 +89,15 @@
                                resource)))
         entitlement-manager (TestEntitlementManager. assertion-fn)]
     (is (authz/run-as? entitlement-manager test-user-1 test-user-2))))
+
+(deftest test-member-of?
+  (let [test-user "test-user-1"
+        test-group "test-group-2"
+        assertion-fn (fn [[subject action resource]]
+                       (and (= test-user subject)
+                            (= :member-of action)
+                            (= {:resource-type :group
+                                :user test-group}
+                               resource)))
+        entitlement-manager (TestEntitlementManager. assertion-fn)]
+    (is (authz/member-of? entitlement-manager test-user test-group))))


### PR DESCRIPTION
## Changes proposed in this PR

- extends can-run-as support for permitted-user checks

## Why are we making these changes?

Makes the permitted-user check equivalent to run-as-user checks by using the `can-run-as` support for the entitlement manager.
