### PR TITLE
Use utils/clj->json consistently in Waiter

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -26,7 +26,8 @@
             [waiter.interstitial :as interstitial]
             [waiter.service-description :as sd]
             [waiter.util.client-tools :refer :all]
-            [waiter.util.date-utils :as du])
+            [waiter.util.date-utils :as du]
+            [waiter.util.utils :as utils])
   (:import (java.io ByteArrayInputStream)
            (java.net URLEncoder)))
 
@@ -498,10 +499,10 @@
           override-endpoint (str "/apps/" service-id "/override")]
       (with-service-cleanup
         service-id
-        (-> (make-request waiter-url override-endpoint :body (json/write-str overrides) :method :post)
+        (-> (make-request waiter-url override-endpoint :body (utils/clj->json overrides) :method :post)
             (assert-response-status 200))
         (let [{:keys [body] :as response}
-              (make-request waiter-url override-endpoint :body (json/write-str overrides) :method :get)]
+              (make-request waiter-url override-endpoint :body (utils/clj->json overrides) :method :get)]
           (assert-response-status response 200)
           (let [response-data (-> body str json/read-str walk/keywordize-keys)]
             (is (= (retrieve-username) (:last-updated-by response-data)))

--- a/waiter/integration/waiter/metrics_output_test.clj
+++ b/waiter/integration/waiter/metrics_output_test.clj
@@ -14,8 +14,7 @@
 ;; limitations under the License.
 ;;
 (ns waiter.metrics-output-test
-  (:require [clojure.data.json :as json]
-            [clojure.test :refer :all]
+  (:require [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [schema.core :as s]
             [waiter.schema :as schema]

--- a/waiter/src/waiter/auth/kerberos.clj
+++ b/waiter/src/waiter/auth/kerberos.clj
@@ -16,7 +16,6 @@
 (ns waiter.auth.kerberos
   (:require [clj-time.core :as t]
             [clojure.core.async :as async]
-            [clojure.data.json :as json]
             [clojure.java.shell :as shell]
             [clojure.string :as str]
             [clojure.tools.logging :as log]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -239,7 +239,7 @@
     (-> (make-inter-router-requests-fn
           dest-endpoint
           :acceptable-router? #(= dest-router-id %)
-          :body (utils/map->json {:instance instance :period-in-ms blacklist-period-ms :reason reason})
+          :body (utils/clj->json {:instance instance :period-in-ms blacklist-period-ms :reason reason})
           :method :post)
         (get dest-router-id))
     (catch Exception e
@@ -1335,7 +1335,7 @@
                                   (do
                                     (log/info "x-waiter-authentication is not supported as an on-the-fly header"
                                               {:service-description service-description, :token token})
-                                    (utils/map->json-response {:error "An authentication parameter is not supported for on-the-fly headers"}
+                                    (utils/clj->json-response {:error "An authentication parameter is not supported for on-the-fly headers"}
                                                               :status 400))
 
                                   ;; ensure service description formed comes entirely from the token by ensuring absence of on-the-fly headers
@@ -1343,7 +1343,7 @@
                                   (do
                                     (log/info "request cannot proceed as it is mixing an authentication disabled token with on-the-fly headers"
                                               {:service-description service-description, :token token})
-                                    (utils/map->json-response {:error "An authentication disabled token may not be combined with on-the-fly headers"}
+                                    (utils/clj->json-response {:error "An authentication disabled token may not be combined with on-the-fly headers"}
                                                               :status 400))
 
                                   authentication-disabled?

--- a/waiter/src/waiter/mesos/marathon.clj
+++ b/waiter/src/waiter/mesos/marathon.clj
@@ -14,8 +14,8 @@
 ;; limitations under the License.
 ;;
 (ns waiter.mesos.marathon
-  (:require [clojure.data.json :as json]
-            [waiter.util.http-utils :as http-utils])
+  (:require [waiter.util.http-utils :as http-utils]
+            [waiter.util.utils :as utils])
   (:import org.eclipse.jetty.client.HttpClient))
 
 (defrecord MarathonApi [^HttpClient http-client ^String marathon-url spnego-auth])
@@ -29,7 +29,7 @@
   "Create and start a new app specified by the descriptor."
   [{:keys [http-client marathon-url spnego-auth]} descriptor]
   (http-utils/http-request http-client (str marathon-url "/v2/apps")
-                           :body (json/write-str descriptor)
+                           :body (utils/clj->json descriptor)
                            :content-type "application/json"
                            :spnego-auth spnego-auth
                            :request-method :post))
@@ -92,7 +92,7 @@
   "Update the descriptor of an existing app specified by the app-id."
   [{:keys [http-client marathon-url spnego-auth]} app-id descriptor]
   (http-utils/http-request http-client (str marathon-url "/v2/apps/" app-id)
-                           :body (json/write-str descriptor)
+                           :body (utils/clj->json descriptor)
                            :content-type "application/json"
                            :query-string {"force" true}
                            :request-method :put

--- a/waiter/src/waiter/mesos/mesos.clj
+++ b/waiter/src/waiter/mesos/mesos.clj
@@ -15,7 +15,8 @@
 ;;
 (ns waiter.mesos.mesos
   (:require [clojure.string :as str]
-            [waiter.util.http-utils :as http-utils])
+            [waiter.util.http-utils :as http-utils]
+            [waiter.util.utils :as utils])
   (:import org.eclipse.jetty.client.HttpClient))
 
 (defrecord MesosApi [^HttpClient http-client spnego-auth slave-port slave-directory])

--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -14,8 +14,7 @@
 ;; limitations under the License.
 ;;
 (ns waiter.request-log
-  (:require [clojure.data.json :as json]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
             [metrics.timers :as timers]
             [waiter.metrics :as metrics]
@@ -26,7 +25,7 @@
 (defn log
   "Log log-data as JSON"
   [log-data]
-  (log/log "RequestLog" :info nil (json/write-str log-data :escape-slash false)))
+  (log/log "RequestLog" :info nil (utils/clj->json log-data)))
 
 (defn request->context
   "Convert a request into a context suitable for logging."

--- a/waiter/src/waiter/scaling.clj
+++ b/waiter/src/waiter/scaling.clj
@@ -174,7 +174,7 @@
         (if instance-killed?
           (cid/cinfo correlation-id "killed instance" instance-id)
           (cid/cinfo correlation-id "unable to kill instance" kill-response))
-        (-> (utils/map->json-response {:kill-response kill-response
+        (-> (utils/clj->json-response {:kill-response kill-response
                                        :service-id service-id
                                        :source-router-id src-router-id
                                        :success instance-killed?}

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -17,7 +17,6 @@
   (:require [clj-time.coerce :as tc]
             [clj-time.core :as t]
             [clojure.core.cache :as cache]
-            [clojure.data.json :as json]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [metrics.timers :as timers]
@@ -41,7 +40,7 @@
       http-client
       (str url "/jobs")
       :accept "application/json"
-      :body (json/write-str job-description)
+      :body (utils/clj->json job-description)
       :content-type "application/json"
       :headers (cond-> {} impersonate (assoc "x-cook-impersonate" run-as-user))
       :request-method :post

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -235,7 +235,7 @@
   "Make a JSON-patch request on a given Kubernetes object."
   [k8s-object-uri http-client ops]
   (api-request http-client k8s-object-uri
-               :body (utils/map->json ops)
+               :body (utils/clj->json ops)
                :content-type "application/json-patch+json"
                :request-method :patch))
 
@@ -328,9 +328,9 @@
                      pod-name)
         base-body {:kind "DeleteOptions" :apiVersion "v1"}
         ;; we use a 5-minute (300s) grace period on pods to enable manual victim selection on scale-down
-        term-json (-> base-body (assoc :gracePeriodSeconds 300) utils/map->json)
+        term-json (-> base-body (assoc :gracePeriodSeconds 300) utils/clj->json)
         ;; setting the grace period to 0 seconds results in an immediate SIGKILL to the pod
-        kill-json (-> base-body (assoc :gracePeriodSeconds 0) utils/map->json)
+        kill-json (-> base-body (assoc :gracePeriodSeconds 0) utils/clj->json)
         make-kill-response (fn [killed? message status]
                              {:instance-id id :killed? killed?
                               :message message :service-id service-id :status status})]
@@ -365,7 +365,7 @@
         request-url (str api-server-url "/apis/" replicaset-api-version "/namespaces/"
                          (service-description->namespace service-description) "/replicasets")
         response-json (api-request http-client request-url
-                                   :body (utils/map->json spec-json)
+                                   :body (utils/clj->json spec-json)
                                    :request-method :post)]
     (replicaset->Service response-json)))
 
@@ -374,7 +374,7 @@
    Owned Pods will be removed asynchronously by the Kubernetes garbage collector."
   [{:keys [api-server-url http-client] :as scheduler} {:keys [id] :as service}]
   (let [replicaset-url (build-replicaset-url scheduler service)
-        kill-json (utils/map->json
+        kill-json (utils/clj->json
                     {:kind "DeleteOptions" :apiVersion "v1"
                      :propagationPolicy "Background"})]
     (api-request http-client replicaset-url :request-method :delete :body kill-json)

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -201,7 +201,7 @@
 (defn display-settings
   "Endpoint to display the current settings in use."
   [settings]
-  (utils/map->json-response (into (sorted-map) (sanitize-settings settings))))
+  (utils/clj->json-response (into (sorted-map) (sanitize-settings settings))))
 
 (def settings-defaults
   {:authenticator-config {:kind :one-user

--- a/waiter/src/waiter/simulator.clj
+++ b/waiter/src/waiter/simulator.clj
@@ -17,7 +17,7 @@
   (:require [clojure.data.json :as json]
             [clojure.walk :as walk]
             [waiter.scaling :as scaling]
-            [waiter.util.utils :refer [non-neg?]])
+            [waiter.util.utils :as utils :refer [non-neg?]])
   (:import (java.util Random)))
 
 (let [random (Random.)]
@@ -264,5 +264,5 @@
     "/sim" (case request-method
              :get {:body (slurp (clojure.java.io/resource "web/sim.html"))}
              :post {:body (let [{:strs [client-curve config]} (json/read-str (slurp body))]
-                            (json/write-str (simulate (walk/stringify-keys config) {} (eval (read-string client-curve)))))
+                            (utils/clj->json (simulate (walk/stringify-keys config) {} (eval (read-string client-curve)))))
                     :headers {"Content-Type" "application/json"}})))

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -882,7 +882,7 @@
   [waiter-url {:keys [token] :as token-map} &
    {:keys [headers query-params] :or {headers {}, query-params {}}}]
   (make-request waiter-url "/token"
-                :body (json/write-str token-map)
+                :body (utils/clj->json token-map)
                 :headers (assoc headers "host" token)
                 :method :post
                 :query-params query-params))

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -146,7 +146,7 @@
     (symbol? v) (str/join "/" ((juxt namespace name) v))
     :else v))
 
-(defn map->json
+(defn clj->json
   "Convert the input Clojure data structure into a json string."
   [data-map]
   (json/write-str
@@ -155,10 +155,10 @@
     :key-fn stringify-keys
     :value-fn stringify-elements))
 
-(defn map->json-response
+(defn clj->json-response
   "Convert the input data into a json response."
   [data-map & {:keys [headers status] :or {headers {} status 200}}]
-  {:body (map->json data-map)
+  {:body (clj->json data-map)
    :status status
    :headers (assoc headers "content-type" "application/json")})
 

--- a/waiter/src/waiter/work_stealing.clj
+++ b/waiter/src/waiter/work_stealing.clj
@@ -255,7 +255,7 @@
                                                            :body (-> reservation-parameters
                                                                      (assoc :router-id router-id
                                                                             :service-id service-id)
-                                                                     (utils/map->json-response)
+                                                                     (utils/clj->json-response)
                                                                      :body)
                                                            :method :post)
                             (get target-router-id)

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -232,7 +232,7 @@
     (testing "override-service-handler"
       (let [user "tu1"
             request {:authorization/user user
-                     :body (StringBufferInputStream. (json/write-str {"scale-factor" 0.3, "cmd" "overridden-cmd"}))
+                     :body (StringBufferInputStream. (utils/clj->json {"scale-factor" 0.3, "cmd" "overridden-cmd"}))
                      :request-method :post
                      :uri (str "/apps/" test-service-id "/override")}
             {:keys [status body]} (request-handler request)]
@@ -241,7 +241,7 @@
         (is (= {"scale-factor" 0.3} (:overrides (sd/service-id->overrides kv-store test-service-id)))))
       (let [user "tu1"
             request {:authorization/user user
-                     :body (StringBufferInputStream. (json/write-str {"scale-factor" 0.3, "cmd" "overridden-cmd"}))
+                     :body (StringBufferInputStream. (utils/clj->json {"scale-factor" 0.3, "cmd" "overridden-cmd"}))
                      :request-method :get
                      :uri (str "/apps/" test-service-id "/override")}
             {:keys [status body]} (request-handler request)]
@@ -250,7 +250,7 @@
         (is (= test-service-id (-> body json/read-str walk/keywordize-keys :service-id))))
       (let [user "tu1"
             request {:authorization/user user
-                     :body (StringBufferInputStream. (json/write-str {"scale-factor" 0.3, "cmd" "overridden-cmd"}))
+                     :body (StringBufferInputStream. (utils/clj->json {"scale-factor" 0.3, "cmd" "overridden-cmd"}))
                      :request-method :delete
                      :uri (str "/apps/" test-service-id "/override")}
             {:keys [status body]} (request-handler request)]
@@ -1064,7 +1064,7 @@
       (let [test-request {:headers {"host" "www.token-3.com", "x-waiter-run-as-user" "test-user"}}
             {:keys [handled-request response]} (execute-request test-request)]
         (is (nil? handled-request))
-        (is (= (utils/map->json-response {:error "An authentication disabled token may not be combined with on-the-fly headers"}
+        (is (= (utils/clj->json-response {:error "An authentication disabled token may not be combined with on-the-fly headers"}
                                          :status 400)
                response))))
 
@@ -1078,7 +1078,7 @@
       (let [test-request {:headers {"host" "www.service.com", "x-waiter-token" "a-named-token-A", "x-waiter-authentication" "disabled"}}
             {:keys [handled-request response]} (execute-request test-request)]
         (is (nil? handled-request))
-        (is (= (utils/map->json-response {:error "An authentication parameter is not supported for on-the-fly headers"}
+        (is (= (utils/clj->json-response {:error "An authentication parameter is not supported for on-the-fly headers"}
                                          :status 400)
                response))))
 
@@ -1092,7 +1092,7 @@
       (let [test-request {:headers {"host" "www.service.com", "x-waiter-authentication" "disabled", "x-waiter-token" "a-named-token-B"}}
             {:keys [handled-request response]} (execute-request test-request)]
         (is (nil? handled-request))
-        (is (= (utils/map->json-response {:error "An authentication parameter is not supported for on-the-fly headers"}
+        (is (= (utils/clj->json-response {:error "An authentication parameter is not supported for on-the-fly headers"}
                                          :status 400)
                response))))
 
@@ -1100,7 +1100,7 @@
       (let [test-request {:headers {"host" "www.service.com", "x-waiter-run-as-user" "test-user", "x-waiter-token" "a-named-token-B"}}
             {:keys [handled-request response]} (execute-request test-request)]
         (is (nil? handled-request))
-        (is (= (utils/map->json-response {:error "An authentication disabled token may not be combined with on-the-fly headers"}
+        (is (= (utils/clj->json-response {:error "An authentication disabled token may not be combined with on-the-fly headers"}
                                          :status 400)
                response))))
 
@@ -1114,7 +1114,7 @@
       (let [test-request {:headers {"host" "www.service.com", "x-waiter-authentication" "disabled", "x-waiter-token" "a-named-token-C"}}
             {:keys [handled-request response]} (execute-request test-request)]
         (is (nil? handled-request))
-        (is (= (utils/map->json-response {:error "An authentication parameter is not supported for on-the-fly headers"}
+        (is (= (utils/clj->json-response {:error "An authentication parameter is not supported for on-the-fly headers"}
                                          :status 400)
                response))))
 

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -32,7 +32,8 @@
             [waiter.service-description :as sd]
             [waiter.statsd :as statsd]
             [waiter.test-helpers :refer :all]
-            [waiter.util.async-utils :as au])
+            [waiter.util.async-utils :as au]
+            [waiter.util.utils :as utils])
   (:import (clojure.core.async.impl.channels ManyToManyChannel)
            (clojure.lang ExceptionInfo)
            (java.io StringBufferInputStream StringReader)))
@@ -632,7 +633,7 @@
         (let [instance-rpc-chan (instance-rpc-chan-factory response-status)
               request {:uri (str "/work-stealing")
                        :request-method :post
-                       :body (StringBufferInputStream. (json/write-str (walk/stringify-keys request-body)))}
+                       :body (StringBufferInputStream. (utils/clj->json (walk/stringify-keys request-body)))}
               {:keys [status body]} (fa/<?? (work-stealing-handler instance-rpc-chan request))]
           (is (= expected-status status))
           (is (every? #(str/includes? (str body) %) expected-body-fragments)))))))
@@ -641,7 +642,7 @@
   (let [instance-rpc-chan (async/chan)
         test-service-id "test-service-id"
         request {:body (StringBufferInputStream.
-                         (json/write-str
+                         (utils/clj->json
                            {"cid" "test-cid"
                             "instance" {"id" "test-instance-id", "service-id" test-service-id}
                             "request-id" "test-request-id"
@@ -1187,7 +1188,7 @@
   (let [instance-rpc-chan (async/chan)
         test-service-id "test-service-id"
         request {:body (StringBufferInputStream.
-                         (json/write-str
+                         (utils/clj->json
                            {"instance" {"id" "test-instance-id", "service-id" test-service-id}
                             "period-in-ms" 1000
                             "reason" "blacklist"}))}

--- a/waiter/test/waiter/mesos/marathon_test.clj
+++ b/waiter/test/waiter/mesos/marathon_test.clj
@@ -16,7 +16,8 @@
 (ns waiter.mesos.marathon-test
   (:require [clojure.test :refer :all]
             [waiter.mesos.marathon :refer :all]
-            [waiter.util.http-utils :as http-utils]))
+            [waiter.util.http-utils :as http-utils]
+            [waiter.util.utils :as utils]))
 
 (def ^:private http-client (Object.))
 

--- a/waiter/test/waiter/mesos/mesos_test.clj
+++ b/waiter/test/waiter/mesos/mesos_test.clj
@@ -17,7 +17,8 @@
   (:require [clojure.string :as str]
             [clojure.test :refer :all]
             [waiter.mesos.mesos :refer :all]
-            [waiter.util.http-utils :as http-utils]))
+            [waiter.util.http-utils :as http-utils]
+            [waiter.util.utils :as utils]))
 
 (deftest test-mesos-api
   (let [http-client (Object.)

--- a/waiter/test/waiter/scheduler/cook_test.clj
+++ b/waiter/test/waiter/scheduler/cook_test.clj
@@ -46,7 +46,7 @@
                         (is (= http-client in-http-client))
                         (is (= (str cook-url "/jobs") in-request-url))
                         (is (= {:accept "application/json"
-                                :body (utils/map->json job-description)
+                                :body (utils/clj->json job-description)
                                 :content-type "application/json"
                                 :headers {}
                                 :request-method :post
@@ -64,7 +64,7 @@
                         (is (= http-client in-http-client))
                         (is (= (str cook-url "/jobs") in-request-url))
                         (is (= {:accept "application/json"
-                                :body (utils/map->json job-description)
+                                :body (utils/clj->json job-description)
                                 :content-type "application/json"
                                 :headers {"x-cook-impersonate" "test-user"}
                                 :request-method :post

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -25,7 +25,8 @@
             [waiter.mesos.marathon :as marathon]
             [waiter.mesos.mesos :as mesos]
             [waiter.scheduler :as scheduler]
-            [waiter.util.date-utils :as du])
+            [waiter.util.date-utils :as du]
+            [waiter.util.utils :as utils])
   (:import waiter.scheduler.marathon.MarathonScheduler))
 
 (deftest test-response-data->service-instances
@@ -1279,7 +1280,7 @@
         marathon-descriptor {:reference (Object.)}
         deployment-error-response (->> {:deployments [{:id "d-1234"}]
                                         :message "App is locked by one or more deployments."}
-                                       json/write-str
+                                       utils/clj->json
                                        (assoc {:status 409} :body))
         create-app-error-factory (fn [error-call-limit create-call-counter]
                                    (fn [in-marathon-api in-marathon-descriptor]

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -294,7 +294,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description-1))
+                 :body (StringBufferInputStream. (utils/clj->json service-description-1))
                  :headers {}
                  :request-method :post})]
           (is (= 200 status))
@@ -332,7 +332,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames (public-entitlement-manager) make-peer-requests-fn (constantly true)
                 {:authorization/user auth-user
-                 :body (-> service-description-1 (assoc "owner" "tu2" "token" token) json/write-str StringBufferInputStream.)
+                 :body (-> service-description-1 (assoc "owner" "tu2" "token" token) utils/clj->json StringBufferInputStream.)
                  :headers {}
                  :request-method :post})]
           (is (= 200 status))
@@ -362,7 +362,7 @@
           (doseq [key (keys (apply dissoc (select-keys service-description-1 sd/service-parameter-keys) json-keys))]
             (is (str/includes? body (str (get service-description-1 key)))))
           (doseq [key json-keys]
-            (is (str/includes? body (json/write-str (get service-description-1 key)))))))
+            (is (str/includes? body (utils/clj->json (get service-description-1 key)))))))
 
       (testing "get:new-service-description:token query parameter"
         (let [{:keys [body headers status]}
@@ -378,7 +378,7 @@
           (doseq [key (keys (apply dissoc (select-keys service-description-1 sd/service-parameter-keys) json-keys))]
             (is (str/includes? body (str (get service-description-1 key)))))
           (doseq [key json-keys]
-            (is (str/includes? body (json/write-str (get service-description-1 key)))))))
+            (is (str/includes? body (utils/clj->json (get service-description-1 key)))))))
 
       (testing "post:update-service-description:with-changes"
         (let [existing-service-description (kv/fetch kv-store token :refresh true)
@@ -386,7 +386,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description-2))
+                 :body (StringBufferInputStream. (utils/clj->json service-description-2))
                  :headers {}
                  :request-method :post})]
           (is (= 200 status))
@@ -413,7 +413,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str (assoc existing-service-parameter-template "token" token)))
+                 :body (StringBufferInputStream. (utils/clj->json (assoc existing-service-parameter-template "token" token)))
                  :headers {}
                  :request-method :post})]
           (is (= 200 status))
@@ -439,7 +439,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames (public-entitlement-manager) make-peer-requests-fn (constantly true)
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str (assoc existing-service-parameter-template "owner" auth-user "token" token)))
+                 :body (StringBufferInputStream. (utils/clj->json (assoc existing-service-parameter-template "owner" auth-user "token" token)))
                  :headers {}
                  :request-method :post})]
           (is (= 200 status))
@@ -464,7 +464,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames (public-entitlement-manager) make-peer-requests-fn (constantly true)
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str (assoc service-description-2 "owner" "tu2")))
+                 :body (StringBufferInputStream. (utils/clj->json (assoc service-description-2 "owner" "tu2")))
                  :headers {}
                  :request-method :post})]
           (is (= 200 status))
@@ -488,7 +488,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames (public-entitlement-manager) make-peer-requests-fn (constantly true)
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description-2))
+                 :body (StringBufferInputStream. (utils/clj->json service-description-2))
                  :headers {}
                  :request-method :post})]
           (is (= 200 status))
@@ -589,7 +589,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {}
                  :request-method :post})]
           (is (= 200 status))
