### PR TITLE
Scale down in the presence of pending deployments

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -249,6 +249,10 @@
                                ;; How long (milliseconds) to cache the framework id:
                                :framework-id-ttl 900000
 
+                               ;; Controls the rate at which any mismatch in task count and instances is
+                               ;; corrected by triggering new deployments
+                               :sync-deployment-interval-ms 60000
+
                                ;; The URL for your Marathon HTTP API:
                                :url "http://marathon.example.com:8080"}
 

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -253,11 +253,12 @@
                                ;; corrected by triggering new deployments
                                :sync-deployment {;; Specifies the intervals at which the syncer runs to
                                                  ;; check for mismatches in task and instance counts.
-                                                 :interval-ms 60000
+                                                 :interval-ms 15000
 
-                                                 ;; Specifies the timeout for which a service is in need of a
-                                                 ;; sync deployment before such a deployment is triggered.
-                                                 :timeout-ms 300000}
+                                                 ;; Specifies the number of cycles for which a service is
+                                                 ;; determined to be in need of a sync deployment before
+                                                 ;; such a deployment is actually triggered.
+                                                 :timeout-cycles 4}
 
                                ;; The URL for your Marathon HTTP API:
                                :url "http://marathon.example.com:8080"}

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -251,7 +251,13 @@
 
                                ;; Controls the rate at which any mismatch in task count and instances is
                                ;; corrected by triggering new deployments
-                               :sync-deployment-interval-ms 60000
+                               :sync-deployment {;; Specifies the intervals at which the syncer runs to
+                                                 ;; check for mismatches in task and instance counts.
+                                                 :interval-ms 60000
+
+                                                 ;; Specifies the timeout for which a service is in need of a
+                                                 ;; sync deployment before such a deployment is triggered.
+                                                 :timeout-ms 300000}
 
                                ;; The URL for your Marathon HTTP API:
                                :url "http://marathon.example.com:8080"}

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -606,12 +606,14 @@
                      latch))})
 
 (def scheduler
-  {:scheduler (pc/fnk [[:settings scheduler-config]
+  {:scheduler (pc/fnk [[:curator leader?-fn]
+                       [:settings scheduler-config]
                        [:state service-id-prefix]
                        service-id->service-description-fn*]
                 (let [is-waiter-app?-fn (fn is-waiter-app? [^String service-id]
                                           (str/starts-with? service-id service-id-prefix))]
                   (utils/create-component scheduler-config :context {:is-waiter-app?-fn is-waiter-app?-fn
+                                                                     :leader?-fn leader?-fn
                                                                      :service-id->service-description-fn service-id->service-description-fn*})))
    ; This function is only included here for initializing the scheduler above.
    ; Prefer accessing the non-starred version of this function through the routines map.

--- a/waiter/src/waiter/mesos/marathon.clj
+++ b/waiter/src/waiter/mesos/marathon.clj
@@ -60,9 +60,9 @@
 
 (defn get-apps
   "List all running apps including running and failed tasks."
-  [{:keys [http-client marathon-url spnego-auth]}]
+  [{:keys [http-client marathon-url spnego-auth]} query-params]
   (http-utils/http-request http-client (str marathon-url "/v2/apps")
-                           :query-string {"embed" ["apps.lastTaskFailure" "apps.tasks"]}
+                           :query-string query-params
                            :request-method :get
                            :spnego-auth spnego-auth))
 

--- a/waiter/src/waiter/mesos/marathon.clj
+++ b/waiter/src/waiter/mesos/marathon.clj
@@ -42,6 +42,15 @@
                            :request-method :delete
                            :spnego-auth spnego-auth))
 
+(defn delete-deployment
+  "Cancel the deployment with deployment-id.
+   No rollback deployment is created to revert the changes of deployment."
+  [{:keys [http-client marathon-url spnego-auth]} deployment-id]
+  (http-utils/http-request http-client (str marathon-url "/v2/deployments/" deployment-id)
+                           :query-string {"force" true}
+                           :request-method :delete
+                           :spnego-auth spnego-auth))
+
 (defn get-app
   "List the app specified by app-id."
   [{:keys [http-client marathon-url spnego-auth]} app-id]

--- a/waiter/src/waiter/scaling.clj
+++ b/waiter/src/waiter/scaling.clj
@@ -87,18 +87,20 @@
     {:executor-multiplexer-chan executor-multiplexer-chan
      :query-chan query-chan}))
 
-(defn- execute-scale-up-request
-  "Helper function to scale-up instances of a service."
-  [scheduler service-id scale-to-instances]
-  (try
-    (scheduler/suppress-transient-server-exceptions
-      "autoscaler"
-      (log/info "scaling service to" scale-to-instances "instances")
-      (scheduler/scale-app scheduler service-id scale-to-instances)
-      (counters/inc! (metrics/service-counter service-id "scaling" "scale-up" "success")))
-    (catch Exception e
-      (counters/inc! (metrics/service-counter service-id "scaling" "scale-up" "fail"))
-      (log/warn e "unexpected error when trying to scale" service-id "to" scale-to-instances "instances"))))
+(defn- execute-scale-service-request
+  "Helper function to scale instances of a service.
+   The force? flag can be used to detmerine whether we will make a best effort or a forced scale operation."
+  [scheduler service-id scale-to-instances force?]
+  (let [mode (if force? "scale-force" "scale-up")]
+    (try
+      (scheduler/suppress-transient-server-exceptions
+        "autoscaler"
+        (log/info mode "service to" scale-to-instances "instances")
+        (scheduler/scale-app scheduler service-id scale-to-instances force?)
+        (counters/inc! (metrics/service-counter service-id "scaling" mode "success")))
+      (catch Exception e
+        (counters/inc! (metrics/service-counter service-id "scaling" mode "fail"))
+        (log/warn e "unexpected error when trying to scale" service-id "to" scale-to-instances "instances")))))
 
 (defn- execute-scale-down-request
   "Helper function to scale-down instances of a service.
@@ -227,7 +229,7 @@
                             (do
                               (log/info "allowing previous scale operation to complete before scaling up again")
                               (counters/inc! (metrics/service-counter service-id "scaling" "scale-up" "ignore")))
-                            (execute-scale-up-request scheduler service-id scale-to-instances))
+                            (execute-scale-service-request scheduler service-id scale-to-instances false))
                           executor-state)
 
                         (pos? num-instances-to-kill)
