### PR TITLE
includes lower-case constraint in metadata error messages

### DIFF
--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -220,7 +220,7 @@
       (str
         (when-let [bad-keys (seq (map #(.value %) (get metadata-error :bad-keys)))]
           (str "The following metadata keys are invalid: " (str/join ", " bad-keys)
-               ". Keys must be made up of letters, numbers, and hyphens and must start with a letter. "))
+               ". Keys must be made up of lower-case letters, numbers, and hyphens and must start with a letter. "))
         (when-let [bad-key-values (seq (get metadata-error :bad-key-values))]
           (str "The following metadata keys did not have string values: " (str/join ", " bad-key-values)
                ". Metadata values must be strings. "))

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -1828,8 +1828,9 @@
     (testing "invalid keys"
       (let [error-msg (generate-friendly-metadata-error-message
                         (s/check service-description-schema
-                                 (assoc service-description "metadata" {1 "a", 2 "b"})))]
-        (is (str/includes? error-msg "The following metadata keys are invalid: 1, 2") error-msg)
+                                 (assoc service-description "metadata" {1 "a" 2 "b" "C" "c"})))]
+        (is (str/includes? error-msg "Keys must be made up of lower-case letters, numbers, and hyphens") error-msg)
+        (is (str/includes? error-msg "The following metadata keys are invalid: 1, 2, C") error-msg)
         (is (not (str/includes? error-msg "Metadata values must be strings.")) error-msg)))
     (testing "invalid keys and values"
       (let [error-msg (generate-friendly-metadata-error-message


### PR DESCRIPTION
## Changes proposed in this PR

- includes lower-case constraint in metadata error messages

## Why are we making these changes?

More accurately specifies the error in metadata entries for a service description.

