### PR TITLE
renames app to service in waiter scheduler and scaler

### DIFF
--- a/waiter/docs/notes/scaling.md
+++ b/waiter/docs/notes/scaling.md
@@ -1,10 +1,10 @@
 # Waiter's Scaling Logic
 
 * `autoscaler-goroutine` runs in a loop every `timeout-interval-ms` ms.
-* `autoscaler-goroutine` determines global services state and triggers scaling of individual services via `scale-apps`.
-    * `scale-apps` calls `scale-app` per service with `expired-instances`, `healthy-instances`, `outstanding-requests`, `target-instances`, `instances` (scheduled instances) to retrieve the `scale-amount`.
-        * `scale-app` computes `scale-amount`, `scale-to-instances` and `target-instances` as `scaling-state`.
-    * `scale-apps` uses `scale-amount` to determine calling `apply-scaling!` with `outstanding-requests`, `task-count` (requested instances), `instances` (scheduled instances), `scale-amount` and `scale-to-instances`.
+* `autoscaler-goroutine` determines global services state and triggers scaling of individual services via `scale-services`.
+    * `scale-services` calls `scale-service` per service with `expired-instances`, `healthy-instances`, `outstanding-requests`, `target-instances`, `instances` (scheduled instances) to retrieve the `scale-amount`.
+        * `scale-service` computes `scale-amount`, `scale-to-instances` and `target-instances` as `scaling-state`.
+    * `scale-services` uses `scale-amount` to determine calling `apply-scaling!` with `outstanding-requests`, `task-count` (requested instances), `instances` (scheduled instances), `scale-amount` and `scale-to-instances`.
         * `apply-scaling!` sends scaling request along `executor-multiplexer-chan`.
         * `service-scaling-executor` reads `executor-multiplexer-chan` to trigger scale-up or scale-down calls.
-    * `scale-apps` returns `scaling-state` to use as seed data for next iteration of scaling computation for the service.
+    * `scale-services` returns `scaling-state` to use as seed data for next iteration of scaling computation for the service.

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -846,7 +846,7 @@
                        {:keys [executor-multiplexer-chan]} autoscaling-multiplexer]
                    (scaling/autoscaler-goroutine
                      {} leader?-fn service-id->metrics-fn executor-multiplexer-chan scheduler autoscaler-interval-ms
-                     scaling/scale-app service-id->service-description-fn router-state-push-mult)))
+                     scaling/scale-service service-id->service-description-fn router-state-push-mult)))
    :autoscaling-multiplexer (pc/fnk [[:routines delegate-instance-kill-request-fn peers-acknowledged-blacklist-requests-fn]
                                      [:scheduler scheduler]
                                      [:state instance-rpc-chan scaling-timeout-config]]

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -282,7 +282,7 @@
                        :current-user auth-user
                        :service-id service-id
                        :status 403})))