@@ -243,9 +245,21 @@
                               (assoc executor-state :last-scale-down-time (t/now))
                               executor-state)
                             (do
-                              (log/debug "skipping scale-down as" inter-kill-request-wait-time-ms "ms has not elapsed since last scale down operation")
+                              (log/debug "skipping scale-down as" inter-kill-request-wait-time-ms
+                                         "ms has not elapsed since last scale down operation")
                               (counters/inc! (metrics/service-counter service-id "scaling" "scale-down" "ignore"))
                               executor-state)))
+
+                        (and scale-to-instances
+                             task-count
+                             (neg? scale-amount)
+                             (neg? (- task-count scale-to-instances)))
+                        (do
+                          (log/info "potential overshoot detected, triggering scale-force for service"
+                                    {:scale-to-instances scale-to-instances :task-count task-count})
+                          (counters/inc! (metrics/service-counter service-id "scaling" "scale-force" "total"))
+                          (execute-scale-service-request scheduler service-id scale-to-instances true)
+                          executor-state)
 
                         :else
                         (do

--- a/waiter/src/waiter/scaling.clj
+++ b/waiter/src/waiter/scaling.clj
@@ -250,10 +250,7 @@
                               (counters/inc! (metrics/service-counter service-id "scaling" "scale-down" "ignore"))
                               executor-state)))
 
-                        (and scale-to-instances
-                             task-count
-                             (neg? scale-amount)
-                             (neg? (- task-count scale-to-instances)))
+                        (and (neg? scale-amount) (< task-count scale-to-instances))
                         (do
                           (log/info "potential overshoot detected, triggering scale-force for service"
                                     {:scale-to-instances scale-to-instances :task-count task-count})

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -100,9 +100,9 @@
       :result :deleted|:error|:no-such-service-exists
       :success true|false}")
 
-  (scale-app [this ^String service-id target-instances]
-    "Instructs the scheduler to scale up/down instances of the specified service to
-    the specified number of instances.")
+  (scale-app [this ^String service-id target-instances force]
+    "Instructs the scheduler to scale up/down instances of the specified service to the specified number
+     of instances. The force flag can be used enforce the scaling by ignoring previous pending operations.")
 
   (retrieve-directory-content [this ^String service-id ^String instance-id ^String host ^String directory]
     "Retrieves the content of the directory for the specified instance (identified by `instance-id`) on the

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -521,7 +521,7 @@
              :service-id->out-of-sync-state {}))
          (send service-id->out-of-sync-state-store))))
 
-(defn start-sync-deployment-maintainer
+(defn- start-sync-deployment-maintainer
   "Launches the sync-deployment maintainer which triggers new deployments for services which have a mismatch
    in the counts for requested and scheduled instances."
   [leader?-fn service-id->out-of-sync-state-store marathon-scheduler {:keys [interval-ms timeout-cycles]}]

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -227,8 +227,8 @@
 (defn- get-apps
   "Makes a call with hardcoded embed parameters.
    Filters the apps to return only Waiter apps."
-  [marathon-api is-waiter-app?-fn]
-  (let [apps (marathon/get-apps marathon-api)]
+  [marathon-api is-waiter-app?-fn query-params]
+  (let [apps (marathon/get-apps marathon-api query-params)]
     (filter #(is-waiter-app?-fn (app->waiter-service-id %)) (:apps apps))))
 
 (defn marathon-descriptor
@@ -295,13 +295,13 @@
   scheduler/ServiceScheduler
 
   (get-apps->instances [_]
-    (let [apps (get-apps marathon-api is-waiter-app?-fn)]
+    (let [apps (get-apps marathon-api is-waiter-app?-fn {"embed" ["apps.lastTaskFailure" "apps.tasks"]})]
       (response-data->service->service-instances
         apps retrieve-framework-id-fn mesos-api service-id->failed-instances-transient-store
         service-id->service-description)))
 
   (get-apps [_]
-    (map response->Service (get-apps marathon-api is-waiter-app?-fn)))
+    (map response->Service (get-apps marathon-api is-waiter-app?-fn {"embed" ["apps.lastTaskFailure" "apps.tasks"]})))
 
   (get-instances [_ service-id]
     (ss/try+

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -455,7 +455,8 @@
     (->> (get-apps-with-deployments marathon-scheduler)
          (filter is-out-of-sync?)
          (map (fn [{:keys [id instances tasks]}]
-                [id {:instances-requested instances :instances-scheduled (count tasks)}]))
+                [(remove-slash-prefix id)
+                 {:instances-requested instances :instances-scheduled (count tasks)}]))
          (into {}))
     (catch Exception e
       (log/error e "unable to retrieve out-of-sync services"))))

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -555,10 +555,10 @@
 
 (defn- start-sync-deployment-maintainer
   "Starts the sync-deployment-maintainer"
-  [leader?-fn marathon-scheduler {:keys [interval-ms timeout-ms]}]
+  [leader?-fn marathon-scheduler {:keys [interval-ms timeout-cycles]}]
   (let [sync-deployment-interval (t/millis interval-ms)
         sync-deployment-start (t/plus (t/now) sync-deployment-interval)
-        trigger-timeout (t/millis timeout-ms)
+        trigger-timeout (t/millis (* interval-ms timeout-cycles))
         timeout-chan (->> sync-deployment-interval
                           (du/time-seq sync-deployment-start)
                           chime/chime-ch)]
@@ -585,8 +585,7 @@
          (utils/pos-int? (:socket-timeout http-options))
          (not (str/blank? home-path-prefix))
          (utils/pos-int? (:interval-ms sync-deployment))
-         (utils/pos-int? (:timeout-ms sync-deployment))
-         (<= (:interval-ms sync-deployment) (:timeout-ms sync-deployment))]}
+         (utils/pos-int? (:timeout-cycles sync-deployment))]}
   (when (or (not slave-directory) (not mesos-slave-port))
     (log/info "scheduler mesos-slave-port or slave-directory is missing, log directory and url support will be disabled"))
   (let [http-client (http-utils/http-client-factory http-options)

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -604,7 +604,7 @@
        :result :no-such-service-exists
        :message (str service-id " does not exist!")}))
 
-  (scale-app [this service-id scale-to-instances]
+  (scale-app [this service-id scale-to-instances _]
     (if (scheduler/app-exists? this service-id)
       (let [completion-promise (promise)]
         (send id->service-agent set-service-scale service-id scale-to-instances completion-promise)

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -276,7 +276,8 @@
                                                 :spnego-auth true}
                                  :force-kill-after-ms 60000
                                  :framework-id-ttl 900000
-                                 :sync-deployment-interval-ms 60000}
+                                 :sync-deployment {:interval-ms (-> 1 t/minutes t/in-millis)
+                                                   :timeout-ms (-> 5 t/minutes t/in-millis)}}
                       :shell {:factory-fn 'waiter.scheduler.shell/shell-scheduler
                               :failed-instance-retry-interval-ms 5000
                               :health-check-interval-ms 5000

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -275,7 +275,8 @@
                                                 :socket-timeout 10000
                                                 :spnego-auth true}
                                  :force-kill-after-ms 60000
-                                 :framework-id-ttl 900000}
+                                 :framework-id-ttl 900000
+                                 :sync-deployment-interval-ms 60000}
                       :shell {:factory-fn 'waiter.scheduler.shell/shell-scheduler
                               :failed-instance-retry-interval-ms 5000
                               :health-check-interval-ms 5000

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -276,8 +276,8 @@
                                                 :spnego-auth true}
                                  :force-kill-after-ms 60000
                                  :framework-id-ttl 900000
-                                 :sync-deployment {:interval-ms (-> 1 t/minutes t/in-millis)
-                                                   :timeout-ms (-> 5 t/minutes t/in-millis)}}
+                                 :sync-deployment {:interval-ms (-> 15 t/seconds t/in-millis)
+                                                   :timeout-cycles 4}}
                       :shell {:factory-fn 'waiter.scheduler.shell/shell-scheduler
                               :failed-instance-retry-interval-ms 5000
                               :health-check-interval-ms 5000

--- a/waiter/src/waiter/util/http_utils.clj
+++ b/waiter/src/waiter/util/http_utils.clj
@@ -50,7 +50,7 @@
       (ss/throw+ response))
     (let [response-body (-> response :body async/<!!)]
       (cond-> response-body
-        (and (string? response-body) (pos? (count response-body)))
+        (not-empty response-body)
         (-> json/read-str walk/keywordize-keys)))))
 
 (defn ^HttpClient http-client-factory

--- a/waiter/src/waiter/util/http_utils.clj
+++ b/waiter/src/waiter/util/http_utils.clj
@@ -48,11 +48,10 @@
       (throw error))
     (when (and throw-exceptions (not (<= 200 status 299)))
       (ss/throw+ response))
