### PR TITLE
Deflake test-grace-period-with-tokens

### DIFF
--- a/waiter/integration/waiter/request_timeout_test.clj
+++ b/waiter/integration/waiter/request_timeout_test.clj
@@ -180,12 +180,13 @@
 (deftest ^:parallel ^:integration-fast test-grace-period-with-tokens
   (testing-using-waiter-url
     (let [grace-period (t/minutes 2)
+          startup-delay-ms (-> grace-period t/in-millis (* 0.75) long)
           token (rand-name)]
       (try
         (log/info "Creating token for" token)
         (let [{:keys [status body]}
               (post-token waiter-url {:cmd (kitchen-cmd (str "--port $PORT0 --start-up-sleep-ms "
-                                                             (t/in-millis grace-period)))
+                                                             startup-delay-ms))
                                       :version "not-used"
                                       :cpus 1
                                       :mem 1024


### PR DESCRIPTION
## Changes proposed in this PR

Kitchen only sleeps for 75% of the startup grace period.

## Why are we making these changes?

Sleeping for the full grace period makes this test fail regularly since there's no room for variation in the launch time of the Kitchen service instance.