### PR TITLE
[WIP] Instability Fallback

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -945,7 +945,6 @@
                                  http-client (http/client {:connect-timeout health-check-timeout-ms
                                                            :idle-timeout health-check-timeout-ms})
                                  timeout-chan (chime/chime-ch (du/time-seq (t/now) (t/seconds scheduler-syncer-interval-secs)))]
-                             ; (clojure.pprint/pprint scheduler-state-mult-chan)
                              (assoc (scheduler/start-scheduler-syncer
                                       clock scheduler scheduler-state-chan timeout-chan service-id->service-description-fn
                                       scheduler/available? http-client failed-check-threshold)

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -881,8 +881,10 @@
                                    router-state-chan (async/tap router-state-push-mult (au/latest-chan))]
                                (descriptor/instability-maintainer router-state-chan)))
    :instability-fallback (pc/fnk pc/fnk [[:curator kv-store]
-                                         [:settings service-description-defaults metric-group-mappings]]
-                           (descriptor/compute-instability-replacement kv-store service-description-defaults metric-group-mappings))
+                                         [:settings service-description-defaults metric-group-mappings]
+                                         [:scheduler scheduler]
+                                         [:state start-app-cache-atom task-threadpool]]
+                           (descriptor/compute-instability-replacement kv-store service-description-defaults metric-group-mappings scheduler start-app-cache-atom task-threadpool))
    :interstitial-maintainer (pc/fnk [[:routines service-id->service-description-fn]
                                      [:state interstitial-state-atom]
                                      scheduler-maintainer]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -880,6 +880,9 @@
                              (let [router-state-push-mult (get-in router-state-maintainer [:maintainer-chans :router-state-push-mult])
                                    router-state-chan (async/tap router-state-push-mult (au/latest-chan))]
                                (descriptor/instability-maintainer router-state-chan)))
+   :instability-fallback (pc/fnk pc/fnk [[:curator kv-store]
+                                         [:settings service-description-defaults metric-group-mappings]]
+                           (descriptor/compute-instability-replacement kv-store service-description-defaults metric-group-mappings))
    :interstitial-maintainer (pc/fnk [[:routines service-id->service-description-fn]
                                      [:state interstitial-state-atom]
                                      scheduler-maintainer]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -876,6 +876,10 @@
                                      (metrics/transient-metrics-gc scheduler-state-chan local-usage-agent service-gc-go-routine metrics-config)]
                                  (metrics/transient-metrics-data-producer service-id->metrics-chan service-id->metrics-fn metrics-config)
                                  metrics-gc-chans))
+   :instability-maintainer (pc/fnk [router-state-maintainer]
+                             (let [router-state-push-mult (get-in router-state-maintainer [:maintainer-chans :router-state-push-mult])
+                                   router-state-chan (async/tap router-state-push-mult (au/latest-chan))]
+                               (descriptor/instability-maintainer router-state-chan)))
    :interstitial-maintainer (pc/fnk [[:routines service-id->service-description-fn]
                                      [:state interstitial-state-atom]
                                      scheduler-maintainer]
@@ -941,6 +945,7 @@
                                  http-client (http/client {:connect-timeout health-check-timeout-ms
                                                            :idle-timeout health-check-timeout-ms})
                                  timeout-chan (chime/chime-ch (du/time-seq (t/now) (t/seconds scheduler-syncer-interval-secs)))]
+                             ; (clojure.pprint/pprint scheduler-state-mult-chan)
                              (assoc (scheduler/start-scheduler-syncer
                                       clock scheduler scheduler-state-chan timeout-chan service-id->service-description-fn
                                       scheduler/available? http-client failed-check-threshold)

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -43,6 +43,11 @@
   [fallback-state service-id]
   (-> fallback-state :healthy-service-ids (contains? service-id)))
 
+(defn service-instable?
+  "Returns true if the requested service-id exists as per the state in the instable-state."
+  [instable-state service-id]
+  (-> instable-state :instability-service-ids (contains? service-id)))
+
 (defn missing-run-as-user?
   "Returns true if the exception is due to a missing run-as-user validation on the service description."
   [exception]

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -28,6 +28,7 @@
             [waiter.headers :as headers]
             [waiter.metrics :as metrics]
             [waiter.middleware :as middleware]
+            [waiter.service :as service]
             [waiter.service-description :as sd]
             [waiter.token :as token]
             [waiter.util.async-utils :as au]
@@ -48,7 +49,7 @@
 (defn service-instable?
   "Returns true if the requested service-id exists as per the state in the instable-state."
   [instable-state service-id]
-  (-> instable-state :instability-service-ids (contains? service-id)))
+  (-> instable-state :instability-service-ids->replacement (contains? service-id)))
 
 (defn missing-run-as-user?
   "Returns true if the exception is due to a missing run-as-user validation on the service description."
@@ -227,23 +228,31 @@
                                 :healthy (service-healthy? fallback-state service-id)})
                     (recur (inc iteration) previous-descriptor)))))))))))
 
-(defn compute-instability-replacement
-  "Long running daemon process that computes replacements for instable services if they do not have one yet."
-  [kv-store service-description-defaults metric-group-mappings]
-  (let [nm (reduce (fn [m [service-id descriptor]]
-                     (assoc m service-id (if (nil? descriptor) (sd/service-id->service-description kv-store service-id service-description-defaults metric-group-mappings) descriptor)))
-                   {}
-                   (@instability-state-atom :instability-service-ids->replacement))]
-    (reset! instability-state-atom {:instability-service-ids->replacement nm})))
-
 (defn retrieve-instability-descriptor
-  "Computer the instability descriptor with 10% greater memory based on the provided descriptor."
+  [service-id]
+  (get (@instability-state-atom :instability-service-ids->replacement) service-id))
+
+(defn compute-instability-descriptor
+  "Compute the instability descriptor with 10% greater memory based on the provided descriptor."
   [descriptor]
   (if (contains? descriptor "mem")
     (let [add-mem (int (* 0.1 (get descriptor "mem")))]
       (update-in descriptor ["mem"] + add-mem))
     (let [add-mem (int (* 0.1 (get ((descriptor :sources) :headers) "mem")))]
       (update-in descriptor [:sources :headers "mem"] + add-mem))))
