### PR TITLE
Statsd reporting for service launch metrics

### DIFF
--- a/waiter/integration/waiter/metrics_output_test.clj
+++ b/waiter/integration/waiter/metrics_output_test.clj
@@ -181,12 +181,11 @@
           router->endpoint (routers waiter-url)
           router-urls (vals router->endpoint)
           service-name (rand-name)
-          sleep-seconds 20
+          sleep-millis 20000
           min-startup-seconds 10 ; 20s +/- 10s for 2 polls with 5s granularity
           max-startup-seconds 60 ; the service shouldn't take more than a minute to become healthy
           instance-count 2
-          req-headers {:x-waiter-cmd (kitchen-cmd (str "-p $PORT0 --start-up-sleep-ms "
-                                                       (* 1000 sleep-seconds)))
+          req-headers {:x-waiter-cmd (kitchen-cmd (str "-p $PORT0 --start-up-sleep-ms " sleep-millis))
                        :x-waiter-cmd-type "shell"
                        :x-waiter-min-instances instance-count
                        :x-waiter-name service-name}
@@ -215,11 +214,11 @@
                       (get service-scheduling-metric "count")))
               (is (<= instance-count
                       (get waiter-scheduling-metric "count"))))
-            (testing "reasonable values for current service's launch metrics"
+            (testing "reasonable values for current service's startup-time metrics"
               (is (<= min-startup-seconds
                       (get-percentile-value service-startup-metric "1.0")
                       max-startup-seconds)))
-            (testing "reasonable values for global launch metrics"
+            (testing "reasonable values for scheduling-time metrics"
               (is (<= (get-percentile-value waiter-scheduling-metric "0.0")
                       (get-percentile-value service-scheduling-metric "0.0")))
               (is (<= (get-percentile-value service-scheduling-metric "1.0")

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -875,11 +875,13 @@
                                     initial-state {}]
                                 (interstitial/interstitial-maintainer
                                   service-id->service-description-fn scheduler-state-chan interstitial-state-atom initial-state)))
-   :launch-metrics-maintainer (pc/fnk [[:routines service-id->service-description-fn]
+   :launch-metrics-maintainer (pc/fnk [[:curator leader?-fn]
+                                       [:routines service-id->service-description-fn]
                                        router-state-maintainer]
                                 (let [{{:keys [router-state-push-mult]} :maintainer-chans} router-state-maintainer]
                                   (scheduler/start-launch-metrics-maintainer
                                     (async/tap router-state-push-mult (au/latest-chan))
+                                    leader?-fn
                                     service-id->service-description-fn)))
    :messages (pc/fnk [[:settings {messages nil}]]
                (when messages

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -875,10 +875,12 @@
                                     initial-state {}]
                                 (interstitial/interstitial-maintainer
                                   service-id->service-description-fn scheduler-state-chan interstitial-state-atom initial-state)))
-   :launch-metrics-maintainer (pc/fnk [router-state-maintainer]
+   :launch-metrics-maintainer (pc/fnk [[:routines service-id->service-description-fn]
+                                       router-state-maintainer]
                                 (let [{{:keys [router-state-push-mult]} :maintainer-chans} router-state-maintainer]
                                   (scheduler/start-launch-metrics-maintainer
-                                    (async/tap router-state-push-mult (au/latest-chan)))))
+                                    (async/tap router-state-push-mult (au/latest-chan))
+                                    service-id->service-description-fn)))
    :messages (pc/fnk [[:settings {messages nil}]]
                (when messages
                  (utils/load-messages messages)))

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -736,7 +736,7 @@
             (metrics/report-duration service-schedule-timer duration)
             (when leader?
               (statsd/histo! metric-group "schedule_time"
-                             (t/in-millis duration)))))
+                             (du/interval->nanoseconds duration)))))
         ;; Report startup time for instances that are now healthy
         (doseq [instance-id started-instance-ids]
           (let [start-time (starting-instance-id->start-timestamp' instance-id)
@@ -744,7 +744,7 @@
             (metrics/report-duration service-startup-timer duration)
             (when leader?
               (statsd/histo! metric-group "startup_time"
-                             (t/in-millis duration)))))
+                             (du/interval->nanoseconds duration)))))
         ;; tracker-state'
         (assoc tracker-state
                :instance-counts instance-counts'

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -27,6 +27,7 @@
             [slingshot.slingshot :as ss]
             [waiter.correlation-id :as cid]
             [waiter.metrics :as metrics]
+            [waiter.statsd :as statsd]
             [waiter.util.async-utils :as au]
             [waiter.util.date-utils :as du]
             [waiter.util.utils :as utils])