-    (-> response
-        :body
-        async/<!!
-        json/read-str
-        walk/keywordize-keys)))
+    (let [response-body (-> response :body async/<!!)]
+      (cond-> response-body
+        (and (string? response-body) (pos? (count response-body)))
+        (-> json/read-str walk/keywordize-keys)))))
 
 (defn ^HttpClient http-client-factory
   "Creates a HttpClient."

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -287,7 +287,7 @@
 
 (deftest test-service-view-logs-handler
   (let [scheduler (marathon/->MarathonScheduler (Object.) {:slave-port 5051} (fn [] nil) "/home/path/"
-                                                (atom {}) (atom {}) {} 0 (constantly true))
+                                                (atom {}) (atom {}) (atom {}) {} 0 (constantly true) (atom nil))
         configuration {:routines {:generate-log-url-fn (partial handler/generate-log-url identity)}
                        :scheduler {:scheduler scheduler}
                        :wrap-secure-request-fn utils/wrap-identity}

--- a/waiter/test/waiter/mesos/marathon_test.clj
+++ b/waiter/test/waiter/mesos/marathon_test.clj
@@ -42,6 +42,10 @@
       (with-redefs [http-utils/http-request (assert-endpoint-request-method :delete (str "/v2/apps/" app-id))]
         (delete-app marathon-api app-id)))
 
+    (testing "delete-deployment"
+      (with-redefs [http-utils/http-request (assert-endpoint-request-method :delete "/v2/deployments/d1234")]
+        (delete-deployment marathon-api "d1234")))
+
     (testing "get-apps"
       (with-redefs [http-utils/http-request (assert-endpoint-request-method :get "/v2/apps")]
         (get-apps marathon-api)))

--- a/waiter/test/waiter/mesos/marathon_test.clj
+++ b/waiter/test/waiter/mesos/marathon_test.clj
@@ -14,25 +14,30 @@
 ;; limitations under the License.
 ;;
 (ns waiter.mesos.marathon-test
-  (:require [clojure.string :as str]
-            [clojure.test :refer :all]
+  (:require [clojure.test :refer :all]
             [waiter.mesos.marathon :refer :all]
             [waiter.util.http-utils :as http-utils]))
 
+(def ^:private http-client (Object.))
+
+(def ^:private marathon-url "http://www.marathon.com:1234")
+
+(defn- assert-endpoint-request-method
+  ([expected-method expected-url]
+    (assert-endpoint-request-method expected-method expected-url nil))
+  ([expected-method expected-url expected-query-string]
+    (fn [in-http-client in-request-url & {:keys [query-string request-method]}]
+      (is (= http-client in-http-client))
+      (is (= expected-method request-method))
+      (when expected-query-string
+        (is (= expected-query-string query-string)))
+      (let [expected-absolute-url (str marathon-url expected-url)]
+        (is (= expected-absolute-url in-request-url))))))
+
 (deftest test-marathon-rest-api-endpoints
-  (let [http-client (Object.)
-        marathon-url "http://www.marathon.com:1234"
-        app-id "test-app-id"
+  (let [app-id "test-app-id"
         task-id "test-app-id.test-task-id"
-        marathon-api (api-factory http-client {} marathon-url)
-        assert-endpoint-request-method (fn [expected-method expected-url]
-                                         (fn [in-http-client in-request-url & {:keys [request-method]}]
-                                           (is (= http-client in-http-client))
-                                           (is (= expected-method request-method))
-                                           (let [expected-absolute-url (if (str/starts-with? expected-url "http://")
-                                                                         expected-url
-                                                                         (str marathon-url expected-url))]
-                                             (is (= expected-absolute-url in-request-url)))))]
+        marathon-api (api-factory http-client {} marathon-url)]
 
     (testing "create-app"
       (with-redefs [http-utils/http-request (assert-endpoint-request-method :post "/v2/apps")]
@@ -43,12 +48,16 @@
         (delete-app marathon-api app-id)))
 
     (testing "delete-deployment"
-      (with-redefs [http-utils/http-request (assert-endpoint-request-method :delete "/v2/deployments/d1234")]
-        (delete-deployment marathon-api "d1234")))
+      (let [deployment-id "d1234"
+            endpoint (str "/v2/deployments/" deployment-id)
+            query-string {"force" true}]
+        (with-redefs [http-utils/http-request (assert-endpoint-request-method :delete endpoint query-string)]
+          (delete-deployment marathon-api deployment-id))))
 
     (testing "get-apps"
-      (with-redefs [http-utils/http-request (assert-endpoint-request-method :get "/v2/apps")]
-        (get-apps marathon-api)))
+      (let [query-string {"embed" ["apps.lastTaskFailure" "apps.tasks"]}]
+        (with-redefs [http-utils/http-request (assert-endpoint-request-method :get "/v2/apps" query-string)]
+          (get-apps marathon-api query-string))))
 
     (testing "get-deployments"
       (with-redefs [http-utils/http-request (assert-endpoint-request-method :get "/v2/deployments")]
@@ -59,9 +68,13 @@
         (get-info marathon-api)))
 
     (testing "kill-task"
-      (with-redefs [http-utils/http-request (assert-endpoint-request-method :delete (str "/v2/apps/" app-id "/tasks/" task-id))]
-        (kill-task marathon-api app-id task-id false true)))
+      (let [endpoint (str "/v2/apps/" app-id "/tasks/" task-id)
+            query-string {"force" true "scale" false}]
+        (with-redefs [http-utils/http-request (assert-endpoint-request-method :delete endpoint query-string)]
+          (kill-task marathon-api app-id task-id false true))))
 
     (testing "update-app"
-      (with-redefs [http-utils/http-request (assert-endpoint-request-method :put (str "/v2/apps/" app-id))]
-        (update-app marathon-api app-id {})))))
+      (let [endpoint (str "/v2/apps/" app-id)
+            query-string {"force" true}]
+        (with-redefs [http-utils/http-request (assert-endpoint-request-method :put endpoint query-string)]
+          (update-app marathon-api app-id {}))))))