-    (let [delete-result (scheduler/delete-app scheduler service-id)
+    (let [delete-result (scheduler/delete-service scheduler service-id)
           response-status (case (:result delete-result)
                             :deleted 200
                             :no-such-service-exists 404

--- a/waiter/src/waiter/mesos/marathon.clj
+++ b/waiter/src/waiter/mesos/marathon.clj
@@ -34,7 +34,7 @@
                            :spnego-auth spnego-auth
                            :request-method :post))
 
-(defn delete-app
+(defn delete-service
   "Delete the app specified by the app-id."
   [{:keys [http-client marathon-url spnego-auth]} app-id]
   (http-utils/http-request http-client (str marathon-url "/v2/apps/" app-id)

--- a/waiter/src/waiter/mesos/marathon.clj
+++ b/waiter/src/waiter/mesos/marathon.clj
@@ -34,7 +34,7 @@
                            :spnego-auth spnego-auth
                            :request-method :post))
 
-(defn delete-service
+(defn delete-app
   "Delete the app specified by the app-id."
   [{:keys [http-client marathon-url spnego-auth]} app-id]
   (http-utils/http-request http-client (str marathon-url "/v2/apps/" app-id)

--- a/waiter/src/waiter/scaling.clj
+++ b/waiter/src/waiter/scaling.clj
@@ -61,8 +61,8 @@
                     (log/info "service-scaling-multiplexer received" {:service-id service-id :scale-amount scale-amount})
                     (let [service-id->scaling-executor-chan
                           (cond-> service-id->scaling-executor-chan
-                                  (not (get service-id->scaling-executor-chan service-id))
-                                  (assoc service-id (scaling-executor-factory service-id)))
+                            (not (get service-id->scaling-executor-chan service-id))
+                            (assoc service-id (scaling-executor-factory service-id)))
                           {:keys [executor-chan]} (get service-id->scaling-executor-chan service-id)]
                       (if scale-amount
                         (do
@@ -382,11 +382,11 @@
               {:keys [target-instances scale-to-instances scale-amount]}
               (if (and target-instances scale-ticks)
                 (scale-service-fn (assoc service-description "scale-ticks" scale-ticks)
-                              {:healthy-instances healthy-instances
-                               :expired-instances expired-instances
-                               :outstanding-requests outstanding-requests
-                               :target-instances target-instances
-                               :total-instances instances})
+                                  {:healthy-instances healthy-instances
+                                   :expired-instances expired-instances
+                                   :outstanding-requests outstanding-requests
+                                   :target-instances target-instances
+                                   :total-instances instances})
                 (do
                   (log/info "no target instances available for service"
                             {:scheduler-state scheduler-state, :service-id service-id})
@@ -494,15 +494,15 @@
                                           (when (seq excluded-service-ids)
                                             (cid/cinfo correlation-id "services excluded this iteration" excluded-service-ids))
                                           (scale-services scalable-service-ids
-                                                      (pc/map-from-keys #(service-id->service-description-fn %) scalable-service-ids)
-                                                      ; default to 0 outstanding requests for services without metrics
-                                                      (pc/map-from-keys #(get-in global-state' [% "outstanding"] 0) scalable-service-ids)
-                                                      service-id->scale-state
-                                                      apply-scaling-fn
-                                                      scale-ticks
-                                                      scale-service-fn
-                                                      service-id->router-state
-                                                      service-id->scheduler-state')))
+                                                          (pc/map-from-keys #(service-id->service-description-fn %) scalable-service-ids)
+                                                          ; default to 0 outstanding requests for services without metrics
+                                                          (pc/map-from-keys #(get-in global-state' [% "outstanding"] 0) scalable-service-ids)
+                                                          service-id->scale-state
+                                                          apply-scaling-fn
+                                                          scale-ticks
+                                                          scale-service-fn
+                                                          service-id->router-state
+                                                          service-id->scheduler-state')))
                                       service-id->scale-state)]
                                 (cid/cinfo correlation-id "scaling iteration took" (difference-in-millis (t/now) cycle-start-time)
                                            "ms for" (count service->scale-state') "services.")

--- a/waiter/src/waiter/scaling.clj
+++ b/waiter/src/waiter/scaling.clj
@@ -36,7 +36,7 @@
   (when-let [apps (try
                     (scheduler/retry-on-transient-server-exceptions
                       "get-app-instance-stats"
-                      (scheduler/get-apps scheduler))
+                      (scheduler/get-services scheduler))
                     (catch Exception ex
                       (log/warn ex "fetch failed for instance counts from scheduler")))]
     (zipmap (map :id apps)

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -75,7 +75,7 @@
 
 (defprotocol ServiceScheduler
 
-  (get-apps->instances [this]
+  (get-service->instances [this]
     "Returns a map of scheduler/Service records -> map of scheduler/ServiceInstance records.
      The nested map has the following keys: :active-instances, :failed-instances and :killed-instances.
      The active-instances should not be assumed to be healthy (or live).
@@ -381,7 +381,7 @@
                                           (metrics/waiter-timer "core" "scheduler" "get-apps")
                                           (retry-on-transient-server-exceptions
                                             "request-available-waiter-apps"
-                                            (get-apps->instances scheduler)))]
+                                            (get-service->instances scheduler)))]
     (log/trace "request-available-waiter-apps:apps" (keys service->service-instances))
     service->service-instances))
 

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -102,7 +102,7 @@
     "Sends a call to Scheduler to start an app with the descriptor if the app does not already exist.
      Returns truth-y value if the app creation was successful and nil otherwise.")
 
-  (delete-app [this ^String service-id]
+  (delete-service [this ^String service-id]
     "Instructs the scheduler to delete the specified service.
      Returns a map containing the following structure:
      {:message message
@@ -275,7 +275,7 @@
   "Performs scheduler GC by tracking which services are idle (i.e. have no outstanding requests).
    The function launches a go-block that tracks the metrics state of all services currently being managed by the scheduler.
    Idle services are detected based on no changes to the metrics state past the `idle-timeout-mins` period.
-   They are then deleted by the leader using the `delete-app` function.
+   They are then deleted by the leader using the `delete-service` function.
    If an error occurs while deleting a service, there will be repeated attempts to delete it later."
   [scheduler scheduler-state-chan service-id->metrics-fn {:keys [scheduler-gc-interval-ms]} service-gc-go-routine
    service-id->idle-timeout]
@@ -305,7 +305,7 @@
           perform-gc-fn (fn [service-id]
                           (log/info "deleting idle service" service-id)
                           (try
-                            (delete-app scheduler service-id)
+                            (delete-service scheduler service-id)
                             (catch Exception e
                               (log/error e "unable to delete idle service" service-id))))]
       (log/info "starting scheduler-services-gc")
@@ -322,7 +322,7 @@
   "Performs scheduler GC by tracking which services are broken (i.e. has no healthy instance, but at least one failed instance possibly due to a broken command).
    The function launches a go-block that tracks the metrics state of all services currently being managed by the scheduler.
    Faulty services are detected based on no changes to the healthy/failed instances state past the `broken-service-timeout-mins` period, respectively.
-   They are then deleted by the leader using the `delete-app` function.
+   They are then deleted by the leader using the `delete-service` function.
    If an error occurs while deleting a service, there will be repeated attempts to delete it later."
   [scheduler scheduler-state-chan {:keys [broken-service-timeout-mins broken-service-min-hosts scheduler-gc-broken-service-interval-ms]} service-gc-go-routine]
   (let [service-data-chan (au/latest-chan)]
@@ -361,7 +361,7 @@
           perform-gc-fn (fn [service-id]
                           (log/info "deleting broken service" service-id)
                           (try
-                            (delete-app scheduler service-id)
+                            (delete-service scheduler service-id)
                             (catch Exception e
                               (log/error e "unable to delete broken service" service-id))))]
       (log/info "starting scheduler-broken-services-gc")

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -109,7 +109,7 @@
       :result :deleted|:error|:no-such-service-exists
       :success true|false}")
 
-  (scale-app [this ^String service-id target-instances force]
+  (scale-service [this ^String service-id target-instances force]
     "Instructs the scheduler to scale up/down instances of the specified service to the specified number
      of instances. The force flag can be used enforce the scaling by ignoring previous pending operations.")
 

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -95,7 +95,7 @@
      Returns a map containing the following structure:
      {:instance-id instance-id, :killed? <boolean>, :message <string>,  :service-id service-id, :status status-code}")
 
-  (app-exists? [this ^String service-id]
+  (service-exists? [this ^String service-id]
     "Returns truth-y value if the app exists and nil otherwise.")
 
   (create-app-if-new [this descriptor]

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -98,7 +98,7 @@
   (service-exists? [this ^String service-id]
     "Returns truth-y value if the app exists and nil otherwise.")
 
-  (create-app-if-new [this descriptor]
+  (create-service-if-new [this descriptor]
     "Sends a call to Scheduler to start an app with the descriptor if the app does not already exist.
      Returns truth-y value if the app creation was successful and nil otherwise.")
 

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -81,7 +81,7 @@
      The active-instances should not be assumed to be healthy (or live).
      The failed-instances are guaranteed to be dead.")
 
-  (get-apps [this]
+  (get-services [this]
     "Returns a list of scheduler/Service records")
 
   (get-instances [this ^String service-id]
@@ -378,7 +378,7 @@
   "Queries the scheduler and builds a list of available Waiter apps."
   [scheduler]
   (when-let [service->service-instances (timers/start-stop-time!
-                                          (metrics/waiter-timer "core" "scheduler" "get-apps")
+                                          (metrics/waiter-timer "core" "scheduler" "get-services")
                                           (retry-on-transient-server-exceptions
                                             "request-available-waiter-apps"
                                             (get-service->instances scheduler)))]

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -345,7 +345,7 @@
              (transient {}))
            (persistent!))))
 
-  (get-apps [_]
+  (get-services [_]
     (let [all-jobs (mapcat #(get-jobs cook-api % ["running" "waiting"] :search-interval search-interval)
                            allowed-users)
           service-id->jobs (group-by #(-> % :labels :service-id) all-jobs)]

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -428,7 +428,7 @@
        :result :already-exists
        :success false}))
 
-  (delete-app [this service-id]
+  (delete-service [this service-id]
     (if (scheduler/service-exists? this service-id)
       (let [success (try
                       (let [{:strs [run-as-user] :as service-description} (service-id->service-description-fn service-id)

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -328,7 +328,7 @@
 
   scheduler/ServiceScheduler
 
-  (get-apps->instances [_]
+  (get-service->instances [_]
     (let [all-jobs (mapcat #(get-jobs cook-api % ["running" "waiting"] :search-interval search-interval)
                            allowed-users)
           service-id->jobs (group-by #(-> % :labels :service-id) all-jobs)]

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -449,7 +449,7 @@
        :result :no-such-service-exists
        :success false}))
 
-  (scale-app [this service-id scale-to-instances _]
+  (scale-service [this service-id scale-to-instances _]
     (if (scheduler/service-exists? this service-id)
       (let [result (try
                      (let [service-description (service-id->service-description-fn service-id)

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -403,7 +403,7 @@
       (catch [:status 404] _
         (log/warn "service-exists?: service" service-id "does not exist!"))))
 
-  (create-app-if-new [this {:keys [service-id] :as descriptor}]
+  (create-service-if-new [this {:keys [service-id] :as descriptor}]
     (if-not (scheduler/service-exists? this service-id)
       (timers/start-stop-time!
         (metrics/waiter-timer "core" "create-app")

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -10,11 +10,8 @@
 ;;
 (ns waiter.scheduler.kubernetes
   (:require [clj-time.core :as t]
-            [clojure.core.async :as async]
             [clojure.data.json :as json]
-            [clojure.edn :as edn]
             [clojure.java.io :as io]
-            [clojure.java.shell :as shell]
             [clojure.string :as string]
             [clojure.tools.logging :as log]
             [plumbing.core :as pc]
@@ -127,10 +124,10 @@
           failures (-> service-id->failed-instances-transient-store deref (get service-id))]
       (when-not (contains? failures newest-failure-id)
         (let [newest-failure-instance (cond-> (assoc live-instance
-                                                     :flags failure-flags
-                                                     :healthy? false
-                                                     :id newest-failure-id
-                                                     :started-at newest-failure-start-time)
+                                                :flags failure-flags
+                                                :healthy? false
+                                                :id newest-failure-id
+                                                :started-at newest-failure-start-time)
                                         ;; To match the behavior of the marathon scheduler,
                                         ;; we don't include the exit code in failed instances that were killed by k8s.
                                         (not (killed-by-k8s? newest-failure))
@@ -176,7 +173,7 @@
                             :accept "application/json"
                             (cond-> options
                               auth-str (assoc-in [:headers "Authorization"] auth-str)
-                              (and (not content-type ) body) (assoc :content-type "application/json")))]
+                              (and (not content-type) body) (assoc :content-type "application/json")))]
       (scheduler/log "response from K8s API server:" (json/write-str result))
       result)
     (catch [:status 400] _
@@ -194,7 +191,7 @@
   [{:keys [api-server-url http-client orchestrator-name replicaset-api-version] :as scheduler}]
   (->> (str api-server-url "/apis/" replicaset-api-version
             "/replicasets?labelSelector=managed-by="
-             orchestrator-name)
+            orchestrator-name)
        (api-request http-client)
        :items
        (mapv replicaset->Service)))
@@ -551,7 +548,7 @@
         backend-protocol-lower (string/lower-case backend-proto)
         backend-protocol-upper (string/upper-case backend-proto)
         health-check-url (sd/service-description->health-check-url service-description)
-        memory  (str mem "Mi")
+        memory (str mem "Mi")
         ssl? (= "https" backend-protocol-lower)]
     {:kind "ReplicaSet"
      :apiVersion replicaset-api-version
@@ -624,7 +621,7 @@
          (utils/pos-int? max-name-length)
          (not (string/blank? orchestrator-name))
          (integer? pod-base-port)
-         (< 0 pod-base-port 65527)  ; max port is 65535, and we need to reserve up to 10 ports
+         (< 0 pod-base-port 65527) ; max port is 65535, and we need to reserve up to 10 ports
          (utils/pos-int? pod-suffix-length)
          (not (string/blank? replicaset-api-version))
          (symbol? (:factory-fn replicaset-spec-builder))

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -452,14 +452,14 @@
          :service-id service-id
          :status 500})))
 
-  (app-exists? [this service-id]
+  (service-exists? [this service-id]
     (ss/try+
       (some? (service-id->service this service-id))
       (catch [:status 404] _
         (comment "App does not exist."))))
 
   (create-app-if-new [this {:keys [service-id] :as descriptor}]
-    (when-not (scheduler/app-exists? this service-id)
+    (when-not (scheduler/service-exists? this service-id)
       (ss/try+
         (create-service descriptor this)
         (catch [:status 409] _

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -415,7 +415,7 @@
                                 service-id->service-description-fn]
   scheduler/ServiceScheduler
 
-  (get-apps->instances [this]
+  (get-service->instances [this]
     (pc/map-from-keys #(instances-breakdown! this %)
                       (get-services this)))
 

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -485,7 +485,7 @@
         {:result :error
          :message "Internal error while deleting service"})))
 
-  (scale-app [this service-id scale-to-instances _]
+  (scale-service [this service-id scale-to-instances _]
     (ss/try+
       (if-let [service (service-id->service this service-id)]
         (do

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -419,7 +419,7 @@
     (pc/map-from-keys #(instances-breakdown! this %)
                       (get-services this)))
 
-  (get-apps [this]
+  (get-services [this]
     (get-services this))
 
   (get-instances [this service-id]

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -458,7 +458,7 @@
       (catch [:status 404] _
         (comment "App does not exist."))))
 
-  (create-app-if-new [this {:keys [service-id] :as descriptor}]
+  (create-service-if-new [this {:keys [service-id] :as descriptor}]
     (when-not (scheduler/service-exists? this service-id)
       (ss/try+
         (create-service descriptor this)

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -468,7 +468,7 @@
         (catch Throwable e
           (log/error e "Error starting new app." descriptor)))))
 
-  (delete-app [this service-id]
+  (delete-service [this service-id]
     (ss/try+
       (let [service (service-id->service this service-id)
             delete-result (delete-service this service)]

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -327,7 +327,7 @@
 
   scheduler/ServiceScheduler
 
-  (get-apps->instances [_]
+  (get-service->instances [_]
     (let [apps (get-apps marathon-api is-waiter-app?-fn {"embed" ["apps.lastTaskFailure" "apps.tasks"]})]
       (response-data->service->service-instances
         apps retrieve-framework-id-fn mesos-api service-id->failed-instances-transient-store

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -333,7 +333,7 @@
         apps retrieve-framework-id-fn mesos-api service-id->failed-instances-transient-store
         service-id->service-description)))
 
-  (get-apps [_]
+  (get-services [_]
     (map response->Service (get-apps marathon-api is-waiter-app?-fn {"embed" ["apps.lastTaskFailure" "apps.tasks"]})))
 
   (get-instances [_ service-id]

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -379,12 +379,12 @@
         (when-not (scheduler/service-exists? this service-id)
           (start-new-service-wrapper marathon-api service-id marathon-descriptor)))))
 
-  (delete-app [_ service-id]
+  (delete-service [_ service-id]
     (ss/try+
       (let [delete-result (scheduler/retry-on-transient-server-exceptions
-                            (str "in delete-app[" service-id "]")
+                            (str "in delete-service[" service-id "]")
                             (log/info "deleting service" service-id)
-                            (marathon/delete-app marathon-api service-id))]
+                            (marathon/delete-service marathon-api service-id))]
         (when delete-result
           (remove-failed-instances-for-service! service-id->failed-instances-transient-store service-id)
           (scheduler/remove-killed-instances-for-service! service-id)
@@ -395,7 +395,7 @@
           {:result :error
            :message "Marathon did not provide deploymentId for delete request"}))
       (catch [:status 404] {}
-        (log/warn "[delete-app] Service does not exist:" service-id)
+        (log/warn "[delete-service] Service does not exist:" service-id)
         {:result :no-such-service-exists
          :message "Marathon reports service does not exist"})
       (catch [:status 409] e
@@ -403,8 +403,8 @@
                   {:deployment-info (extract-deployment-info marathon-api e)
                    :service-id service-id}))
       (catch [:status 503] {}
-        (log/warn "[delete-app] Marathon unavailable (Error 503).")
-        (log/debug (:throwable &throw-context) "[delete-app] Marathon unavailable"))))
+        (log/warn "[delete-service] Marathon unavailable (Error 503).")
+        (log/debug (:throwable &throw-context) "[delete-service] Marathon unavailable"))))
 
   (scale-app [_ service-id scale-to-instances force]
     (ss/try+

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -272,7 +272,7 @@
   (ss/try+
     (log/info "Starting new app for" service-id "with descriptor" (dissoc marathon-descriptor :env))
     (scheduler/retry-on-transient-server-exceptions
-      (str "create-app-if-new[" service-id "]")
+      (str "create-service-if-new[" service-id "]")
       (marathon/create-app marathon-api marathon-descriptor))
     (catch [:status 409] e
       (conflict-handler {:deployment-info (extract-deployment-info marathon-api e)
@@ -371,7 +371,7 @@
       (catch [:status 404] _
         (log/warn "service-exists?: service" service-id "does not exist!"))))
 
-  (create-app-if-new [this descriptor]
+  (create-service-if-new [this descriptor]
     (timers/start-stop-time!
       (metrics/waiter-timer "core" "create-app")
       (let [service-id (:service-id descriptor)

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -384,7 +384,7 @@
       (let [delete-result (scheduler/retry-on-transient-server-exceptions
                             (str "in delete-service[" service-id "]")
                             (log/info "deleting service" service-id)
-                            (marathon/delete-service marathon-api service-id))]
+                            (marathon/delete-app marathon-api service-id))]
         (when delete-result
           (remove-failed-instances-for-service! service-id->failed-instances-transient-store service-id)
           (scheduler/remove-killed-instances-for-service! service-id)

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -363,20 +363,20 @@
                (fn [existing-time] (or existing-time current-time))))
       kill-result))
 
-  (app-exists? [_ service-id]
+  (service-exists? [_ service-id]
     (ss/try+
       (scheduler/suppress-transient-server-exceptions
-        (str "app-exists?[" service-id "]")
+        (str "service-exists?[" service-id "]")
         (marathon/get-app marathon-api service-id))
       (catch [:status 404] _
-        (log/warn "app-exists?: service" service-id "does not exist!"))))
+        (log/warn "service-exists?: service" service-id "does not exist!"))))
 
   (create-app-if-new [this descriptor]
     (timers/start-stop-time!
       (metrics/waiter-timer "core" "create-app")
       (let [service-id (:service-id descriptor)
             marathon-descriptor (marathon-descriptor home-path-prefix service-id->password-fn descriptor)]
-        (when-not (scheduler/app-exists? this service-id)
+        (when-not (scheduler/service-exists? this service-id)
           (start-new-service-wrapper marathon-api service-id marathon-descriptor)))))
 
   (delete-app [_ service-id]

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -154,21 +154,21 @@
                                 (cond-> {:host host
                                          :protocol backend-proto
                                          :service-id (remove-slash-prefix appId)}
-                                        log-directory
-                                        (assoc :log-directory log-directory)
+                                  log-directory
+                                  (assoc :log-directory log-directory)
 
-                                        message
-                                        (assoc :message (str/trim message))
+                                  message
+                                  (assoc :message (str/trim message))
 
-                                        (str/includes? (str message) "Memory limit exceeded:")
-                                        (assoc :flags #{:memory-limit-exceeded})
+                                  (str/includes? (str message) "Memory limit exceeded:")
+                                  (assoc :flags #{:memory-limit-exceeded})
 
-                                        (str/includes? (str message) "Task was killed since health check failed")
-                                        (assoc :flags #{:never-passed-health-checks})
+                                  (str/includes? (str message) "Task was killed since health check failed")
+                                  (assoc :flags #{:never-passed-health-checks})
 
-                                        (str/includes? (str message) "Command exited with status")
-                                        (assoc :exit-code (try (-> message (str/split #"\s+") last Integer/parseInt)
-                                                               (catch Throwable _))))))
+                                  (str/includes? (str message) "Command exited with status")
+                                  (assoc :exit-code (try (-> message (str/split #"\s+") last Integer/parseInt)
+                                                         (catch Throwable _))))))
         healthy?-fn #(let [health-checks (:healthCheckResults %)]
                        (and
                          (and (seq health-checks)
@@ -416,8 +416,8 @@
             (marathon/delete-deployment marathon-api (:id current-deployment))))
         (let [old-descriptor (:app (marathon/get-app marathon-api service-id))
               scale-to-instances' (cond-> scale-to-instances
-                                          ;; avoid unintentional scale-down in force mode
-                                          force (max (-> old-descriptor :tasks count)))
+                                    ;; avoid unintentional scale-down in force mode
+                                    force (max (-> old-descriptor :tasks count)))
               _ (when (not= scale-to-instances scale-to-instances')
                   (log/info "adjusting scale to instances to" scale-to-instances' "in force mode"))
               new-descriptor (-> (select-keys old-descriptor [:cmd :cpus :id :mem])

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -406,10 +406,10 @@
         (log/warn "[delete-service] Marathon unavailable (Error 503).")
         (log/debug (:throwable &throw-context) "[delete-service] Marathon unavailable"))))
 
-  (scale-app [_ service-id scale-to-instances force]
+  (scale-service [_ service-id scale-to-instances force]
     (ss/try+
       (scheduler/suppress-transient-server-exceptions
-        (str "in scale-app[" service-id "]")
+        (str "in scale-service[" service-id "]")
         (when force
           (when-let [current-deployment (extract-service-deployment-info marathon-api service-id)]
             (log/info "forcefully deleting deployment" current-deployment)
@@ -428,7 +428,7 @@
                   {:deployment-info (extract-deployment-info marathon-api e)
                    :service-id service-id}))
       (catch [:status 503] {}
-        (log/warn "[scale-app] Marathon unavailable (Error 503).")
+        (log/warn "[scale-service] Marathon unavailable (Error 503).")
         (log/debug (:throwable &throw-context) "[autoscaler] Marathon unavailable"))))
 
   (retrieve-directory-content [_ service-id instance-id host directory]
@@ -479,7 +479,7 @@
   [marathon-scheduler service-id {:keys [instances-scheduled] :as task-data}]
   (try
     (log/info "triggering sync deployment" {:service-id service-id :task-data task-data})
-    (scheduler/scale-app marathon-scheduler service-id instances-scheduled false)
+    (scheduler/scale-service marathon-scheduler service-id instances-scheduled false)
     (catch Exception e
       (log/error e "unable to sync marathon deployment for" service-id))))
 

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -445,7 +445,7 @@
             (deliver completion-promise :scaled)
             (assoc-in id->service [service-id :service :instances] scale-to-instances))
           (do
-            (log/info "received scale-app call, but current (" current-instances ") >= target (" scale-to-instances ")")
+            (log/info "received scale-service call, but current (" current-instances ") >= target (" scale-to-instances ")")
             (deliver completion-promise :scaling-not-needed)
             id->service)))
       (do
@@ -611,7 +611,7 @@
        :result :no-such-service-exists
        :message (str service-id " does not exist!")}))
 
-  (scale-app [this service-id scale-to-instances _]
+  (scale-service [this service-id scale-to-instances _]
     (if (scheduler/service-exists? this service-id)
       (let [completion-promise (promise)]
         (send id->service-agent set-service-scale service-id scale-to-instances completion-promise)

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -549,7 +549,7 @@
                       (service-entry->instances service-entry))
                     id->service))))
 
-  (get-apps [_]
+  (get-services [_]
     (let [id->service @id->service-agent]
       (map (fn [[_ {:keys [service]}]] service) id->service)))
 

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -543,7 +543,7 @@
 
   scheduler/ServiceScheduler
 
-  (get-apps->instances [_]
+  (get-service->instances [_]
     (let [id->service @id->service-agent]
       (into {} (map (fn [[_ service-entry]]
                       (service-entry->instances service-entry))

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -579,7 +579,7 @@
   (service-exists? [_ service-id]
     (contains? @id->service-agent service-id))
 
-  (create-app-if-new [this {:keys [service-id service-description]}]
+  (create-service-if-new [this {:keys [service-id service-description]}]
     (if-not (scheduler/service-exists? this service-id)
       (let [completion-promise (promise)]
         (send id->service-agent create-service service-id service-description

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -596,7 +596,7 @@
        :result :already-exists
        :message (str service-id " already exists!")}))
 
-  (delete-app [this service-id]
+  (delete-service [this service-id]
     (if (scheduler/service-exists? this service-id)
       (let [completion-promise (promise)]
         (send id->service-agent delete-service service-id port->reservation-atom port-grace-period-ms completion-promise)

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -196,7 +196,7 @@
   [{:keys [service id->instance] :as service-entry}]
   (let [running (->> id->instance vals (filter active?) count)
         healthy (->> id->instance vals (filter healthy?) count)
-        unhealthy (->> id->instance vals (filter unhealthy?) count) ]
+        unhealthy (->> id->instance vals (filter unhealthy?) count)]
     (assoc service-entry :service (-> service
                                       (assoc :task-count running)
                                       (assoc :task-stats {:healthy healthy
@@ -240,9 +240,9 @@
               (launch-service service-id service-description service-id->password-fn
                               work-directory port->reservation-atom port-range)]
           (deliver completion-promise :created)
-          (let [service-entry (-> {:service service 
+          (let [service-entry (-> {:service service
                                    :id->instance {(:id instance) instance}}
-                                  update-task-stats)] 
+                                  update-task-stats)]
             (assoc id->service service-id service-entry)))))
     (catch Throwable e
       (log/error e "error attempting to create service" service-id)
@@ -327,7 +327,7 @@
       (release-port! port->reservation-atom port port-grace-period-ms)
       (assoc instance :healthy? false
                       :failed? (if (zero? exit-value) false true)
-                      :killed? true                          ; does not actually mean killed -- using this to mark inactive
+                      :killed? true ; does not actually mean killed -- using this to mark inactive
                       :exit-code exit-value))
     instance))
 
@@ -514,13 +514,13 @@
            (cond-> {:name (.getName file)
                     :size (.length file)
                     :type (if (.isDirectory file) "directory" "file")}
-                   (.isDirectory file)
-                   (assoc :path (-> file
-                                    (.toPath)
-                                    (.relativize (.getPath (File. (str working-directory))))
-                                    (str)))
-                   (.isFile file)
-                   (assoc :url (str (.toURL file)))))
+             (.isDirectory file)
+             (assoc :path (-> file
+                              (.toPath)
+                              (.relativize (.getPath (File. (str working-directory))))
+                              (str)))
+             (.isFile file)
+             (assoc :url (str (.toURL file)))))
          directory-content)))
 
 ; The ShellScheduler's shell-agent holds all of the state about which

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -559,7 +559,7 @@
       (second (service-entry->instances service-entry))))
 
   (kill-instance [this {:keys [id service-id] :as instance}]
-    (if (scheduler/app-exists? this service-id)
+    (if (scheduler/service-exists? this service-id)
       (let [completion-promise (promise)]
         (send id->service-agent kill-instance service-id id
               port->reservation-atom port-grace-period-ms
@@ -576,11 +576,11 @@
        :result :no-such-service-exists
        :message (str service-id " does not exist!")}))
 
-  (app-exists? [_ service-id]
+  (service-exists? [_ service-id]
     (contains? @id->service-agent service-id))
 
   (create-app-if-new [this {:keys [service-id service-description]}]
-    (if-not (scheduler/app-exists? this service-id)
+    (if-not (scheduler/service-exists? this service-id)
       (let [completion-promise (promise)]
         (send id->service-agent create-service service-id service-description
               service-id->password-fn work-directory port->reservation-atom
@@ -597,7 +597,7 @@
        :message (str service-id " already exists!")}))
 
   (delete-app [this service-id]
-    (if (scheduler/app-exists? this service-id)
+    (if (scheduler/service-exists? this service-id)
       (let [completion-promise (promise)]
         (send id->service-agent delete-service service-id port->reservation-atom port-grace-period-ms completion-promise)
         (let [result (deref completion-promise)
@@ -612,7 +612,7 @@
        :message (str service-id " does not exist!")}))
 
   (scale-app [this service-id scale-to-instances _]
-    (if (scheduler/app-exists? this service-id)
+    (if (scheduler/service-exists? this service-id)
       (let [completion-promise (promise)]
         (send id->service-agent set-service-scale service-id scale-to-instances completion-promise)
         (let [result (deref completion-promise)

--- a/waiter/src/waiter/service.clj
+++ b/waiter/src/waiter/service.clj
@@ -307,7 +307,7 @@
                                (try
                                  (when pre-start-fn
                                    (pre-start-fn))
-                                 (scheduler/create-app-if-new scheduler descriptor)
+                                 (scheduler/create-service-if-new scheduler descriptor)
                                  (catch Exception e
                                    (log/warn e "Error starting new app")))))]
             (.submit start-app-threadpool

--- a/waiter/src/waiter/simulator.clj
+++ b/waiter/src/waiter/simulator.clj
@@ -183,7 +183,7 @@
         (if (<= tick (min max-total-ticks total-ticks))
           (let [{:keys [scale-amount target-instances]}
                 (if (zero? (mod tick scale-ticks))
-                  (scaling/scale-app config state)
+                  (scaling/scale-service config state)
                   {:scale-amount 0 :target-instances target-instances})]
             (let [client-change-amount (client-curve tick 0)
                   total-clients (or total-clients 0)

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -488,7 +488,7 @@
     (log/debug service-id "has" instances "instances.")
     instances))
 
-(defn scale-app-to [waiter-url service-id target-instances]
+(defn scale-service-to [waiter-url service-id target-instances]
   (let [marathon-url (marathon-url waiter-url)]
     (log/info service-id "being scaled to" target-instances "task(s).")
     (let [http-options {:conn-timeout 10000, :socket-timeout 10000, :spnego-auth use-spnego}
@@ -522,7 +522,7 @@
                (throw (Exception. (str "Unable to delete" service-id)))))))
        (catch Exception _
          (try
-           (scale-app-to waiter-url service-id 0)
+           (scale-service-to waiter-url service-id 0)
            (catch Exception e
              (log/error "Error in deleting app" service-id ":" (.getMessage e)))))))))
 

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -403,7 +403,7 @@
                        :wrap-secure-request-fn utils/wrap-identity}
         handlers {:service-handler-fn ((:service-handler-fn request-handlers) configuration)}]
     (testing "service-handler:delete-successful"
-      (with-redefs [scheduler/delete-app (fn [_ service-id] {:result :deleted, :service-id service-id})
+      (with-redefs [scheduler/delete-service (fn [_ service-id] {:result :deleted, :service-id service-id})
                     sd/fetch-core (fn [_ service-id & _] {"run-as-user" user, "name" (str service-id "-name")})]
         (let [request {:request-method :delete, :uri (str "/apps/" service-id), :authorization/user user}
               {:keys [body headers status]} ((ring-handler-factory waiter-request?-fn handlers) request)]
@@ -411,7 +411,7 @@
           (is (= {"content-type" "application/json"} headers))
           (is (= {"success" true, "service-id" service-id, "result" "deleted"} (json/read-str body))))))
     (testing "service-handler:delete-nil-response"
-      (with-redefs [scheduler/delete-app (fn [_ _] nil)
+      (with-redefs [scheduler/delete-service (fn [_ _] nil)
                     sd/fetch-core (fn [_ service-id & _] {"run-as-user" user, "name" (str service-id "-name")})]
         (let [request {:request-method :delete, :uri (str "/apps/" service-id), :authorization/user user}
               {:keys [body headers status]} ((ring-handler-factory waiter-request?-fn handlers) request)]
@@ -419,7 +419,7 @@
           (is (= {"content-type" "application/json"} headers))
           (is (= {"success" false, "service-id" service-id} (json/read-str body))))))
     (testing "service-handler:delete-unauthorized-user"
-      (with-redefs [scheduler/delete-app (fn [_ _] (throw (IllegalStateException. "Unexpected call!")))
+      (with-redefs [scheduler/delete-service (fn [_ _] (throw (IllegalStateException. "Unexpected call!")))
                     sd/fetch-core (fn [_ service-id & _] {"run-as-user" (str "another-" user), "name" (str service-id "-name")})]
         (let [request {:authorization/user user
                        :headers {"accept" "application/json"}
@@ -430,7 +430,7 @@
           (is (= {"content-type" "application/json"} headers))
           (is (str/includes? body "User not allowed to delete service")))))
     (testing "service-handler:delete-404-response"
-      (with-redefs [scheduler/delete-app (fn [_ _] {:result :no-such-service-exists})
+      (with-redefs [scheduler/delete-service (fn [_ _] {:result :no-such-service-exists})
                     sd/fetch-core (fn [_ service-id & _] {"run-as-user" user, "name" (str service-id "-name")})]
         (let [request {:request-method :delete, :uri (str "/apps/" service-id), :authorization/user user}
               {:keys [body headers status]} ((ring-handler-factory waiter-request?-fn handlers) request)]
@@ -438,7 +438,7 @@
           (is (= {"content-type" "application/json"} headers))
           (is (= {"result" "no-such-service-exists", "service-id" service-id, "success" false} (json/read-str body))))))
     (testing "service-handler:delete-non-existent-service"
-      (with-redefs [scheduler/delete-app (fn [_ _] (throw (IllegalStateException. "Unexpected call!")))
+      (with-redefs [scheduler/delete-service (fn [_ _] (throw (IllegalStateException. "Unexpected call!")))
                     sd/fetch-core (fn [_ _ & _] {})]
         (let [request {:authorization/user user
                        :headers {"accept" "application/json"}
@@ -452,7 +452,7 @@
           (is (= "Service not found" message))
           (is (= "test-service-1" service-id)))))
     (testing "service-handler:delete-throws-exception"
-      (with-redefs [scheduler/delete-app (fn [_ _] (throw (RuntimeException. "Error in deleting service")))
+      (with-redefs [scheduler/delete-service (fn [_ _] (throw (RuntimeException. "Error in deleting service")))
                     sd/fetch-core (fn [_ service-id & _] {"run-as-user" user, "name" (str service-id "-name")})]
         (let [request {:authorization/user user
                        :headers {"accept" "application/json"}

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -531,7 +531,7 @@
 
       (testing "delete-service-handler:success-regular-user"
         (let [scheduler (reify scheduler/ServiceScheduler
-                          (delete-app [_ service-id]
+                          (delete-service [_ service-id]
                             (is (= test-service-id service-id))
                             {:result :deleted
                              :message "Worked!"}))
@@ -543,7 +543,7 @@
 
       (testing "delete-service-handler:success-regular-user-deleting-for-another-user"
         (let [scheduler (reify scheduler/ServiceScheduler
-                          (delete-app [_ service-id]
+                          (delete-service [_ service-id]
                             (is (= test-service-id service-id))
                             {:deploymentId "good"}))
               request {:authorization/user "another-user"}]

--- a/waiter/test/waiter/mesos/marathon_test.clj
+++ b/waiter/test/waiter/mesos/marathon_test.clj
@@ -24,15 +24,15 @@
 
 (defn- assert-endpoint-request-method
   ([expected-method expected-url]
-    (assert-endpoint-request-method expected-method expected-url nil))
+   (assert-endpoint-request-method expected-method expected-url nil))
   ([expected-method expected-url expected-query-string]
-    (fn [in-http-client in-request-url & {:keys [query-string request-method]}]
-      (is (= http-client in-http-client))
-      (is (= expected-method request-method))
-      (when expected-query-string
-        (is (= expected-query-string query-string)))
-      (let [expected-absolute-url (str marathon-url expected-url)]
-        (is (= expected-absolute-url in-request-url))))))
+   (fn [in-http-client in-request-url & {:keys [query-string request-method]}]
+     (is (= http-client in-http-client))
+     (is (= expected-method request-method))
+     (when expected-query-string
+       (is (= expected-query-string query-string)))
+     (let [expected-absolute-url (str marathon-url expected-url)]
+       (is (= expected-absolute-url in-request-url))))))
 
 (deftest test-marathon-rest-api-endpoints
   (let [app-id "test-app-id"

--- a/waiter/test/waiter/mesos/marathon_test.clj
+++ b/waiter/test/waiter/mesos/marathon_test.clj
@@ -43,9 +43,9 @@
       (with-redefs [http-utils/http-request (assert-endpoint-request-method :post "/v2/apps")]
         (create-app marathon-api {})))
 
-    (testing "delete-app"
+    (testing "delete-service"
       (with-redefs [http-utils/http-request (assert-endpoint-request-method :delete (str "/v2/apps/" app-id))]
-        (delete-app marathon-api app-id)))
+        (delete-service marathon-api app-id)))
 
     (testing "delete-deployment"
       (let [deployment-id "d1234"

--- a/waiter/test/waiter/mesos/marathon_test.clj
+++ b/waiter/test/waiter/mesos/marathon_test.clj
@@ -43,9 +43,9 @@
       (with-redefs [http-utils/http-request (assert-endpoint-request-method :post "/v2/apps")]
         (create-app marathon-api {})))
 
-    (testing "delete-service"
+    (testing "delete-app"
       (with-redefs [http-utils/http-request (assert-endpoint-request-method :delete (str "/v2/apps/" app-id))]
-        (delete-service marathon-api app-id)))
+        (delete-app marathon-api app-id)))
 
     (testing "delete-deployment"
       (let [deployment-id "d1234"

--- a/waiter/test/waiter/scaling_test.clj
+++ b/waiter/test/waiter/scaling_test.clj
@@ -116,8 +116,8 @@
                             :max-blacklist-time-ms 60000}
             make-scheduler (fn [operation-tracker-atom]
                              (reify scheduler/ServiceScheduler
-                               (scale-app [_ service-id scale-to-instances force]
-                                 (swap! operation-tracker-atom conj [:scale-app service-id scale-to-instances])
+                               (scale-service [_ service-id scale-to-instances force]
+                                 (swap! operation-tracker-atom conj [:scale-service service-id scale-to-instances])
                                  (is (= test-service-id service-id))
                                  (is (false? force))
                                  (when (neg? scale-to-instances)
@@ -231,8 +231,8 @@
                             :max-blacklist-time-ms 60000}
             make-scheduler (fn [operation-tracker-atom]
                              (reify scheduler/ServiceScheduler
-                               (scale-app [_ service-id scale-to-instances force]
-                                 (swap! operation-tracker-atom conj [:scale-app service-id scale-to-instances force])
+                               (scale-service [_ service-id scale-to-instances force]
+                                 (swap! operation-tracker-atom conj [:scale-service service-id scale-to-instances force])
                                  (is (= test-service-id service-id))
                                  (when (neg? scale-to-instances)
                                    (throw (Exception. "throwing exception as required by test")))
@@ -301,7 +301,7 @@
             (mock-reservation-system instance-rpc-chan [])
             (async/>!! executor-chan (make-scaling-message test-service-id 10 30 25 20 nil))
             (is (= equilibrium-state (retrieve-state-fn query-chan)))
-            (is (= [[:scale-app "test-service-id" 30 false]] @scheduler-operation-tracker-atom))
+            (is (= [[:scale-service "test-service-id" 30 false]] @scheduler-operation-tracker-atom))
             (async/>!! exit-chan :exit)))
 
         (testing "scale-force:trigger"
@@ -316,7 +316,7 @@
             (mock-reservation-system instance-rpc-chan [])
             (async/>!! executor-chan (make-scaling-message test-service-id -5 25 20 20 nil))
             (is (= equilibrium-state (retrieve-state-fn query-chan)))
-            (is (= [[:scale-app "test-service-id" 25 true]] @scheduler-operation-tracker-atom))
+            (is (= [[:scale-service "test-service-id" 25 true]] @scheduler-operation-tracker-atom))
             (async/>!! exit-chan :exit)))
 
         (testing "scale-down:no-instance-globally"
@@ -558,7 +558,7 @@
                   [:correlation-id :scale-amount :scale-to-instances :service-id :task-count :total-instances])))
     (is (= :test-data (async/<!! executor-multiplexer-chan)))))
 
-(deftest scale-apps-test
+(deftest scale-services-test
   (let [config {"min-instances" 1
                 "max-instances" 10}
         ; assert that we are applying scaling
@@ -580,12 +580,12 @@
                                    (is (= 10 scale-to-instances))
                                    10)))
         ; simple scaling function that targets outstanding-requests
-        test-scale-app (fn [{:strs [min-instances max-instances]} {:keys [total-instances outstanding-requests]}]
+        test-scale-service (fn [{:strs [min-instances max-instances]} {:keys [total-instances outstanding-requests]}]
                          (let [scale-to-instances (max min-instances (min max-instances outstanding-requests))]
                            {:scale-to-instances scale-to-instances
                             :target-instances scale-to-instances
                             :scale-amount (- scale-to-instances total-instances)}))]
-    (let [result (scale-apps ["app1" "app2" "app3" "app4"]
+    (let [result (scale-services ["app1" "app2" "app3" "app4"]
                              {"app1" (merge config {})
                               "app2" (merge config {})
                               "app3" (merge config {"min-instances" 5})
@@ -598,7 +598,7 @@
                               "app2" {:target-instances 5}
                               "app3" {:target-instances 0}
                               "app4" {:target-instances 10}} ; scale state
-                             apply-scaling 5 test-scale-app
+                             apply-scaling 5 test-scale-service
                              {"app1" {:healthy-instances 5 :task-count 5 :expired-instances 0}
                               "app2" {:healthy-instances 5 :task-count 5 :expired-instances 0}
                               "app3" {:healthy-instances 0 :task-count 0 :expired-instances 0}
@@ -617,7 +617,7 @@
   (is (= 0.5 (normalize-factor 0.5 1)))
   (is (= 0.75 (normalize-factor 0.5 2))))
 
-(deftest scale-app-test
+(deftest scale-service-test
   (let [jitter-threshold 0.9
         default-scaling {"concurrency-level" 1
                          "expired-instance-restart-rate" 0.1
@@ -635,7 +635,7 @@
         scales-like (fn [expected-scale-amount expected-scale-to-instances expected-target-instances
                          config total-instances outstanding-requests target-instances healthy-instances expired-instances]
                       (let [{:keys [scale-amount scale-to-instances target-instances]}
-                            (scale-app config {:total-instances total-instances
+                            (scale-service config {:total-instances total-instances
                                                :outstanding-requests outstanding-requests
                                                :target-instances target-instances
                                                :healthy-instances healthy-instances
@@ -711,7 +711,7 @@
       service-id->service-description (fn [id] {:service-id id
                                                 "min-instances" 1})
       timeout-interval-ms 10000
-      scale-app-fn (fn [_ state]
+      scale-service-fn (fn [_ state]
                      (case (int (:total-instances state))
                        2
                        {:scale-to-instances 3
@@ -736,13 +736,13 @@
                                          initial-timeout-chan (async/chan 1)
                                          scheduler (reify scheduler/ServiceScheduler
                                                      (get-apps [_] scheduler-data)
-                                                     (scale-app [_ _ _ _] {}))
+                                                     (scale-service [_ _ _ _] {}))
                                          autoscaler-chans-map
                                          (autoscaler-goroutine (assoc initial-state
                                                                  :previous-cycle-start-time (t/minus (t/now) (t/seconds 10))
                                                                  :timeout-chan initial-timeout-chan)
                                                                leader?-fn service-id->metrics-fn instance-killer-multiplexer-fn scheduler
-                                                               timeout-interval-ms scale-app-fn service-id->service-description state-mult)]
+                                                               timeout-interval-ms scale-service-fn service-id->service-description state-mult)]
                                      (async/tap state-mult state-chan-reader)
                                      (merge autoscaler-chans-map
                                             {:initial-timeout-chan initial-timeout-chan

--- a/waiter/test/waiter/scaling_test.clj
+++ b/waiter/test/waiter/scaling_test.clj
@@ -581,32 +581,32 @@
                                    10)))
         ; simple scaling function that targets outstanding-requests
         test-scale-service (fn [{:strs [min-instances max-instances]} {:keys [total-instances outstanding-requests]}]
-                         (let [scale-to-instances (max min-instances (min max-instances outstanding-requests))]
-                           {:scale-to-instances scale-to-instances
-                            :target-instances scale-to-instances
-                            :scale-amount (- scale-to-instances total-instances)}))]
+                             (let [scale-to-instances (max min-instances (min max-instances outstanding-requests))]
+                               {:scale-to-instances scale-to-instances
+                                :target-instances scale-to-instances
+                                :scale-amount (- scale-to-instances total-instances)}))]
     (let [result (scale-services ["app1" "app2" "app3" "app4"]
-                             {"app1" (merge config {})
-                              "app2" (merge config {})
-                              "app3" (merge config {"min-instances" 5})
-                              "app4" (merge config {"max-instances" 10})} ; service description
-                             {"app1" 10
-                              "app2" 5
-                              "app3" 0
-                              "app4" 15} ; outstanding requests
-                             {"app1" {:target-instances 5}
-                              "app2" {:target-instances 5}
-                              "app3" {:target-instances 0}
-                              "app4" {:target-instances 10}} ; scale state
-                             apply-scaling 5 test-scale-service
-                             {"app1" {:healthy-instances 5 :task-count 5 :expired-instances 0}
-                              "app2" {:healthy-instances 5 :task-count 5 :expired-instances 0}
-                              "app3" {:healthy-instances 0 :task-count 0 :expired-instances 0}
-                              "app4" {:healthy-instances 15 :task-count 15 :expired-instances 0}}
-                             {"app1" {:instances 5 :task-count 5}
-                              "app2" {:instances 5 :task-count 5}
-                              "app3" {:instances 0 :task-count 0}
-                              "app4" {:instances 15 :task-count 15}})]
+                                 {"app1" (merge config {})
+                                  "app2" (merge config {})
+                                  "app3" (merge config {"min-instances" 5})
+                                  "app4" (merge config {"max-instances" 10})} ; service description
+                                 {"app1" 10
+                                  "app2" 5
+                                  "app3" 0
+                                  "app4" 15} ; outstanding requests
+                                 {"app1" {:target-instances 5}
+                                  "app2" {:target-instances 5}
+                                  "app3" {:target-instances 0}
+                                  "app4" {:target-instances 10}} ; scale state
+                                 apply-scaling 5 test-scale-service
+                                 {"app1" {:healthy-instances 5 :task-count 5 :expired-instances 0}
+                                  "app2" {:healthy-instances 5 :task-count 5 :expired-instances 0}
+                                  "app3" {:healthy-instances 0 :task-count 0 :expired-instances 0}
+                                  "app4" {:healthy-instances 15 :task-count 15 :expired-instances 0}}
+                                 {"app1" {:instances 5 :task-count 5}
+                                  "app2" {:instances 5 :task-count 5}
+                                  "app3" {:instances 0 :task-count 0}
+                                  "app4" {:instances 15 :task-count 15}})]
       (is (= 10 (get-in result ["app1" :target-instances])))
       (is (= 5 (get-in result ["app2" :target-instances])))
       (is (= 5 (get-in result ["app3" :target-instances])))
@@ -636,10 +636,10 @@
                          config total-instances outstanding-requests target-instances healthy-instances expired-instances]
                       (let [{:keys [scale-amount scale-to-instances target-instances]}
                             (scale-service config {:total-instances total-instances
-                                               :outstanding-requests outstanding-requests
-                                               :target-instances target-instances
-                                               :healthy-instances healthy-instances
-                                               :expired-instances expired-instances})]
+                                                   :outstanding-requests outstanding-requests
+                                                   :target-instances target-instances
+                                                   :healthy-instances healthy-instances
+                                                   :expired-instances expired-instances})]
                         (is (> epsilon (Math/abs (double (- scale-amount expected-scale-amount))))
                             (str "scale-amount=" scale-amount " expected-scale-amount=" expected-scale-amount))
                         (is (= scale-to-instances expected-scale-to-instances)
@@ -712,19 +712,19 @@
                                                 "min-instances" 1})
       timeout-interval-ms 10000
       scale-service-fn (fn [_ state]
-                     (case (int (:total-instances state))
-                       2
-                       {:scale-to-instances 3
-                        :target-instances 3
-                        :scale-amount 1}
-                       3
-                       {:scale-to-instances 4
-                        :target-instances 4
-                        :scale-amount 2}
-                       4
-                       {:scale-to-instances 0
-                        :target-instances 0
-                        :scale-amount -4}))
+                         (case (int (:total-instances state))
+                           2
+                           {:scale-to-instances 3
+                            :target-instances 3
+                            :scale-amount 1}
+                           3
+                           {:scale-to-instances 4
+                            :target-instances 4
+                            :scale-amount 2}
+                           4
+                           {:scale-to-instances 0
+                            :target-instances 0
+                            :scale-amount -4}))
       start-autoscaler-goroutine (fn start-autoscaler-goroutine [initial-state scheduler-data]
                                    (let [metrics-chan (async/chan 1)
                                          service-id->metrics-fn (fn service-id->metrics-fn []

--- a/waiter/test/waiter/scaling_test.clj
+++ b/waiter/test/waiter/scaling_test.clj
@@ -735,7 +735,7 @@
                                          state-mult (async/mult state-chan)
                                          initial-timeout-chan (async/chan 1)
                                          scheduler (reify scheduler/ServiceScheduler
-                                                     (get-apps [_] scheduler-data)
+                                                     (get-services [_] scheduler-data)
                                                      (scale-service [_ _ _ _] {}))
                                          autoscaler-chans-map
                                          (autoscaler-goroutine (assoc initial-state

--- a/waiter/test/waiter/scheduler/cook_test.clj
+++ b/waiter/test/waiter/scheduler/cook_test.clj
@@ -720,7 +720,7 @@
           (is (seq (service-id->failed-instances service-id->failed-instances-transient-store "S2")))
 
           (is (= {service-1 service-1-instances, service-2 service-2-instances}
-                 (scheduler/get-apps->instances scheduler))))
+                 (scheduler/get-service->instances scheduler))))
         (finally
           (scheduler/remove-killed-instances-for-service! "S1")
           (preserve-only-failed-instances-for-services! service-id->failed-instances-transient-store []))))))

--- a/waiter/test/waiter/scheduler/cook_test.clj
+++ b/waiter/test/waiter/scheduler/cook_test.clj
@@ -813,7 +813,7 @@
                                     (is (= min-instances num-instances))
                                     true)]
           (is (= {:message "Created foo" :result :created :success true}
-                 (scheduler/create-app-if-new cook-scheduler descriptor)))
+                 (scheduler/create-service-if-new cook-scheduler descriptor)))
           (is (= :invoked (deref updated-invoked-promise 0 :not-invoked))))))
 
     (testing "create service - failure"
@@ -826,14 +826,14 @@
                                     (is (= min-instances num-instances))
                                     (throw (ex-info "Failed" {})))]
           (is (= {:message "Unable to create foo" :result :failed :success false}
-                 (scheduler/create-app-if-new cook-scheduler descriptor)))
+                 (scheduler/create-service-if-new cook-scheduler descriptor)))
           (is (= :invoked (deref updated-invoked-promise 0 :not-invoked))))))
 
     (testing "create service - service exists"
       (with-redefs [retrieve-jobs (fn [_ _ in-service-id & _] (= service-id in-service-id))]
         (is (scheduler/service-exists? cook-scheduler service-id))
         (is (= {:message "foo already exists!" :result :already-exists :success false}
-               (scheduler/create-app-if-new cook-scheduler descriptor)))))))
+               (scheduler/create-service-if-new cook-scheduler descriptor)))))))
 
 (deftest test-delete-service
   (with-redefs [retrieve-jobs (constantly [{:uuid "uuid-1"}

--- a/waiter/test/waiter/scheduler/cook_test.clj
+++ b/waiter/test/waiter/scheduler/cook_test.clj
@@ -843,20 +843,20 @@
 
       (with-redefs [delete-jobs (constantly {:deploymentId 12345})]
         (is (= {:message "Deleted foo" :result :deleted :success true}
-               (scheduler/delete-app scheduler "foo"))))
+               (scheduler/delete-service scheduler "foo"))))
 
       (with-redefs [delete-jobs (constantly {})]
         (is (= {:message "Deleted foo" :result :deleted :success true}
-               (scheduler/delete-app scheduler "foo"))))
+               (scheduler/delete-service scheduler "foo"))))
 
       (with-redefs [delete-jobs (fn [_ _] (throw (ex-info "Delete error" {:status 400})))]
         (is (= {:message "Unable to delete foo" :result :failed :success false}
-               (scheduler/delete-app scheduler "foo"))))
+               (scheduler/delete-service scheduler "foo"))))
 
       (with-redefs [delete-jobs (constantly {})
                     retrieve-jobs (constantly nil)]
         (is (= {:message "foo does not exist!" :result :no-such-service-exists :success false}
-               (scheduler/delete-app scheduler "foo")))))))
+               (scheduler/delete-service scheduler "foo")))))))
 
 (deftest test-scale-service
   (let [cook-api (Object.)

--- a/waiter/test/waiter/scheduler/cook_test.clj
+++ b/waiter/test/waiter/scheduler/cook_test.clj
@@ -876,7 +876,7 @@
                                     (is (= service-id in-service-id))
                                     true)]
           (is (= {:message "test-service-id does not exist!" :result :no-such-service-exists :success false}
-                 (scheduler/scale-app cook-scheduler service-id instances false)))
+                 (scheduler/scale-service cook-scheduler service-id instances false)))
           (is (= :not-invoked (deref updated-invoked-promise 0 :not-invoked))))))
 
     (testing "scale of service - no-op"
@@ -897,7 +897,7 @@
                                     (is (= 20 extra-instances))
                                     true)]
           (is (= {:message "Scaled test-service-id" :result :scaling-not-needed :success true}
-                 (scheduler/scale-app cook-scheduler service-id instances false)))
+                 (scheduler/scale-service cook-scheduler service-id instances false)))
           (is (= :not-invoked (deref updated-invoked-promise 0 :not-invoked))))))
 
     (testing "scale of service - success"
@@ -918,7 +918,7 @@
                                     (is (= 20 extra-instances))
                                     true)]
           (is (= {:message "Scaled test-service-id" :result :scaled :success true}
-                 (scheduler/scale-app cook-scheduler service-id instances false)))
+                 (scheduler/scale-service cook-scheduler service-id instances false)))
           (is (= :invoked (deref updated-invoked-promise 0 :not-invoked))))))
 
     (testing "scale of service - fail"
@@ -939,7 +939,7 @@
                                     (is (= 20 extra-instances))
                                     (throw (ex-info "Launch failed!" {})))]
           (is (= {:message "Unable to scale test-service-id" :result :failed :success false}
-                 (scheduler/scale-app cook-scheduler service-id instances false)))
+                 (scheduler/scale-service cook-scheduler service-id instances false)))
           (is (= :invoked (deref updated-invoked-promise 0 :not-invoked))))))))
 
 (deftest test-service-id->state

--- a/waiter/test/waiter/scheduler/cook_test.clj
+++ b/waiter/test/waiter/scheduler/cook_test.clj
@@ -327,8 +327,8 @@
                                :application {:name "test-service"
                                              :version "foo/bar:baz"}
                                :container {:docker {:force-pull-image false
-                                                 :image "namespace:foo,name:bar,label:baz"
-                                                 :network "HOST"}
+                                                    :image "namespace:foo,name:bar,label:baz"
+                                                    :network "HOST"}
                                            :type "docker"}
                                :name (str "test-service-1." job-uuid)
                                :uuid job-uuid)]}]

--- a/waiter/test/waiter/scheduler/cook_test.clj
+++ b/waiter/test/waiter/scheduler/cook_test.clj
@@ -805,7 +805,7 @@
 
     (testing "create service - success"
       (let [updated-invoked-promise (promise)]
-        (with-redefs [scheduler/app-exists? (constantly false)
+        (with-redefs [scheduler/service-exists? (constantly false)
                       launch-jobs (fn [in-cook-api in-service-id _ _ _ num-instances & _]
                                     (deliver updated-invoked-promise :invoked)
                                     (is (= cook-api in-cook-api))
@@ -818,7 +818,7 @@
 
     (testing "create service - failure"
       (let [updated-invoked-promise (promise)]
-        (with-redefs [scheduler/app-exists? (constantly false)
+        (with-redefs [scheduler/service-exists? (constantly false)
                       launch-jobs (fn [in-cook-api in-service-id _ _ _ num-instances & _]
                                     (deliver updated-invoked-promise :invoked)
                                     (is (= cook-api in-cook-api))
@@ -831,7 +831,7 @@
 
     (testing "create service - service exists"
       (with-redefs [retrieve-jobs (fn [_ _ in-service-id & _] (= service-id in-service-id))]
-        (is (scheduler/app-exists? cook-scheduler service-id))
+        (is (scheduler/service-exists? cook-scheduler service-id))
         (is (= {:message "foo already exists!" :result :already-exists :success false}
                (scheduler/create-app-if-new cook-scheduler descriptor)))))))
 

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -770,14 +770,14 @@
                        (scheduler/create-service-if-new dummy-scheduler descriptor))]
           (is (= service actual)))))))
 
-(deftest test-delete-app
+(deftest test-delete-service
   (let [service-id "test-service-id"
         service (scheduler/make-Service {:id service-id :instances 1 :k8s/app-name service-id :k8s/namespace "myself"})
         dummy-scheduler (make-dummy-scheduler [service-id])]
     (with-redefs [service-id->service (constantly service)]
       (testing "successful-delete"
         (let [actual (with-redefs [api-request (constantly {:status "OK"})]
-                       (scheduler/delete-app dummy-scheduler service-id))]
+                       (scheduler/delete-service dummy-scheduler service-id))]
           (is (= {:message (str "Kubernetes deleted ReplicaSet for " service-id)
                   :result :deleted}
                  actual))))
@@ -785,13 +785,13 @@
         (let [actual (with-redefs [api-request (fn mocked-api-request [_ url & {:keys [request-method]}]
                                                  (when (= request-method :delete)
                                                    (ss/throw+ {:status 404})))]
-                       (scheduler/delete-app dummy-scheduler service-id))]
+                       (scheduler/delete-service dummy-scheduler service-id))]
           (is (= {:message "Kubernetes reports service does not exist"
                   :result :no-such-service-exists}
                  actual))))
       (testing "unsuccessful-delete: internal error"
         (let [actual (with-redefs [api-request (fn [& _] (throw-exception))]
-                       (scheduler/delete-app dummy-scheduler service-id))]
+                       (scheduler/delete-service dummy-scheduler service-id))]
           (is (= {:message "Internal error while deleting service"
                   :result :error}
                  actual)))))))

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -751,23 +751,23 @@
         dummy-scheduler (make-dummy-scheduler [service-id])]
     (testing "unsuccessful-create: app already exists"
       (let [actual (with-redefs [service-id->service (constantly service)]
-                     (scheduler/create-app-if-new dummy-scheduler descriptor))]
+                     (scheduler/create-service-if-new dummy-scheduler descriptor))]
         (is (nil? actual))))
     (with-redefs [service-id->service (constantly nil)]
       (testing "unsuccessful-create: service creation conflict (already running)"
         (let [actual (with-redefs [api-request (fn mocked-api-request [& _]
                                                  (ss/throw+ {:status 409}))]
-                       (scheduler/create-app-if-new dummy-scheduler descriptor))]
+                       (scheduler/create-service-if-new dummy-scheduler descriptor))]
         (is (nil? actual))))
       (testing "unsuccessful-create: internal error"
         (let [actual (with-redefs [api-request (fn mocked-api-request [& _]
                                                    (throw-exception))]
-                       (scheduler/create-app-if-new dummy-scheduler descriptor))]
+                       (scheduler/create-service-if-new dummy-scheduler descriptor))]
           (is (nil? actual))))
       (testing "successful create"
         (let [actual (with-redefs [api-request (constantly service)
                                    replicaset->Service identity]
-                       (scheduler/create-app-if-new dummy-scheduler descriptor))]
+                       (scheduler/create-service-if-new dummy-scheduler descriptor))]
           (is (= service actual)))))))
 
 (deftest test-delete-app

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -634,7 +634,7 @@
                         :status 500)
                  actual)))))))
 
-(deftest test-scheduler-app-exists?
+(deftest test-scheduler-service-exists?
   (let [service-id "test-app-1234"
         empty-response
         {:kind "ReplicaSetList"
@@ -665,7 +665,7 @@
     (doseq [{:keys [api-server-response expected-result]} test-cases]
       (let [dummy-scheduler (make-dummy-scheduler [service-id])
             actual-result (with-redefs [api-request (constantly api-server-response)]
-                            (scheduler/app-exists? dummy-scheduler service-id))]
+                            (scheduler/service-exists? dummy-scheduler service-id))]
         (is (= expected-result actual-result))))))
 
 (deftest test-killed-instances-transient-store

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -395,7 +395,7 @@
                                  sanitize-k8s-service-records))]
         (assert-data-equal expected-result actual-result)))))
 
-(deftest test-scheduler-get-apps->instances
+(deftest test-scheduler-get-service->instances
   (let [services-response
         {:kind "ReplicaSetList"
          :apiVersion "extensions/v1beta1"
@@ -572,7 +572,7 @@
         response-iterator (.iterator api-server-responses)
         actual (with-redefs [api-request (fn [& _] (.next response-iterator))]
                  (->> dummy-scheduler
-                      scheduler/get-apps->instances
+                      scheduler/get-service->instances
                       sanitize-k8s-service-records))]
     (assert-data-equal expected actual)
     (scheduler/preserve-only-killed-instances-for-services! [])))

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -796,7 +796,7 @@
                   :result :error}
                  actual)))))))
 
-(deftest test-scale-app
+(deftest test-scale-service
   (let [instances' 4
         service-id "test-service-id"
         service (scheduler/make-Service {:id service-id :instances 1 :k8s/app-name service-id :k8s/namespace "myself"})
@@ -804,7 +804,7 @@
     (with-redefs [service-id->service (constantly service)]
       (testing "successful-scale"
         (let [actual (with-redefs [api-request (constantly {:status "OK"})]
-                       (scheduler/scale-app dummy-scheduler service-id instances' false))]
+                       (scheduler/scale-service dummy-scheduler service-id instances' false))]
           (is (= {:success true
                   :status 200
                   :result :scaled
@@ -812,7 +812,7 @@
                  actual))))
       (testing "unsuccessful-scale: service not found"
         (let [actual (with-redefs [service-id->service (constantly nil)]
-                       (scheduler/scale-app dummy-scheduler service-id instances' false))]
+                       (scheduler/scale-service dummy-scheduler service-id instances' false))]
           (is (= {:success false
                   :status 404
                   :result :no-such-service-exists
@@ -823,7 +823,7 @@
                                                  (if (= request-method :patch)
                                                    (ss/throw+ {:status 409})
                                                    {:spec {:replicas 1}}))]
-                       (scheduler/scale-app dummy-scheduler service-id instances' false))]
+                       (scheduler/scale-service dummy-scheduler service-id instances' false))]
           (is (= {:success false
                   :status 409
                   :result :conflict
@@ -831,7 +831,7 @@
                  actual))))
       (testing "unsuccessful-scale: internal error"
         (let [actual (with-redefs [api-request (fn [& _] (throw-exception))]
-                       (scheduler/scale-app dummy-scheduler service-id instances' false))]
+                       (scheduler/scale-service dummy-scheduler service-id instances' false))]
           (is (= {:success false
                   :status 500
                   :result :failed

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -326,7 +326,7 @@
               (str name))
           (scheduler/preserve-only-killed-instances-for-services! []))))))
 
-(deftest test-scheduler-get-apps
+(deftest test-scheduler-get-services
   (let [test-cases
         [{:api-server-response
           {:kind "ReplicaSetList"
@@ -391,7 +391,7 @@
       (let [dummy-scheduler (make-dummy-scheduler ["test-app-1234" "test-app-6789"])
             actual-result (with-redefs [api-request (constantly api-server-response)]
                             (->> dummy-scheduler
-                                 scheduler/get-apps
+                                 scheduler/get-services
                                  sanitize-k8s-service-records))]
         (assert-data-equal expected-result actual-result)))))
 

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -835,23 +835,23 @@
         (is (= {:instance-id instance-id :killed? false :message "exception from test" :service-id service-id, :status 500}
                (process-kill-instance-request marathon-api service-id instance-id {})))))))
 
-(deftest test-delete-app
+(deftest test-delete-service
   (let [scheduler (create-marathon-scheduler)]
 
-    (with-redefs [marathon/delete-app (constantly {:deploymentId 12345})]
+    (with-redefs [marathon/delete-service (constantly {:deploymentId 12345})]
       (is (= {:result :deleted
               :message "Marathon deleted with deploymentId 12345"}
-             (scheduler/delete-app scheduler "foo"))))
+             (scheduler/delete-service scheduler "foo"))))
 
-    (with-redefs [marathon/delete-app (constantly {})]
+    (with-redefs [marathon/delete-service (constantly {})]
       (is (= {:result :error
               :message "Marathon did not provide deploymentId for delete request"}
-             (scheduler/delete-app scheduler "foo"))))
+             (scheduler/delete-service scheduler "foo"))))
 
-    (with-redefs [marathon/delete-app (fn [_ _] (ss/throw+ {:status 404}))]
+    (with-redefs [marathon/delete-service (fn [_ _] (ss/throw+ {:status 404}))]
       (is (= {:result :no-such-service-exists
               :message "Marathon reports service does not exist"}
-             (scheduler/delete-app scheduler "foo"))))))
+             (scheduler/delete-service scheduler "foo"))))))
 
 (deftest test-extract-deployment-info
   (let [marathon-api (Object.)

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -1222,7 +1222,7 @@
                       (is (= {"embed" ["apps.deployments" "apps.tasks"]} in-query-params))
                       {:apps (deref app-entries-atom)})
                     scheduler/scale-service (fn [_ in-service-id in-target in-force]
-                                          (swap! scheduler-operations-atom conj [in-service-id in-target in-force]))
+                                              (swap! scheduler-operations-atom conj [in-service-id in-target in-force]))
                     t/now (fn [] (deref current-time-atom))]
         (let [leader-atom (atom true)
               leader?-fn (fn [] (deref leader-atom))

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -910,7 +910,7 @@
         (is (= {:affectedApps ["/waiter-app-1234"] :id "1234a" :version "v1234a"}
                (extract-service-deployment-info marathon-api "waiter-app-1234")))))))
 
-(deftest test-scale-app
+(deftest test-scale-service
   (let [marathon-api (Object.)
         marathon-scheduler (create-marathon-scheduler :force-kill-after-ms 60000 :marathon-api marathon-api)
         service-id "test-service-id"]
@@ -934,7 +934,7 @@
                                             (is (= service-id in-service-id))
                                             (is (= {:cmd "tc" :cpus 2 :id service-id :instances instances :mem 4} descriptor))
                                             (deliver updated-invoked-promise :invoked))]
-          (scheduler/scale-app marathon-scheduler service-id instances false)
+          (scheduler/scale-service marathon-scheduler service-id instances false)
           (is (= :invoked (deref updated-invoked-promise 0 :not-invoked))))))
 
     (testing "forced scale of service - fewer instances"
@@ -962,7 +962,7 @@
                                             (is (= service-id in-service-id))
                                             (is (= {:cmd "tc" :cpus 2 :id service-id :instances 15 :mem 4} descriptor))
                                             (deliver updated-invoked-promise :invoked))]
-          (scheduler/scale-app marathon-scheduler service-id instances true)
+          (scheduler/scale-service marathon-scheduler service-id instances true)
           (is (= :invoked (deref deleted-deployment-promise 0 :not-invoked)))
           (is (= :invoked (deref updated-invoked-promise 0 :not-invoked))))))
 
@@ -991,7 +991,7 @@
                                             (is (= service-id in-service-id))
                                             (is (= {:cmd "tc" :cpus 2 :id service-id :instances instances :mem 4} descriptor))
                                             (deliver updated-invoked-promise :invoked))]
-          (scheduler/scale-app marathon-scheduler service-id instances true)
+          (scheduler/scale-service marathon-scheduler service-id instances true)
           (is (= :invoked (deref deleted-deployment-promise 0 :not-invoked)))
           (is (= :invoked (deref updated-invoked-promise 0 :not-invoked))))))))
 
@@ -1221,7 +1221,7 @@
                       (is (= marathon-api in-marathon-api))
                       (is (= {"embed" ["apps.deployments" "apps.tasks"]} in-query-params))
                       {:apps (deref app-entries-atom)})
-                    scheduler/scale-app (fn [_ in-service-id in-target in-force]
+                    scheduler/scale-service (fn [_ in-service-id in-target in-force]
                                           (swap! scheduler-operations-atom conj [in-service-id in-target in-force]))
                     t/now (fn [] (deref current-time-atom))]
         (let [leader-atom (atom true)

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -838,17 +838,17 @@
 (deftest test-delete-service
   (let [scheduler (create-marathon-scheduler)]
 
-    (with-redefs [marathon/delete-service (constantly {:deploymentId 12345})]
+    (with-redefs [marathon/delete-app (constantly {:deploymentId 12345})]
       (is (= {:result :deleted
               :message "Marathon deleted with deploymentId 12345"}
              (scheduler/delete-service scheduler "foo"))))
 
-    (with-redefs [marathon/delete-service (constantly {})]
+    (with-redefs [marathon/delete-app (constantly {})]
       (is (= {:result :error
               :message "Marathon did not provide deploymentId for delete request"}
              (scheduler/delete-service scheduler "foo"))))
 
-    (with-redefs [marathon/delete-service (fn [_ _] (ss/throw+ {:status 404}))]
+    (with-redefs [marathon/delete-app (fn [_ _] (ss/throw+ {:status 404}))]
       (is (= {:result :no-such-service-exists
               :message "Marathon reports service does not exist"}
              (scheduler/delete-service scheduler "foo"))))))

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -216,16 +216,16 @@
     (is (= {:success false, :result :already-exists, :message "foo already exists!"}
            (create-test-service scheduler "foo")))
     (is (= {:success true, :result :deleted, :message "Deleted foo"}
-           (scheduler/delete-app scheduler "foo")))))
+           (scheduler/delete-service scheduler "foo")))))
 
