### PR TITLE
avoid setting the content-type by default

### DIFF
--- a/kitchen/project.clj
+++ b/kitchen/project.clj
@@ -14,7 +14,7 @@
 ;; limitations under the License.
 ;;
 (defproject kitchen "0.1.0-SNAPSHOT"
-  :dependencies [^{:voom {:repo "https://github.com/twosigma/jet.git" :branch "untyped-content-provider-default"}}
+  :dependencies [^{:voom {:repo "https://github.com/twosigma/jet.git" :branch "waiter-patch"}}
                  [cc.qbits/jet "0.7.10-20180626_194651-g716c5e0"]
                  [log4j/log4j "1.2.17" :exclusions [javax.mail/mail
                                                     javax.jms/jms

--- a/kitchen/project.clj
+++ b/kitchen/project.clj
@@ -14,8 +14,8 @@
 ;; limitations under the License.
 ;;
 (defproject kitchen "0.1.0-SNAPSHOT"
-  :dependencies [^{:voom {:repo "https://github.com/twosigma/jet.git" :branch "waiter-patch"}}
-                 [cc.qbits/jet "0.7.10-20180504_143513-g8f00b45"]
+  :dependencies [^{:voom {:repo "https://github.com/twosigma/jet.git" :branch "untyped-content-provider-default"}}
+                 [cc.qbits/jet "0.7.10-20180626_194651-g716c5e0"]
                  [log4j/log4j "1.2.17" :exclusions [javax.mail/mail
                                                     javax.jms/jms
                                                     com.sun.jmdk/jmxtools

--- a/kitchen/src/kitchen/core.clj
+++ b/kitchen/src/kitchen/core.clj
@@ -398,8 +398,11 @@
   (Thread/sleep (Integer/parseInt (get headers "x-kitchen-delay-ms" "1")))
   (when (contains? headers "x-kitchen-throw")
     (throw (ex-info "Instructed by header to throw" {})))
-  (let [response {:status (if (contains? headers "x-kitchen-act-busy") 503 200)
-                  :body (if (contains? headers "x-kitchen-echo") body "Hello World")}
+  (let [response {:body (if (contains? headers "x-kitchen-echo") body "Hello World")
+                  :headers (cond-> {}
+                             (contains? headers "x-kitchen-content-type")
+                             (assoc "content-type" (get headers "x-kitchen-content-type")))
+                  :status (if (contains? headers "x-kitchen-act-busy") 503 200)}
         cookies (get headers "x-kitchen-cookies")]
     (cond-> response cookies (add-cookies cookies))))
 

--- a/kitchen/test/kitchen/core_test.clj
+++ b/kitchen/test/kitchen/core_test.clj
@@ -51,9 +51,11 @@
 (deftest default-handler-test
   (testing "Default handler"
     (testing "should echo request body when x-kitchen-echo is present"
-      (let [handle-echo #(default-handler {:headers {"x-kitchen-echo" true} :body %})]
-        (is (= {:body "foo" :status 200} (handle-echo "foo")))
-        (is (= {:body "bar" :status 200} (handle-echo "bar")))))
+      (let [handle-echo #(default-handler {:headers %1 :body %2})]
+        (is (= {:body "foo" :headers {} :status 200}
+               (handle-echo {"x-kitchen-echo" true} "foo")))
+        (is (= {:body "bar" :headers {"content-type" "feefiefoe"} :status 200}
+               (handle-echo {"x-kitchen-echo" true "x-kitchen-content-type" "feefiefoe"} "bar")))))
     (testing "should set cookies when x-kitchen-cookies is present"
       (let [handle-cookies #(sort (get-in (default-handler {:headers {"x-kitchen-cookies" %}}) [:headers "Set-Cookie"]))]
         (is (= ["a=b" "c=d"] (handle-cookies "a=b,c=d")))

--- a/token-syncer/project.clj
+++ b/token-syncer/project.clj
@@ -14,8 +14,8 @@
 ;; limitations under the License.
 ;;
 (defproject token-syncer "0.1.0-SNAPSHOT"
-  :dependencies [^{:voom {:repo "https://github.com/twosigma/jet.git" :branch "waiter-patch"}}
-                 [cc.qbits/jet "0.7.10-20180504_143513-g8f00b45"]
+  :dependencies [^{:voom {:repo "https://github.com/twosigma/jet.git" :branch "untyped-content-provider-default"}}
+                 [cc.qbits/jet "0.7.10-20180626_194651-g716c5e0"]
                  [clj-time "0.12.0"]
                  [commons-codec/commons-codec "1.10"]
                  [org.clojure/clojure "1.8.0"]

--- a/token-syncer/project.clj
+++ b/token-syncer/project.clj
@@ -14,7 +14,7 @@
 ;; limitations under the License.
 ;;
 (defproject token-syncer "0.1.0-SNAPSHOT"
-  :dependencies [^{:voom {:repo "https://github.com/twosigma/jet.git" :branch "untyped-content-provider-default"}}
+  :dependencies [^{:voom {:repo "https://github.com/twosigma/jet.git" :branch "waiter-patch"}}
                  [cc.qbits/jet "0.7.10-20180626_194651-g716c5e0"]
                  [clj-time "0.12.0"]
                  [commons-codec/commons-codec "1.10"]

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -30,8 +30,8 @@
 
   :dependencies [[bidi "2.0.16"
                   :exclusions [prismatic/schema ring/ring-core]]
-                 ^{:voom {:repo "https://github.com/twosigma/jet.git" :branch "waiter-patch"}}
-                 [cc.qbits/jet "0.7.10-20180504_143513-g8f00b45"]
+                 ^{:voom {:repo "https://github.com/twosigma/jet.git" :branch "untyped-content-provider-default"}}
+                 [cc.qbits/jet "0.7.10-20180626_194651-g716c5e0"]
                  ^{:voom {:repo "https://github.com/twosigma/clj-http.git" :branch "waiter-patch"}}
                  [clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-io org.clojure/tools.reader potemkin slingshot]]

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -30,7 +30,7 @@
 
   :dependencies [[bidi "2.0.16"
                   :exclusions [prismatic/schema ring/ring-core]]
-                 ^{:voom {:repo "https://github.com/twosigma/jet.git" :branch "untyped-content-provider-default"}}
+                 ^{:voom {:repo "https://github.com/twosigma/jet.git" :branch "waiter-patch"}}
                  [cc.qbits/jet "0.7.10-20180626_194651-g716c5e0"]
                  ^{:voom {:repo "https://github.com/twosigma/clj-http.git" :branch "waiter-patch"}}
                  [clj-http "1.0.2-20180124_201819-gcdf23e5"

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -474,9 +474,10 @@
   "Creates an instance of HttpClient with the specified timeout."
   [connection-timeout-ms]
   (let [client (http/client {:connect-timeout connection-timeout-ms
-                             :follow-redirects? false})
-        _ (.clear (.getContentDecoderFactories client))
-        _ (.setCookieStore client (HttpCookieStore$Empty.))]
+                             :follow-redirects? false})]
+    (.clear (.getContentDecoderFactories client))
+    (.setCookieStore client (HttpCookieStore$Empty.))
+    (.setDefaultRequestContentType client nil)
     client))
 
 ;; PRIVATE API

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -218,9 +218,6 @@
         ; Also remove hop-by-hop headers https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.5.1
         headers (-> (dissoc passthrough-headers "authorization" "expect")
                     (headers/dissoc-hop-by-hop-headers)
-                    ;; ensure a value (potentially nil) is available for content-type to prevent Jetty from generating a default content-type
-                    ;; please see org.eclipse.jetty.client.HttpConnection#normalizeRequest(request) for the control-flow for content-type header
-                    (assoc "content-type" (get passthrough-headers "content-type"))
                     (assoc "cookie" (auth/remove-auth-cookie (get passthrough-headers "cookie"))))
         waiter-debug-enabled? (utils/request->debug-enabled? request)]
     (try

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -161,6 +161,7 @@
   []
   (let [client (http/client)]
     (.setCookieStore client (HttpCookieStore$Empty.))
+    (.setDefaultRequestContentType client nil)
     client))
 
 (defn current-test-name


### PR DESCRIPTION
## Changes proposed in this PR

- avoid setting the content-type by default

## Why are we making these changes?

Waiter, which is acting as a proxy, should not insert a `content-type` header if the client did not provide one in the request.

## Related PRs

https://github.com/twosigma/jet/pull/10 which adds support for not providing a `content-type` based on the body.