### PR TITLE
Fix exit-code check in upload-logs ci script

### DIFF
--- a/waiter/bin/ci/upload_logs.sh
+++ b/waiter/bin/ci/upload_logs.sh
@@ -45,8 +45,8 @@ tar -cJf $tarball --transform="s|\\./[^/]*/\\.*|${dump_name}/|" --warning=no-fil
 # 0 = Successful termination
 # 1 = Some files differ (we're OK with this)
 # 2 = Fatal error
-if [ $exitcode == 2 ]; then
-  echo "The tar command exited with exit code $exitcode, exiting..."
+if [ "$exitcode" == 2 ]; then
+  echo "The tar command exited with a fatal error (exit code $exitcode), exiting..."
   exit $exitcode
 fi
 ./waiter/bin/ci/gdrive_upload "travis-${dump_name}" $tarball


### PR DESCRIPTION
## Changes proposed in this PR

Put quotes around `"$exitcode"` so that there's always a left-hand value in the test expression.

## Why are we making these changes?

I've been seeing an error in `upload_logs.sh` when `$exitcode` isn't set:

```
Uploading logs...
/home/travis/build/twosigma/waiter/waiter/bin/ci/../../bin/ci/upload_logs.sh: line 48: [: ==: unary operator expected
```
