### PR TITLE
adds support for configurable Access-Control-Expose-Headers

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -201,6 +201,10 @@
                ;; :kind :allow-all allows all cross-origin requests
                :allow-all {:factory-fn waiter.cors/allow-all-validator}
 
+               ;; Headers exposed to CORS clients for Waiter API requests
+               ;; read more at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
+               :exposed-headers ["etag"]
+
                ;; The value to use for the Access-Control-Max-Age header:
                :max-age 3600}
 

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -833,7 +833,13 @@
                                                (ws/inter-router-request-middleware router-id (first passwords) request)))
    :websocket-request-authenticator (pc/fnk [[:state passwords]]
                                       (fn websocket-request-authenticator [request response]
-                                        (ws/request-authenticator (first passwords) request response)))})
+                                        (ws/request-authenticator (first passwords) request response)))
+   :wrap-cors-exposed-headers-fn (pc/fnk [[:settings cors-config]
+                                          waiter-request?-fn]
+                                   ;; cors-config schema is not a map, so we need to destructure separately
+                                   (let [{:keys [exposed-headers]} cors-config]
+                                     (fn wrap-cors-exposed-headers-fn [handler]
+                                       (cors/wrap-cors-exposed-headers handler waiter-request?-fn exposed-headers))))})
 
 (def daemons
   {:autoscaler (pc/fnk [[:curator leader?-fn]

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -74,8 +74,7 @@
    :scheduler core/scheduler
    :settings (pc/fnk dummy-symbol-for-fnk-schema-logic :- settings/settings-schema [] settings)
    :state core/state
-   :http-server (pc/fnk [[:routines generate-log-url-fn waiter-request?-fn websocket-request-authenticator
-                          wrap-cors-exposed-headers-fn]
+   :http-server (pc/fnk [[:routines generate-log-url-fn waiter-request?-fn websocket-request-authenticator]
                          [:settings cors-config host port support-info websocket-config]
                          [:state cors-validator router-id]
                          handlers] ; Insist that all systems are running before we start server
@@ -83,7 +82,6 @@
                                        {:ring-handler (-> (core/ring-handler-factory waiter-request?-fn handlers)
                                                           (cors/wrap-cors-preflight cors-validator (:max-age cors-config))
                                                           core/wrap-error-handling
-                                                          wrap-cors-exposed-headers-fn
                                                           (core/wrap-debug generate-log-url-fn)
                                                           rlog/wrap-log
                                                           core/correlation-id-middleware

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -74,7 +74,8 @@
    :scheduler core/scheduler
    :settings (pc/fnk dummy-symbol-for-fnk-schema-logic :- settings/settings-schema [] settings)
    :state core/state
-   :http-server (pc/fnk [[:routines generate-log-url-fn waiter-request?-fn websocket-request-authenticator]
+   :http-server (pc/fnk [[:routines generate-log-url-fn waiter-request?-fn websocket-request-authenticator
+                          wrap-cors-exposed-headers-fn]
                          [:settings cors-config host port support-info websocket-config]
                          [:state cors-validator router-id]
                          handlers] ; Insist that all systems are running before we start server
@@ -82,6 +83,7 @@
                                        {:ring-handler (-> (core/ring-handler-factory waiter-request?-fn handlers)
                                                           (cors/wrap-cors-preflight cors-validator (:max-age cors-config))
                                                           core/wrap-error-handling
+                                                          wrap-cors-exposed-headers-fn
                                                           (core/wrap-debug generate-log-url-fn)
                                                           rlog/wrap-log
                                                           core/correlation-id-middleware

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -33,6 +33,7 @@
    (s/required-key :cors-config) (s/constrained
                                    {:kind s/Keyword
                                     (s/optional-key :ttl) schema/positive-int
+                                    (s/required-key :exposed-headers) [schema/non-empty-string]
                                     (s/required-key :max-age) schema/positive-int
                                     s/Keyword schema/require-symbol-factory-fn}
                                    schema/contains-kind-sub-map?)
@@ -207,6 +208,7 @@
                  :patterns {:factory-fn 'waiter.cors/pattern-based-validator
                             :allowed-origins []}
                  :allow-all {:factory-fn 'waiter.cors/allow-all-validator}
+                 :exposed-headers ["etag", "x-cid"]
                  :max-age 3600}
    :blacklist-config {:blacklist-backoff-base-time-ms 10000
                       :max-blacklist-time-ms 300000}

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -32,9 +32,9 @@
                                        (s/required-key :max-blacklist-time-ms) schema/positive-int}
    (s/required-key :cors-config) (s/constrained
                                    {:kind s/Keyword
-                                    (s/optional-key :ttl) schema/positive-int
-                                    (s/required-key :exposed-headers) [schema/non-empty-string]
+                                    (s/optional-key :exposed-headers) [schema/non-empty-string]
                                     (s/required-key :max-age) schema/positive-int
+                                    (s/optional-key :ttl) schema/positive-int
                                     s/Keyword schema/require-symbol-factory-fn}
                                    schema/contains-kind-sub-map?)
    (s/required-key :cluster-config) {(s/required-key :min-routers) schema/positive-int


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for configurable Access-Control-Expose-Headers

## Why are we making these changes?

This change allows clients that make CORS Waiter api requests to access etags and x-cid response headers.

[Helpful link explaining](https://www.html5rocks.com/en/tutorials/cors/#toc-cors-server-flowchart) where `Access-Control-Expose-Header` needs to be added.

### Examples

The new behavior adds an `Access-Control-Expose-Header` in the CORS options response:
```
# non-CORS Waiter API request does not add Access-Control-Expose-Headers
$ curl --head -XGET http://localhost:9091/token -H"x-waiter-token: kitchen" -H"Origin: http://localhost:9091"
HTTP/1.1 200 OK
Content-Type: application/json
Access-Control-Allow-Origin: http://localhost:9091
Access-Control-Allow-Credentials: true
ETag: E-33b707d6398729508fd972e4fa800b14
Transfer-Encoding: chunked
x-cid: 1ecf625e931c6-376c4cf8e9108067

# CORS Waiter API request adds Access-Control-Expose-Headers
$ curl --head -XGET http://localhost:9091/token -H"x-waiter-token: kitchen" -H"Origin: http://cors-host:9091"
HTTP/1.1 200 OK
Access-Control-Allow-Origin: http://cors-host:9091
Access-Control-Allow-Credentials: true
Access-Control-Expose-Headers: etag, x-cid
Content-Type: application/json
ETag: E-33b707d6398729508fd972e4fa800b14
Transfer-Encoding: chunked
x-cid: 1ecfab8cc3b95-52971d2f05708340

# Request to backend does not add Access-Control-Expose-Headers
$ curl --head -XGET http://localhost:9091/backend -H"x-waiter-token: kitchen" -H"Origin: http://cors-host:9091"
HTTP/1.1 200 OK
Access-Control-Allow-Origin: http://cors-host:9091
Access-Control-Allow-Credentials: true
Content-Length: 11
Content-Type: text/plain
Date: Tue, 31 Jul 2018 20:16:52 GMT
Server: BaseHTTP/0.6 Python/3.5.3
x-cid: 1ecfe711ce6ea-2971899c66b3a236
```