### PR TITLE
moves retrieve-log-url and retrieve-directory-content-from-host

### DIFF
--- a/waiter/src/waiter/mesos/mesos.clj
+++ b/waiter/src/waiter/mesos/mesos.clj
@@ -14,7 +14,8 @@
 ;; limitations under the License.
 ;;
 (ns waiter.mesos.mesos
-  (:require [waiter.util.http-utils :as http-utils])
+  (:require [clojure.string :as str]
+            [waiter.util.http-utils :as http-utils])
   (:import org.eclipse.jetty.client.HttpClient))
 
 (defrecord MesosApi [^HttpClient http-client spnego-auth slave-port slave-directory])
@@ -46,6 +47,20 @@
   (when (and slave-port host directory)
     (str "http://" host ":" slave-port "/files/download?path=" directory)))
 
+(defn retrieve-directory-content-from-host
+  "Retrieve the content of the directory for the given instance on the specified agent."
+  [mesos-api host directory]
+  (let [response-parsed (list-directory-content mesos-api host directory)]
+    (map (fn [entry]
+           (merge {:name (subs (:path entry) (inc (count directory)))
+                   :size (:size entry)}
+                  (if (= (:nlink entry) 1)
+                    {:type "file"
+                     :url (build-directory-download-link mesos-api host (:path entry))}
+                    {:type "directory"
+                     :path (:path entry)})))
+         response-parsed)))
+
 (defn get-agent-state
   "Returns information about the frameworks, executors and the agent’s master."
   [{:keys [http-client slave-port spnego-auth]} host]
@@ -54,3 +69,14 @@
                              :request-method :get
                              :spnego-auth spnego-auth
                              :throw-exceptions false)))
+
+(defn retrieve-log-url
+  "Retrieve the directory path for the specified task running on the specified agent."
+  [mesos-api task-id host framework-name]
+  (let [response-parsed (get-agent-state mesos-api host)
+        matching-frameworks (->> (concat (:completed_frameworks response-parsed) (:frameworks response-parsed))
+                                 (filter #(or (str/includes? (str/lower-case (:role %)) framework-name)
+                                              (str/includes? (str/lower-case (:name %)) framework-name))))
+        executors (mapcat #(concat (:completed_executors %) (:executors %)) matching-frameworks)
+        log-directory (str (:directory (first (filter #(= (:id %) task-id) executors))))]
+    log-directory))

--- a/waiter/src/waiter/mesos/mesos.clj
+++ b/waiter/src/waiter/mesos/mesos.clj
@@ -47,19 +47,22 @@
   (when (and slave-port host directory)
     (str "http://" host ":" slave-port "/files/download?path=" directory)))
 
+(defn- process-directory-entry
+  "Converts an individual directory entry into a map representing the entry."
+  [mesos-api host directory {:keys [nlink path size]}]
+  (-> (if (= nlink 1)
+        {:type "file"
+         :url (build-directory-download-link mesos-api host path)}
+        {:path path
+         :type "directory"})
+      (assoc :name (subs path (inc (count directory)))
+             :size size)))
+
 (defn retrieve-directory-content-from-host
   "Retrieve the content of the directory for the given instance on the specified agent."
   [mesos-api host directory]
-  (let [response-parsed (list-directory-content mesos-api host directory)]
-    (map (fn [entry]
-           (merge {:name (subs (:path entry) (inc (count directory)))
-                   :size (:size entry)}
-                  (if (= (:nlink entry) 1)
-                    {:type "file"
-                     :url (build-directory-download-link mesos-api host (:path entry))}
-                    {:type "directory"
-                     :path (:path entry)})))
-         response-parsed)))
+  (->> (list-directory-content mesos-api host directory)
+       (map #(process-directory-entry mesos-api host directory %))))
 
 (defn get-agent-state
   "Returns information about the frameworks, executors and the agent’s master."
@@ -75,8 +78,8 @@
   [mesos-api task-id host framework-name]
   (let [response-parsed (get-agent-state mesos-api host)
         matching-frameworks (->> (concat (:completed_frameworks response-parsed) (:frameworks response-parsed))
-                                 (filter #(or (str/includes? (str/lower-case (:role %)) framework-name)
-                                              (str/includes? (str/lower-case (:name %)) framework-name))))
+                                 (filter #(or (-> % :name str str/lower-case (str/includes? framework-name))
+                                              (-> % :role str str/lower-case (str/includes? framework-name)))))
         executors (mapcat #(concat (:completed_executors %) (:executors %)) matching-frameworks)
         log-directory (str (:directory (first (filter #(= (:id %) task-id) executors))))]
     log-directory))

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -502,12 +502,10 @@
                                                    }]
                                     }"]
                       (-> response-body json/read-str walk/keywordize-keys)))]
-      (is (= "/path/to/instance2/directory" (retrieve-log-url mesos-api instance-id host))))))
+      (is (= "/path/to/instance2/directory" (mesos/retrieve-log-url mesos-api instance-id host "marathon"))))))
 
 (deftest test-retrieve-directory-content-from-host
-  (let [service-id "service-id-1"
-        instance-id "service-id-1.instance-id-2"
-        host "www.example.com"
+  (let [host "www.example.com"
         mesos-slave-port 5051
         directory "/path/to/instance2/directory"
         mesos-api (mesos/api-factory (Object.) {} mesos-slave-port directory)]
@@ -538,7 +536,7 @@
                                    :size 4000
                                    :type "directory"
                                    :path "/path/to/instance2/directory/dir4"})]
-        (is (= expected-result (retrieve-directory-content-from-host mesos-api service-id instance-id host directory)))))))
+        (is (= expected-result (mesos/retrieve-directory-content-from-host mesos-api host directory)))))))
 
 (deftest test-marathon-descriptor
   (let [service-id->password-fn (fn [service-id] (str service-id "-password"))]


### PR DESCRIPTION

## Changes proposed in this PR

- moves retrieve-log-url and retrieve-directory-content-from-host to mesos.clj from mararthon.clj

## Why are we making these changes?

In preparation for Cook scheduler (https://github.com/twosigma/waiter/pull/366), we need to move some mesos specific functions we will reuse to `mesos.clj`.
