### PR TITLE
removes logic for automatically determining metric groups from tokens

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -292,6 +292,7 @@
               (log/info "creating configuration using token" token)
               (let [{:keys [body status]}
                     (post-token waiter-url {:health-check-url "/probe"
+                                            :metric-group token-prefix
                                             :name service-id-prefix
                                             :token token})]
                 (when (not= 200 status)
@@ -303,6 +304,7 @@
                 (is (contains? response-body "last-update-time"))
                 (is (= {"health-check-url" "/probe"
                         "last-update-user" (retrieve-username)
+                        "metric-group" token-prefix
                         "name" service-id-prefix
                         "owner" (retrieve-username)
                         "previous" {}

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -259,25 +259,12 @@
   (when service-name
     (some #(when (re-matches (first %) service-name) (second %)) mappings)))
 
-(defn- source-tokens->metric-group
-  "When there is a single source token and it contains a dot (.), extracts the
-   part of the token before the dot as the metric group. If this fragment satisfies
-   the metric-group schema, return the fragment."
-  [source-tokens]
-  (when (= 1 (count source-tokens))
-    (when-let [token (-> source-tokens first (get "token"))]
-      (when-let [index-of-dot (str/index-of token ".")]
-        (let [metric-group (subs token 0 index-of-dot)]
-          (when-not (s/check schema/valid-metric-group metric-group)
-            metric-group))))))
-
 (defn metric-group-filter
   "Filter for descriptors which resolves the metric group"
-  [{:strs [name metric-group source-tokens] :as service-description} mappings]
+  [{:strs [name metric-group] :as service-description} mappings]
   (cond-> service-description
           (nil? metric-group)
           (assoc "metric-group" (or (name->metric-group mappings name)
-                                    (source-tokens->metric-group source-tokens)
                                     "other"))))
 
 (defn merge-defaults

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -1917,8 +1917,8 @@
       (testing "should use mapping when metric group not specified"
         (is (= "mapped" (mg-filter {"name" "foo"}))))
 
-      (testing "should use source-tokens when single token specified"
-        (is (= "example-1" (mg-filter {"cpus" 1 "source-tokens" [{"token" "example-1.app.com" "version" "hash-1"}]}))))
+      (testing "should ignore source-tokens when single token specified"
+        (is (= "other" (mg-filter {"cpus" 1 "source-tokens" [{"token" "example-1.app.com" "version" "hash-1"}]}))))
 
       (testing "should use other when token in source-tokens does not validate"
         (is (= "other" (mg-filter {"cpus" 1 "source-tokens" [{"token" "example-1@app.com" "version" "hash-1"}]}))))


### PR DESCRIPTION
## Changes proposed in this PR

- removes logic for automatically determining metric groups from tokens

## Why are we making these changes?

We prefer to allow the user (or an admin) to explicitly configure the metric group associated with a service.