@@ -655,12 +656,13 @@
 (def instance-counts-zero {:healthy 0 :requested 0 :scheduled 0})
 
 (defn- make-launch-tracker
-  ([service-id]
-   (make-launch-tracker service-id instance-counts-zero #{}))
-  ([service-id instance-counts known-instance-ids]
+  ([service-id service-id->service-description-fn]
+   (make-launch-tracker service-id service-id->service-description-fn instance-counts-zero #{}))
+  ([service-id service-id->service-description-fn instance-counts known-instance-ids]
    {:instance-counts instance-counts
     :instance-scheduling-start-times []
     :known-instance-ids known-instance-ids
+    :metric-group (-> service-id service-id->service-description-fn (get "metric-group"))
     :service-schedule-timer (metrics/service-timer service-id "launch-overhead" "schedule-time")
     :service-startup-timer (metrics/service-timer service-id "launch-overhead" "startup-time")
     :starting-instance-id->start-timestamp {}}))
@@ -670,16 +672,18 @@
    1) the time from requesting a new instance until it is scheduled (the \"schedule\" time), and
    2) the time from scheduling a new instance until it becomes healthy (the \"startup\" time)."
   [service-id->launch-tracker new-service-ids removed-service-ids service-id->healthy-instances
-   service-id->unhealthy-instances service-id->instance-counts waiter-schedule-timer]
+   service-id->unhealthy-instances service-id->instance-counts
+   service-id->service-description-fn waiter-schedule-timer]
   (let [current-time (t/now)
         ;; Remove deleted services and add newly-discovered services
         service-id->launch-tracker'
         (merge (reduce dissoc service-id->launch-tracker removed-service-ids)
-               (pc/map-from-keys make-launch-tracker new-service-ids))]
+               (pc/map-from-keys #(make-launch-tracker % service-id->service-description-fn)
+                                 new-service-ids))]
     ;; Update all trackers...
     (pc/for-map [[service-id
-                  {:keys [known-instance-ids instance-counts instance-scheduling-start-times
-                          service-schedule-timer service-startup-timer
+                  {:keys [instance-counts instance-scheduling-start-times known-instance-ids
+                          metric-group service-schedule-timer service-startup-timer
                           starting-instance-id->start-timestamp] :as tracker-state}]
                  service-id->launch-tracker']
       service-id
@@ -729,7 +733,9 @@
         (doseq [start-time matched-start-times]
           (let [duration (metrics/duration-between start-time current-time)]
             (metrics/report-duration waiter-schedule-timer duration)
-            (metrics/report-duration service-schedule-timer duration)))
+            (metrics/report-duration service-schedule-timer duration)
+            (statsd/histo! metric-group "schedule_time_seconds"
+                           (t/in-seconds duration))))
         ;; Report startup time for instances that are now healthy
         (doseq [instance-id started-instance-ids]
           (let [start-time (starting-instance-id->start-timestamp' instance-id)]
@@ -745,7 +751,8 @@
   "Build the initially-observed state for the launch-metrics-maintainer's state loop
    from the first state observed on the router-state-updates channel."
   [{:keys [iteration service-id->healthy-instances service-id->instance-counts
-           service-id->unhealthy-instances] :as initial-router-state}]
+           service-id->unhealthy-instances] :as initial-router-state}
+   service-id->service-description-fn]
   (let [initial-service-ids (-> service-id->instance-counts keys set)
         initial-service-id->launch-tracker
         (pc/for-map [service-id initial-service-ids]
@@ -756,7 +763,10 @@
                                                   service-id->unhealthy-instances]
                            instance (get service-id->instances service-id)]
                        (:id instance)))]
-            (make-launch-tracker service-id instance-counts known-instance-ids)))]
+            (make-launch-tracker service-id
+                                 service-id->service-description-fn
+                                 instance-counts
+                                 known-instance-ids)))]
     (log/info "Starting launch metrics loop on iteration" iteration
               "with services:" initial-service-ids)
     {:known-service-ids initial-service-ids
@@ -767,7 +777,7 @@
   "go block to collect metrics on the instance launch overhead of waiter services.
 
   Updates to state for the router are then read from `router-state-updates-chan`."
-  [router-state-updates-chan]
+  [router-state-updates-chan service-id->service-description-fn]
   (let [exit-chan (async/chan 1)
         query-chan (au/latest-chan)
         update-state-timer (metrics/waiter-timer "state" "launch-metrics-maintainer" "update-state")
@@ -796,7 +806,7 @@
                   ([router-state]
                    (cond
                      (nil? service-id->launch-tracker)
-                     (build-initial-service-launch-trackers router-state)
+                     (build-initial-service-launch-trackers router-state service-id->service-description-fn)
 
                      (< previous-iteration (:iteration router-state))
                      (timers/start-stop-time!
@@ -809,7 +819,8 @@
                              service-id->launch-tracker' (update-launch-trackers
                                                            service-id->launch-tracker new-service-ids removed-service-ids
                                                            service-id->healthy-instances service-id->unhealthy-instances
-                                                           service-id->instance-counts waiter-schedule-timer)]
+                                                           service-id->instance-counts service-id->service-description-fn
+                                                           waiter-schedule-timer)]
                          {:known-service-ids incoming-service-ids
                           :previous-iteration iteration
                           :service-id->launch-tracker service-id->launch-tracker'}))

--- a/waiter/src/waiter/util/date_utils.clj
+++ b/waiter/src/waiter/util/date_utils.clj
@@ -64,3 +64,10 @@
   (if (and duration started-at)
     (t/after? current-time (t/plus started-at duration))
     false))
+
+(defn interval->nanoseconds
+  "Convert a time interval to a duration in nanoseconds."
+  [interval]
+  ;; clj-time.core doesn't have a in-nanos function.
+  ;; We shouldn't need to worry about overflows here if our intervals are < 200 years.
+  (-> interval t/in-millis (* 1e6)))

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -585,6 +585,7 @@
         empty-service-id->healthy-instances {}
         empty-service-id->unhealthy-instances {}
         empty-service-id->instance-counts {}
+        empty-service-id->service-description {}
         req1 {:requested 1}
         req3 {:requested 3}
         waiter-timer (metrics/waiter-timer "launch-overhead" "schedule-time")
@@ -592,11 +593,11 @@
         empty-trackers' (update-launch-trackers
                           empty-trackers empty-new-service-ids empty-removed-service-ids
                           empty-service-id->healthy-instances empty-service-id->unhealthy-instances
-                          empty-service-id->instance-counts waiter-timer)
+                          empty-service-id->instance-counts empty-service-id->service-description waiter-timer)
         empty-trackers'' (update-launch-trackers
                            empty-trackers empty-new-service-ids #{"service-foo"}
                            empty-service-id->healthy-instances empty-service-id->unhealthy-instances
-                           empty-service-id->instance-counts waiter-timer)
+                           empty-service-id->instance-counts empty-service-id->service-description waiter-timer)
         _ (testing "update-launch-trackers: empty -> empty"
             (is (= empty-trackers empty-trackers'))
             (is (= empty-trackers empty-trackers'')))
@@ -605,7 +606,7 @@
         trackers-1 (update-launch-trackers
                      empty-trackers #{"service-1" "service-2"} empty-removed-service-ids
                      empty-service-id->healthy-instances empty-service-id->unhealthy-instances
-                     service-id->instance-counts-1 waiter-timer)
+                     service-id->instance-counts-1 empty-service-id->service-description waiter-timer)
         _ (testing "update-launch-trackers: empty -> non-empty"
             (check-trackers trackers-1 {"service-1" {:scheduling-instance-count 1}
                                         "service-2" {:scheduling-instance-count 1}}))
@@ -613,7 +614,7 @@
         trackers-2 (update-launch-trackers
                      trackers-1 empty-new-service-ids #{"service-1" "service-2"}
                      empty-service-id->healthy-instances empty-service-id->unhealthy-instances
-                     empty-service-id->instance-counts waiter-timer)
+                     empty-service-id->instance-counts empty-service-id->service-description waiter-timer)
         _ (testing "update-launch-trackers: trivial non-empty -> empty"
             (is (= empty-trackers trackers-2)))
 
