### PR TITLE
 supports quanta-based scaling (while scaling-up)

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -442,7 +442,13 @@
            :autoscaler-interval-ms 1000
 
            ;; Throttles the rate at which kill requests are sent to the scheduler:
-           :inter-kill-request-wait-time-ms 1000}
+           :inter-kill-request-wait-time-ms 1000
+
+           ;; Individual scale-up operations are throttled so that we can minimize overshoot of instances.
+           ;; The number of new instances started per scale-up is the maximum of 1 and the resource consumed
+           ;; limit calculated based on the cpus and mem specified in the quanta-constraints.
+           :quanta-constraints {:cpus 64
+                                :mem 524288}}
 
  ; ---------- Service Descriptions ----------
 

--- a/waiter/resources/web/sim.html
+++ b/waiter/resources/web/sim.html
@@ -98,6 +98,9 @@ textarea {
                 <h4>Scaler Settings</h4>
                 <label>scale every (secs) <input id="scale-ticks" value="5" type="number"/></label>
                 <label>simulation length (secs) <input id="total-ticks" value="3600" type="number"/></label>
+                <label>use quanta scaling <input id="use-quanta" checked type="checkbox"/></label>
+                <label>quanta cpus <input id="quanta-cpus" value="64" type="number"/></label>
+                <label>quanta memory (in MB) <input id="quanta-mem" value="524288" type="number"/></label>
             </div>
         </div>
         <div id="summary">

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -850,13 +850,14 @@
    :autoscaling-multiplexer (pc/fnk [[:routines delegate-instance-kill-request-fn peers-acknowledged-blacklist-requests-fn
                                       service-id->service-description-fn]
                                      [:scheduler scheduler]
+                                     [:settings [:scaling quanta-constraints]]
                                      [:state instance-rpc-chan scaling-timeout-config]]
                               (scaling/service-scaling-multiplexer
                                 (fn scaling-executor-factory [service-id]
                                   (scaling/service-scaling-executor
                                     service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
                                     delegate-instance-kill-request-fn service-id->service-description-fn
-                                    scaling-timeout-config))
+                                    quanta-constraints scaling-timeout-config))
                                 {}))
    :fallback-maintainer (pc/fnk [[:state fallback-state-atom]
                                  scheduler-maintainer]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -847,14 +847,16 @@
                    (scaling/autoscaler-goroutine
                      {} leader?-fn service-id->metrics-fn executor-multiplexer-chan scheduler autoscaler-interval-ms
                      scaling/scale-service service-id->service-description-fn router-state-push-mult)))
