### PR TITLE
adds service-id->password-fn in the scheduler context during creation

### DIFF
--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -71,13 +71,17 @@
 (defprotocol ServiceScheduler
 
   (get-apps->instances [this]
-    "Returns a map of scheduler/Service records -> scheduler/ServiceInstance records.")
+    "Returns a map of scheduler/Service records -> map of scheduler/ServiceInstance records.
+     The nested map has the following keys: :active-instances, :failed-instances and :killed-instances.
+     The active-instances should not be assumed to be healthy (or live).
+     The failed-instances are guaranteed to be dead.")
 
   (get-apps [this]
     "Returns a list of scheduler/Service records")
 
   (get-instances [this ^String service-id]
-    "Retrieve a {:active-instances [...]. :failed-instances [...]} map of scheduler/ServiceInstance records for the given service-id.
+    "Retrieve a {:active-instances [...] :failed-instances [...] :killed-instances [...]} map of
+     scheduler/ServiceInstance records for the given service-id.
      The active-instances should not be assumed to be healthy (or live).
      The failed-instances are guaranteed to be dead.")
 
@@ -89,7 +93,7 @@
   (app-exists? [this ^String service-id]
     "Returns truth-y value if the app exists and nil otherwise.")
 
-  (create-app-if-new [this service-id->password-fn descriptor]
+  (create-app-if-new [this descriptor]
     "Sends a call to Scheduler to start an app with the descriptor if the app does not already exist.
      Returns truth-y value if the app creation was successful and nil otherwise.")
 

--- a/waiter/src/waiter/service.clj
+++ b/waiter/src/waiter/service.clj
@@ -289,7 +289,7 @@
 (defn start-new-service
   "Sends a call to the scheduler to start an app with the descriptor.
    Cached to prevent too many duplicate requests going to the scheduler."
-  [scheduler service-id->password-fn descriptor cache-atom ^ExecutorService start-app-threadpool
+  [scheduler descriptor cache-atom ^ExecutorService start-app-threadpool
    & {:keys [pre-start-fn start-fn] :or {pre-start-fn nil, start-fn nil}}]
   (let [cache-key (:service-id descriptor)]
     (when-not (cache/has? @cache-atom cache-key)
@@ -307,7 +307,7 @@
                                (try
                                  (when pre-start-fn
                                    (pre-start-fn))
-                                 (scheduler/create-app-if-new scheduler service-id->password-fn descriptor)
+                                 (scheduler/create-app-if-new scheduler descriptor)
                                  (catch Exception e
                                    (log/warn e "Error starting new app")))))]
             (.submit start-app-threadpool

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -287,7 +287,8 @@
 
 (deftest test-service-view-logs-handler
   (let [scheduler (marathon/->MarathonScheduler (Object.) {:slave-port 5051} (fn [] nil) "/home/path/"
-                                                (atom {}) (atom {}) (atom {}) {} 0 (constantly true) (atom nil))
+                                                (atom {}) (atom {}) (atom {}) {} 0
+                                                (constantly true) (constantly true) (atom nil))
         configuration {:routines {:generate-log-url-fn (partial handler/generate-log-url identity)}
                        :scheduler {:scheduler scheduler}
                        :wrap-secure-request-fn utils/wrap-identity}

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -588,19 +588,19 @@
 
 (defn- create-marathon-scheduler
   [& {:as marathon-config}]
-  (-> (merge {:force-kill-after-ms 1000
-              :home-path-prefix "/home/path/"
-              :is-waiter-app?-fn (constantly true)
-              :marathon-api {}
-              :mesos-api {}
-              :retrieve-framework-id-fn (constantly nil)
-              :service-id->failed-instances-transient-store (atom {})
-              :service-id->kill-info-store (atom {})
-              :service-id->out-of-sync-state-store (atom {})
-              :service-id->password-fn #(str % ".password")
-              :service-id->service-description (constantly nil)
-              :sync-deployment-maintainer-atom (atom nil)}
-             marathon-config)
+  (-> {:force-kill-after-ms 1000
+       :home-path-prefix "/home/path/"
+       :is-waiter-app?-fn (constantly true)
+       :marathon-api {}
+       :mesos-api {}
+       :retrieve-framework-id-fn (constantly nil)
+       :service-id->failed-instances-transient-store (atom {})
+       :service-id->kill-info-store (atom {})
+       :service-id->out-of-sync-state-store (atom {})
+       :service-id->password-fn #(str % ".password")
+       :service-id->service-description (constantly nil)
+       :sync-deployment-maintainer-atom (atom nil)}
+      (merge marathon-config)
       map->MarathonScheduler))
 
 (deftest test-kill-instance-last-force-kill-time-store

--- a/waiter/test/waiter/service_test.clj
+++ b/waiter/test/waiter/service_test.clj
@@ -243,13 +243,12 @@
                             atom))
         start-app-threadpool (Executors/newFixedThreadPool 20)
         scheduler (Object.)
-        descriptor {:id "test-service-id"}
-        service-id->password-fn #(str % "-password")]
+        descriptor {:id "test-service-id"}]
     (testing "start-new-service"
       (let [cache-atom (make-cache-fn 100 20)
             start-called-atom (atom false)
             start-fn (fn [] (reset! start-called-atom (not @start-called-atom)))
-            start-app-result (start-new-service scheduler service-id->password-fn descriptor cache-atom start-app-threadpool :start-fn start-fn)]
+            start-app-result (start-new-service scheduler descriptor cache-atom start-app-threadpool :start-fn start-fn)]
         (is (not (nil? start-app-result)))
         (.get ^Future start-app-result)
         (is @start-called-atom)))
@@ -257,23 +256,23 @@
       (let [cache-atom (make-cache-fn 100 1000)
             start-called-atom (atom false)
             start-fn (fn [] (reset! start-called-atom (not @start-called-atom)))]
-        (let [start-app-result-1 (start-new-service scheduler service-id->password-fn descriptor cache-atom start-app-threadpool :start-fn start-fn)]
+        (let [start-app-result-1 (start-new-service scheduler descriptor cache-atom start-app-threadpool :start-fn start-fn)]
           (is (not (nil? start-app-result-1)))
           (.get ^Future start-app-result-1)
           (is @start-called-atom))
-        (let [start-app-result-2 (start-new-service scheduler service-id->password-fn descriptor cache-atom start-app-threadpool :start-fn start-fn)]
+        (let [start-app-result-2 (start-new-service scheduler descriptor cache-atom start-app-threadpool :start-fn start-fn)]
           (is (nil? start-app-result-2)))))
     (testing "app-starting-after-cache-eviction"
       (let [cache-atom (make-cache-fn 100 20)
             start-called-atom (atom 0)]
         (let [start-fn (fn [] (reset! start-called-atom 1))
-              start-app-result-1 (start-new-service scheduler service-id->password-fn descriptor cache-atom start-app-threadpool :start-fn start-fn)]
+              start-app-result-1 (start-new-service scheduler descriptor cache-atom start-app-threadpool :start-fn start-fn)]
           (is (not (nil? start-app-result-1)))
           (.get ^Future start-app-result-1)
           (is (= 1 @start-called-atom)))
         (Thread/sleep 30)
         (let [start-fn (fn [] (reset! start-called-atom 2))
-              start-app-result-2 (start-new-service scheduler service-id->password-fn descriptor cache-atom start-app-threadpool :start-fn start-fn)]
+              start-app-result-2 (start-new-service scheduler descriptor cache-atom start-app-threadpool :start-fn start-fn)]
           (is (not (nil? start-app-result-2)))
           (.get ^Future start-app-result-2))
         (is (= 2 @start-called-atom))))
@@ -288,7 +287,7 @@
                     service-id (str "test-service-id-" app-num)
                     descriptor {:id service-id}
                     start-fn (fn [] (swap! start-called-atom assoc service-id (not (get @start-called-atom service-id))))
-                    start-app-result (start-new-service scheduler service-id->password-fn descriptor cache-atom start-app-threadpool :start-fn start-fn)]
+                    start-app-result (start-new-service scheduler descriptor cache-atom start-app-threadpool :start-fn start-fn)]
                 (if-not (nil? start-app-result)
                   (do
                     (.get ^Future start-app-result)


### PR DESCRIPTION
## Changes proposed in this PR

- adds service-id->password-fn in the scheduler context during creation
- changes signature of `ServiceScheduler/create-app-if-new`

## Why are we making these changes?

In preparation for Cook scheduler (https://github.com/twosigma/waiter/pull/366), we need to move the `service-id->password-fn` into the scheduler as a field.
