### PR TITLE
Adds support for effective-parameters in the /apps/<service-id> endpoint

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -320,7 +320,8 @@
                 (is (= (name-from-service-description waiter-url service-id) service-id-prefix))
                 (is (= (make-source-tokens-entries waiter-url token)
                        (source-tokens-from-service-description waiter-url service-id)))
-                (is (= token-prefix (service-id->metric-group waiter-url service-id))))
+                (is (= token-prefix (service-id->metric-group waiter-url service-id))
+                    (str {:service-id service-id :token token})))
 
               (log/info "request with hostname token" token "along with x-waiter headers except permitted-user")
               (let [request-headers (merge (dissoc service-description :x-waiter-permitted-user) {"host" token})
@@ -331,7 +332,8 @@
                 (is (= (name-from-service-description waiter-url service-id) service-id-prefix))
                 (is (= (make-source-tokens-entries waiter-url token)
                        (source-tokens-from-service-description waiter-url service-id)))
-                (is (= token-prefix (service-id->metric-group waiter-url service-id)))
+                (is (= token-prefix (service-id->metric-group waiter-url service-id))
+                    (str {:service-id service-id :token token}))
                 ;; the above request hashes to a different service-id than the rest of the test, so we need to cleanup
                 (delete-service waiter-url service-id))
 
@@ -344,7 +346,8 @@
                 (is (= (name-from-service-description waiter-url service-id) service-id-prefix))
                 (is (= (make-source-tokens-entries waiter-url token)
                        (source-tokens-from-service-description waiter-url service-id)))
-                (is (= token-prefix (service-id->metric-group waiter-url service-id)))
+                (is (= token-prefix (service-id->metric-group waiter-url service-id))
+                    (str {:service-id service-id :token token}))
 
                 (testing "backend request headers"
                   (let [{:keys [body] :as response} (make-request waiter-url "/request-info" :headers request-headers)
@@ -381,7 +384,8 @@
                 (is (every? #(not (str/blank? (get headers %)))
                             (concat required-response-headers (retrieve-debug-response-headers waiter-url)))
                     (str headers))
-                (is (= token-prefix (service-id->metric-group waiter-url service-id)))
+                (is (= token-prefix (service-id->metric-group waiter-url service-id))
+                    (str {:service-id service-id :token token}))
                 (delete-service waiter-url service-id))))
           (finally
             (delete-token-and-assert waiter-url token)))))))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1095,14 +1095,16 @@
                                     (metrics-sync/incoming-router-metrics-handler
                                       router-metrics-agent metrics-sync-interval-ms bytes-encryptor bytes-decryptor request))))
    :service-handler-fn (pc/fnk [[:curator kv-store]
-                                [:routines allowed-to-manage-service?-fn generate-log-url-fn make-inter-router-requests-sync-fn]
+                                [:routines allowed-to-manage-service?-fn generate-log-url-fn make-inter-router-requests-sync-fn
+                                 service-id->service-description-fn]
                                 [:scheduler scheduler]
                                 [:state router-id]
                                 wrap-secure-request-fn]
                          (wrap-secure-request-fn
                            (fn service-handler-fn [{:as request {:keys [service-id]} :route-params}]
                              (handler/service-handler router-id service-id scheduler kv-store allowed-to-manage-service?-fn
-                                                      generate-log-url-fn make-inter-router-requests-sync-fn request))))
+                                                      generate-log-url-fn make-inter-router-requests-sync-fn
+                                                      service-id->service-description-fn request))))
    :service-id-handler-fn (pc/fnk [[:curator kv-store]
                                    [:routines store-service-description-fn]
                                    wrap-descriptor-fn wrap-secure-request-fn]

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -390,9 +390,12 @@
         settings-json (try-parse-json (:body settings-result))]
     (walk/keywordize-keys settings-json)))
 
-(defn service-settings [waiter-url service-id & {:keys [keywordize-keys] :or {keywordize-keys true}}]
+(defn service-settings
+  "Fetches and returns the service data at the /apps/<service-id> endpoint."
+  [waiter-url service-id & {:keys [keywordize-keys query-params]
+                            :or {keywordize-keys true query-params {}}}]
   (let [settings-path (str "/apps/" service-id)
-        settings-result (make-request waiter-url settings-path)]
+        settings-result (make-request waiter-url settings-path :query-params query-params)]
     (log/debug "service" service-id ":" settings-result)
     (cond-> (some-> settings-result :body try-parse-json)
             keywordize-keys walk/keywordize-keys)))

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -383,7 +383,7 @@
           (is (= 200 status) body)
           (is (every? #(str/includes? body %) ["test.host.com" "5051" "file" "directory" "name" "url" "download"])))))))
 
-(deftest test-apps-handler-delete
+(deftest test-service-handler-delete
   (let [user "test-user"
         service-id "test-service-1"
         kv-store (kv/->LocalKeyValueStore (atom {}))
@@ -395,7 +395,8 @@
         configuration {:curator {:kv-store nil}
                        :routines {:allowed-to-manage-service?-fn allowed-to-manage-service?
                                   :generate-log-url-fn nil
-                                  :make-inter-router-requests-sync-fn nil}
+                                  :make-inter-router-requests-sync-fn nil
+                                  :service-id->service-description-fn (constantly {})}
                        :scheduler {:scheduler (Object.)}
                        :state {:router-id "router-id"}
                        :wrap-secure-request-fn utils/wrap-identity}
@@ -460,14 +461,15 @@
           (is (= 500 status))
           (is (= {"content-type" "application/json"} headers)))))))
 
-(deftest test-apps-handler-get
+(deftest test-service-handler-get
   (let [user "waiter-user"
         service-id "test-service-1"
         waiter-request?-fn (fn [_] true)
         configuration {:curator {:kv-store nil}
                        :routines {:allowed-to-manage-service?-fn (constantly true)
                                   :generate-log-url-fn (partial handler/generate-log-url #(str "http://www.example.com" %))
-                                  :make-inter-router-requests-sync-fn nil}
+                                  :make-inter-router-requests-sync-fn nil
+                                  :service-id->service-description-fn (constantly {})}
                        :scheduler {:scheduler (Object.)}
                        :state {:router-id "router-id"}
                        :wrap-secure-request-fn utils/wrap-identity}


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for querying effective parameters in the /apps/<service-id> endpoint
- includes service-id in the failed metric group report

## Why are we making these changes?

We would like to make it easy to debug metric group failures. Currently, there is no way to view the effective parameters of an already deleted service. We address that shortcoming with this PR.

