### PR TITLE
simulator UI improvements

### DIFF
--- a/waiter/resources/web/sim.html
+++ b/waiter/resources/web/sim.html
@@ -103,10 +103,11 @@ textarea {
         <div id="summary">
             <div id="simulation-summary" class="config-box right-align">
                 <h4>Simulation Summary</h4>
+                <label>total requests &nbsp; <span id="res-total-requests" class="right-align">0</span></label>
                 <label>total queue time &nbsp; <span id="res-total-queue-time" class="right-align">0</span></label>
                 <label>total idle server time &nbsp; <span id="res-total-idle-server-time" class="right-align">0</span></label>
-                <label>total utilization time &nbsp; <span id="res-total-utilization" class="right-align">0</span></label>
                 <label>total waste time &nbsp; <span id="res-total-waste" class="right-align">0</span></label>
+                <label>total utilization time &nbsp; <span id="res-total-utilization" class="right-align">0</span></label>
             </div>
             <div class="clearfix"></div>
         </div>
@@ -254,6 +255,7 @@ $(function() {
                 }
 
                 // add the results
+                $("#res-total-requests").text(numberWithCommas(data[numTicks - 1]["total-requests"]));
                 $("#res-total-queue-time").text(numberWithCommas(data[numTicks - 1]["total-queue-time"]));
                 $("#res-total-idle-server-time").text(numberWithCommas(data[numTicks - 1]["total-idle-server-time"]));
                 $("#res-total-utilization").text(numberWithCommas(data[numTicks - 1]["total-utilization"]));

--- a/waiter/resources/web/sim.html
+++ b/waiter/resources/web/sim.html
@@ -1,8 +1,8 @@
 <!doctype html>
 <html>
     <head>
-		<title>Autoscaler Simulator</title>
-		<style>
+        <title>Autoscaler Simulator</title>
+        <style>
 #chart {
     height: 400px;
     width: 100%;
@@ -53,110 +53,108 @@ textarea {
     border: 2px solid #ccc;
     border-radius: 4px;
 }
-		</style>
+.tooltip {
+    background-color:#fee;
+    border: 1px solid #fdd;
+    display: none;
+    opacity: 0.80;
+    padding: 2px;
+    position: absolute;
+}
+#metrics-controls div {
+    font-weight; bold;
+    float: left;
+    padding: 5px;
+    width: 250px;
+}
+#metrics-controls input {
+    margin-right: 5px;
+}
+        </style>
     </head>
 
-	<body>
-		<div id="config">
-			<div class="config-box left-align">
-				<h4>Client Settings</h4>
-				<label>time between requests (secs) <input id="idle-ticks" value="1" type="number"/></label>
-				<label>request time (secs) <input id="request-ticks" value="5" type="number"/></label>
-				<label>randomize times (gaussian) <input id="randomize-times" checked type="checkbox"/></label>
-				<label>clients exit immediately <input id="clients-exit-immediately" checked type="checkbox"/></label>
-				<label>client curve <br/><textarea id="client-curve">{600 100 1800 -100}</textarea></label>
-			</div>
-			<div class="config-box left-align">
-				<h4>Service Settings</h4>
-				<label>cpus <input id="cpus" value="2" type="number"/></label>
-				<label>memory (in MB) <input id="mem" value="512" type="number"/></label>
-				<label>startup time (secs) <input id="startup-ticks" value="30" type="number"/></label>
-				<label>min-instances <input id="min-instances" value="1" type="number"/></label>
-				<label>max-instances <input id="max-instances" value="500" type="number"/></label>
-				<label>scale up factor <input id="scale-up-factor" value="0.01" type="number" step="0.001"/></label>
-				<label>scale down factor <input id="scale-down-factor" value="0.001" type="number" step="0.001"/></label>
-				<label>jitter threshold <input id="jitter-threshold" value="0.5" type="number" step="0.01"/></label>
-			</div>
-			<div class="config-box left-align">
-				<h4>Scaler Settings</h4>
-				<label>scale every (secs) <input id="scale-ticks" value="5" type="number"/></label>
-				<label>simulation length (secs) <input id="total-ticks" value="3600" type="number"/></label>
-			</div>
+    <body>
+        <div id="config">
+            <div class="config-box left-align">
+                <h4>Client Settings</h4>
+                <label>time between requests (secs) <input id="idle-ticks" value="1" type="number"/></label>
+                <label>request time (secs) <input id="request-ticks" value="5" type="number"/></label>
+                <label>randomize times (gaussian) <input id="randomize-times" checked type="checkbox"/></label>
+                <label>clients exit immediately <input id="clients-exit-immediately" checked type="checkbox"/></label>
+                <label>client curve <br/><textarea id="client-curve">{600 100 1800 -100}</textarea></label>
+            </div>
+            <div class="config-box left-align">
+                <h4>Service Settings</h4>
+                <label>cpus <input id="cpus" value="2" type="number"/></label>
+                <label>memory (in MB) <input id="mem" value="512" type="number"/></label>
+                <label>startup time (secs) <input id="startup-ticks" value="30" type="number"/></label>
+                <label>min-instances <input id="min-instances" value="1" type="number"/></label>
+                <label>max-instances <input id="max-instances" value="500" type="number"/></label>
+                <label>scale up factor <input id="scale-up-factor" value="0.01" type="number" step="0.001"/></label>
+                <label>scale down factor <input id="scale-down-factor" value="0.001" type="number" step="0.001"/></label>
+                <label>jitter threshold <input id="jitter-threshold" value="0.5" type="number" step="0.01"/></label>
+            </div>
+            <div class="config-box left-align">
+                <h4>Scaler Settings</h4>
+                <label>scale every (secs) <input id="scale-ticks" value="5" type="number"/></label>
+                <label>simulation length (secs) <input id="total-ticks" value="3600" type="number"/></label>
+            </div>
         </div>
         <div id="summary">
