### PR TITLE
adds missing `mesos-slave-port` and `slave-directory` config to config-full.edn

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -250,7 +250,14 @@
                                :framework-id-ttl 900000
 
                                ;; The port on which the mesos agents are listening.
+                               ;; This is an optional parameter.
+                               ;; When absent log directory and log url support will be disabled.
                                :mesos-slave-port 5051
+
+                               ;; The base directory where the agent directories are being written.
+                               ;; This is an optional parameter.
+                               ;; When absent log directory and log url support will be disabled.
+                               :slave-directory "/home/mesos/agent/workspace/"
 
                                ;; Controls the rate at which any mismatch in task count and instances is
                                ;; corrected by triggering new deployments

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -249,6 +249,9 @@
                                ;; How long (milliseconds) to cache the framework id:
                                :framework-id-ttl 900000
 
+                               ;; The port on which the mesos agents are listening.
+                               :mesos-slave-port 5051
+
                                ;; Controls the rate at which any mismatch in task count and instances is
                                ;; corrected by triggering new deployments
                                :sync-deployment {;; Specifies the intervals at which the syncer runs to

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -276,6 +276,7 @@
                                                 :spnego-auth true}
                                  :force-kill-after-ms 60000
                                  :framework-id-ttl 900000
+                                 :mesos-slave-port 5051
                                  :sync-deployment {:interval-ms (-> 15 t/seconds t/in-millis)
                                                    :timeout-cycles 4}}
                       :shell {:factory-fn 'waiter.scheduler.shell/shell-scheduler

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -276,7 +276,6 @@
                                                 :spnego-auth true}
                                  :force-kill-after-ms 60000
                                  :framework-id-ttl 900000
-                                 :mesos-slave-port 5051
                                  :sync-deployment {:interval-ms (-> 15 t/seconds t/in-millis)
                                                    :timeout-cycles 4}}
                       :shell {:factory-fn 'waiter.scheduler.shell/shell-scheduler


### PR DESCRIPTION
## Changes proposed in this PR

- adds missing `mesos-slave-port` and `slave-directory` config to config-full.edn

## Why are we making these changes?
 
Improves documentation of Marathon scheduler.