@@ -611,7 +611,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {}
                  :request-method :post})]
           (is (= 200 status))
@@ -634,7 +634,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {}
                  :request-method :post})]
           (is (= 200 status))
@@ -661,7 +661,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {}
                  :request-method :post})]
           (is (= 200 status))
@@ -693,7 +693,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description-2))
+                 :body (StringBufferInputStream. (utils/clj->json service-description-2))
                  :headers {}
                  :request-method :post})]
           (is (= 200 status))
@@ -725,7 +725,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description-2))
+                 :body (StringBufferInputStream. (utils/clj->json service-description-2))
                  :headers {}
                  :request-method :post})]
           (is (= 200 status))
@@ -745,7 +745,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {"x-waiter-token" token}
                  :request-method :post})]
           (is (= 200 status))
@@ -770,7 +770,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {"x-waiter-token" token}
                  :request-method :post})]
           (is (= 200 status))
@@ -798,7 +798,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:authorization/user test-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {"x-waiter-token" token}
                  :query-params {"update-mode" "admin"}
                  :request-method :post})]
@@ -826,7 +826,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:authorization/user test-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {"x-waiter-token" token}
                  :query-params {"update-mode" "admin"}
                  :request-method :post})]
@@ -855,7 +855,7 @@
                   (run-handle-token-request
                     kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                     {:authorization/user test-user
-                     :body (StringBufferInputStream. (json/write-str new-service-description))
+                     :body (StringBufferInputStream. (utils/clj->json new-service-description))
                      :headers {"x-waiter-token" token}
                      :request-method :post})]
               (is (= 200 status))