@@ -621,7 +622,7 @@
         trackers-3 (update-launch-trackers
                      trackers-1 #{"service-3"} #{"service-2"}
                      empty-service-id->healthy-instances empty-service-id->unhealthy-instances
-                     service-id->instance-counts-3 waiter-timer)
+                     service-id->instance-counts-3 empty-service-id->service-description waiter-timer)
         _ (testing "update-launch-trackers: simultaneously add and remove services"
             (check-trackers trackers-3 {"service-1" {:scheduling-instance-count 1}
                                         "service-3" {:scheduling-instance-count 1}}))
@@ -629,7 +630,7 @@
         trackers-4 (update-launch-trackers
                      trackers-3 empty-new-service-ids empty-removed-service-ids
                      empty-service-id->healthy-instances {"service-1" [(make-service-instance 1 1)]}
-                     service-id->instance-counts-3 waiter-timer)
+                     service-id->instance-counts-3 empty-service-id->service-description waiter-timer)
         _ (testing "update-launch-trackers: scheduled a service instance"
             (check-trackers trackers-4 {"service-1" {:known-instance-ids #{"inst-1.1"}
                                                      :starting-instance-ids ["inst-1.1"]}
@@ -640,7 +641,8 @@
                      trackers-4 #{"service-4"} empty-removed-service-ids
                      {"service-1" [(make-service-instance 1 1)]
                       "service-3" [(make-service-instance 3 1)]}
-                     empty-service-id->unhealthy-instances service-id->instance-counts-5 waiter-timer)
+                     empty-service-id->unhealthy-instances service-id->instance-counts-5
+                     empty-service-id->service-description waiter-timer)
         _ (testing "update-launch-trackers: service instances started, and a new service appears"
             (check-trackers trackers-5 {"service-1" {:known-instance-ids #{"inst-1.1"}}
                                         "service-3" {:known-instance-ids #{"inst-3.1"}}
@@ -652,7 +654,7 @@
                      {"service-1" [(make-service-instance 1 1)]
                       "service-4" [(make-service-instance 4 1)]}
                      {"service-5" [(make-service-instance 5 1)]}
-                     service-id->instance-counts-6 waiter-timer)
+                     service-id->instance-counts-6 empty-service-id->service-description waiter-timer)
         _ (testing "update-launch-trackers: simultaneously add and remove services,
                     and a healthy instance appears"
             (check-trackers trackers-6 {"service-1" {:known-instance-ids #{"inst-1.1"}}
@@ -666,7 +668,7 @@
                      {"service-1" [(make-service-instance 1 1)]
                       "service-4" [(make-service-instance 4 1)]}
                      {"service-5" [(make-service-instance 5 1)]}
-                     service-id->instance-counts-7 waiter-timer)
+                     service-id->instance-counts-7 empty-service-id->service-description waiter-timer)
         _ (testing "update-launch-trackers: service 5 scales to 3 instances"
             (check-trackers trackers-7 {"service-1" {:known-instance-ids #{"inst-1.1"}}
                                         "service-4" {:known-instance-ids #{"inst-4.1"}}
@@ -683,7 +685,7 @@
                       "service-5" [(make-service-instance 5 1)
                                    (make-service-instance 5 2)
                                    (make-service-instance 5 3)]}
-                     service-id->instance-counts-8 waiter-timer)
+                     service-id->instance-counts-8 empty-service-id->service-description waiter-timer)
         _ (testing "update-launch-trackers: all requested instances transition to unhealthy"
             (check-trackers trackers-8 {"service-1" {:known-instance-ids #{"inst-1.1"}}
                                         "service-4" {:known-instance-ids #{"inst-4.1"}}
@@ -698,7 +700,7 @@
                                    (make-service-instance 5 2)
                                    (make-service-instance 5 3)]}
                      empty-service-id->unhealthy-instances
-                     service-id->instance-counts-8 waiter-timer)
+                     service-id->instance-counts-8 empty-service-id->service-description waiter-timer)
         _ (testing "update-launch-trackers: all instances transition to healthy"
             (check-trackers trackers-9 {"service-1" {:known-instance-ids #{"inst-1.1"}}
                                         "service-4" {:known-instance-ids #{"inst-4.1"}}
@@ -707,7 +709,7 @@
         trackers-10 (update-launch-trackers
                       trackers-9 empty-new-service-ids #{"service-1" "service-4" "service-5"}
                       empty-service-id->healthy-instances empty-service-id->unhealthy-instances
-                      empty-service-id->instance-counts waiter-timer)]
+                      empty-service-id->instance-counts empty-service-id->service-description waiter-timer)]
     (testing "update-launch-trackers: transition back to empty"
       (is (= empty-trackers trackers-10)))))
 
@@ -717,7 +719,9 @@
           (fn make-metric-maintainer
             [state-0]
             (let [state-updates-chan (async/chan 1)
-                  maintainer (start-launch-metrics-maintainer state-updates-chan)]
+                  maintainer (start-launch-metrics-maintainer
+                               state-updates-chan
+                               (constantly {"metric-group" "default"}))]
               (async/>!! state-updates-chan state-0)
               (assoc maintainer :update-chan state-updates-chan)))
           update-metric-maintainer-state
@@ -761,6 +765,7 @@
                               {service-id {:instance-counts instance-counts
                                            :instance-scheduling-start-times []
                                            :known-instance-ids #{"inst1" "inst2"}
+                                           :metric-group "default"
                                            :starting-instance-id->start-timestamp {}}}}
 
             instance-counts' {:healthy 2 :requested 6 :scheduled 3}
@@ -776,6 +781,7 @@
                               {service-id {:instance-counts instance-counts'
                                            :instance-scheduling-start-times [:time :time]
                                            :known-instance-ids #{"inst1" "inst2" "inst3"}
+                                           :metric-group "default"
                                            :starting-instance-id->start-timestamp {"inst3" :time}}}}]
         (testing "non-empty initial router state"
           (is (= expected-state-1 actual-state-1)))


### PR DESCRIPTION
## Changes proposed in this PR

Adds `statsd` reporting for a subset of the service instance launch metrics added in #305.

## Why are we making these changes?

The current codahale metrics disappear when a Waiter router is restarted. We would like to persist some of the metrics so that we have historical data.