-(deftest test-delete-app
+(deftest test-delete-service
   (let [scheduler (create-shell-scheduler common-scheduler-config)]
     (is (= {:success true, :result :created, :message "Created foo"}
            (create-test-service scheduler "foo")))
     (ensure-agent-finished scheduler)
     (is (scheduler/service-exists? scheduler "foo"))
     (is (= {:success true, :result :deleted, :message "Deleted foo"}
-           (scheduler/delete-app scheduler "foo")))
+           (scheduler/delete-service scheduler "foo")))
     (ensure-agent-finished scheduler)
     (is (not (scheduler/service-exists? scheduler "foo")))))
 
@@ -277,7 +277,7 @@
         (is (= {:killed? true, :success true, :result :deleted, :message (str "Deleted " (:id instance))}
                (scheduler/kill-instance scheduler instance)))
         (is (= {:success true, :result :deleted, :message "Deleted foo"}
-               (scheduler/delete-app scheduler "foo")))
+               (scheduler/delete-service scheduler "foo")))
         (ensure-agent-finished scheduler)
         (is (= {:success false, :result :no-such-service-exists, :message "foo does not exist!"}
                (scheduler/kill-instance scheduler instance)))))))
@@ -343,7 +343,7 @@
       (is (= {:running 1, :healthy 0, :unhealthy 1, :staged 0}
              (task-stats scheduler))))
     (is (= {:success true, :result :deleted, :message "Deleted foo"}
-           (scheduler/delete-app scheduler "foo")))))
+           (scheduler/delete-service scheduler "foo")))))
 
 (deftest test-get-apps
   (let [scheduler-config common-scheduler-config
@@ -418,11 +418,11 @@
                   :shell-scheduler/mem 32}])
            (scheduler/get-apps scheduler)))
     (is (= {:success true, :result :deleted, :message "Deleted foo"}
-           (scheduler/delete-app scheduler "foo")))
+           (scheduler/delete-service scheduler "foo")))
     (is (= {:success true, :result :deleted, :message "Deleted bar"}
-           (scheduler/delete-app scheduler "bar")))
+           (scheduler/delete-service scheduler "bar")))
     (is (= {:success true, :result :deleted, :message "Deleted baz"}
-           (scheduler/delete-app scheduler "baz")))))
+           (scheduler/delete-service scheduler "baz")))))
 
 (deftest test-service-id->state
   (let [scheduler (create-shell-scheduler common-scheduler-config)
@@ -478,7 +478,7 @@
                  (assoc-in host-keys (get-in result host-keys)))
              result)))
     (is (= {:success true, :result :deleted, :message "Deleted foo"}
-           (scheduler/delete-app scheduler "foo")))))
+           (scheduler/delete-service scheduler "foo")))))
 
 (deftest test-port-reserved?
   (let [port->reservation-atom (atom {})
@@ -525,7 +525,7 @@
     (let [instances (scheduler/get-instances scheduler "foo")]
       (is (= 2 (count (:failed-instances instances)))))
     (is (= {:success true, :result :deleted, :message "Deleted foo"}
-           (scheduler/delete-app scheduler "foo")))))
+           (scheduler/delete-service scheduler "foo")))))
 
 (deftest test-enforce-grace-period
   (let [scheduler-config common-scheduler-config

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -53,7 +53,7 @@
   "Gets the task-stats for the first service in the given scheduler"
   [scheduler]
   (-> scheduler
-      scheduler/get-apps->instances
+      scheduler/get-service->instances
       keys
       first
       :task-stats))

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -47,7 +47,7 @@
                                                   "ports" 1}
                                                  custom-service-description)
                      :service-id service-id}]