@@ -892,7 +892,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn nil
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {}
                  :request-method :post})]
           (is (= 400 status))
@@ -907,7 +907,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn nil
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {}
                  :request-method :post})]
           (is (= 403 status))
@@ -922,7 +922,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn validate-service-description-fn
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {"x-waiter-token" token}
                  :request-method :post})]
           (is (= 400 status))
@@ -938,7 +938,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {"x-waiter-token" token}
                  :request-method :post})]
           (is (= 403 status))
@@ -954,7 +954,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {"x-waiter-token" token}
                  :request-method :post})]
           (is (= 403 status))
@@ -969,7 +969,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {"x-waiter-token" token}
                  :request-method :post})]
           (is (= 403 status))
@@ -989,7 +989,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:request-method :post :authorization/user test-user :headers {"x-waiter-token" token}
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :query-params {"update-mode" "foobar"}})]
           (is (= 400 status))
           (is (str/includes? body "Invalid update-mode"))
@@ -1011,7 +1011,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:authorization/user test-user
-                 :body (StringBufferInputStream. (json/write-str service-description'))
+                 :body (StringBufferInputStream. (utils/clj->json service-description'))
                  :headers {"x-waiter-token" token}
                  :query-params {"update-mode" "admin"}
                  :request-method :post})]
@@ -1033,7 +1033,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:authorization/user test-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {"if-match" (str (clock-millis))
                            "x-waiter-token" token}
                  :query-params {"update-mode" "admin"}
@@ -1055,7 +1055,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:authorization/user test-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {"if-match" (str (clock-millis))
                            "x-waiter-token" token}
                  :query-params {"update-mode" "admin"}
@@ -1074,7 +1074,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn validate-service-description-fn
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {"x-waiter-token" token}
                  :request-method :post})]
           (is (= 400 status))
