### PR TITLE
uses keyword->str at all json write sites in utils

### DIFF
--- a/waiter/test/waiter/util/utils_test.clj
+++ b/waiter/test/waiter/util/utils_test.clj
@@ -132,11 +132,19 @@
     (let [{:keys [status]} (map->streaming-json-response {} :status 404)]
       (is (= status 404))))
   (testing "converts regex patters to strings"
-    (is (= {"foo" ["bar"]} (-> {:foo [#"bar"]}
-                               map->streaming-json-response
-                               :body
-                               json-response->str
-                               json/read-str)))))
+    (is (= {"foo" ["bar"]}
+           (-> {:foo [#"bar"]}
+               map->streaming-json-response
+               :body
+               json-response->str
+               json/read-str))))
+  (testing "converts namespaced keywords"
+    (is (= {"foo/bar" "fuu/baz"}
+           (-> {:foo/bar :fuu/baz}
+               map->streaming-json-response
+               :body
+               json-response->str
+               json/read-str)))))
 
 (defrecord TestResponse [status friendly-error-message])
 


### PR DESCRIPTION
## Changes proposed in this PR

- uses keyword->str at all json write sites in utils

## Why are we making these changes?

We want to include the namespace prefix of keywords in all our json output.

