### PR TITLE
Fix launch metric tests

### DIFF
--- a/waiter/integration/waiter/metrics_output_test.clj
+++ b/waiter/integration/waiter/metrics_output_test.clj
@@ -155,14 +155,14 @@
      (is (number? p-value#) (str "missing p" p# " value"))
      p-value#))
 
-(defn- n-scheduled-instances-observed?
-  "Returns true if the launch-metrics state reflects at least $n$ scheduled
+(defn- n-healthy-instances-observed?
+  "Returns true if the launch-metrics state reflects at least $n$ healthy
    instances in the instance counts for the given service on the given router."
   [router-url cookies service-id n]
   (-> (make-request router-url "/state/launch-metrics" :cookies cookies :verbose true)
       :body
       try-parse-json
-      (get-in ["state" "service-id->launch-tracker" service-id "instance-counts" "scheduled"] 0)
+      (get-in ["state" "service-id->launch-tracker" service-id "instance-counts" "healthy"] 0)
       (>= n)))
 
 (deftest ^:parallel ^:integration-slow test-launch-metrics-output
@@ -189,7 +189,7 @@
         (assert-response-status first-response 200)
         ; on each router, check that the launch-metrics are present and have sane values
         (doseq [[router-id router-url] router->endpoint]
-          (wait-for #(n-scheduled-instances-observed? router-url cookies service-id instance-count)
+          (wait-for #(n-healthy-instances-observed? router-url cookies service-id instance-count)
                     :interval 1 :timeout min-startup-seconds)
           (let [metrics-response (->> "/metrics"
                                       (make-request router-url)

--- a/waiter/integration/waiter/metrics_output_test.clj
+++ b/waiter/integration/waiter/metrics_output_test.clj
@@ -120,7 +120,7 @@
       (doall (map (fn [router-id]
                     (let [router-url (str (get router->endpoint router-id))
                           metrics-json-response (make-request router-url "/metrics")
-                          metrics-response (json/read-str (:body metrics-json-response))
+                          metrics-response (try-parse-json (:body metrics-json-response))
                           service-metrics (get-in metrics-response ["services" service-id])]
                       (log/info "asserting jvm metrics output for" router-url)
                       (assert-metrics-output (get metrics-response "jvm") jvm-metrics-schema)
@@ -161,7 +161,7 @@
   [router-url service-id n]
   (-> (make-request router-url "/state/launch-metrics")
       :body
-      json/read-str
+      try-parse-json
       (get-in ["state" "service-id->launch-tracker" service-id "instance-counts" "scheduled"] 0)
       (>= n)))
 
@@ -194,7 +194,7 @@
           (let [metrics-response (->> "/metrics"
                                       (make-request router-url)
                                       :body
-                                      json/read-str)
+                                      try-parse-json)
                 service-launch-metrics (get-in metrics-response ["services" service-id "timers" "launch-overhead"])
                 service-scheduling-metric (get service-launch-metrics "schedule-time")
                 service-startup-metric (get service-launch-metrics "startup-time")

--- a/waiter/integration/waiter/metrics_output_test.clj
+++ b/waiter/integration/waiter/metrics_output_test.clj
@@ -159,7 +159,7 @@
   "Returns true if the launch-metrics state reflects at least $n$ scheduled
    instances in the instance counts for the given service on the given router."
   [router-url service-id n]
-  (-> (make-request router-url "/state/launch-metrics")
+  (-> (make-request router-url "/state/launch-metrics" :verbose true)
       :body
       try-parse-json
       (get-in ["state" "service-id->launch-tracker" service-id "instance-counts" "scheduled"] 0)

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -490,7 +490,9 @@
                                               [:update-service-instances
                                                (assoc service-instance-info
                                                       :failed-instances all-failed-instances
-                                                      :instance-counts {:requested instances :scheduled task-count}
+                                                      :instance-counts {:healthy (count healthy-instances)
+                                                                        :requested instances
+                                                                        :scheduled task-count}
                                                       :scheduler-sync-time request-instances-time
                                                       :service-id service-id)])
                                         scheduler-messages)
@@ -650,7 +652,7 @@
 
 ;; Support for tracking service instance launching time stats
 
-(def instance-counts-zero {:requested 0 :scheduled 0})
+(def instance-counts-zero {:healthy 0 :requested 0 :scheduled 0})
 
 (defn- make-launch-tracker
   ([service-id]

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -746,7 +746,7 @@
         (testing "empty initial router state"
           (is (= expected-state actual-state))))
       (let [service-id "service1"
-            instance-counts {:requested 3 :scheduled 2}
+            instance-counts {:healthy 1 :requested 3 :scheduled 2}
             initial-router-state {:iteration 7
                                   :service-id->healthy-instances {service-id [{:id "inst1"}]}
                                   :service-id->instance-counts {service-id instance-counts}
@@ -763,7 +763,7 @@
                                            :known-instance-ids #{"inst1" "inst2"}
                                            :starting-instance-id->start-timestamp {}}}}
 
-            instance-counts' {:requested 6 :scheduled 3}
+            instance-counts' {:healthy 2 :requested 6 :scheduled 3}
             updated-router-state {:iteration 9
                                   :service-id->healthy-instances {service-id [{:id "inst1"} {:id "inst2"}]}
                                   :service-id->instance-counts {service-id instance-counts'}


### PR DESCRIPTION
## Changes proposed in this PR

- Use cookie authentication in requests to routers.
- Wait for *healthy* (not *scheduled*) instances before checking metric values.
- Use `try-parse-json` helper in tests.

## Why are we making these changes?

Using cookies avoids authentication problems when doing Keberos auth. The *healthy* vs *scheduled* bug was causing races in the test. Using `try-parse-json` gives us better error reporting.