-   :autoscaling-multiplexer (pc/fnk [[:routines delegate-instance-kill-request-fn peers-acknowledged-blacklist-requests-fn]
+   :autoscaling-multiplexer (pc/fnk [[:routines delegate-instance-kill-request-fn peers-acknowledged-blacklist-requests-fn
+                                      service-id->service-description-fn]
                                      [:scheduler scheduler]
                                      [:state instance-rpc-chan scaling-timeout-config]]
                               (scaling/service-scaling-multiplexer
                                 (fn scaling-executor-factory [service-id]
                                   (scaling/service-scaling-executor
                                     service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
-                                    delegate-instance-kill-request-fn scaling-timeout-config))
+                                    delegate-instance-kill-request-fn service-id->service-description-fn
+                                    scaling-timeout-config))
                                 {}))
    :fallback-maintainer (pc/fnk [[:state fallback-state-atom]
                                  scheduler-maintainer]

--- a/waiter/src/waiter/scaling.clj
+++ b/waiter/src/waiter/scaling.clj
@@ -188,7 +188,7 @@
    Killing of an instance may be delegated to peer routers via delegate-instance-kill-request-fn if no instance is available locally.
    The executor also respects inter-kill-request-wait-time-ms between successive scale-down operations."
   [service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn delegate-instance-kill-request-fn
-   service-id->service-description-fn {:keys [inter-kill-request-wait-time-ms] :as timeout-config}]
+   service-id->service-description-fn quanta-constraints {:keys [inter-kill-request-wait-time-ms] :as timeout-config}]
   {:pre [(>= inter-kill-request-wait-time-ms 0)]}
   (log/info "[scaling-executor] starting instance killer for" service-id)
   (let [base-correlation-id (str "scaling-executor-" service-id)

--- a/waiter/src/waiter/scaling.clj
+++ b/waiter/src/waiter/scaling.clj
@@ -188,7 +188,7 @@
    Killing of an instance may be delegated to peer routers via delegate-instance-kill-request-fn if no instance is available locally.
    The executor also respects inter-kill-request-wait-time-ms between successive scale-down operations."
   [service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn delegate-instance-kill-request-fn
-   {:keys [inter-kill-request-wait-time-ms] :as timeout-config}]
+   service-id->service-description-fn {:keys [inter-kill-request-wait-time-ms] :as timeout-config}]
   {:pre [(>= inter-kill-request-wait-time-ms 0)]}
   (log/info "[scaling-executor] starting instance killer for" service-id)
   (let [base-correlation-id (str "scaling-executor-" service-id)

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -86,7 +86,9 @@
    (s/required-key :router-syncer) {(s/required-key :delay-ms) schema/positive-int
                                     (s/required-key :interval-ms) schema/positive-int}
    (s/required-key :scaling) {(s/required-key :autoscaler-interval-ms) schema/positive-int
-                              (s/required-key :inter-kill-request-wait-time-ms) schema/positive-int}
+                              (s/required-key :inter-kill-request-wait-time-ms) schema/positive-int
+                              (s/required-key :quanta-constraints) {(s/required-key :cpus) schema/positive-int
+                                                                    (s/required-key :mem) schema/positive-int}}
    (s/required-key :scheduler-config) (s/constrained
                                         {:kind s/Keyword
                                          s/Keyword schema/require-symbol-factory-fn}
@@ -269,7 +271,9 @@
                    :interval-ms 1500}
    :scaling {:autoscaler-interval-ms 1000
              ; throttles the rate at which kill requests are sent to the scheduler
-             :inter-kill-request-wait-time-ms 1000}
+             :inter-kill-request-wait-time-ms 1000
+             :quanta-constraints {:cpus 64
+                                  :mem (* 512 1024)}}
    :scheduler-config {:kind :marathon
                       :cook {:factory-fn 'waiter.scheduler.cook/cook-scheduler
                              :failed-tracker-interval-ms 10000

--- a/waiter/test/waiter/scaling_test.clj
+++ b/waiter/test/waiter/scaling_test.clj
@@ -256,6 +256,7 @@
             delegate-instance-kill-request-fn (fn [service-id]
                                                 (is (= test-service-id service-id))
                                                 false)
+            service-id->service-description-fn (constantly {})
             equilibrium-state {}
             make-scaling-message (fn [service-id scale-amount scale-to-instances task-count total-instances response-chan]
                                    {:service-id service-id, :scale-amount scale-amount, :scale-to-instances scale-to-instances,
@@ -268,7 +269,7 @@
                 {:keys [executor-chan exit-chan query-chan]}
                 (service-scaling-executor
                   test-service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
-                  delegate-instance-kill-request-fn timeout-config)]
+                  delegate-instance-kill-request-fn service-id->service-description-fn timeout-config)]
             (mock-reservation-system instance-rpc-chan [])
             (async/>!! executor-chan {:service-id test-service-id, :scale-amount 0})
             (is (= equilibrium-state (retrieve-state-fn query-chan)))
@@ -282,7 +283,7 @@
                 {:keys [executor-chan exit-chan query-chan]}
                 (service-scaling-executor
                   test-service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
-                  delegate-instance-kill-request-fn timeout-config)]
+                  delegate-instance-kill-request-fn service-id->service-description-fn timeout-config)]
             (mock-reservation-system instance-rpc-chan [])
             (async/>!! executor-chan (make-scaling-message test-service-id 10 30 25 30 nil))
             (is (= equilibrium-state (retrieve-state-fn query-chan)))
@@ -297,7 +298,7 @@
                 {:keys [executor-chan exit-chan query-chan]}
                 (service-scaling-executor
                   test-service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
-                  delegate-instance-kill-request-fn timeout-config)]
+                  delegate-instance-kill-request-fn service-id->service-description-fn timeout-config)]
             (mock-reservation-system instance-rpc-chan [])
             (async/>!! executor-chan (make-scaling-message test-service-id 10 30 25 20 nil))
             (is (= equilibrium-state (retrieve-state-fn query-chan)))