@@ -1090,7 +1090,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn nil
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :request-method :post})]
           (is (= 400 status))
           (is (str/includes? body "Token must match pattern"))))
@@ -1105,7 +1105,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :request-method :post})]
           (is (= 400 status))
           (is (str/includes? body "Unsupported key(s) in token"))))
@@ -1120,7 +1120,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :request-method :post})]
           (is (= 400 status))
           (is (str/includes? body "Cannot modify last-update-time token metadata"))))
@@ -1135,7 +1135,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :request-method :post})]
           (is (= 400 status))
           (is (str/includes? body "Cannot modify root token metadata"))))
@@ -1151,7 +1151,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
                 {:request-method :post :authorization/user "tu1"
-                 :body (StringBufferInputStream. (json/write-str service-description))})]
+                 :body (StringBufferInputStream. (utils/clj->json service-description))})]
           (is (= 400 status))
           (is (str/includes? body "Cannot modify previous token metadata"))))
 
@@ -1164,7 +1164,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn validate-service-description-fn
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {"accept" "application/json"}
                  :request-method :post})
               {{:strs [message]} "waiter-error"} (json/read-str body)]
@@ -1182,7 +1182,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn validate-service-description-fn
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {"accept" "application/json"}
                  :request-method :post})
               {{:strs [message]} "waiter-error"} (json/read-str body)]
