### PR TITLE
assigns a non-'other' metric group to a service (when possible)

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -134,6 +134,9 @@
           (let [response (make-request 24000)]
             (assert-response-status response 200))))
 
+      (testing "metric group should be waiter_kitchen"
+        (is (= "waiter_kitchen" (service-id->metric-group waiter-url service-id))))
+
       (delete-service waiter-url service-id))))
 
 (deftest ^:parallel ^:integration-fast test-basic-logs
@@ -187,6 +190,10 @@
           service-settings (service-settings waiter-url service-id)
           command (get-in service-settings [:service-description :cmd])]
       (is (= (:x-waiter-cmd headers) command))
+
+      (testing "metric group should be other"
+        (is (= "other" (service-id->metric-group waiter-url service-id))))
+
       (delete-service waiter-url service-id))))
 
 (deftest ^:parallel ^:integration-fast test-basic-unsupported-command-type

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -788,6 +788,12 @@
     :interval interval
     :timeout timeout))
 
+(defn service-id->metric-group
+  "Retrieves the metric-group corresponding to the provided service-id"
+  [waiter-url service-id]
+  (-> (service waiter-url service-id {"effective-parameters" "true"})
+      (get-in ["effective-parameters" "metric-group"])))
+
 (defn retrieve-debug-response-headers
   [waiter-url]
   (let [settings (waiter-settings waiter-url)

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -1917,6 +1917,16 @@
       (testing "should use mapping when metric group not specified"
         (is (= "mapped" (mg-filter {"name" "foo"}))))
 
+      (testing "should use source-tokens when single token specified"
+        (is (= "example-1" (mg-filter {"cpus" 1 "source-tokens" [{"token" "example-1.app.com" "version" "hash-1"}]}))))
+
+      (testing "should use other when token in source-tokens does not validate"
+        (is (= "other" (mg-filter {"cpus" 1 "source-tokens" [{"token" "example-1@app.com" "version" "hash-1"}]}))))
+
+      (testing "should use other when source-tokens has multiple tokens"
+        (is (= "other" (mg-filter {"cpus" 1 "source-tokens" [{"token" "example-1.app.com" "version" "hash-1"}
+                                                             {"token" "example-2.app.com" "version" "hash-2"}]}))))
+
       (testing "should use 'other' when metric group not specified and name not mapped"
         (is (= "other" (mg-filter {})))))))
 


### PR DESCRIPTION
## Changes proposed in this PR

- assigns a non-'other' metric group to a service using the token name

## Why are we making these changes?

We would like to more accurately identify the different services running on Waiter without defaulting them to `other`. With this PR we are going to use the first part of the token before a dot character as the default metric group name when it exists and satisfies the metric group schema.

