### PR TITLE
Lift current-test-name utility function

### DIFF
--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -166,8 +166,7 @@
 (defn current-test-name
   "Get the name of the currently-running test."
   []
-  (str (or (-> *testing-vars* first meta :name)
-           "test-unknown-name")))
+  (-> *testing-vars* first meta :name (or "test-unknown-name") str))
 
 (defmacro testing-using-waiter-url
   [& body]

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -163,9 +163,15 @@
     (.setCookieStore client (HttpCookieStore$Empty.))
     client))
 
+(defn current-test-name
+  "Get the name of the currently-running test."
+  []
+  (str (or (-> *testing-vars* first meta :name)
+           "test-unknown-name")))
+
 (defmacro testing-using-waiter-url
   [& body]
-  `(let [name# (str (or (:name (meta (first *testing-vars*))) "test-unknown-name"))]
+  `(let [name# (current-test-name)]
      (testing name#
        (cid/with-correlation-id
          name#


### PR DESCRIPTION
## Changes proposed in this PR

Life the code for retrieving the current clojure.test test name to its own utility function.

## Why are we making these changes?

I want to call this from some unit testing code that passes a cid through an async/channel.