-			<div id="simulation-summary" class="config-box right-align">
-				<h4>Simulation Summary</h4>
-				<label>total queue time &nbsp; <input id="res-total-queue-time" value="0" type="text" readonly/></label>
-				<label>total idle server time &nbsp; <input id="res-total-idle-server-time" value="0" type="text" readonly/></label>
-				<label>average utilization &nbsp; <input id="res-average-utilization" value="0" type="text" readonly/></label>
-				<label>average waste &nbsp; <input id="res-average-waste" value="0" type="text" readonly/></label>
-			</div>
-			<div class="clearfix"></div>
-		</div>
-		<button id="sim-button">Sim</button>
-		<button id="image-button"
-				title="Downloads the chart as a png image excluding the legend and axis values">Download Image</button>
-		<div id="chart"></div>
-		<div>
-			<div id="metrics-controls"></div>
-		</div>
-	</body>
+            <div id="simulation-summary" class="config-box right-align">
+                <h4>Simulation Summary</h4>
+                <label>total queue time &nbsp; <span id="res-total-queue-time" class="right-align">0</span></label>
+                <label>total idle server time &nbsp; <span id="res-total-idle-server-time" class="right-align">0</span></label>
+                <label>total utilization time &nbsp; <span id="res-total-utilization" class="right-align">0</span></label>
+                <label>total waste time &nbsp; <span id="res-total-waste" class="right-align">0</span></label>
+            </div>
+            <div class="clearfix"></div>
+        </div>
+        <button id="sim-button">Sim</button>
+        <button id="image-button"
+                title="Downloads the chart as a png image excluding the legend and axis values">Download Image</button>
+        <div id="chart"></div>
+        <div id="tooltip" class="tooltip"></div>
+        <div>
+            <div id="metrics-controls"></div>
+        </div>
+    </body>
 
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.0/jquery.min.js"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/flot/0.8.3/jquery.flot.min.js"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/flot/0.8.3/jquery.flot.time.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.0/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/flot/0.8.3/jquery.flot.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/flot/0.8.3/jquery.flot.time.min.js"></script>
     <script>
