### PR TITLE
Integration heavy/lite lein test selectors

### DIFF
--- a/waiter/integration/waiter/autoscaling_test.clj
+++ b/waiter/integration/waiter/autoscaling_test.clj
@@ -37,7 +37,7 @@
       (is (wait-for #(= 1 (count-instances)) :timeout 300) "Never scaled back down to 1 instance")
       (delete-service waiter-url service-id))))
 
-(deftest ^:parallel ^:integration-slow test-scaling-healthy-app
+(deftest ^:parallel ^:integration-slow ^:resource-heavy test-scaling-healthy-app
   (testing-using-waiter-url
     (let [concurrency-level 3
           custom-headers {:x-kitchen-delay-ms 5000
@@ -48,7 +48,7 @@
       (scaling-for-service-test "Scaling healthy app" waiter-url 3 concurrency-level
                                 #(make-kitchen-request waiter-url custom-headers)))))
 
-(deftest ^:parallel ^:integration-slow test-scaling-unhealthy-app
+(deftest ^:parallel ^:integration-fast ^:resource-heavy test-scaling-unhealthy-app
   (testing-using-waiter-url
     (let [concurrency-level 3
           custom-headers {:x-waiter-concurrency-level concurrency-level
@@ -87,7 +87,7 @@
     (log/info "waiting for" num-threads "threads to complete")
     (await-futures futures)))
 
-(deftest ^:parallel ^:integration-slow test-scale-factor
+(deftest ^:parallel ^:integration-slow ^:resource-heavy test-scale-factor
   (testing-using-waiter-url
     (let [delay-secs 5
           num-threads 10
@@ -112,7 +112,7 @@
           waiter-url cookies request-fn requests-per-thread delay-secs service-id
           num-threads expected-instances)))))
 
-(deftest ^:parallel ^:integration-slow test-concurrency-level
+(deftest ^:parallel ^:integration-slow ^:resource-heavy test-concurrency-level
   (testing-using-waiter-url
     (let [delay-secs 5
           requests-per-thread 50
@@ -142,7 +142,7 @@
             waiter-url cookies request-fn requests-per-thread delay-secs service-id
             num-threads expected-instances))))))
 
-(deftest ^:parallel ^:integration-slow test-expired-instance
+(deftest ^:parallel ^:integration-slow ^:resource-heavy test-expired-instance
   (testing-using-waiter-url
     (let [extra-headers {:x-waiter-instance-expiry-mins 1 ;; can't set it any lower :(
                          :x-waiter-name (rand-name)}

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -513,7 +513,7 @@
       (is (str/includes? set-cookie "HttpOnly=true"))
       (is (= (System/getProperty "user.name") (str body))))))
 
-(deftest ^:parallel ^:integration-slow test-killed-instances
+(deftest ^:parallel ^:integration-slow ^:resource-heavy test-killed-instances
   (testing-using-waiter-url
     (let [headers {:x-waiter-name (rand-name)
                    :x-waiter-max-instances 5

--- a/waiter/integration/waiter/killed_instance_test.clj
+++ b/waiter/integration/waiter/killed_instance_test.clj
@@ -22,7 +22,7 @@
             [waiter.util.date-utils :as du]
             [clojure.core.async :as async]))
 
-(deftest ^:parallel ^:integration-slow test-delegate-kill-instance
+(deftest ^:parallel ^:integration-slow ^:resource-heavy test-delegate-kill-instance
   (testing-using-waiter-url
     (let [requests-per-thread 5
           router-count (count (routers waiter-url))
@@ -66,7 +66,7 @@
     (when (some #(= "blacklisted" %) (:status-tags instance-state))
       (get-in responder-state [:instance-id->blacklist-expiry-time instance-keyword]))))
 
-(deftest ^:parallel ^:integration-slow test-blacklisted-instance-not-reserved
+(deftest ^:parallel ^:integration-slow ^:resource-heavy test-blacklisted-instance-not-reserved
   ;; Verifies that a blacklisted instance is not used to process a request.
   ;; The test first blacklists an instance on all routers.
   ;; It then makes a few requests and verifies if they responded inside the blacklist

--- a/waiter/integration/waiter/metrics_output_test.clj
+++ b/waiter/integration/waiter/metrics_output_test.clj
@@ -99,7 +99,7 @@
   `(is (nil? (s/check ~metrics-schema ~metrics-data))
        (str ~metrics-data)))
 
-(deftest ^:parallel ^:integration-fast test-metrics-output
+(deftest ^:parallel ^:integration-slow test-metrics-output
   (testing-using-waiter-url
     (let [router->endpoint (routers waiter-url)
           router-urls (vec (vals router->endpoint))
@@ -174,7 +174,7 @@
       (get-in ["state" "service-id->launch-tracker" service-id])
       some?))
 
-(deftest ^:parallel ^:integration-slow test-launch-metrics-output
+(deftest ^:parallel ^:integration-slow ^:resource-heavy test-launch-metrics-output
   (testing-using-waiter-url
     (let [waiter-settings (waiter-settings waiter-url)
           metrics-sync-interval-ms (get-in waiter-settings [:metrics-config :metrics-sync-interval-ms])

--- a/waiter/integration/waiter/new_app_test.clj
+++ b/waiter/integration/waiter/new_app_test.clj
@@ -44,7 +44,7 @@
 
       (delete-service waiter-url service-id))))
 
-(deftest ^:parallel ^:integration-slow test-new-app-gc
+(deftest ^:parallel ^:integration-slow ^:resource-heavy test-new-app-gc
   (testing-using-waiter-url
     (let [idle-timeout-in-mins 1
           {:keys [service-id]} (make-request-with-debug-info

--- a/waiter/integration/waiter/work_stealing_integration_test.clj
+++ b/waiter/integration/waiter/work_stealing_integration_test.clj
@@ -18,7 +18,7 @@
             [clojure.tools.logging :as log]
             [waiter.util.client-tools :refer :all]))
 
-(deftest ^:parallel ^:integration-slow test-work-stealing-load-balancing
+(deftest ^:parallel ^:integration-slow ^:resource-heavy test-work-stealing-load-balancing
   (testing-using-waiter-url
     (let [request-fn (fn [router-url waiter-headers & {:keys [cookies] :or {cookies nil}}]
                        (log/info "making kitchen request")

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -25,6 +25,8 @@
                    :integration (every-pred (some-fn :integration-slow :integration-fast) (complement :explicit))
                    :integration-slow (every-pred :integration-slow (complement :explicit))
                    :integration-fast (every-pred :integration-fast (complement :explicit))
+                   :integration-heavy (every-pred :resource-heavy (some-fn :integration-slow :integration-fast) (complement :explicit))
+                   :integration-lite (every-pred (complement :resource-heavy) (some-fn :integration-slow :integration-fast) (complement :explicit))
                    :dev :dev
                    :perf (every-pred :perf (complement :explicit))}
 


### PR DESCRIPTION
## Changes proposed in this PR

Add the `:resource-heavy` metadata key to integration tests that start multiple service instances.

## Why are we making these changes?

Tests that start many service instances concurrently tend to be flaky when running on our Kubernetes back-end in Travis. We need to run these serially for our Kubernetes integration testing.