-     (scheduler/create-app-if-new scheduler descriptor))))
+     (scheduler/create-service-if-new scheduler descriptor))))
 
 (defn- task-stats
   "Gets the task-stats for the first service in the given scheduler"
@@ -209,7 +209,7 @@
                        :expiry-time nil}}
                @port->reservation-atom))))))
 
-(deftest test-create-app-if-new
+(deftest test-create-service-if-new
   (let [scheduler (create-shell-scheduler common-scheduler-config)]
     (is (= {:success true, :result :created, :message "Created foo"}
            (create-test-service scheduler "foo")))

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -223,11 +223,11 @@
     (is (= {:success true, :result :created, :message "Created foo"}
            (create-test-service scheduler "foo")))
     (ensure-agent-finished scheduler)
-    (is (scheduler/app-exists? scheduler "foo"))
+    (is (scheduler/service-exists? scheduler "foo"))
     (is (= {:success true, :result :deleted, :message "Deleted foo"}
            (scheduler/delete-app scheduler "foo")))
     (ensure-agent-finished scheduler)
-    (is (not (scheduler/app-exists? scheduler "foo")))))
+    (is (not (scheduler/service-exists? scheduler "foo")))))
 
 (deftest test-scale-app
   (let [scheduler-config common-scheduler-config
@@ -240,7 +240,7 @@
       (is (= {:success true, :result :created, :message "Created foo"}
              (create-test-service scheduler "foo" {"cmd" "sleep 10000"})))
       (ensure-agent-finished scheduler)
-      (is (scheduler/app-exists? scheduler "foo"))
+      (is (scheduler/service-exists? scheduler "foo"))
       ;; Scale up, instances: 2
       (is (= {:success true, :result :scaled, :message "Scaled foo"}
              (scheduler/scale-app scheduler "foo" 2 false)))

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -229,12 +229,12 @@
     (ensure-agent-finished scheduler)
     (is (not (scheduler/service-exists? scheduler "foo")))))
 
-(deftest test-scale-app
+(deftest test-scale-service
   (let [scheduler-config common-scheduler-config
         scheduler (create-shell-scheduler scheduler-config)]
     ;; Bogus service
     (is (= {:success false, :result :no-such-service-exists, :message "bar does not exist!"}
-           (scheduler/scale-app scheduler "bar" 2 false)))
+           (scheduler/scale-service scheduler "bar" 2 false)))
     (with-redefs [perform-health-check (constantly true)]
       ;; Create service, instances: 1
       (is (= {:success true, :result :created, :message "Created foo"}
@@ -243,14 +243,14 @@
       (is (scheduler/service-exists? scheduler "foo"))
       ;; Scale up, instances: 2
       (is (= {:success true, :result :scaled, :message "Scaled foo"}
-             (scheduler/scale-app scheduler "foo" 2 false)))
+             (scheduler/scale-service scheduler "foo" 2 false)))
       (force-maintain-instance-scale scheduler)
       (force-update-service-health scheduler scheduler-config)
       (is (= {:running 2, :healthy 2, :unhealthy 0, :staged 0}
              (task-stats scheduler)))
       ;; No need to scale down, instances: 2
       (is (= {:success false, :result :scaling-not-needed, :message "Unable to scale foo"}
-             (scheduler/scale-app scheduler "foo" 1 false)))
+             (scheduler/scale-service scheduler "foo" 1 false)))
       (ensure-agent-finished scheduler)
       ;; Successfully kill one instance, instances: 1
       (let [instance (first (:active-instances (scheduler/get-instances scheduler "foo")))]
@@ -261,7 +261,7 @@
              (task-stats scheduler)))
       ;; Scale up, instances: 2
       (is (= {:success true, :result :scaled, :message "Scaled foo"}
-             (scheduler/scale-app scheduler "foo" 2 false)))
+             (scheduler/scale-service scheduler "foo" 2 false)))
       (force-maintain-instance-scale scheduler)
       (force-update-service-health scheduler scheduler-config)
       (is (= {:running 2, :healthy 2, :unhealthy 0, :staged 0}

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -345,7 +345,7 @@
     (is (= {:success true, :result :deleted, :message "Deleted foo"}
            (scheduler/delete-service scheduler "foo")))))
 