-
-const numberWithCommas = (x) => {
-  return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-}
-
-const showTooltip = (x, y, contents) => {
-    $('<div id="tooltip">' + contents + '</div>')
-    .css({
-        position: 'absolute',
-        display: 'none',
-        top: y + 5,
-        left: x + 5,
-        border: '1px solid #fdd',
-        padding: '2px',
-        'background-color': '#fee',
-        opacity: 0.80
-    })
-    .appendTo("body")
-    .fadeIn(200);
-}
 
 $(function() {
 
-	$("#simulation-summary").hide();
+    $("#simulation-summary").hide();
 
-	var plotObject = null;
-	$("#image-button").hide();
-	$("#image-button").click(function() {
-		if (plotObject != null) {
-			var plotCanvas = plotObject.getCanvas();
-			var plotImage = plotCanvas.toDataURL();
-			plotImage = plotImage.replace("image/png","image/octet-stream");
-			document.location.href = plotImage;
-		}
-	});
+    var plotObject = null;
+    $("#image-button").hide();
+    $("#image-button").click(function() {
+        if (plotObject != null) {
+            var plotCanvas = plotObject.getCanvas();
+            var plotImage = plotCanvas.toDataURL();
+            plotImage = plotImage.replace("image/png","image/octet-stream");
+            document.location.href = plotImage;
+        }
+    });
 
     if (window.location.hash) {
-    	var configStr = window.location.hash.substr(1).replace(/%22/g, "\"").replace(/%20/g, " ");
-    	var data = JSON.parse(configStr);
+        var configStr = window.location.hash.substr(1).replace(/%22/g, "\"").replace(/%20/g, " ");
+        var data = JSON.parse(configStr);
         var simConfig = data["config"] || {};
         $("#client-curve").val(data["client-curve"]);
         $.map($("#config input"),
             function(el) {
-            	var metricName = $(el).attr("id");
+                var metricName = $(el).attr("id");
                 if (simConfig[metricName] != null) {
-					var inputType = $(el).attr("type");
-					if (inputType == "number") {
-						$(el).val(simConfig[metricName]);
-					} else if (inputType == "checkbox") {
-						$(el).prop("checked", simConfig[metricName]);
-					}
+                    var inputType = $(el).attr("type");
+                    if (inputType == "number") {
+                        $(el).val(simConfig[metricName]);
+                    } else if (inputType == "checkbox") {
+                        $(el).prop("checked", simConfig[metricName]);
+                    }
                 }
                 return el;
             });
@@ -170,12 +168,12 @@ $(function() {
                 var metricName = $(el).attr("id");
                 var inputType = $(el).attr("type");
                 if (inputType == "number") {
-                	var metricValue = $(el).val();
-                	if (metricValue.indexOf(".") >= 0) {
-                		simConfig[metricName] = parseFloat(metricValue);
-                	} else {
-                		simConfig[metricName] = parseInt(metricValue, 10);
-                	}
+                    var metricValue = $(el).val();
+                    if (metricValue.indexOf(".") >= 0) {
+                        simConfig[metricName] = parseFloat(metricValue);
+                    } else {
+                        simConfig[metricName] = parseInt(metricValue, 10);
+                    }
                 } else if (inputType == "checkbox") {
                     simConfig[metricName] = $(el).is(":checked");
                 }
@@ -187,18 +185,30 @@ $(function() {
             "client-curve": $("#client-curve").val()
         };
 
-		var currentSelectedMetrics = {};
-		$("#metrics-controls input:checked")
-			.each(function(index, el) {
-				currentSelectedMetrics[$(el).data("metric-name")] = true;
-			});
-		if ($.isEmptyObject(currentSelectedMetrics)) {
-			currentSelectedMetrics["outstanding-requests"] = true;
+        var currentSelectedMetrics = {};
+        $("#metrics-controls input:checked")
+            .each(function(index, el) {
+                currentSelectedMetrics[$(el).data("metric-name")] = true;
+            });
+        if ($.isEmptyObject(currentSelectedMetrics)) {
+            currentSelectedMetrics["outstanding-requests"] = true;
             currentSelectedMetrics["total-instances"] = true;
             currentSelectedMetrics["healthy-instances"] = true;
-		}
+        }
 
         window.location.hash = JSON.stringify(data);
+
+        const numberWithCommas = (x) => {
+          return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+        }
+
+        const showTooltip = (x, y, contents) => {
+            console.log("x: " + x + " , y: " + y);
+            $("#tooltip")
+            .text(contents)
+            .css({ left: x + 5, top: y + 5 })
+            .fadeIn(200);
+        }
 
         $.ajax("/sim", {
             data: JSON.stringify(data),
@@ -227,7 +237,7 @@ $(function() {
                         selectedMetrics[$(el).data("metric-name")] = true;
                     });
 
-				var numTicks = data.length;
+                var numTicks = data.length;
                 for (var tick = 0; tick < numTicks; tick++) {
                     var state = data[tick];
                     $.each(state, function(key, value) {
@@ -243,19 +253,11 @@ $(function() {
                     });
                 }
 
-                var totalUtilization = 0.0;
-                var totalWaste = 0.0;
-                for (var tick = 0; tick < numTicks; tick++) {
-                	var state = data[tick];
-                	totalUtilization += state["utilization"];
-                	totalWaste += state["waste"];
-                }
-                var averageUtilization = totalUtilization / numTicks;
-                $("#res-average-utilization").val(averageUtilization.toFixed(2));
-                var averageWaste = totalWaste / numTicks;
-                $("#res-average-waste").val(averageWaste.toFixed(2));
-                $("#res-total-queue-time").val(numberWithCommas(data[numTicks - 1]["total-queue-time"]));
-                $("#res-total-idle-server-time").val(numberWithCommas(data[numTicks - 1]["total-idle-server-time"]));
+                // add the results
+                $("#res-total-queue-time").text(numberWithCommas(data[numTicks - 1]["total-queue-time"]));
+                $("#res-total-idle-server-time").text(numberWithCommas(data[numTicks - 1]["total-idle-server-time"]));
+                $("#res-total-utilization").text(numberWithCommas(data[numTicks - 1]["total-utilization"]));
+                $("#res-total-waste").text(numberWithCommas(data[numTicks - 1]["total-waste"]));
 
                 plotObject = $.plot("#chart", $.map(dataSets, function(value) {
                     return [value];
@@ -271,18 +273,18 @@ $(function() {
                 });
 
                 var previousPoint = null;
-				$("#chart").bind("plothover", function (event, pos, item) {
-					if (item) {
-						if (previousPoint != item.datapoint) {
-							previousPoint = item.datapoint;
-							$("#tooltip").remove();
-							showTooltip(item.pageX, item.pageY, item.datapoint[1]);
-						}
-					} else {
-						$("#tooltip").remove();
-						previousPoint = null;
-					}
-				});
+                $("#chart").bind("plothover", function (event, pos, item) {
+                    if (item) {
+                        if (previousPoint != item.datapoint) {
+                            previousPoint = item.datapoint;
+                            $("#tooltip").hide();
+                            showTooltip(item.pageX, item.pageY, item.datapoint[1]);
+                        }
+                    } else {
+                        $("#tooltip").hide();
+                        previousPoint = null;
+                    }
+                });
             };
 
             $("#metrics-controls").empty();
@@ -297,7 +299,7 @@ $(function() {
                     colorMap[metric] = colors[colorIndex++];
                 }
                 var input = $('<input type="checkbox">').data("metric-name", metric).click(function() {
-                	currentSelectedMetrics[$(this).data("metric-name")] = $(this).is(":checked");
+                    currentSelectedMetrics[$(this).data("metric-name")] = $(this).is(":checked");
                     plot();
                 });
                 if (currentSelectedMetrics[metric])
@@ -305,9 +307,6 @@ $(function() {
                 $("#metrics-controls")
                     .append($("<div/>")
                     .css("color", colorMap[metric])
-                    .css("font-weight", "bold")
-                    .css("float", "left")
-                    .css("width", "250px")
                     .append(input)
                     .append(metric));
             });

--- a/waiter/resources/web/sim.html
+++ b/waiter/resources/web/sim.html
@@ -298,7 +298,8 @@ $(function() {
             metrics.sort();
             $.each(metrics, function(index, metric) {
                 if (!colorMap[metric]) {
-                    colorMap[metric] = colors[colorIndex++];
+                    colorMap[metric] = colors[colorIndex];
+                    colorIndex = (colorIndex + 1) % colors.length;
                 }
                 var input = $('<input type="checkbox">').data("metric-name", metric).click(function() {
                     currentSelectedMetrics[$(this).data("metric-name")] = $(this).is(":checked");

--- a/waiter/resources/web/sim.html
+++ b/waiter/resources/web/sim.html
@@ -4,72 +4,102 @@
 		<title>Autoscaler Simulator</title>
 		<style>
 #chart {
-    height: 300px;
-     width: 100%;
+    height: 400px;
+    width: 100%;
 }
- body {
+body {
     font-family:Lato, sans-serif;
 }
- button {
+button {
     font-family:Lato, sans-serif;
 }
- html {
+html {
     height:100%;
 }
- input[type=number] {
-    width:55px;
+.left-align {
+    float:left;
 }
- .config-box {
+.right-align {
+    float:right;
+}
+.config-box {
     background-color:#ddd;
     border:solid 1px #333;
-    float:left;
-     margin-right:5px;
-     padding:3px;
+    margin:5px;
+    padding:5px;
 }
- .config-box label {
-     display:block;
+.config-box label {
+    display:block;
 }
- .config-box h4 {
-     margin: 0;
+.config-box input {
+    float:right;
+    text-align: right;
+    width:55px;
 }
- .clearfix {
-     clear: both;
+.config-box h4 {
+    margin: 0;
 }
- .hide {
-     display:none;
+.clearfix {
+    clear: both;
+}
+.hide {
+    display:none;
+}
+textarea {
+    width: 100%;
+    height: 70px;
+    padding: 10px;
+    box-sizing: border-box;
+    border: 2px solid #ccc;
+    border-radius: 4px;
 }
 		</style>
     </head>
 
 	<body>
 		<div id="config">
-			<div class="config-box">
+			<div class="config-box left-align">
 				<h4>Client Settings</h4>
-				<label>client curve <textarea id="client-curve">{600 50 1800 -50}</textarea></label>
-				<label>time between requests (secs) <input id="idle-ticks" value="1" type="number"> </label>
-				<label>request time (secs) <input id="request-ticks" value="5" type="number"> </label>
+				<label>time between requests (secs) <input id="idle-ticks" value="1" type="number"/></label>
+				<label>request time (secs) <input id="request-ticks" value="5" type="number"/></label>
+				<label>randomize times (gaussian) <input id="randomize-times" checked type="checkbox"/></label>
+				<label>clients exit immediately <input id="clients-exit-immediately" checked type="checkbox"/></label>
+				<label>client curve <br/><textarea id="client-curve">{600 100 1800 -100}</textarea></label>
 			</div>
-			<div class="config-box">
+			<div class="config-box left-align">
 				<h4>Service Settings</h4>
-				<label>startup time (secs) <input id="startup-ticks" value="30" type="number"> </label>
-				<label>min-instances <input id="min-instances" value="1" type="number"> </label>
-				<label>max-instances <input id="max-instances" value="500" type="number"> </label>
-				<label>scale up factor <input id="scale-up-factor" value="0.01" type="number" step="0.001"> </label>
-				<label>scale down factor <input id="scale-down-factor" value="0.001" type="number" step="0.001"> </label>
-				<label>jitter threshold <input id="jitter-threshold" value="0.5" type="number" step="0.01"> </label>
+				<label>cpus <input id="cpus" value="2" type="number"/></label>
+				<label>memory (in MB) <input id="mem" value="512" type="number"/></label>
+				<label>startup time (secs) <input id="startup-ticks" value="30" type="number"/></label>
+				<label>min-instances <input id="min-instances" value="1" type="number"/></label>
+				<label>max-instances <input id="max-instances" value="500" type="number"/></label>
+				<label>scale up factor <input id="scale-up-factor" value="0.01" type="number" step="0.001"/></label>
+				<label>scale down factor <input id="scale-down-factor" value="0.001" type="number" step="0.001"/></label>
+				<label>jitter threshold <input id="jitter-threshold" value="0.5" type="number" step="0.01"/></label>
 			</div>
-			<div class="config-box">
+			<div class="config-box left-align">
 				<h4>Scaler Settings</h4>
-				<label>scale every (secs) <input id="scale-ticks" value="5" type="number"> </label>
-				<label>simulation length (secs) <input id="total-ticks" value="3600" type="number"> </label>
+				<label>scale every (secs) <input id="scale-ticks" value="5" type="number"/></label>
+				<label>simulation length (secs) <input id="total-ticks" value="3600" type="number"/></label>
+			</div>
+        </div>
+        <div id="summary">
+			<div id="simulation-summary" class="config-box right-align">
+				<h4>Simulation Summary</h4>
+				<label>total queue time &nbsp; <input id="res-total-queue-time" value="0" type="text" readonly/></label>
+				<label>total idle server time &nbsp; <input id="res-total-idle-server-time" value="0" type="text" readonly/></label>
+				<label>average utilization &nbsp; <input id="res-average-utilization" value="0" type="text" readonly/></label>
+				<label>average waste &nbsp; <input id="res-average-waste" value="0" type="text" readonly/></label>
 			</div>
 			<div class="clearfix"></div>
 		</div>
 		<button id="sim-button">Sim</button>
+		<button id="image-button"
+				title="Downloads the chart as a png image excluding the legend and axis values">Download Image</button>
 		<div id="chart"></div>
-		<label>
+		<div>
 			<div id="metrics-controls"></div>
-		</label>
+		</div>
 	</body>
 
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.0/jquery.min.js"></script>
@@ -77,45 +107,96 @@
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/flot/0.8.3/jquery.flot.time.min.js"></script>
     <script>
 
+const numberWithCommas = (x) => {
+  return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
+const showTooltip = (x, y, contents) => {
+    $('<div id="tooltip">' + contents + '</div>')
+    .css({
+        position: 'absolute',
+        display: 'none',
+        top: y + 5,
+        left: x + 5,
+        border: '1px solid #fdd',
+        padding: '2px',
+        'background-color': '#fee',
+        opacity: 0.80
+    })
+    .appendTo("body")
+    .fadeIn(200);
+}
+
 $(function() {
 
+	$("#simulation-summary").hide();
+
+	var plotObject = null;
+	$("#image-button").hide();
+	$("#image-button").click(function() {
+		if (plotObject != null) {
+			var plotCanvas = plotObject.getCanvas();
+			var plotImage = plotCanvas.toDataURL();
+			plotImage = plotImage.replace("image/png","image/octet-stream");
+			document.location.href = plotImage;
+		}
+	});
+
     if (window.location.hash) {
-        var data = JSON.parse(window.location.hash.substr(1));
+    	var configStr = window.location.hash.substr(1).replace(/%22/g, "\"").replace(/%20/g, " ");
+    	var data = JSON.parse(configStr);
         var simConfig = data["config"] || {};
         $("#client-curve").val(data["client-curve"]);
-        $("#idle-ticks").val(simConfig["idle-ticks"]);
-        $("#request-ticks").val(simConfig["request-ticks"]);
-        $("#startup-ticks").val(simConfig["startup-ticks"]);
-        $("#scale-ticks").val(simConfig["scale-ticks"]);
-        if (simConfig["min-instances"])
-            $("#min-instances").val(simConfig["min-instances"]);
-        if (simConfig["max-instances"])
-            $("#max-instances").val(simConfig["max-instances"]);
-        $("#scale-up-factor").val(simConfig["scale-up-factor"]);
-        $("#scale-down-factor").val(simConfig["scale-down-factor"]);
-        $("#jitter-threshold").val(simConfig["jitter-threshold"]);
-        $("#total-ticks").val(simConfig["total-ticks"]);
+        $.map($("#config input"),
+            function(el) {
+            	var metricName = $(el).attr("id");
+                if (simConfig[metricName] != null) {
+					var inputType = $(el).attr("type");
+					if (inputType == "number") {
+						$(el).val(simConfig[metricName]);
+					} else if (inputType == "checkbox") {
+						$(el).prop("checked", simConfig[metricName]);
+					}
+                }
+                return el;
+            });
     }
 
     $("#sim-button").click(function() {
 
-        var simConfig = {
-            "idle-ticks": parseInt($("#idle-ticks").val(), 10),
-            "request-ticks": parseInt($("#request-ticks").val(), 10),
-            "startup-ticks": parseInt($("#startup-ticks").val(), 10),
-            "scale-ticks": parseInt($("#scale-ticks").val(), 10),
-            "max-instances": parseInt($("#max-instances").val(), 10),
-            "min-instances": parseInt($("#min-instances").val(), 10),
-            "scale-up-factor": parseFloat($("#scale-up-factor").val()),
-            "scale-down-factor": parseFloat($("#scale-down-factor").val()),
-            "jitter-threshold": parseFloat($("#jitter-threshold").val()),
-            "total-ticks": parseInt($("#total-ticks").val(), 10)
-        };
+        var simConfig = {};
+        $.map($("#config input"),
+            function(el) {
+                var metricName = $(el).attr("id");
+                var inputType = $(el).attr("type");
+                if (inputType == "number") {
+                	var metricValue = $(el).val();
+                	if (metricValue.indexOf(".") >= 0) {
+                		simConfig[metricName] = parseFloat(metricValue);
+                	} else {
+                		simConfig[metricName] = parseInt(metricValue, 10);
+                	}
+                } else if (inputType == "checkbox") {
+                    simConfig[metricName] = $(el).is(":checked");
+                }
+                return el;
+            });
 
         var data = {
             "config": simConfig,
             "client-curve": $("#client-curve").val()
         };
+
+		var currentSelectedMetrics = {};
+		$("#metrics-controls input:checked")
+			.each(function(index, el) {
+				currentSelectedMetrics[$(el).data("metric-name")] = true;
+			});
+		if ($.isEmptyObject(currentSelectedMetrics)) {
+			currentSelectedMetrics["outstanding-requests"] = true;
+            currentSelectedMetrics["total-instances"] = true;
+            currentSelectedMetrics["healthy-instances"] = true;
+		}
 
         window.location.hash = JSON.stringify(data);
 
@@ -136,24 +217,19 @@ $(function() {
                 "total-instances": "blue",
                 "healthy-instances": "green"
             };
-            var defaultChecked = {
-                "outstanding-requests": true,
-                "total-instances": true,
-                "healthy-instances": true
-            };
 
             var plot = function() {
                 var dataSets = {};
 
-                var selectedMetrics = [];
-
+                var selectedMetrics = currentSelectedMetrics;
                 $("#metrics-controls input:checked")
                     .each(function(index, el) {
                         selectedMetrics[$(el).data("metric-name")] = true;
                     });
 
-                for (var tick = 0; tick < data.length; tick++) {
-                    state = data[tick];
+				var numTicks = data.length;
+                for (var tick = 0; tick < numTicks; tick++) {
+                    var state = data[tick];
                     $.each(state, function(key, value) {
                         if (!selectedMetrics[key])
                             return;
@@ -167,22 +243,46 @@ $(function() {
                     });
                 }
 
-                $.plot("#chart", $.map(dataSets, function(value) {
+                var totalUtilization = 0.0;
+                var totalWaste = 0.0;
+                for (var tick = 0; tick < numTicks; tick++) {
+                	var state = data[tick];
+                	totalUtilization += state["utilization"];
+                	totalWaste += state["waste"];
+                }
+                var averageUtilization = totalUtilization / numTicks;
+                $("#res-average-utilization").val(averageUtilization.toFixed(2));
+                var averageWaste = totalWaste / numTicks;
+                $("#res-average-waste").val(averageWaste.toFixed(2));
+                $("#res-total-queue-time").val(numberWithCommas(data[numTicks - 1]["total-queue-time"]));
+                $("#res-total-idle-server-time").val(numberWithCommas(data[numTicks - 1]["total-idle-server-time"]));
+
+                plotObject = $.plot("#chart", $.map(dataSets, function(value) {
                     return [value];
                 }), {
+                    grid: { hoverable: true },
                     legend: {
-                        show: false
+                        backgroundColor: "white",
+                        noColumns: 0
                     },
-                    xaxis: {
-                        mode: "time"
-                    },
-                    series: {
-                        lines: {
-                            lineWidth: 1
-                        }
-                    },
-                    shadowSize: 0
+                    series: { lines: { lineWidth: 2 } },
+                    shadowSize: 0,
+                    xaxis: { mode: "time" }
                 });
+
+                var previousPoint = null;
+				$("#chart").bind("plothover", function (event, pos, item) {
+					if (item) {
+						if (previousPoint != item.datapoint) {
+							previousPoint = item.datapoint;
+							$("#tooltip").remove();
+							showTooltip(item.pageX, item.pageY, item.datapoint[1]);
+						}
+					} else {
+						$("#tooltip").remove();
+						previousPoint = null;
+					}
+				});
             };
 
             $("#metrics-controls").empty();
@@ -197,19 +297,27 @@ $(function() {
                     colorMap[metric] = colors[colorIndex++];
                 }
                 var input = $('<input type="checkbox">').data("metric-name", metric).click(function() {
+                	currentSelectedMetrics[$(this).data("metric-name")] = $(this).is(":checked");
                     plot();
                 });
-                if (defaultChecked[metric])
+                if (currentSelectedMetrics[metric])
                     input.attr("checked", true);
                 $("#metrics-controls")
-                    .append($("<label/>").css("font-weight", "bold").css("color", colorMap[metric])
-                        .append(input)
-                        .append(metric));
+                    .append($("<div/>")
+                    .css("color", colorMap[metric])
+                    .css("font-weight", "bold")
+                    .css("float", "left")
+                    .css("width", "250px")
+                    .append(input)
+                    .append(metric));
             });
 
             $(window).resize(plot);
 
             plot();
+
+            $("#image-button").show();
+            $("#simulation-summary").show();
 
         }, "json");
     });

--- a/waiter/src/waiter/simulator.clj
+++ b/waiter/src/waiter/simulator.clj
@@ -59,10 +59,10 @@
     total-idle-server-time The total amount of ticks that servers have been sitting idle.
     total-utilization      The total number of server ticks that have been used to process requests.
     total-waste            The total number of server ticks that have been wasted as the servers were idle.
-    utilization            The percentage of servers that are in use during the current tick.
+    utilization-percent    The percentage of servers that are in use during the current tick.
     wait-time-max          The maximum wait time of any queued request during the current tick.
     wait-time-max-ema      The EMA of the maximum wait time with a weight coefficient of 0.1.
-    waste                  The percentage of servers that are not in use during the current tick.
+    waste-percent          The percentage of servers that are not in use during the current tick.
     scale-ups              The total number of scale up operations.
     scale-downs            The total number of scale down operations."
   [{:strs [clients-exit-immediately idle-ticks randomize-times request-ticks startup-ticks]}
@@ -148,12 +148,12 @@
         idle-servers' (+ (max 0 (- available-servers interested-clients)) requests-to-cancel)
         num-active-requests (count active-requests')
         total-instances (+ (count starting-servers') num-active-requests idle-servers')
-        utilization (if (pos? total-instances)
-                      (* 100.0 (/ num-active-requests total-instances))
-                      0.0)
-        waste (if (pos? total-instances)
-                (- 100.0 utilization)
-                0.0)]
+        utilization-percent (if (pos? total-instances)
+                              (* 100.0 (/ num-active-requests total-instances))
+                              0.0)
+        waste-percent (if (pos? total-instances)
+                        (- 100.0 utilization-percent)
+                        0.0)]
     (assoc current-state
       :activating-clients activating-clients
       :active-requests active-requests'
@@ -181,10 +181,10 @@
       :total-requests (+ total-requests remaining-activating-clients)
       :total-utilization (+ total-utilization num-active-requests)
       :total-waste (+ total-waste (- total-instances num-active-requests))
-      :utilization utilization
+      :utilization-percent utilization-percent
       :wait-time-max wait-time-max'
       :wait-time-max-ema wait-time-max-ema'
-      :waste waste)))
+      :waste-percent waste-percent)))
 
 (let [default-initial-state {:clients-to-kill 0
                              :idle-clients []
@@ -204,10 +204,10 @@
                              :total-requests 0
                              :total-utilization 0
                              :total-waste 0
-                             :utilization 0.0
+                             :utilization-percent 0.0
                              :wait-time-max 0
                              :wait-time-max-ema 0.0
-                             :waste 0.0}
+                             :waste-percent 0.0}
       simulation-defaults {"clients-exit-immediately" true
                            "concurrency-level" 1
                            "cpus" 2

--- a/waiter/src/waiter/simulator.clj
+++ b/waiter/src/waiter/simulator.clj
@@ -55,6 +55,7 @@
 
   Stats:
     total-queue-time       The total amount of ticks that clients have been sitting in the queue.
+    total-requests         The total number of requests made so far.
     total-idle-server-time The total amount of ticks that servers have been sitting idle.
     total-utilization      The total number of server ticks that have been used to process requests.
     total-waste            The total number of server ticks that have been wasted as the servers were idle.
@@ -67,7 +68,7 @@
   [{:strs [clients-exit-immediately idle-ticks randomize-times request-ticks startup-ticks]}
    {:keys [clients-to-kill idle-clients queued-clients wait-time-max wait-time-max-ema idle-servers
            active-requests starting-servers total-queue-time scale-ups scale-downs total-idle-server-time
-           total-utilization total-waste]
+           total-requests total-utilization total-waste]
     :as current-state}
    tick scale-amount target-instances client-change-amount]
   {:pre [(non-neg? clients-to-kill)
@@ -177,6 +178,7 @@
       :total-idle-server-time (+ total-idle-server-time idle-servers)
       :total-instances total-instances
       :total-queue-time (+ total-queue-time (count queued-clients))
+      :total-requests (+ total-requests remaining-activating-clients)
       :total-utilization (+ total-utilization num-active-requests)
       :total-waste (+ total-waste (- total-instances num-active-requests))
       :utilization utilization
@@ -199,6 +201,7 @@
                              :target-instances 0
                              :scale-ups 0
                              :scale-downs 0
+                             :total-requests 0
                              :total-utilization 0
                              :total-waste 0
                              :utilization 0.0

--- a/waiter/src/waiter/simulator.clj
+++ b/waiter/src/waiter/simulator.clj
@@ -209,21 +209,21 @@
                              :wait-time-max-ema 0.0
                              :waste-percent 0.0}
       simulation-defaults {"clients-exit-immediately" true
-                           "concurrency-level" 1
                            "cpus" 2
-                           "expired-instance-restart-rate" 0.1
-                           "idle-ticks" 2
-                           "jitter-threshold" 0.5
-                           "max-instances" 1000
+                           "concurrency-level" 1
                            "mem" 256
-                           "min-instances" 1
+                           "idle-ticks" 2
                            "request-ticks" 5
+                           "startup-ticks" 500
                            "scale-factor" 1
                            "scale-up-factor" 0.1
                            "scale-down-factor" 0.01
                            "scale-ticks" 1
-                           "startup-ticks" 500
-                           "total-ticks" 3600}]
+                           "jitter-threshold" 0.5
+                           "min-instances" 1
+                           "max-instances" 1000
+                           "total-ticks" 3600
+                           "expired-instance-restart-rate" 0.1}]
   (defn simulate
     "Simulates traffic in order to test out the scaling function.
     client-curve is a function from tick to client-change-amount."


### PR DESCRIPTION
## Changes proposed in this PR

- text fields align to the right
- chart is larger (400px heaight)
- result summary box added
- remembers previously selected metrics to render on chart
- added ability to download chart as an image
- ability to turn off gaussian randomization
- ability for clients to exit gracefully
- added waste, max queue time, max queue time EMA
- tooltip to view data value on chart
- adds legends

## Why are we making these changes?

We want to easily compare our scaling algorithms (https://github.com/twosigma/waiter/pull/396) by rendering various metrics.

**Before**
<img width="1436" alt="sim-before" src="https://user-images.githubusercontent.com/6611249/43980585-56888d3a-9cb4-11e8-9a26-dad9dee25b6a.png">

**After**
<img width="1440" alt="sim-after" src="https://user-images.githubusercontent.com/6611249/43980589-5f0c068a-9cb4-11e8-9695-9b198e95c82b.png">