+
+(defn compute-instability-replacement
+  "Long running daemon process that computes replacements for instable services if they do not have one yet."
+  [kv-store service-description-defaults metric-group-mappings scheduler start-app-cache-atom task-threadpool]
+  (let [nm (reduce (fn [m [service-id descriptor]]
+                     (assoc m service-id (if (nil? descriptor)
+                                           (let [new-descriptor (compute-instability-descriptor (sd/service-id->service-description kv-store service-id service-description-defaults metric-group-mappings))]
+                                             (service/start-new-service scheduler new-descriptor start-app-cache-atom task-threadpool)
+                                             new-descriptor)
+                                           descriptor)))
+                   {}
+                   (@instability-state-atom :instability-service-ids->replacement))]
+    (reset! instability-state-atom {:instability-service-ids->replacement nm})))
 
 (defn resolve-descriptor
   "Resolves the descriptor that should be used based on available healthy services.
@@ -254,7 +263,7 @@
   [descriptor->previous-descriptor search-history-length request-time fallback-state instability-state latest-descriptor]
   (let [{:keys [service-id]} latest-descriptor]
     (if (service-instable? instability-state service-id)
-      (or (retrieve-instability-descriptor latest-descriptor)
+      (or (retrieve-instability-descriptor service-id)
           (do
             (log/info "no instability replacement service found for" (:service-id latest-descriptor))
             latest-descriptor))

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -239,8 +239,11 @@
 (defn retrieve-instability-descriptor
   "Computer the instability descriptor with 10% greater memory based on the provided descriptor."
   [descriptor]
-  (let [add-mem (int (* 0.1 (get ((descriptor :sources) :headers) "mem")))]
-    (update-in descriptor [:sources :headers "mem"] + add-mem)))
+  (if (contains? descriptor "mem")
+    (let [add-mem (int (* 0.1 (get descriptor "mem")))]
+      (update-in descriptor ["mem"] + add-mem))
+    (let [add-mem (int (* 0.1 (get ((descriptor :sources) :headers) "mem")))]
+      (update-in descriptor [:sources :headers "mem"] + add-mem))))
 
 (defn resolve-descriptor
   "Resolves the descriptor that should be used based on available healthy services.

--- a/waiter/test/waiter/descriptor_test.clj
+++ b/waiter/test/waiter/descriptor_test.clj
@@ -171,9 +171,12 @@
                       :sources {:headers {"mem" 102
                                           "cpus" 1
                                           "cmd" "/bin/kitchen -p $PORT0"
-                                          "version" "foobar"}}}]
-
-    (testing "simple test"
+                                          "version" "foobar"}}}
+        descriptor-3 {"cmd" "tc", "cpus" 1, "mem" 60, "version" "a1b2c3",
+                      "run-as-user" "tu1", "permitted-user" "tu2", "metric-group" "other"}
+        descriptor-4 {"cmd" "tc", "cpus" 1, "mem" 102, "version" "a1b2c3",
+                      "run-as-user" "tu1", "permitted-user" "tu2", "metric-group" "other"}]
+    (testing "simple test, sources case"
       (let [expected-descriptor {:service-id "service-1"
                          :sources {:headers {"mem" 66
                                              "cpus" 1
@@ -181,13 +184,23 @@
                                              "version" "foobar"}}}
            result-descriptor (retrieve-instability-descriptor descriptor-1)]
       (is (= expected-descriptor result-descriptor))))
-    (testing "mem increment by value not divisible 10 test"
+    (testing "mem increment by value not divisible 10 test, sources case"
       (let [expected-descriptor {:service-id "service-1"
                                  :sources {:headers {"mem" 112
                                                      "cpus" 1
                                                      "cmd" "/bin/kitchen -p $PORT0"
                                                      "version" "foobar"}}}
             result-descriptor (retrieve-instability-descriptor descriptor-2)]
+        (is (= expected-descriptor result-descriptor))))
+    (testing "simple test, kv-store case"
+      (let [expected-descriptor {"cmd" "tc", "cpus" 1, "mem" 66, "version" "a1b2c3",
+                                 "run-as-user" "tu1", "permitted-user" "tu2", "metric-group" "other"}
+            result-descriptor (retrieve-instability-descriptor descriptor-3)]
+        (is (= expected-descriptor result-descriptor))))
+    (testing "mem increment by value not divisble by 10 test, kv-store case"
+      (let [expected-descriptor {"cmd" "tc", "cpus" 1, "mem" 112, "version" "a1b2c3",
+                                 "run-as-user" "tu1", "permitted-user" "tu2", "metric-group" "other"}
+            result-descriptor (retrieve-instability-descriptor descriptor-4)]
         (is (= expected-descriptor result-descriptor))))))
 
 (deftest test-retrieve-fallback-descriptor


### PR DESCRIPTION
## Changes proposed in this PR

- Creating a fallback for instable services to restart them with additional memory allocated when they OOM

## Why are we making these changes?

- Many services fail due to OOM and are restarted with the same config, which will just lead to another OOM eventually. Adjusting the mem request incrementally will help the service avoid OOMing in the future.