@@ -312,7 +313,7 @@
                 {:keys [executor-chan exit-chan query-chan]}
                 (service-scaling-executor
                   test-service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
-                  delegate-instance-kill-request-fn timeout-config)]
+                  delegate-instance-kill-request-fn service-id->service-description-fn timeout-config)]
             (mock-reservation-system instance-rpc-chan [])
             (async/>!! executor-chan (make-scaling-message test-service-id -5 25 20 20 nil))
             (is (= equilibrium-state (retrieve-state-fn query-chan)))
@@ -332,7 +333,7 @@
                 {:keys [executor-chan exit-chan query-chan]}
                 (service-scaling-executor
                   test-service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
-                  delegate-instance-kill-request-fn timeout-config)]
+                  delegate-instance-kill-request-fn service-id->service-description-fn timeout-config)]
             (mock-reservation-system
               instance-rpc-chan
               [(fn [[{:keys [reason]} response-chan]]
@@ -359,7 +360,7 @@
                 {:keys [executor-chan exit-chan query-chan]}
                 (service-scaling-executor
                   test-service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
-                  delegate-instance-kill-request-fn timeout-config)]
+                  delegate-instance-kill-request-fn service-id->service-description-fn timeout-config)]
             (mock-reservation-system
               instance-rpc-chan
               [(fn [[{:keys [reason]} response-chan]]
@@ -382,7 +383,7 @@
                 {:keys [executor-chan exit-chan query-chan]}
                 (service-scaling-executor
                   test-service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
-                  delegate-instance-kill-request-fn timeout-config)]
+                  delegate-instance-kill-request-fn service-id->service-description-fn timeout-config)]
             (let [instance-1 {:id "instance-1", :service-id test-service-id, :success-flag true}]
               (mock-reservation-system
                 instance-rpc-chan
@@ -416,7 +417,7 @@
                 {:keys [executor-chan exit-chan query-chan]}
                 (service-scaling-executor
                   test-service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
-                  delegate-instance-kill-request-fn timeout-config)
+                  delegate-instance-kill-request-fn service-id->service-description-fn timeout-config)
                 latch (CountDownLatch. 1)]
             (let [instance-1 {:id "instance-1", :service-id test-service-id, :success-flag true}]
               (mock-reservation-system
@@ -449,7 +450,7 @@
                 {:keys [executor-chan exit-chan query-chan]}
                 (service-scaling-executor
                   test-service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
-                  delegate-instance-kill-request-fn timeout-config)
+                  delegate-instance-kill-request-fn service-id->service-description-fn timeout-config)
                 latch (CountDownLatch. 1)]
             (let [instance-1 {:id "instance-1", :service-id test-service-id, :success-flag true}
                   instance-2 {:id "instance-2", :service-id test-service-id, :success-flag true}]
@@ -487,7 +488,7 @@
                 {:keys [executor-chan exit-chan query-chan]}
                 (service-scaling-executor
                   test-service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
-                  delegate-instance-kill-request-fn timeout-config)
+                  delegate-instance-kill-request-fn service-id->service-description-fn timeout-config)
                 latch (CountDownLatch. 1)]
             (let [instance-1 {:id "instance-1", :service-id test-service-id, :success-flag true}
                   instance-2 {:id "instance-2", :service-id test-service-id, :success-flag false}]
@@ -525,7 +526,7 @@
                 {:keys [executor-chan exit-chan query-chan]}
                 (service-scaling-executor
                   test-service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
-                  delegate-instance-kill-request-fn timeout-config)]
+                  delegate-instance-kill-request-fn service-id->service-description-fn timeout-config)]
             (let [instance-1 {:id "instance-1", :service-id test-service-id, :success-flag true}]
               (mock-reservation-system
                 instance-rpc-chan

--- a/waiter/test/waiter/scaling_test.clj
+++ b/waiter/test/waiter/scaling_test.clj
@@ -679,20 +679,25 @@
                                                    :healthy-instances healthy-instances
                                                    :expired-instances expired-instances})]
                         (is (> epsilon (Math/abs (double (- scale-amount expected-scale-amount))))
-                            (str "scale-amount=" scale-amount " expected-scale-amount=" expected-scale-amount))
+                            (str (last *testing-contexts*) ": scale-amount=" scale-amount
+                                 " expected-scale-amount=" expected-scale-amount))
                         (is (= scale-to-instances expected-scale-to-instances)
-                            (str "scale-to-instances=" scale-to-instances " expected-scale-to-instances=" expected-scale-to-instances))
+                            (str (last *testing-contexts*) ": scale-to-instances=" scale-to-instances
+                                 " expected-scale-to-instances=" expected-scale-to-instances))
                         (is (> epsilon (Math/abs (double (- target-instances expected-target-instances))))
-                            (str "target-instances=" target-instances " expected-target-instances=" expected-target-instances))))]
+                            (str (last *testing-contexts*) ": target-instances=" target-instances
+                                 " expected-target-instances=" expected-target-instances))))]
     (testing "scale whole way"
       (scales-like 5 10 10, fast-scaling 5 10 5 5 0))
