### PR TITLE
Use Two Sigma OSS copyright header

### DIFF
--- a/kitchen/project.clj
+++ b/kitchen/project.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (defproject kitchen "0.1.0-SNAPSHOT"
   :dependencies [^{:voom {:repo "https://github.com/twosigma/jet.git" :branch "waiter-patch"}}

--- a/kitchen/src/kitchen/core.clj
+++ b/kitchen/src/kitchen/core.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns kitchen.core
   (:require [clj-time.core :as t]

--- a/kitchen/src/kitchen/pi.clj
+++ b/kitchen/src/kitchen/pi.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns kitchen.pi
   (:import (java.util.concurrent ThreadLocalRandom)))

--- a/kitchen/src/kitchen/utils.clj
+++ b/kitchen/src/kitchen/utils.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns kitchen.utils
   ; Despite not being explicitly used, the clojure.core.async

--- a/kitchen/test/kitchen/core_test.clj
+++ b/kitchen/test/kitchen/core_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns kitchen.core-test
   (:require [clojure.core.async :as async]

--- a/kitchen/test/kitchen/pi_test.clj
+++ b/kitchen/test/kitchen/pi_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns kitchen.pi-test
   (:require [clojure.test :refer :all]

--- a/kitchen/test/kitchen/utils_test.clj
+++ b/kitchen/test/kitchen/utils_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns kitchen.utils-test
   (:require [clojure.data.json :as json]

--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns token-syncer.basic-test
   (:require [clojure.string :as str]

--- a/token-syncer/project.clj
+++ b/token-syncer/project.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (defproject token-syncer "0.1.0-SNAPSHOT"
   :dependencies [^{:voom {:repo "https://github.com/twosigma/jet.git" :branch "waiter-patch"}}

--- a/token-syncer/src/token_syncer/cli.clj
+++ b/token-syncer/src/token_syncer/cli.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2018 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns token-syncer.cli
   (:require [clojure.tools.cli :as tools-cli]

--- a/token-syncer/src/token_syncer/commands/backup.clj
+++ b/token-syncer/src/token_syncer/commands/backup.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2018 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns token-syncer.commands.backup
   (:require [clojure.data.json :as json]

--- a/token-syncer/src/token_syncer/commands/syncer.clj
+++ b/token-syncer/src/token_syncer/commands/syncer.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns token-syncer.commands.syncer
   (:require [clojure.pprint :as pp]

--- a/token-syncer/src/token_syncer/main.clj
+++ b/token-syncer/src/token_syncer/main.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns token-syncer.main
   (:require [clojure.string :as str]

--- a/token-syncer/src/token_syncer/spnego.clj
+++ b/token-syncer/src/token_syncer/spnego.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns token-syncer.spnego
   (:require [clojure.tools.logging :as log])

--- a/token-syncer/src/token_syncer/utils.clj
+++ b/token-syncer/src/token_syncer/utils.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns token-syncer.utils)
 

--- a/token-syncer/src/token_syncer/waiter.clj
+++ b/token-syncer/src/token_syncer/waiter.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns token-syncer.waiter
   (:require [clj-time.core :as t]

--- a/token-syncer/test/token_syncer/cli_test.clj
+++ b/token-syncer/test/token_syncer/cli_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2018 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns token-syncer.cli-test
   (:require [clojure.test :refer :all]

--- a/token-syncer/test/token_syncer/commands/backup_test.clj
+++ b/token-syncer/test/token_syncer/commands/backup_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2018 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns token-syncer.commands.backup-test
   (:require [clojure.test :refer :all]

--- a/token-syncer/test/token_syncer/commands/syncer_test.clj
+++ b/token-syncer/test/token_syncer/commands/syncer_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns token-syncer.commands.syncer-test
   (:require [clojure.set :as set]

--- a/token-syncer/test/token_syncer/main_test.clj
+++ b/token-syncer/test/token_syncer/main_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns token-syncer.main-test
   (:require [clojure.test :refer :all]

--- a/token-syncer/test/token_syncer/waiter_test.clj
+++ b/token-syncer/test/token_syncer/waiter_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns token-syncer.waiter-test
   (:require [clojure.core.async :as async]

--- a/waiter/integration/waiter/async_request_integration_test.clj
+++ b/waiter/integration/waiter/async_request_integration_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.async-request-integration-test
   (:require [clojure.string :as str]

--- a/waiter/integration/waiter/autoscaling_test.clj
+++ b/waiter/integration/waiter/autoscaling_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.autoscaling-test
   (:require [clj-time.core :as t]

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.basic-test
   (:require [clj-time.core :as t]

--- a/waiter/integration/waiter/busy_instance_test.clj
+++ b/waiter/integration/waiter/busy_instance_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.busy-instance-test
   (:require [clojure.string :as str]

--- a/waiter/integration/waiter/cookie_support_integration_test.clj
+++ b/waiter/integration/waiter/cookie_support_integration_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.cookie-support-integration-test
   (:require [clojure.data.json :as json]

--- a/waiter/integration/waiter/deployment_errors_test.clj
+++ b/waiter/integration/waiter/deployment_errors_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) Two Sigma Investments, LLC.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LLC.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.deployment-errors-test
   (:require [clojure.pprint :as pprint]

--- a/waiter/integration/waiter/instance_reservation_test.clj
+++ b/waiter/integration/waiter/instance_reservation_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.instance-reservation-test
   (:require [clj-time.core :as t]

--- a/waiter/integration/waiter/killed_instance_test.clj
+++ b/waiter/integration/waiter/killed_instance_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.killed-instance-test
   (:require [clojure.core.async :as async]

--- a/waiter/integration/waiter/latency_test.clj
+++ b/waiter/integration/waiter/latency_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.latency-test
   (:require [clojure.java.shell :as shell]

--- a/waiter/integration/waiter/metrics_output_test.clj
+++ b/waiter/integration/waiter/metrics_output_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.metrics-output-test
   (:require [clojure.data.json :as json]

--- a/waiter/integration/waiter/new_app_test.clj
+++ b/waiter/integration/waiter/new_app_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.new-app-test
   (:require [clojure.test :refer :all]

--- a/waiter/integration/waiter/request_method_test.clj
+++ b/waiter/integration/waiter/request_method_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.request-method-test
   (:require [clojure.test :refer :all]

--- a/waiter/integration/waiter/request_timeout_test.clj
+++ b/waiter/integration/waiter/request_timeout_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.request-timeout-test
   (:require [clj-time.core :as time]

--- a/waiter/integration/waiter/response_headers_test.clj
+++ b/waiter/integration/waiter/response_headers_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.response-headers-test
   (:require [clojure.string :as str]

--- a/waiter/integration/waiter/statsd_support_test.clj
+++ b/waiter/integration/waiter/statsd_support_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.statsd-support-test
   (:require [clojure.test :refer :all]

--- a/waiter/integration/waiter/streaming_test.clj
+++ b/waiter/integration/waiter/streaming_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.streaming-test
   (:require [clojure.test :refer :all]

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.token-request-test
   (:require [clj-time.core :as t]

--- a/waiter/integration/waiter/websocket_integration_test.clj
+++ b/waiter/integration/waiter/websocket_integration_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.websocket-integration-test
   (:require [clj-time.core :as t]

--- a/waiter/integration/waiter/work_stealing_integration_test.clj
+++ b/waiter/integration/waiter/work_stealing_integration_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.work-stealing-integration-test
   (:require [clojure.test :refer :all]

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (defproject waiter "0.1.0-SNAPSHOT"
   :test-paths ["test" "integration"]

--- a/waiter/src/waiter/async_request.clj
+++ b/waiter/src/waiter/async_request.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.async-request
   (:require [clojure.core.async :as async]

--- a/waiter/src/waiter/auth/authentication.clj
+++ b/waiter/src/waiter/auth/authentication.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.auth.authentication
   (:require [clj-time.core :as t]

--- a/waiter/src/waiter/auth/kerberos.clj
+++ b/waiter/src/waiter/auth/kerberos.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.auth.kerberos
   (:require [clj-time.core :as t]

--- a/waiter/src/waiter/auth/spnego.clj
+++ b/waiter/src/waiter/auth/spnego.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.auth.spnego
   (:require [clojure.core.async :as async]

--- a/waiter/src/waiter/authorization.clj
+++ b/waiter/src/waiter/authorization.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.authorization)
 

--- a/waiter/src/waiter/cookie_support.clj
+++ b/waiter/src/waiter/cookie_support.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.cookie-support
   (:require [clj-time.core :as t]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.core
   (:require [bidi.bidi :as bidi]

--- a/waiter/src/waiter/correlation_id.clj
+++ b/waiter/src/waiter/correlation_id.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.correlation-id
   (:require [clojure.tools.logging :as log]

--- a/waiter/src/waiter/cors.clj
+++ b/waiter/src/waiter/cors.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.cors
   (:require [clojure.core.async :as async]

--- a/waiter/src/waiter/curator.clj
+++ b/waiter/src/waiter/curator.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.curator
   (:require [clojure.tools.logging :as log]

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.descriptor
   (:require [clj-time.core :as t]

--- a/waiter/src/waiter/discovery.clj
+++ b/waiter/src/waiter/discovery.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.discovery
   (:require [clojure.tools.logging :as log])

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -1,14 +1,18 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
 ;;
-;; This namespace will act as an asylum for floating handlers.
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
 (ns waiter.handler
   (:require [clj-time.core :as t]
             [clojure.core.async :as async]

--- a/waiter/src/waiter/headers.clj
+++ b/waiter/src/waiter/headers.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.headers
   (:require [cheshire.core :as json]

--- a/waiter/src/waiter/interstitial.clj
+++ b/waiter/src/waiter/interstitial.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.interstitial
   (:require [clj-time.coerce :as ct]

--- a/waiter/src/waiter/kv.clj
+++ b/waiter/src/waiter/kv.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.kv
   (:require [clj-time.core :as t]

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.main
   (:require [clj-time.core :as t]

--- a/waiter/src/waiter/mesos/marathon.clj
+++ b/waiter/src/waiter/mesos/marathon.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.mesos.marathon
   (:require [clojure.data.json :as json]

--- a/waiter/src/waiter/mesos/mesos.clj
+++ b/waiter/src/waiter/mesos/mesos.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.mesos.mesos
   (:require [waiter.util.http-utils :as http-utils])

--- a/waiter/src/waiter/metrics.clj
+++ b/waiter/src/waiter/metrics.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.metrics
   (:require [clj-time.core :as t]

--- a/waiter/src/waiter/metrics_sync.clj
+++ b/waiter/src/waiter/metrics_sync.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.metrics-sync
   (:require [clj-time.core :as t]

--- a/waiter/src/waiter/middleware.clj
+++ b/waiter/src/waiter/middleware.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2018 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.middleware
   (:require [clojure.core.async :as async]

--- a/waiter/src/waiter/password_store.clj
+++ b/waiter/src/waiter/password_store.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.password-store
   (:require [clojure.tools.logging :as log]))

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.process-request
   (:require [clojure.core.async :as async]

--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2018 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.request-log
   (:require [clojure.data.json :as json]

--- a/waiter/src/waiter/scaling.clj
+++ b/waiter/src/waiter/scaling.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.scaling
   (:require [clj-time.core :as t]

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.scheduler
   (:require [clj-time.core :as t]

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.scheduler.marathon
   (:require [clj-time.core :as t]

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.scheduler.shell
   (:require [clj-time.core :as t]

--- a/waiter/src/waiter/schema.clj
+++ b/waiter/src/waiter/schema.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.schema
   (:require [clojure.string :as str]

--- a/waiter/src/waiter/service.clj
+++ b/waiter/src/waiter/service.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.service
   (:require [clj-time.core :as t]

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.service-description
   (:require [clj-time.core :as t]

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.settings
   (:require [clj-time.core :as t]

--- a/waiter/src/waiter/simulator.clj
+++ b/waiter/src/waiter/simulator.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.simulator
   (:require [clojure.data.json :as json]

--- a/waiter/src/waiter/state.clj
+++ b/waiter/src/waiter/state.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.state
   (:require [clj-time.coerce :as tc]

--- a/waiter/src/waiter/statsd.clj
+++ b/waiter/src/waiter/statsd.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.statsd
   (:require [clj-time.core :as t]

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.token
   (:require [clojure.data.json :as json]

--- a/waiter/src/waiter/util/async_utils.clj
+++ b/waiter/src/waiter/util/async_utils.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.util.async-utils
   (:require [clojure.core.async :as async]

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.util.client-tools
   (:require [clj-time.core :as t]

--- a/waiter/src/waiter/util/date_utils.clj
+++ b/waiter/src/waiter/util/date_utils.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2018 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.util.date-utils
   (:require [chime :as chime]

--- a/waiter/src/waiter/util/http_utils.clj
+++ b/waiter/src/waiter/util/http_utils.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.util.http-utils
   (:require [clojure.core.async :as async]

--- a/waiter/src/waiter/util/ring_utils.clj
+++ b/waiter/src/waiter/util/ring_utils.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2018 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.util.ring-utils
   (:require [clojure.core.async :as async]

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.util.utils
   (:require [clojure.core.cache :as cache]

--- a/waiter/src/waiter/websocket.clj
+++ b/waiter/src/waiter/websocket.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.websocket
   (:require [clj-time.core :as t]

--- a/waiter/src/waiter/work_stealing.clj
+++ b/waiter/src/waiter/work_stealing.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.work-stealing
   (:require [clj-time.core :as t]

--- a/waiter/test-files/test-bar.edn
+++ b/waiter/test-files/test-bar.edn
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 {:bar1 "one.${system.user.name}"
  :bar2 2

--- a/waiter/test-files/test-foo.edn
+++ b/waiter/test-files/test-foo.edn
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 {:foo1 "one.${foo2}"
  :foo2 2

--- a/waiter/test/waiter/async_request_test.clj
+++ b/waiter/test/waiter/async_request_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.async-request-test
   (:require [clojure.core.async :as async]

--- a/waiter/test/waiter/auth/authenticator_test.clj
+++ b/waiter/test/waiter/auth/authenticator_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.auth.authenticator-test
   (:require [clj-time.core :as t]

--- a/waiter/test/waiter/auth/kerberos_test.clj
+++ b/waiter/test/waiter/auth/kerberos_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.auth.kerberos-test
   (:require [clojure.core.async :as async]

--- a/waiter/test/waiter/auth/spnego_test.clj
+++ b/waiter/test/waiter/auth/spnego_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.auth.spnego-test
   (:require [clj-time.core :as t]

--- a/waiter/test/waiter/authorization_test.clj
+++ b/waiter/test/waiter/authorization_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.authorization-test
   (:require [clojure.test :refer :all]

--- a/waiter/test/waiter/cookie_support_test.clj
+++ b/waiter/test/waiter/cookie_support_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.cookie-support-test
   (:require [clojure.core.async :as async]

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.core-test
   (:require [clj-time.core :as t]

--- a/waiter/test/waiter/correlation_id_test.clj
+++ b/waiter/test/waiter/correlation_id_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.correlation-id-test
   (:require [clojure.string :as str]

--- a/waiter/test/waiter/cors_test.clj
+++ b/waiter/test/waiter/cors_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.cors-test
   (:require [clojure.test :refer :all]

--- a/waiter/test/waiter/curator_test.clj
+++ b/waiter/test/waiter/curator_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.curator-test
   (:require [clojure.core.async :as async]

--- a/waiter/test/waiter/descriptor_test.clj
+++ b/waiter/test/waiter/descriptor_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2018 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.descriptor-test
   (:require [clj-time.core :as t]

--- a/waiter/test/waiter/discovery_test.clj
+++ b/waiter/test/waiter/discovery_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.discovery-test
   (:require [clojure.test :refer :all]

--- a/waiter/test/waiter/dummy_test.clj
+++ b/waiter/test/waiter/dummy_test.clj
@@ -1,16 +1,18 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
 ;;
-;;;; This is a dummy test that exists only so that it can be run in the Jenkinsfile in order to force-load the
-;;;; dependencies that parallel-test requires in order to run.
-
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
 (ns waiter.dummy-test
   (:require [clojure.test :refer :all]))
 

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.handler-test
   (:require [clj-time.core :as t]

--- a/waiter/test/waiter/headers_test.clj
+++ b/waiter/test/waiter/headers_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.headers-test
   (:require [clojure.test :refer :all]

--- a/waiter/test/waiter/interstitial_test.clj
+++ b/waiter/test/waiter/interstitial_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2018 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.interstitial-test
   (:require [clj-time.coerce :as coerce]

--- a/waiter/test/waiter/kv_test.clj
+++ b/waiter/test/waiter/kv_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.kv-test
   (:require [clj-time.core :as t]

--- a/waiter/test/waiter/mesos/marathon_test.clj
+++ b/waiter/test/waiter/mesos/marathon_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.mesos.marathon-test
   (:require [clojure.string :as str]

--- a/waiter/test/waiter/mesos/mesos_test.clj
+++ b/waiter/test/waiter/mesos/mesos_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.mesos.mesos-test
   (:require [clojure.string :as str]

--- a/waiter/test/waiter/metrics_sync_test.clj
+++ b/waiter/test/waiter/metrics_sync_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.metrics-sync-test
   (:require [clj-time.core :as t]

--- a/waiter/test/waiter/metrics_test.clj
+++ b/waiter/test/waiter/metrics_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.metrics-test
   (:require [clj-time.core :as t]

--- a/waiter/test/waiter/middleware_test.clj
+++ b/waiter/test/waiter/middleware_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2018 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.middleware-test
   (:require [clojure.core.async :as async]

--- a/waiter/test/waiter/mocks.clj
+++ b/waiter/test/waiter/mocks.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.mocks
   (:require [clojure.core.async :as async]

--- a/waiter/test/waiter/password_store_test.clj
+++ b/waiter/test/waiter/password_store_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.password-store-test
   (:require [clojure.test :refer :all]

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.process-request-test
   (:require [clj-time.core :as t]

--- a/waiter/test/waiter/request_log_test.clj
+++ b/waiter/test/waiter/request_log_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.request-log-test
   (:require [clj-time.core :as t]

--- a/waiter/test/waiter/scaling_test.clj
+++ b/waiter/test/waiter/scaling_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.scaling-test
   (:require [clj-time.core :as t]

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.scheduler.marathon-test
   (:require [clj-time.core :as t]

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.scheduler.shell-test
   (:require [clj-time.core :as t]

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.scheduler-test
   (:require [clj-time.core :as t]

--- a/waiter/test/waiter/schema_test.clj
+++ b/waiter/test/waiter/schema_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.schema-test
   (:use [clojure.test])

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.service-description-test
   (:require [clj-time.core :as t]

--- a/waiter/test/waiter/service_test.clj
+++ b/waiter/test/waiter/service_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.service-test
   (:require [clojure.core.async :as async]

--- a/waiter/test/waiter/settings_test.clj
+++ b/waiter/test/waiter/settings_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.settings-test
   (:require [clojure.test :refer :all]

--- a/waiter/test/waiter/simulator_test.clj
+++ b/waiter/test/waiter/simulator_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.simulator-test
   (:require [clojure.test :refer :all]

--- a/waiter/test/waiter/state_service_responder_test.clj
+++ b/waiter/test/waiter/state_service_responder_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.state-service-responder-test
   (:require [clj-time.core :as t]

--- a/waiter/test/waiter/state_test.clj
+++ b/waiter/test/waiter/state_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.state-test
   (:require [clj-time.core :as t]

--- a/waiter/test/waiter/statsd_test.clj
+++ b/waiter/test/waiter/statsd_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.statsd-test
   (require [clojure.core.async :as async]

--- a/waiter/test/waiter/test_helpers.clj
+++ b/waiter/test/waiter/test_helpers.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.test-helpers
   (:require [clj-time.core :as t]

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.token-test
   (:require [clj-time.core :as t]

--- a/waiter/test/waiter/util/async_utils_test.clj
+++ b/waiter/test/waiter/util/async_utils_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.util.async-utils-test
   (:require [clojure.core.async :as async]

--- a/waiter/test/waiter/util/client_tools_test.clj
+++ b/waiter/test/waiter/util/client_tools_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.util.client-tools-test
   (:require [clojure.test :refer :all]

--- a/waiter/test/waiter/util/http_utils_test.clj
+++ b/waiter/test/waiter/util/http_utils_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.util.http-utils-test
   (:require [clojure.core.async :as async]

--- a/waiter/test/waiter/util/ring_utils_test.clj
+++ b/waiter/test/waiter/util/ring_utils_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2018 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.util.ring-utils-test
   (:require [clojure.core.async :as async]

--- a/waiter/test/waiter/util/utils_test.clj
+++ b/waiter/test/waiter/util/utils_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.util.utils-test
   (:require [clj-time.core :as t]

--- a/waiter/test/waiter/util/utils_test_ns.clj
+++ b/waiter/test/waiter/util/utils_test_ns.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.util.utils-test-ns)
 

--- a/waiter/test/waiter/websocket_test.clj
+++ b/waiter/test/waiter/websocket_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.websocket-test
   (:require [clojure.core.async :as async]

--- a/waiter/test/waiter/work_stealing_test.clj
+++ b/waiter/test/waiter/work_stealing_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.work-stealing-test
   (:require [clojure.core.async :as async]

--- a/waiter/test/waiter/zk_test.clj
+++ b/waiter/test/waiter/zk_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.zk-test
   (:import (org.apache.curator.test TestingServer)


### PR DESCRIPTION
## Changes proposed in this PR

Replace internal copyright header with the Two Sigma Open Source header.

## Why are we making these changes?

Seeing the words *THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE* at the top of each source file is a little bit concerning—and very inaccurate.