### PR TITLE
Use utils/map->json to preserve namespaces in k8s spec keys

### DIFF
--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -147,9 +147,13 @@
     :else v))
 
 (defn map->json
-  "Convert the input data into a json string."
+  "Convert the input Clojure data structure into a json string."
   [data-map]
-  (json/write-str data-map :key-fn stringify-keys :value-fn stringify-elements))
+  (json/write-str
+    data-map
+    :escape-slash false  ; escaping the slashes makes the json harder to read
+    :key-fn stringify-keys
+    :value-fn stringify-elements))
 
 (defn map->json-response
   "Convert the input data into a json response."

--- a/waiter/test/waiter/util/utils_test.clj
+++ b/waiter/test/waiter/util/utils_test.clj
@@ -117,7 +117,7 @@
 
     (testing "should convert regex patterns to strings"
       (is (= (json/write-str {"bar" "foo"}) (:body (map->json-response {:bar #"foo"}))))
-      (is (= (json/write-str {"bar" ["foo" "baz"] "foo/bar" "baz"})
+      (is (= (json/write-str {"bar" ["foo" "baz"] "foo/bar" "baz"} :escape-slash false)
              (:body (map->json-response {:bar [#"foo" #"baz"] :foo/bar :baz}))))
       (is (= (json/write-str {"bar" ["foo" "baz"]}) (:body (map->json-response {:bar ["foo" #"baz"]}))))
       (is (= (json/write-str {"bar" [["foo" "baz"]]}) (:body (map->json-response {:bar [["foo" #"baz"]]})))))))


### PR DESCRIPTION
## Changes proposed in this PR

Use the `map->json` utility function to ensure that the namespace component of Clojure keywords are preserved when converting a ReplicaSet spec to JSON in the Kuberentes scheduler.

## Why are we making these changes?

Annotation and label names in Kubernetes objects often use slashes to denote namespaces. The default behavior of the `clojure.data.json/write-str` function is to drop the namespace component of a keyword. We need to override that behavior so that the part before the slash isn't dropped in our JSON output.