### PR TITLE
Make router state queryable

### DIFF
--- a/waiter/src/waiter/state.clj
+++ b/waiter/src/waiter/state.clj
@@ -1150,9 +1150,11 @@
    for modifying this data for the router."
   [scheduler-state-chan router-chan router-id exit-chan service-id->service-description-fn deployment-error-config]
   (let [state-chan (async/chan)
-        router-state-push-chan (au/latest-chan)]
+        router-state-push-chan (au/latest-chan)
+        query-chan (async/chan)]
     {:state-chan state-chan
      :router-state-push-mult (async/mult router-state-push-chan)
+     :query-chan query-chan
      :go-chan
      (async/go
        (try
@@ -1268,6 +1270,11 @@
                                  (async/put! router-state-push-chan new-state))
                                new-state)
                              (recur loop-state' remaining))))))
+
+                   query-chan
+                   ([response-chan]
+                    (async/put! response-chan current-state)
+                    current-state)
 
                    router-chan
                    ([data]


### PR DESCRIPTION
## Changes proposed in this PR

Add a query channel to the router state maintainer.

## Why are we making these changes?

Allows pulling the current router state (currently we only have pushed updates).

I need this feature to correctly initialize the state of the launch metrics loop in #305.