--- a/waiter/test/waiter/mesos/marathon_test.clj
+++ b/waiter/test/waiter/mesos/marathon_test.clj
@@ -20,7 +20,7 @@
 
 (def ^:private http-client (Object.))
 
-(def ^:private marathon-url "http://www.marathon.com:1234")
+(def ^:private marathon-url "http://marathon.localtest.me:1234")
 
 (defn- assert-endpoint-request-method
   ([expected-method expected-url]

--- a/waiter/test/waiter/mesos/mesos_test.clj
+++ b/waiter/test/waiter/mesos/mesos_test.clj
@@ -21,7 +21,7 @@
 
 (deftest test-mesos-api
   (let [http-client (Object.)
-        marathon-url "http://www.marathon.com:1234"
+        marathon-url "http://marathon.localtest.me:1234"
         slave-port 9876
         slave-directory "/some/directory"
         mesos-api (api-factory http-client {} slave-port slave-directory)

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -988,19 +988,6 @@
           (is (= :invoked (deref deleted-deployment-promise 0 :not-invoked)))
           (is (= :invoked (deref updated-invoked-promise 0 :not-invoked))))))))
 
-(defmacro launch-sync-deployment-maintainer
-  [leader?-fn marathon-scheduler interval-ms timeout-cycles & body]
-  `(let [service-id->out-of-sync-state-store# (:service-id->out-of-sync-state-store ~marathon-scheduler)
-        cancel-fn# (start-sync-deployment-maintainer
-                     ~leader?-fn service-id->out-of-sync-state-store# ~marathon-scheduler
-                     {:interval-ms ~interval-ms
-                      :timeout-cycles ~timeout-cycles})]
-     (try
-       (do
-         ~@body)
-       (finally
-         (cancel-fn#)))))
-
 (defmacro run-sync-deployment-maintainer-iteration
   [leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout]
   `(do
@@ -1025,14 +1012,6 @@
                         :instances instances
                         :tasks (map (fn [task-id] [{:id task-id}]) task-ids)})]
 
