### PR TITLE
avoids kv-store writes if token hasn't changed

### DIFF
--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -96,6 +96,7 @@
 
 (def user-metadata-schema
   {(s/optional-key "fallback-period-secs") (s/both s/Int (s/pred #(<= 0 % (t/in-seconds (t/hours 1))) 'at-most-1-hour))
+   (s/optional-key "owner") schema/non-empty-string
    (s/optional-key "stale-timeout-mins") (s/both s/Int (s/pred #(<= 0 % (t/in-minutes (t/hours 4))) 'at-most-4-hours))
    s/Str s/Any})
 
@@ -130,10 +131,10 @@
 (def ^:const on-the-fly-service-description-keys (set/union service-parameter-keys #{"token"}))
 
 ; keys allowed in system metadata for tokens, these need to be distinct from service description keys
-(def ^:const system-metadata-keys #{"deleted" "last-update-time" "last-update-user" "owner" "previous" "root"})
+(def ^:const system-metadata-keys #{"deleted" "last-update-time" "last-update-user" "previous" "root"})
 
 ; keys allowed in user metadata for tokens, these need to be distinct from service description keys
-(def ^:const user-metadata-keys #{"fallback-period-secs" "stale-timeout-mins"})
+(def ^:const user-metadata-keys #{"fallback-period-secs" "owner" "stale-timeout-mins"})
 
 ; keys allowed in metadata for tokens, these need to be distinct from service description keys
 (def ^:const token-metadata-keys (set/union system-metadata-keys user-metadata-keys))

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -139,6 +139,9 @@
 ; keys allowed in metadata for tokens, these need to be distinct from service description keys
 (def ^:const token-metadata-keys (set/union system-metadata-keys user-metadata-keys))
 
+; keys editable by users in the token data
+(def ^:const token-user-editable-keys (set/union service-parameter-keys user-metadata-keys))
+
 ; keys allowed in the token data
 (def ^:const token-data-keys (set/union service-parameter-keys token-metadata-keys))
 

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -55,6 +55,10 @@
   (handle-token-request clock synchronize-fn kv-store token-root history-length waiter-hostnames entitlement-manager
                         make-peer-requests-fn validate-service-description-fn request))
 
+(def optional-metadata-keys (disj sd/user-metadata-keys "owner"))
+
+(def required-metadata-keys (conj sd/system-metadata-keys "owner"))
+
 (deftest test-handle-token-request
   (with-redefs [sd/service-description->service-id (fn [prefix sd] (str prefix (hash (select-keys sd sd/service-parameter-keys))))]
     (let [kv-store (kv/->LocalKeyValueStore (atom {}))
@@ -462,9 +466,9 @@
           (let [body-map (-> body str json/read-str)]
             (doseq [key sd/service-parameter-keys]
               (is (= (get service-description-2 key) (get body-map key))))
-            (doseq [key (disj sd/system-metadata-keys "deleted")]
+            (doseq [key (disj required-metadata-keys "deleted")]
               (is (contains? body-map key) (str "Missing entry for " key)))
-            (doseq [key sd/user-metadata-keys]
+            (doseq [key (conj optional-metadata-keys "deleted")]
               (is (not (contains? body-map key)) (str "Existing entry for " key)))
             (is (not (contains? body-map "deleted"))))))
 
@@ -497,9 +501,9 @@
           (let [body-map (-> body str json/read-str)]
             (doseq [key sd/service-parameter-keys]
               (is (= (get service-description-2 key) (get body-map key))))
-            (doseq [key (disj sd/system-metadata-keys "deleted")]
+            (doseq [key (disj required-metadata-keys "deleted")]
               (is (contains? body-map key) (str "Missing entry for " key)))
-            (doseq [key sd/user-metadata-keys]
+            (doseq [key (conj optional-metadata-keys "deleted")]
               (is (not (contains? body-map key)) (str "Existing entry for " key)))
             (is (not (contains? body-map "deleted"))))))
 


### PR DESCRIPTION
## Changes proposed in this PR

- classifies owner as a user-editable token field
- avoids kv-store writes if token hasn't changed

## Why are we making these changes?

This prevents resolving the token to a new service everytime a user POSTs a token without any actual updates.
