### PR TITLE
Integration test fixes

### DIFF
--- a/waiter/integration/waiter/request_timeout_test.clj
+++ b/waiter/integration/waiter/request_timeout_test.clj
@@ -184,7 +184,8 @@
       (try
         (log/info "Creating token for" token)
         (let [{:keys [status body]}
-              (post-token waiter-url {:cmd (kitchen-cmd (str "-p $PORT0 " (t/in-millis grace-period)))
+              (post-token waiter-url {:cmd (kitchen-cmd (str "--port $PORT0 --start-up-sleep-ms "
+                                                             (t/in-millis grace-period)))
                                       :version "not-used"
                                       :cpus 1
                                       :mem 1024

--- a/waiter/integration/waiter/websocket_integration_test.clj
+++ b/waiter/integration/waiter/websocket_integration_test.clj
@@ -239,7 +239,6 @@
                                     :x-waiter-name (rand-name))
                              (update :x-waiter-cmd
                                      (fn [cmd] (str cmd ;; on-the-fly doesn't support x-waiter-env
-                                                    (str " --mem " kitchen-mem "M")
                                                     " --ws-max-binary-message-size " ws-max-binary-message-size'
                                                     " --ws-max-text-message-size " ws-max-text-message-size'))))
           middleware (fn middleware [_ ^UpgradeRequest request]
@@ -307,7 +306,7 @@
                 (let [backend-string (async/<! in)]
                   (async/>! out (.getBytes (str backend-string) "utf-8"))
                   (let [^ByteBuffer backend-bytes (async/<! in)
-                        bytes-string (-> backend-bytes (.array) (String. "utf-8"))]
+                        bytes-string (some-> backend-bytes (.array) (String. "utf-8"))]
                     (reset! uncorrupted-data-streamed-atom
                             (and (= message-length (count backend-string)) (= backend-string bytes-string)))))
                 (async/>! out "exit")


### PR DESCRIPTION
## Changes proposed in this PR

* Remove invalid `--mem` flag for Kitchen
* Add missing `--start-up-sleep-ms` flag for Kitchen
* Use `some->` to avoid NPE on socket read failure

## Why are we making these changes?

Fewer bugs in our tests will lead to fewer bugs in production (in theory anyway).