### PR TITLE
Fix Kitchen SSL protocol name for Python 3.4

### DIFF
--- a/kitchen/bin/kitchen
+++ b/kitchen/bin/kitchen
@@ -950,7 +950,11 @@ if __name__ == '__main__':
         kitchen = MultiThreadedServer((args.hostname, args.port), Kitchen)
 
         if args.ssl:
-            ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            try:
+                ssl_protocol = ssl.PROTOCOL_TLS_SERVER  # added in python3.6
+            except AttributeError:
+                ssl_protocol = ssl.PROTOCOL_TLSv1_2
+            ssl_context = ssl.SSLContext(ssl_protocol)
             ssl_context.load_cert_chain(keystore_path, password=keystore_password)
             kitchen.socket = ssl_context.wrap_socket(kitchen.socket, server_side=True)
             protocol = 'HTTPS'


### PR DESCRIPTION
## Changes proposed in this PR

Fall back to `ssl.PROTOCOL_TLSv1_2` when `ssl.PROTOCOL_TLS_SERVER` is not available.

## Why are we making these changes?

Since `ssl.PROTOCOL_TLS_SERVER` was added in Python 3.6, the SSL mode wouldn't work in 3.4 or 3.5 without this change.