+    (testing "don't scale up if there are enough instances for outstanding requests"
+      (scales-like 0 5 7, (assoc default-scaling "scale-up-factor" 0.999) 5 4 10 5 0))
     (testing "scale half way"
       (scales-like 5 15 15, default-scaling 10 20 10 10 0))
     (testing "scale three-quarters way (two ticks @ 50% each)"
       (scales-like 15 15 15, (assoc default-scaling "scale-ticks" 2) 0 20 0 0 0))
-    (testing "dont scale above max"
+    (testing "don't scale above max"
       (scales-like 0 50 50, default-scaling 50 100 50 50 0))
-    (testing "dont scale below min"
+    (testing "don't scale below min"
       (scales-like 0 1 1, default-scaling 1 0 1 1 0))
     (testing "scale down to max"
       (scales-like -10 50 50, default-scaling 60 100 60 60 0))

--- a/waiter/test/waiter/scaling_test.clj
+++ b/waiter/test/waiter/scaling_test.clj
@@ -257,6 +257,8 @@
                                                 (is (= test-service-id service-id))
                                                 false)
             service-id->service-description-fn (constantly {})
+            quanta-constraints {:cpus 64
+                                :mem 100000}
             equilibrium-state {}
             make-scaling-message (fn [service-id scale-amount scale-to-instances task-count total-instances response-chan]
                                    {:service-id service-id, :scale-amount scale-amount, :scale-to-instances scale-to-instances,
@@ -269,7 +271,8 @@
                 {:keys [executor-chan exit-chan query-chan]}
                 (service-scaling-executor
                   test-service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
-                  delegate-instance-kill-request-fn service-id->service-description-fn timeout-config)]
+                  delegate-instance-kill-request-fn service-id->service-description-fn quanta-constraints
+                  timeout-config)]
             (mock-reservation-system instance-rpc-chan [])
             (async/>!! executor-chan {:service-id test-service-id, :scale-amount 0})
             (is (= equilibrium-state (retrieve-state-fn query-chan)))
@@ -283,7 +286,8 @@
                 {:keys [executor-chan exit-chan query-chan]}
                 (service-scaling-executor
                   test-service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
-                  delegate-instance-kill-request-fn service-id->service-description-fn timeout-config)]
+                  delegate-instance-kill-request-fn service-id->service-description-fn quanta-constraints
+                  timeout-config)]
             (mock-reservation-system instance-rpc-chan [])
             (async/>!! executor-chan (make-scaling-message test-service-id 10 30 25 30 nil))
             (is (= equilibrium-state (retrieve-state-fn query-chan)))
@@ -298,7 +302,8 @@
                 {:keys [executor-chan exit-chan query-chan]}
                 (service-scaling-executor
                   test-service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
-                  delegate-instance-kill-request-fn service-id->service-description-fn timeout-config)]
+                  delegate-instance-kill-request-fn service-id->service-description-fn quanta-constraints
+                  timeout-config)]
             (mock-reservation-system instance-rpc-chan [])
             (async/>!! executor-chan (make-scaling-message test-service-id 10 30 25 20 nil))
             (is (= equilibrium-state (retrieve-state-fn query-chan)))
@@ -313,7 +318,8 @@
                 {:keys [executor-chan exit-chan query-chan]}
                 (service-scaling-executor
                   test-service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
-                  delegate-instance-kill-request-fn service-id->service-description-fn timeout-config)]
+                  delegate-instance-kill-request-fn service-id->service-description-fn quanta-constraints
+                  timeout-config)]
             (mock-reservation-system instance-rpc-chan [])
             (async/>!! executor-chan (make-scaling-message test-service-id -5 25 20 20 nil))
             (is (= equilibrium-state (retrieve-state-fn query-chan)))