@@ -1199,7 +1199,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn validate-service-description-fn
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {"accept" "application/json"}
                  :request-method :post})
               {{:strs [message]} "waiter-error"} (json/read-str body)]
@@ -1215,7 +1215,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn validate-service-description-fn
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {"accept" "application/json"}
                  :request-method :post})
               {{:strs [message]} "waiter-error"} (json/read-str body)]
@@ -1231,7 +1231,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn validate-service-description-fn
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {"accept" "application/json"}
                  :request-method :post})
               {{:strs [message]} "waiter-error"} (json/read-str body)]
@@ -1247,7 +1247,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn validate-service-description-fn
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {"accept" "application/json"}
                  :request-method :post})
               {{:strs [message]} "waiter-error"} (json/read-str body)]
@@ -1263,7 +1263,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn validate-service-description-fn
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {"accept" "application/json"}
                  :request-method :post})
               {{:strs [message]} "waiter-error"} (json/read-str body)]
@@ -1280,7 +1280,7 @@
                     (run-handle-token-request
                       kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn validate-service-description-fn
                       {:authorization/user auth-user
-                       :body (StringBufferInputStream. (json/write-str service-description))
+                       :body (StringBufferInputStream. (utils/clj->json service-description))
                        :headers {"accept" "application/json"}
                        :request-method :post})
                     {{:strs [message]} "waiter-error"} (json/read-str body)]
