### PR TITLE
handles namespaced keys in json output

### DIFF
--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -114,6 +114,13 @@
     (log/debug "generate-secret-word" [src-id dest-id] "->" secret-word)
     secret-word))
 
+(defn- stringify-keys
+  [k]
+  (cond
+    (keyword? k) (str (.-sym k))
+    (nil? k) (throw (Exception. "JSON object properties may not be nil"))
+    :else (str k)))
+
 (defn stringify-elements
   [k v]
   (cond
@@ -132,7 +139,7 @@
 (defn map->json
   "Convert the input data into a json string."
   [data-map]
-  (json/write-str data-map :value-fn stringify-elements))
+  (json/write-str data-map :key-fn stringify-keys :value-fn stringify-elements))
 
 (defn map->json-response
   "Convert the input data into a json response."

--- a/waiter/test/waiter/util/utils_test.clj
+++ b/waiter/test/waiter/util/utils_test.clj
@@ -117,7 +117,8 @@
 
     (testing "should convert regex patterns to strings"
       (is (= (json/write-str {"bar" "foo"}) (:body (map->json-response {:bar #"foo"}))))
-      (is (= (json/write-str {"bar" ["foo" "baz"]}) (:body (map->json-response {:bar [#"foo" #"baz"]}))))
+      (is (= (json/write-str {"bar" ["foo" "baz"] "foo/bar" "baz"})
+             (:body (map->json-response {:bar [#"foo" #"baz"] :foo/bar :baz}))))
       (is (= (json/write-str {"bar" ["foo" "baz"]}) (:body (map->json-response {:bar ["foo" #"baz"]}))))
       (is (= (json/write-str {"bar" [["foo" "baz"]]}) (:body (map->json-response {:bar [["foo" #"baz"]]})))))))
 


### PR DESCRIPTION
## Changes proposed in this PR

- handles namespaced keys in json output

## Why are we making these changes?

We would like to see the complete namespaced keyword string in JSON output to prevent automatically overriding matching keys.