@@ -333,7 +339,8 @@
                 {:keys [executor-chan exit-chan query-chan]}
                 (service-scaling-executor
                   test-service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
-                  delegate-instance-kill-request-fn service-id->service-description-fn timeout-config)]
+                  delegate-instance-kill-request-fn service-id->service-description-fn quanta-constraints
+                  timeout-config)]
             (mock-reservation-system
               instance-rpc-chan
               [(fn [[{:keys [reason]} response-chan]]
@@ -360,7 +367,8 @@
                 {:keys [executor-chan exit-chan query-chan]}
                 (service-scaling-executor
                   test-service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
-                  delegate-instance-kill-request-fn service-id->service-description-fn timeout-config)]
+                  delegate-instance-kill-request-fn service-id->service-description-fn quanta-constraints
+                  timeout-config)]
             (mock-reservation-system
               instance-rpc-chan
               [(fn [[{:keys [reason]} response-chan]]
@@ -383,7 +391,8 @@
                 {:keys [executor-chan exit-chan query-chan]}
                 (service-scaling-executor
                   test-service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
-                  delegate-instance-kill-request-fn service-id->service-description-fn timeout-config)]
+                  delegate-instance-kill-request-fn service-id->service-description-fn quanta-constraints
+                  timeout-config)]
             (let [instance-1 {:id "instance-1", :service-id test-service-id, :success-flag true}]
               (mock-reservation-system
                 instance-rpc-chan
@@ -417,7 +426,8 @@
                 {:keys [executor-chan exit-chan query-chan]}
                 (service-scaling-executor
                   test-service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
-                  delegate-instance-kill-request-fn service-id->service-description-fn timeout-config)
+                  delegate-instance-kill-request-fn service-id->service-description-fn quanta-constraints
+                  timeout-config)
                 latch (CountDownLatch. 1)]
             (let [instance-1 {:id "instance-1", :service-id test-service-id, :success-flag true}]
               (mock-reservation-system
@@ -450,7 +460,8 @@
                 {:keys [executor-chan exit-chan query-chan]}
                 (service-scaling-executor
                   test-service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
-                  delegate-instance-kill-request-fn service-id->service-description-fn timeout-config)
+                  delegate-instance-kill-request-fn service-id->service-description-fn quanta-constraints
+                  timeout-config)
                 latch (CountDownLatch. 1)]
             (let [instance-1 {:id "instance-1", :service-id test-service-id, :success-flag true}
                   instance-2 {:id "instance-2", :service-id test-service-id, :success-flag true}]
@@ -488,7 +499,8 @@
                 {:keys [executor-chan exit-chan query-chan]}
                 (service-scaling-executor
                   test-service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
-                  delegate-instance-kill-request-fn service-id->service-description-fn timeout-config)
+                  delegate-instance-kill-request-fn service-id->service-description-fn quanta-constraints
+                  timeout-config)
                 latch (CountDownLatch. 1)]
             (let [instance-1 {:id "instance-1", :service-id test-service-id, :success-flag true}
                   instance-2 {:id "instance-2", :service-id test-service-id, :success-flag false}]
@@ -526,7 +538,8 @@
                 {:keys [executor-chan exit-chan query-chan]}
                 (service-scaling-executor
                   test-service-id scheduler instance-rpc-chan peers-acknowledged-blacklist-requests-fn
-                  delegate-instance-kill-request-fn service-id->service-description-fn timeout-config)]
+                  delegate-instance-kill-request-fn service-id->service-description-fn quanta-constraints
+                  timeout-config)]
             (let [instance-1 {:id "instance-1", :service-id test-service-id, :success-flag true}]
               (mock-reservation-system
                 instance-rpc-chan


### PR DESCRIPTION
## Changes proposed in this PR

- adds service-id->service-description-fn parameter to service-scaling-multiplexer
- adds quanta-constraints to settings  
- adds quanta-constraints parameter to service-scaling-multiplexer
- supports quanta-based scaling (while scaling-up)

## Why are we making these changes?

We would like our scale-up operations to be throttled to reduce the chances of overshoot (and waster) in presence of spiky traffic.

