### PR TITLE
Upload logs to google drive on Travis-CI failures

### DIFF
--- a/waiter/bin/ci/gdrive_upload
+++ b/waiter/bin/ci/gdrive_upload
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import base64
+import os
+import sys
+import urllib.parse, urllib.request
+import warnings
+
+if len(sys.argv) != 3:
+    print('USAGE: {} JOB-ID XZ-FILE'.format(sys.argv[0]))
+    print('Upload an xz-compressed file to our Google Drive stash')
+    sys.exit(1)
+
+tarball_path = sys.argv[2]
+
+# upload to google drive
+app_url = os.environ.get('GDRIVE_LOG_POST_URL')
+
+if not app_url:
+    print('Missing application url. Please set GDRIVE_LOG_POST_URL in the environment.')
+    sys.exit(1)
+
+with open(tarball_path, 'rb') as tarball:
+    post_data = urllib.parse.urlencode({
+        'job_id': sys.argv[1],
+        'tarball': base64.b64encode(tarball.read())
+    }).encode("utf-8")
+
+req = urllib.request.Request(app_url, data=post_data)
+with urllib.request.urlopen(req) as response:
+   response_text = response.read()
+
+print()
+print('==============================')
+print('== UPLOAD RESPONSE:')
+print('==============================')
+print(response_text)
+print('==============================')
+print()
+
+if not response_text.strip().endswith(b'successfully'):
+    print('UPLOAD FAILED!')
+    sys.exit(1)

--- a/waiter/bin/ci/run-integration-tests-shell-scheduler.sh
+++ b/waiter/bin/ci/run-integration-tests-shell-scheduler.sh
@@ -35,7 +35,7 @@ WAITER_TEST_KITCHEN_CMD=${KITCHEN_DIR}/bin/run.sh WAITER_URI=127.0.0.1:${WAITER_
 
 # If there were failures, dump the logs
 if [ "$test_failures" = true ]; then
-    echo "integration tests failed -- dumping logs"
-    tail -n +1 -- log/*.log
+    echo "Uploading logs..."
+    ${WAITER_DIR}/bin/ci/upload_logs.sh
     exit 1
 fi

--- a/waiter/bin/ci/run-integration-tests.sh
+++ b/waiter/bin/ci/run-integration-tests.sh
@@ -38,7 +38,7 @@ WAITER_TEST_KITCHEN_CMD=/opt/kitchen/container-run.sh WAITER_URI=127.0.0.1:${WAI
 
 # If there were failures, dump the logs
 if [ "$test_failures" = true ]; then
-    echo "integration tests failed -- dumping logs"
-    tail -n +1 -- log/*.log
+    echo "Uploading logs..."
+    ${WAITER_DIR}/bin/ci/upload_logs.sh
     exit 1
 fi

--- a/waiter/bin/ci/upload_logs.sh
+++ b/waiter/bin/ci/upload_logs.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd ${TRAVIS_BUILD_DIR}
+
+tarball=./dump.txz
+log_dirs=./waiter/log
+dump_name="${TRAVIS_JOB_NUMBER:-dump}"
+
+# Grab Mesos logs
+if [ -d ./waiter/.minimesos ]; then
+    # List the last 10 containers
+    docker ps --all --last 10
+
+    # Extract the Mesos master logs from docker
+    mesos_master_container=$(docker ps --all --latest --filter 'name=minimesos-master-' --format '{{.ID}}')
+    mkdir -p ./mesos/master-logs
+    docker cp --follow-link $mesos_master_container:/var/log/mesos-master.INFO ./mesos/master-logs/
+    docker cp --follow-link $mesos_master_container:/var/log/mesos-master.WARNING ./mesos/master-logs/
+
+    # Extract the Mesos agent logs from docker
+    mesos_agent_containers=$(docker ps --all --last 4 --filter 'name=minimesos-agent-' --format '{{.ID}}')
+    for container in $mesos_agent_containers; do
+        destination=./mesos/agent-logs/$container
+        mkdir -p $destination
+        docker cp --follow-link $container:/var/log/mesos-slave.INFO $destination
+        docker cp --follow-link $container:/var/log/mesos-slave.WARNING $destination
+        docker cp --follow-link $container:/var/log/mesos-slave.ERROR $destination
+        docker cp --follow-link $container:/var/log/mesos-fetcher.INFO $destination || echo "Container $container does not have mesos-fetcher.INFO"
+    done
+
+    log_dirs+=' ./waiter/.minimesos ./mesos/master-logs ./mesos/agent-logs'
+fi
+
+# Grab shell scheduler logs
+if [ -d ./waiter/scheduler ]; then
+    log_dirs+=' ./waiter/scheduler'
+fi
+
+# Tarball-up all of our Waiter/Mesos/etc logs
+tar -cJf $tarball --transform="s|\\./[^/]*/\\.*|${dump_name}/|" --warning=no-file-changed $log_dirs || exitcode=$?
+
+# GNU tar always exits with 0, 1 or 2 (https://www.gnu.org/software/tar/manual/html_section/tar_19.html)
+# 0 = Successful termination
+# 1 = Some files differ (we're OK with this)
+# 2 = Fatal error
+if [ $exitcode == 2 ]; then
+  echo "The tar command exited with exit code $exitcode, exiting..."
+  exit $exitcode
+fi
+./waiter/bin/ci/gdrive_upload "travis-${dump_name}" $tarball


### PR DESCRIPTION
## Changes proposed in this PR

Upload logs to Google Drive when an integration test fails.

## Why are we making these changes?

The logs are too big to dump to stdout (they get truncated, and it takes *forever*).