### PR TITLE
Adds Slack sign up badge to the top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 # Waiter
 
 [![Build Status](https://travis-ci.org/twosigma/waiter.svg)](https://travis-ci.org/twosigma/waiter)
+[![Slack Status](http://waiter-dev.herokuapp.com/badge.svg)](http://waiter-dev.herokuapp.com/)
 
 Welcome to Two Sigma's Waiter project!
 


### PR DESCRIPTION
## Changes proposed in this PR

- adding Slack sign-up badge to the README

## Why are we making these changes?

So that people can easily find our Slack and ask questions / provide feedback.

## Screenshot

![image](https://user-images.githubusercontent.com/444778/41310957-99ffea08-6e48-11e8-8879-d5ec1873a8ed.png)
