### PR TITLE
avoids triggering expired instances logic in scaling when there are no expired instances

### DIFF
--- a/waiter/docs/notes/scaling.md
+++ b/waiter/docs/notes/scaling.md
@@ -1,0 +1,10 @@
+# Waiter's Scaling Logic
+
+* `autoscaler-goroutine` runs in a loop every `timeout-interval-ms` ms.
+* `autoscaler-goroutine` determines global services state and triggers scaling of individual services via `scale-apps`.
+    * `scale-apps` calls `scale-app` per service with `expired-instances`, `healthy-instances`, `outstanding-requests`, `target-instances`, `instances` (scheduled instances) to retrieve the `scale-amount`.
+        * `scale-app` computes `scale-amount`, `scale-to-instances` and `target-instances` as `scaling-state`.
+    * `scale-apps` uses `scale-amount` to determine calling `apply-scaling!` with `outstanding-requests`, `task-count` (requested instances), `instances` (scheduled instances), `scale-amount` and `scale-to-instances`.
+        * `apply-scaling!` sends scaling request along `executor-multiplexer-chan`.
+        * `service-scaling-executor` reads `executor-multiplexer-chan` to trigger scale-up or scale-down calls.
+    * `scale-apps` returns `scaling-state` to use as seed data for next iteration of scaling computation for the service.

--- a/waiter/src/waiter/scaling.clj
+++ b/waiter/src/waiter/scaling.clj
@@ -336,7 +336,8 @@
         ; since the instance killer will kill the expired instances
         scaling-down (< integer-delta 0)
         all-instances-are-healthy (= total-instances healthy-instances)
-        scale-to-instances' (if (and scaling-down all-instances-are-healthy)
+        scale-to-instances' (if (or (and scaling-down all-instances-are-healthy)
+                                    (zero? expired-instances))
                               scale-to-instances
                               (- (+ scale-to-instances expired-instances-to-replace) excess-instances))
         integer-delta' (int (- scale-to-instances' total-instances))]
@@ -383,10 +384,11 @@
           (when-not (zero? scale-amount)
             (apply-scaling-fn service-id
                               {:outstanding-requests outstanding-requests
-                               :task-count task-count
-                               :total-instances instances
                                :scale-amount scale-amount
-                               :scale-to-instances scale-to-instances}))
+                               :scale-to-instances scale-to-instances
+                               :target-instances target-instances
+                               :task-count task-count
+                               :total-instances instances}))
           {:target-instances target-instances
            :scale-to-instances scale-to-instances
            :scale-amount scale-amount}))

--- a/waiter/test/waiter/scaling_test.clj
+++ b/waiter/test/waiter/scaling_test.clj
@@ -678,6 +678,9 @@
       (scales-like 2 3 2, fast-scaling 1 2 0.9 1 1))
     (testing "scale down with expired instances"
       (scales-like -4 1 1, fast-scaling 5 0 5.3 5 5))
+    (testing "scale down without expired instances"
+      (scales-like -2 8 7.919, (assoc default-scaling "scale-down-factor" 0.001 "scale-up-factor" 0.1) 10 0 7.927 9 0)
+      (scales-like -1 8 7.919, (assoc default-scaling "scale-down-factor" 0.001 "scale-up-factor" 0.1) 9 0 7.927 8 0))
     (testing "scale down does not affect unhealthy instance"
       (scales-like 0 2 1, default-scaling 2 0 1.3 1 1))
     (testing "scale down replacement instance for expired"


### PR DESCRIPTION
## Changes proposed in this PR

- avoids triggering expired instances logic in scaling when there are no expired instances

## Why are we making these changes?

We want to avoid jitters in the scaling algorithms, an example is shown in the image below:
![waiter-scaling-jitters](https://user-images.githubusercontent.com/6611249/41128247-1c9b5882-6a73-11e8-92ef-770b2a895caf.png)

When all target instances aren't healthy, the previous code used to incorrectly assume that it is trying to replace expired instances and compute incorrect scaling results that triggered the jitter in the chart above. The proposed fix avoids exploring this path if there are no expired instances.
