### PR TITLE
handles NPE while querying for service state before syncer update

### DIFF
--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -628,7 +628,7 @@
                                                             {:cid (cid/get-correlation-id)
                                                              :response-chan response-chan
                                                              :service-id service-id})
-                                                  (log/info (str "Waiting on response on " key " channel"))
+                                                  (log/info (str "waiting on response from " key " channel"))
                                                   (async/alt!
                                                     response-chan ([state] state)
                                                     (async/timeout timeout-ms) ([_] {:message "Request timeout"})))]

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -535,9 +535,8 @@
         state-query-chan (async/chan 32)]
     (async/go
       (try
-        (loop [{:keys [last-update-time service-id->health-check-context]
-                :or {service-id->health-check-context {}}
-                :as current-state} {}]
+        (loop [{:keys [last-update-time service-id->health-check-context] :as current-state}
+               {:service-id->health-check-context {}}]
           (when-let [next-state
                      (async/alt!
                        exit-chan

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -535,7 +535,9 @@
         state-query-chan (async/chan 32)]
     (async/go
       (try
-        (loop [{:keys [last-update-time service-id->health-check-context] :as current-state} {}]
+        (loop [{:keys [last-update-time service-id->health-check-context]
+                :or {service-id->health-check-context {}}
+                :as current-state} {}]
           (when-let [next-state
                      (async/alt!
                        exit-chan
@@ -574,7 +576,7 @@
                        :priority true)]
             (recur next-state)))
         (catch Exception e
-          (log/error e "Fatal error in scheduler-syncer")
+          (log/error e "fatal error in scheduler-syncer")
           (System/exit 1))))
     {:exit-chan exit-chan
      :query-chan state-query-chan}))

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -260,6 +260,9 @@
                               :flags #{:has-connected :has-responded}
                               :healthy? false
                               :health-check-status 400)]
+    (let [response-chan (async/promise-chan)]
+      (async/>!! query-chan {:response-chan response-chan :service-id "s0"})
+      (is (= {:last-update-time nil :service-specific-state []} (async/<!! response-chan))))
     (async/>!! timeout-chan :timeout)
     (let [[[update-apps-msg update-apps] [update-instances-msg update-instances]] (async/<!! scheduler-state-chan)]
       (is (= :update-available-services update-apps-msg))


### PR DESCRIPTION
## Changes proposed in this PR

- handles NPE while querying for service state before syncer update

## Why are we making these changes?

Avoid router crashes.