@@ -1361,7 +1361,7 @@
               (run-handle-token-request
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn validate-service-description-fn
                 {:authorization/user auth-user
-                 :body (StringBufferInputStream. (json/write-str service-description))
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
                  :headers {"accept" "application/json"}
                  :request-method :post})
               {{:strs [details message]} "waiter-error"} (json/read-str body)]

--- a/waiter/test/waiter/util/http_utils_test.clj
+++ b/waiter/test/waiter/util/http_utils_test.clj
@@ -15,10 +15,10 @@
 ;;
 (ns waiter.util.http-utils-test
   (:require [clojure.core.async :as async]
-            [clojure.data.json :as json]
             [clojure.test :refer :all]
             [qbits.jet.client.http :as http]
-            [waiter.util.http-utils :refer :all])
+            [waiter.util.http-utils :refer :all]
+            [waiter.util.utils :as utils])
   (:import clojure.lang.ExceptionInfo))
 
 (deftest test-http-request
@@ -30,7 +30,7 @@
       (with-redefs [http/request (constantly
                                    (let [response-chan (async/promise-chan)
                                          body-chan (async/promise-chan)]
-                                     (async/>!! body-chan (json/write-str expected-body))
+                                     (async/>!! body-chan (utils/clj->json expected-body))
                                      (async/>!! response-chan {:body body-chan, :status 200})
                                      response-chan))]
         (is (= expected-body (http-request http-client "some-url"))))))