-(deftest test-get-apps
+(deftest test-get-services
   (let [scheduler-config common-scheduler-config
         scheduler (create-shell-scheduler scheduler-config)]
     (is (= {:success true, :result :created, :message "Created foo"}
@@ -416,7 +416,7 @@
                                         "mem" 32
                                         "ports" 1}
                   :shell-scheduler/mem 32}])
-           (scheduler/get-apps scheduler)))
+           (scheduler/get-services scheduler)))
     (is (= {:success true, :result :deleted, :message "Deleted foo"}
            (scheduler/delete-service scheduler "foo")))
     (is (= {:success true, :result :deleted, :message "Deleted bar"}

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -130,7 +130,7 @@
                                   "service11broken" {"outstanding" 95, "total" 80}}
             deleted-services-atom (atom #{})
             scheduler (reify ServiceScheduler
-                        (delete-app [_ service-id]
+                        (delete-service [_ service-id]
                           (swap! available-services-atom disj service-id)
                           (swap! deleted-services-atom conj service-id)))
             scheduler-state-chan (async/chan 1)
@@ -189,7 +189,7 @@
     (let [available-services-atom (atom #{"service6faulty" "service7" "service8stayalive" "service9stayalive" "service10broken" "service11broken"})
           deleted-services-atom (atom #{})
           scheduler (reify ServiceScheduler
-                      (delete-app [_ service-id]
+                      (delete-service [_ service-id]
                         (swap! available-services-atom disj service-id)
                         (swap! deleted-services-atom conj service-id)))
           scheduler-state-chan (async/chan 1)

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -242,7 +242,7 @@
         instance2 (->ServiceInstance "s1.i2" "s1" started-at true nil #{} nil "host" 123 [] "proto" "/log" "test")
         instance3 (->ServiceInstance "s1.i3" "s1" started-at nil nil #{} nil "host" 123 [] "proto" "/log" "test")
         scheduler (reify ServiceScheduler
-                    (get-apps->instances [_]
+                    (get-service->instances [_]
                       {(->Service "s1" {} {} {}) {:active-instances [instance1 instance2 instance3]
                                                   :failed-instances []}
                        (->Service "s2" {} {} {}) {:active-instances []


### PR DESCRIPTION
## Changes proposed in this PR

- renames `get-apps->instances` to `get-service->instances`
- renames `app-exists?` to `app-exists?`
- renames `create-app-if-new` to `create-service-if-new`
- renames `delete-app` to `delete-service`
- renames `scale-app` to `scale-service`
- renames `get-apps` to `get-services`
- undo `delete-service` renaming on `mesos.marathon`
- reformats code and deletes unused code

## Why are we making these changes?

Correct references from `app` to `service` for waiter related terms. 