-  (deftest test-sync-deployment-maintainer-initialization
-    (let [leader?-fn (constantly true)
-          service-id->out-of-sync-state-store (agent initial-state)
-          marathon-scheduler (make-marathon-scheduler service-id->out-of-sync-state-store)]
-      (launch-sync-deployment-maintainer
-        leader?-fn marathon-scheduler interval-ms timeout-cycles
-        (is (= initial-state @service-id->out-of-sync-state-store)))))
-
   (deftest test-sync-deployment-maintainer-no-pending-sync-deployment
     (let [current-time (t/now)]
       (with-redefs [marathon/get-apps
@@ -1046,13 +1025,11 @@
         (let [leader?-fn (constantly true)
               service-id->out-of-sync-state-store (agent initial-state)
               marathon-scheduler (make-marathon-scheduler service-id->out-of-sync-state-store)]
-          (launch-sync-deployment-maintainer
-            leader?-fn marathon-scheduler interval-ms timeout-cycles
-            (run-sync-deployment-maintainer-iteration
-              leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
-            (is (= {:last-update-time current-time
-                    :service-id->out-of-sync-state {}}
-                   @service-id->out-of-sync-state-store)))))))
+          (run-sync-deployment-maintainer-iteration
+            leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
+          (is (= {:last-update-time current-time
+                  :service-id->out-of-sync-state {}}
+                 @service-id->out-of-sync-state-store))))))
 
   (deftest test-sync-deployment-maintainer-ignore-service-with-pending-deployment
     (let [current-time (t/now)]
@@ -1068,14 +1045,12 @@
         (let [leader?-fn (constantly true)
               service-id->out-of-sync-state-store (agent initial-state)
               marathon-scheduler (make-marathon-scheduler service-id->out-of-sync-state-store)]
-          (launch-sync-deployment-maintainer
-            leader?-fn marathon-scheduler interval-ms timeout-cycles
-            (run-sync-deployment-maintainer-iteration
-              leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
-            (is (= {:last-update-time current-time
-                    :service-id->out-of-sync-state
-                    {"ws-s2a" {:data {:instances-requested 2 :instances-scheduled 1} :last-modified-time current-time}}}
-                   @service-id->out-of-sync-state-store)))))))
+          (run-sync-deployment-maintainer-iteration
+            leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
+          (is (= {:last-update-time current-time
+                  :service-id->out-of-sync-state
+                  {"ws-s2a" {:data {:instances-requested 2 :instances-scheduled 1} :last-modified-time current-time}}}
+                 @service-id->out-of-sync-state-store))))))
 
   (deftest test-sync-deployment-maintainer-leadership-changes
     (let [time-0 (t/now)
@@ -1092,37 +1067,35 @@
               leader?-fn (fn [] (deref leader-atom))
               service-id->out-of-sync-state-store (agent initial-state)
               marathon-scheduler (make-marathon-scheduler service-id->out-of-sync-state-store)]
-          (launch-sync-deployment-maintainer
-            leader?-fn marathon-scheduler interval-ms timeout-cycles
-            ;; check we ignore sync-ed services
+          ;; check we ignore sync-ed services
+          (run-sync-deployment-maintainer-iteration
+            leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
+          (is (= {:last-update-time time-0
+                  :service-id->out-of-sync-state
+                  {"ws-s2a" {:data {:instances-requested 2 :instances-scheduled 1} :last-modified-time time-0}}}
+                 @service-id->out-of-sync-state-store))
+
+          ;; check we reset state when we lose leadership
+          (let [time-1 (t/plus time-0 interval-timeout)]
+            (reset! leader-atom false)
+            (reset! current-time-atom time-1)
             (run-sync-deployment-maintainer-iteration
               leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
-            (is (= {:last-update-time time-0
-                    :service-id->out-of-sync-state
-                    {"ws-s2a" {:data {:instances-requested 2 :instances-scheduled 1} :last-modified-time time-0}}}
+            (is (= {:last-update-time time-1
+                    :service-id->out-of-sync-state {}}
                    @service-id->out-of-sync-state-store))
 
-            ;; check we reset state when we lose leadership
-            (let [time-1 (t/plus time-0 interval-timeout)]
-              (reset! leader-atom false)
-              (reset! current-time-atom time-1)
+
+            ;; check we update state when we regain leadership
+            (let [time-2 (t/plus time-1 interval-timeout)]
+              (reset! leader-atom true)
+              (reset! current-time-atom time-2)
               (run-sync-deployment-maintainer-iteration
                 leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
-              (is (= {:last-update-time time-1
-                      :service-id->out-of-sync-state {}}
-                     @service-id->out-of-sync-state-store))
-
-
-              ;; check we update state when we regain leadership
-              (let [time-2 (t/plus time-1 interval-timeout)]
-                (reset! leader-atom true)
-                (reset! current-time-atom time-2)
-                (run-sync-deployment-maintainer-iteration
-                  leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
-                (is (= {:last-update-time time-2
-                        :service-id->out-of-sync-state
-                        {"ws-s2a" {:data {:instances-requested 2 :instances-scheduled 1} :last-modified-time time-2}}}
-                       @service-id->out-of-sync-state-store)))))))))
+              (is (= {:last-update-time time-2
+                      :service-id->out-of-sync-state
+                      {"ws-s2a" {:data {:instances-requested 2 :instances-scheduled 1} :last-modified-time time-2}}}
+                     @service-id->out-of-sync-state-store))))))))
 
   (deftest test-sync-deployment-maintainer-forget-previous-out-of-sync-services
     (let [time-0 (t/now)
@@ -1140,42 +1113,40 @@
               service-id->out-of-sync-state-store (agent initial-state)
               marathon-scheduler (make-marathon-scheduler service-id->out-of-sync-state-store)]
 
-          (launch-sync-deployment-maintainer
-            leader?-fn marathon-scheduler interval-ms timeout-cycles
-            ;; check we ignore sync-ed services
+          ;; check we ignore sync-ed services
+          (run-sync-deployment-maintainer-iteration
+            leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
+          (is (= {:last-update-time time-0
+                  :service-id->out-of-sync-state {}}
+                 @service-id->out-of-sync-state-store))
+
+          ;; check we detect out-of-sync services
+          (let [time-1 (t/plus time-0 interval-timeout)]
+            (swap! app-entries-atom conj (make-app-entry [] "ws-s2a" 2 ["ws-s2a.t1"]))
+            (swap! app-entries-atom conj (make-app-entry [] "ws-s2b" 2 ["ws-s2b.t1"]))
+            (swap! app-entries-atom conj (make-app-entry [] "ws-s2c" 2 ["ws-s2c.t1"]))
+            (reset! current-time-atom time-1)
             (run-sync-deployment-maintainer-iteration
               leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
-            (is (= {:last-update-time time-0
-                    :service-id->out-of-sync-state {}}
+            (is (= {:last-update-time time-1
+                    :service-id->out-of-sync-state
+                    {"ws-s2a" {:data {:instances-requested 2 :instances-scheduled 1} :last-modified-time time-1}
+                     "ws-s2b" {:data {:instances-requested 2 :instances-scheduled 1} :last-modified-time time-1}
+                     "ws-s2c" {:data {:instances-requested 2 :instances-scheduled 1} :last-modified-time time-1}}}
                    @service-id->out-of-sync-state-store))
 
-            ;; check we detect out-of-sync services
-            (let [time-1 (t/plus time-0 interval-timeout)]
-              (swap! app-entries-atom conj (make-app-entry [] "ws-s2a" 2 ["ws-s2a.t1"]))
-              (swap! app-entries-atom conj (make-app-entry [] "ws-s2b" 2 ["ws-s2b.t1"]))
-              (swap! app-entries-atom conj (make-app-entry [] "ws-s2c" 2 ["ws-s2c.t1"]))
-              (reset! current-time-atom time-1)
+            ;; check we forget previously out-of-sync services
+            (let [time-2 (t/plus time-1 interval-timeout)]
+              (swap! app-entries-atom (fn [app-entries] (remove #(= "/ws-s2b" (:id %)) app-entries)))
+              (swap! app-entries-atom (fn [app-entries] (remove #(= "/ws-s2c" (:id %)) app-entries)))
+              (swap! app-entries-atom conj (make-app-entry [] "ws-s2b" 3 ["ws-s2b.t1" "ws-s2b.t2" "ws-s2b.t3"]))
+              (reset! current-time-atom time-2)
               (run-sync-deployment-maintainer-iteration
                 leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
-              (is (= {:last-update-time time-1
+              (is (= {:last-update-time time-2
                       :service-id->out-of-sync-state
-                      {"ws-s2a" {:data {:instances-requested 2 :instances-scheduled 1} :last-modified-time time-1}
-                       "ws-s2b" {:data {:instances-requested 2 :instances-scheduled 1} :last-modified-time time-1}
-                       "ws-s2c" {:data {:instances-requested 2 :instances-scheduled 1} :last-modified-time time-1}}}
-                     @service-id->out-of-sync-state-store))
-
-              ;; check we forget previously out-of-sync services
-              (let [time-2 (t/plus time-1 interval-timeout)]
-                (swap! app-entries-atom (fn [app-entries] (remove #(= "/ws-s2b" (:id %)) app-entries)))
-                (swap! app-entries-atom (fn [app-entries] (remove #(= "/ws-s2c" (:id %)) app-entries)))
-                (swap! app-entries-atom conj (make-app-entry [] "ws-s2b" 3 ["ws-s2b.t1" "ws-s2b.t2" "ws-s2b.t3"]))
-                (reset! current-time-atom time-2)
-                (run-sync-deployment-maintainer-iteration
-                  leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
-                (is (= {:last-update-time time-2
-                        :service-id->out-of-sync-state
-                        {"ws-s2a" {:data {:instances-requested 2 :instances-scheduled 1} :last-modified-time time-1}}}
-                       @service-id->out-of-sync-state-store)))))))))
+                      {"ws-s2a" {:data {:instances-requested 2 :instances-scheduled 1} :last-modified-time time-1}}}
+                     @service-id->out-of-sync-state-store))))))))
 
   (deftest test-sync-deployment-maintainer-detect-new-out-of-sync-deployment
     (let [time-0 (t/now)
@@ -1193,37 +1164,35 @@
               service-id->out-of-sync-state-store (agent initial-state)
               marathon-scheduler (make-marathon-scheduler service-id->out-of-sync-state-store)]
 
-          (launch-sync-deployment-maintainer
-            leader?-fn marathon-scheduler interval-ms timeout-cycles
-            ;; check we ignore sync-ed services
+          ;; check we ignore sync-ed services
+          (run-sync-deployment-maintainer-iteration
+            leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
+          (is (= {:last-update-time time-0
+                  :service-id->out-of-sync-state {}}
+                 @service-id->out-of-sync-state-store))
+
+          ;; check we detect out-of-sync services
+          (let [time-1 (t/plus time-0 interval-timeout)]
+            (swap! app-entries-atom conj (make-app-entry [] "ws-s2a" 2 ["ws-s2a.t1"]))
+            (reset! current-time-atom time-1)
             (run-sync-deployment-maintainer-iteration
               leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
-            (is (= {:last-update-time time-0
-                    :service-id->out-of-sync-state {}}
+            (is (= {:last-update-time time-1
+                    :service-id->out-of-sync-state
+                    {"ws-s2a" {:data {:instances-requested 2 :instances-scheduled 1} :last-modified-time time-1}}}
                    @service-id->out-of-sync-state-store))
 
-            ;; check we detect out-of-sync services
-            (let [time-1 (t/plus time-0 interval-timeout)]
-              (swap! app-entries-atom conj (make-app-entry [] "ws-s2a" 2 ["ws-s2a.t1"]))
-              (reset! current-time-atom time-1)
+            ;; check we detect new out-of-sync services
+            (let [time-2 (t/plus time-1 interval-timeout)]
+              (swap! app-entries-atom conj (make-app-entry [] "ws-s4a" 4 ["ws-s4a.t1" "ws-s4a.t2"]))
+              (reset! current-time-atom time-2)
               (run-sync-deployment-maintainer-iteration
                 leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
-              (is (= {:last-update-time time-1
+              (is (= {:last-update-time time-2
                       :service-id->out-of-sync-state
-                      {"ws-s2a" {:data {:instances-requested 2 :instances-scheduled 1} :last-modified-time time-1}}}
-                     @service-id->out-of-sync-state-store))
-
-              ;; check we detect new out-of-sync services
-              (let [time-2 (t/plus time-1 interval-timeout)]
-                (swap! app-entries-atom conj (make-app-entry [] "ws-s4a" 4 ["ws-s4a.t1" "ws-s4a.t2"]))
-                (reset! current-time-atom time-2)
-                (run-sync-deployment-maintainer-iteration
-                  leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
-                (is (= {:last-update-time time-2
-                        :service-id->out-of-sync-state
-                        {"ws-s2a" {:data {:instances-requested 2 :instances-scheduled 1} :last-modified-time time-1}
-                         "ws-s4a" {:data {:instances-requested 4 :instances-scheduled 2} :last-modified-time time-2}}}
-                       @service-id->out-of-sync-state-store)))))))))
+                      {"ws-s2a" {:data {:instances-requested 2 :instances-scheduled 1} :last-modified-time time-1}
+                       "ws-s4a" {:data {:instances-requested 4 :instances-scheduled 2} :last-modified-time time-2}}}
+                     @service-id->out-of-sync-state-store))))))))
 
   (deftest test-sync-deployment-maintainer-some-pending-sync-deployments
     (let [time-0 (t/now)
@@ -1257,46 +1226,43 @@
                        "ws-s4a" {:data {:instances-requested 4 :instances-scheduled 2} :last-modified-time time-3}}})
               marathon-scheduler (make-marathon-scheduler service-id->out-of-sync-state-store)]
 
-          (launch-sync-deployment-maintainer
-            leader?-fn marathon-scheduler interval-ms timeout-cycles
+          (testing "do not trigger scale on 'active' out-of-sync services"
+            (reset! current-time-atom time-4)
+            (run-sync-deployment-maintainer-iteration
+              leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
+            (await service-id->out-of-sync-state-store)
+            (is (= {:last-update-time time-4
+                    :service-id->out-of-sync-state
+                    {"ws-s2a" {:data {:instances-requested 2 :instances-scheduled 1} :last-modified-time time-1}
+                     "ws-s4a" {:data {:instances-requested 4 :instances-scheduled 2} :last-modified-time time-3}}}
+                   @service-id->out-of-sync-state-store)))
 
-            (testing "do not trigger scale on 'active' out-of-sync services"
-              (reset! current-time-atom time-4)
-              (run-sync-deployment-maintainer-iteration
-                leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
-              (await service-id->out-of-sync-state-store)
-              (is (= {:last-update-time time-4
-                      :service-id->out-of-sync-state
-                      {"ws-s2a" {:data {:instances-requested 2 :instances-scheduled 1} :last-modified-time time-1}
-                       "ws-s4a" {:data {:instances-requested 4 :instances-scheduled 2} :last-modified-time time-3}}}
-                     @service-id->out-of-sync-state-store)))
+          (testing "trigger scale on out-of-sync services"
+            (reset! current-time-atom time-5)
+            (run-sync-deployment-maintainer-iteration
+              leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
+            (is (= {:last-update-time time-5
+                    :service-id->out-of-sync-state
+                    {"ws-s4a" {:data {:instances-requested 4 :instances-scheduled 2} :last-modified-time time-3}}}
+                   @service-id->out-of-sync-state-store))
+            (is (= [["ws-s2a" 1 false]] (deref scheduler-operations-atom))))
 
-            (testing "trigger scale on out-of-sync services"
-              (reset! current-time-atom time-5)
-              (run-sync-deployment-maintainer-iteration
-                leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
-              (is (= {:last-update-time time-5
-                      :service-id->out-of-sync-state
-                      {"ws-s4a" {:data {:instances-requested 4 :instances-scheduled 2} :last-modified-time time-3}}}
-                     @service-id->out-of-sync-state-store))
-              (is (= [["ws-s2a" 1 false]] (deref scheduler-operations-atom))))
+          (testing "trigger scale remaining out-of-sync services"
 
-            (testing "trigger scale remaining out-of-sync services"
+            (swap! app-entries-atom (fn [app-entries] (remove #(= "/ws-s2a" (:id %)) app-entries)))
+            (reset! current-time-atom time-6)
+            (run-sync-deployment-maintainer-iteration
+              leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
+            (is (= {:last-update-time time-6
+                    :service-id->out-of-sync-state
+                    {"ws-s4a" {:data {:instances-requested 4 :instances-scheduled 2} :last-modified-time time-3}}}
+                   @service-id->out-of-sync-state-store))
+            (is (= [["ws-s2a" 1 false]] (deref scheduler-operations-atom)))
 
-              (swap! app-entries-atom (fn [app-entries] (remove #(= "/ws-s2a" (:id %)) app-entries)))
-              (reset! current-time-atom time-6)
-              (run-sync-deployment-maintainer-iteration
-                leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
-              (is (= {:last-update-time time-6
-                      :service-id->out-of-sync-state
-                      {"ws-s4a" {:data {:instances-requested 4 :instances-scheduled 2} :last-modified-time time-3}}}
-                     @service-id->out-of-sync-state-store))
-              (is (= [["ws-s2a" 1 false]] (deref scheduler-operations-atom)))
-
-              (reset! current-time-atom time-7)
-              (run-sync-deployment-maintainer-iteration
-                leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
-              (is (= {:last-update-time time-7
-                      :service-id->out-of-sync-state {}}
-                     @service-id->out-of-sync-state-store))
-              (is (= [["ws-s2a" 1 false] ["ws-s4a" 2 false]] (deref scheduler-operations-atom))))))))))
+            (reset! current-time-atom time-7)
+            (run-sync-deployment-maintainer-iteration
+              leader?-fn service-id->out-of-sync-state-store marathon-scheduler trigger-timeout)
+            (is (= {:last-update-time time-7
+                    :service-id->out-of-sync-state {}}
+                   @service-id->out-of-sync-state-store))
+            (is (= [["ws-s2a" 1 false] ["ws-s4a" 2 false]] (deref scheduler-operations-atom)))))))))

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -1005,9 +1005,9 @@
       interval-timeout (t/millis 2000)
       trigger-timeout (t/millis 6000)
       initial-state {:iteration 0}
-      make-app-entry (fn [deployment-ids app-id instances task-ids]
+      make-app-entry (fn [deployment-ids service-id instances task-ids]
                        {:deployments (map (fn [deployment-id] [{:id deployment-id}]) deployment-ids)
-                        :id app-id
+                        :id (str "/" service-id)
                         :instances instances
                         :tasks (map (fn [task-id] [{:id task-id}]) task-ids)})
       launch-sync-deployment-maintainer
@@ -1151,8 +1151,8 @@
 
             ;; check we forget previously out-of-sync services
             (let [time-2 (t/plus time-1 interval-timeout)]
-              (swap! app-entries-atom (fn [app-entries] (remove #(= "ws-s2b" (:id %)) app-entries)))
-              (swap! app-entries-atom (fn [app-entries] (remove #(= "ws-s2c" (:id %)) app-entries)))
+              (swap! app-entries-atom (fn [app-entries] (remove #(= "/ws-s2b" (:id %)) app-entries)))
+              (swap! app-entries-atom (fn [app-entries] (remove #(= "/ws-s2c" (:id %)) app-entries)))
               (swap! app-entries-atom conj (make-app-entry [] "ws-s2b" 3 ["ws-s2b.t1" "ws-s2b.t2" "ws-s2b.t3"]))
               (reset! current-time-atom time-2)
               (async/>!! timeout-chan :timeout)
@@ -1264,7 +1264,7 @@
 
           (testing "trigger scale remaining out-of-sync services"
 
-            (swap! app-entries-atom (fn [app-entries] (remove #(= "ws-s2a" (:id %)) app-entries)))
+            (swap! app-entries-atom (fn [app-entries] (remove #(= "/ws-s2a" (:id %)) app-entries)))
             (reset! current-time-atom time-6)
             (async/>!! timeout-chan :timeout)
 

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -751,7 +751,7 @@
                         :mesos-slave-port 5051
                         :slave-directory "/foo"
                         :sync-deployment {:interval-ms 15000
-                                          :timeout-ms 60000}
+                                          :timeout-cycles 4}
                         :url "url"}
           create-marathon-scheduler (fn create-marathon-scheduler [config]
                                       (let [result (marathon-scheduler config)

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -245,7 +245,7 @@
         scheduler (create-shell-scheduler scheduler-config)]
     ;; Bogus service
     (is (= {:success false, :result :no-such-service-exists, :message "bar does not exist!"}
-           (scheduler/scale-app scheduler "bar" 2)))
+           (scheduler/scale-app scheduler "bar" 2 false)))
     (with-redefs [perform-health-check (constantly true)]
       ;; Create service, instances: 1
       (is (= {:success true, :result :created, :message "Created foo"}
@@ -254,14 +254,14 @@
       (is (scheduler/app-exists? scheduler "foo"))
       ;; Scale up, instances: 2
       (is (= {:success true, :result :scaled, :message "Scaled foo"}
-             (scheduler/scale-app scheduler "foo" 2)))
+             (scheduler/scale-app scheduler "foo" 2 false)))
       (force-maintain-instance-scale scheduler)
       (force-update-service-health scheduler scheduler-config)
       (is (= {:running 2, :healthy 2, :unhealthy 0, :staged 0}
              (task-stats scheduler)))
       ;; No need to scale down, instances: 2
       (is (= {:success false, :result :scaling-not-needed, :message "Unable to scale foo"}
-             (scheduler/scale-app scheduler "foo" 1)))
+             (scheduler/scale-app scheduler "foo" 1 false)))
       (ensure-agent-finished scheduler)
       ;; Successfully kill one instance, instances: 1
       (let [instance (first (:active-instances (scheduler/get-instances scheduler "foo")))]
@@ -272,7 +272,7 @@
              (task-stats scheduler)))
       ;; Scale up, instances: 2
       (is (= {:success true, :result :scaled, :message "Scaled foo"}
-             (scheduler/scale-app scheduler "foo" 2)))
+             (scheduler/scale-app scheduler "foo" 2 false)))
       (force-maintain-instance-scale scheduler)
       (force-update-service-health scheduler scheduler-config)
       (is (= {:running 2, :healthy 2, :unhealthy 0, :staged 0}


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for forcefully scaling a service by deleting any outstanding deployments
- adds sync-deployment-maintainer to correct deployment state of services that may go out of sync due to failed scale operation that canceled a previous deployment

## Why are we making these changes?

We would like to scale-down without waiting for previous scale-up deployments to complete. Avoiding the delay reduces the wasteful use of resources due to spin-up and almost immediate killing of instances.

### Example log from the deployment syncer:

```
2018-06-18 14:20:02,497 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529349972846] 0 service(s) have out-of-sync deployments: #{}
2018-06-18 14:20:02,497 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529349972846] 0 service(s) qualify for sync deployments: #{}
2018-06-18 14:20:17,517 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529349987836] 1 service(s) have out-of-sync deployments: #{s1475611-8391
5fcbf5fd559791b851e42c7e1f29}
2018-06-18 14:20:17,517 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529349987836] 0 service(s) qualify for sync deployments: #{}
2018-06-18 14:20:32,516 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529350002838] 1 service(s) have out-of-sync deployments: #{s1475611-8391
5fcbf5fd559791b851e42c7e1f29}
2018-06-18 14:20:32,516 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529350002838] 0 service(s) qualify for sync deployments: #{}
2018-06-18 14:20:47,559 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529350017839] 2 service(s) have out-of-sync deployments: #{s1475611-8391
5fcbf5fd559791b851e42c7e1f29 s2365382-db19481494bb9be94798510ad9d99fd0}
2018-06-18 14:20:47,560 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529350017839] 0 service(s) qualify for sync deployments: #{}
2018-06-18 14:21:02,537 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529350032838] 2 service(s) have out-of-sync deployments: #{s1475611-8391
5fcbf5fd559791b851e42c7e1f29 s2365382-db19481494bb9be94798510ad9d99fd0}
2018-06-18 14:21:02,537 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529350032838] 0 service(s) qualify for sync deployments: #{}
2018-06-18 14:21:17,502 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529350062838] 3 service(s) have out-of-sync deployments: #{s1475611-83915fcbf5fd559791b851e42c7e1f29 s2354226-58faf6368292d9a758430337ea4e7c9f s2365382-db19481494bb9be94798510ad9d99fd0}
2018-06-18 14:21:17,502 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529350062838] 1 service(s) qualify for sync deployments: #{s1475611-83915fcbf5fd559791b851e42c7e1f29}
2018-06-18 14:21:17,504 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529350062838] triggering sync deployment {:service-id s1475611-83915fcbf5fd559791b851e42c7e1f29, :task-data {:instances-requested 12, :instances-scheduled 8}}
2018-06-18 14:21:32,498 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529350077841] 2 service(s) have out-of-sync deployments: #{s2354226-58faf6368292d9a758430337ea4e7c9f s2365382-db19481494bb9be94798510ad9d99fd0}
2018-06-18 14:21:32,498 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529350077841] 0 service(s) qualify for sync deployments: #{}
2018-06-18 14:21:47,510 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529350092837] 2 service(s) have out-of-sync deployments: #{s2354226-58faf6368292d9a758430337ea4e7c9f s2365382-db19481494bb9be94798510ad9d99fd0}
2018-06-18 14:21:47,510 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529350092837] 1 service(s) qualify for sync deployments: #{s2365382-db19481494bb9be94798510ad9d99fd0}
2018-06-18 14:21:47,510 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529350092837] triggering sync deployment {:service-id s2365382-db19481494bb9be94798510ad9d99fd0, :task-data {:instances-requested 11, :instances-scheduled 8}}
2018-06-18 14:22:02,499 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529350107841] 1 service(s) have out-of-sync deployments: #{s2354226-58faf6368292d9a758430337ea4e7c9f}
2018-06-18 14:22:02,499 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529350107841] 0 service(s) qualify for sync deployments: #{}
2018-06-18 14:22:17,498 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529350122839] 1 service(s) have out-of-sync deployments: #{s2354226-58faf6368292d9a758430337ea4e7c9f}
2018-06-18 14:22:17,498 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529350122839] 0 service(s) qualify for sync deployments: #{}
2018-06-18 14:22:32,515 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529350137838] 1 service(s) have out-of-sync deployments: #{s2354226-58faf6368292d9a758430337ea4e7c9f}
2018-06-18 14:22:32,515 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529350137838] 1 service(s) qualify for sync deployments: #{s2354226-58faf6368292d9a758430337ea4e7c9f}
2018-06-18 14:22:32,515 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529350137838] triggering sync deployment {:service-id s2354226-58faf6368292d9a758430337ea4e7c9f, :task-data {:instances-requested 10, :instances-scheduled 8}}
2018-06-18 14:22:47,497 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529350152837] 0 service(s) have out-of-sync deployments: #{}
2018-06-18 14:22:47,497 INFO  [clj-agent-send-off-pool-1] - [CID=sync-deployment.1529350152837] 0 service(s) qualify for sync deployments: #{}
```

### Example screenshots from Marathon:

Deployment in flight:
<img width="810" alt="screen shot 2018-06-11 at 3 09 09 pm" src="https://user-images.githubusercontent.com/6611249/41254630-ab4736f0-6d89-11e8-9dff-f9539f3763fb.png">
<img width="858" alt="screen shot 2018-06-11 at 3 09 19 pm" src="https://user-images.githubusercontent.com/6611249/41254629-ab35a6b0-6d89-11e8-993c-6eea479e5638.png">

Deployment forcefully cancelled so that instance and task counts no longer match:
<img width="804" alt="screen shot 2018-06-11 at 3 09 48 pm" src="https://user-images.githubusercontent.com/6611249/41254628-ab22cf9a-6d89-11e8-8a57-f1d87ba360a7.png">

Deployment syncer _patches_ the counts so that they now agree:
<img width="783" alt="screen shot 2018-06-11 at 3 10 35 pm" src="https://user-images.githubusercontent.com/6611249/41254626-aafd2786-6d89-11e8-943d-48223748ae0d.png">

### Example screenshot for service state

<img width="783" alt="service-out-of-sync-state" src="https://user-images.githubusercontent.com/6611249/41307429-beac941e-6e3e-11e8-911f-85161c9b17fa.png">


