### PR TITLE
Capture mesos agent sandboxes in Travis error dumps

### DIFF
--- a/waiter/minimesosFile
+++ b/waiter/minimesosFile
@@ -1,7 +1,7 @@
 minimesos {
     clusterName = "waiter"
     loggingLevel = "INFO"
-    mapAgentSandboxVolume = false
+    mapAgentSandboxVolume = true
     mapPortsToHost = true
     mesosVersion = "1.0.0"
     timeout = 60


### PR DESCRIPTION
## Changes proposed in this PR

Mount sandbox directories.

## Why are we making these changes?

We want to get the sandbox directory contents in the tarball when we have an error in a Travis job.