@@ -53,7 +53,7 @@
       (with-redefs [http/request (constantly
                                    (let [response-chan (async/promise-chan)
                                          body-chan (async/promise-chan)]
-                                     (async/>!! body-chan (json/write-str expected-body))
+                                     (async/>!! body-chan (utils/clj->json expected-body))
                                      (async/>!! response-chan {:body body-chan, :status 400})
                                      response-chan))]
         (is (= expected-body (http-request http-client "some-url" :throw-exceptions false))))))
@@ -63,7 +63,7 @@
       (with-redefs [http/request (constantly
                                    (let [response-chan (async/promise-chan)
                                          body-chan (async/promise-chan)]
-                                     (async/>!! body-chan (json/write-str {}))
+                                     (async/>!! body-chan (utils/clj->json {}))
                                      (async/>!! response-chan {:body body-chan, :status 400})
                                      response-chan))]
         (is (thrown? ExceptionInfo (http-request http-client "some-url")))))))

--- a/waiter/test/waiter/util/utils_test.clj
+++ b/waiter/test/waiter/util/utils_test.clj
@@ -106,21 +106,21 @@
     (is (not (str/includes? actual "dest")))
     (is (not (str/includes? actual "pass")))))
 
-(deftest test-map->json-response
+(deftest test-clj->json-response
   (testing "Conversion from map to JSON response"
 
     (testing "should convert empty map"
-      (let [{:keys [body headers status]} (map->json-response {})]
+      (let [{:keys [body headers status]} (clj->json-response {})]
         (is (= 200 status))
         (is (= {"content-type" "application/json"} headers))
         (is (not (nil? body)))))
 
     (testing "should convert regex patterns to strings"
-      (is (= (json/write-str {"bar" "foo"}) (:body (map->json-response {:bar #"foo"}))))
+      (is (= (json/write-str {"bar" "foo"}) (:body (clj->json-response {:bar #"foo"}))))
       (is (= (json/write-str {"bar" ["foo" "baz"] "foo/bar" "baz"} :escape-slash false)
-             (:body (map->json-response {:bar [#"foo" #"baz"] :foo/bar :baz}))))
-      (is (= (json/write-str {"bar" ["foo" "baz"]}) (:body (map->json-response {:bar ["foo" #"baz"]}))))
-      (is (= (json/write-str {"bar" [["foo" "baz"]]}) (:body (map->json-response {:bar [["foo" #"baz"]]})))))))
+             (:body (clj->json-response {:bar [#"foo" #"baz"] :foo/bar :baz}))))
+      (is (= (json/write-str {"bar" ["foo" "baz"]}) (:body (clj->json-response {:bar ["foo" #"baz"]}))))
+      (is (= (json/write-str {"bar" [["foo" "baz"]]}) (:body (clj->json-response {:bar [["foo" #"baz"]]})))))))
 
 (deftest test-map->streaming-json-response
   (testing "convert empty map"

--- a/waiter/test/waiter/work_stealing_test.clj
+++ b/waiter/test/waiter/work_stealing_test.clj
@@ -427,7 +427,7 @@
                                                   (is (= :post method))
                                                   (let [response-chan (async/promise-chan)
                                                         body-chan (async/promise-chan)]
-                                                    (async/>!! body-chan (json/write-str response-map))
+                                                    (async/>!! body-chan (utils/clj->json response-map))
                                                     (async/>!! response-chan {:body body-chan, :status status})
                                                     {target-router-id response-chan})))]
     (with-redefs [work-stealing-balancer


### PR DESCRIPTION
## Changes proposed in this PR

* Rename `utils/map->json*` to `utils/clj->json*`.
* Use `utils/clj->json` in place of `json/write-str` for consistency.

## Why are we making these changes?

The renamed functions more accurately reflect that they don't just accept maps (vectors, numbers, strings, etc. will also be converted to an equivalent JSON string).

We want to preserve keyword namespaces and not escape slashes in all of our JSON output. Using our helper function everywhere (which has this configuration by default) is an easy way to do that.