### PR TITLE
Adds available service ids in router state maintainer

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1126,11 +1126,11 @@
                                      [:routines prepend-waiter-url router-metrics-helpers service-id->service-description-fn]
                                      [:state entitlement-manager]
                                      wrap-secure-request-fn]
-                              (let [state-chan (get-in router-state-maintainer [:maintainer-chans :state-chan])
+                              (let [query-state-fn (get-in router-state-maintainer [:maintainer-chans :query-state-fn])
                                     {:keys [service-id->metrics-fn]} router-metrics-helpers]
                                 (wrap-secure-request-fn
                                   (fn service-list-handler-fn [request]
-                                    (handler/list-services-handler entitlement-manager state-chan prepend-waiter-url
+                                    (handler/list-services-handler entitlement-manager query-state-fn prepend-waiter-url
                                                                    service-id->service-description-fn service-id->metrics-fn
                                                                    request)))))
    :service-override-handler-fn (pc/fnk [[:curator kv-store]
@@ -1173,10 +1173,10 @@
    :state-all-handler-fn (pc/fnk [[:daemons router-state-maintainer]
                                   [:state router-id]
                                   wrap-secure-request-fn]
-                           (let [state-chan (get-in router-state-maintainer [:maintainer-chans :state-chan])]
+                           (let [query-state-fn (get-in router-state-maintainer [:maintainer-chans :query-state-fn])]
                              (wrap-secure-request-fn
                                (fn state-all-handler-fn [request]
-                                 (handler/get-router-state router-id state-chan request)))))
+                                 (handler/get-router-state router-id query-state-fn request)))))
    :state-fallback-handler-fn (pc/fnk [[:daemons fallback-maintainer]
                                        [:state router-id]
                                        wrap-secure-request-fn]
@@ -1218,10 +1218,10 @@
    :state-maintainer-handler-fn (pc/fnk [[:daemons router-state-maintainer]
                                          [:state router-id]
                                          wrap-secure-request-fn]
-                                  (let [state-chan (get-in router-state-maintainer [:maintainer-chans :state-chan])]
+                                  (let [query-state-fn (get-in router-state-maintainer [:maintainer-chans :query-state-fn])]
                                     (wrap-secure-request-fn
                                       (fn maintainer-state-handler-fn [request]
-                                        (handler/get-chan-latest-state-handler router-id state-chan request)))))
+                                        (handler/get-chan-latest-state-handler router-id query-state-fn request)))))
    :state-router-metrics-handler-fn (pc/fnk [[:routines router-metrics-helpers]
                                              [:state router-id]
                                              wrap-secure-request-fn]

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -534,7 +534,7 @@
   (try
     (log/info (str "Waiting for response from state channel"))
     (let [data (query-state-fn)
-          state (or data {:message "Request timeout"})]
+          state (or data {:message "No data available"})]
       (-> {:router-id router-id :state state}
           (utils/map->streaming-json-response)))
     (catch Exception ex

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -231,45 +231,39 @@
 (defn list-services-handler
   "Retrieves the list of services viewable by the currently logged in user.
    A service is viewable by the run-as-user or a waiter super-user."
-  [entitlement-manager state-chan prepend-waiter-url service-id->service-description-fn service-id->metrics-fn request]
-  (let [timeout-ms 30000
-        current-state (async/alt!!
-                        state-chan ([state-data] state-data)
-                        (async/timeout timeout-ms) ([_] :timeout)
-                        :priority true)]
-    (if (= :timeout current-state)
-      (throw (ex-info "Query for service state timed out" {:status 503}))
-      (let [request-params (-> request ru/query-params-request :query-params)
-            auth-user (get request :authorization/user)
-            run-as-user-param (get request-params "run-as-user")
-            viewable-services (filter
-                                #(let [{:strs [run-as-user] :as service-description} (service-id->service-description-fn % :effective? false)]
-                                   (and service-description
-                                        (if run-as-user-param
-                                          (= run-as-user run-as-user-param)
-                                          (authz/manage-service? entitlement-manager auth-user % service-description))))
-                                (->> (concat (keys (:service-id->healthy-instances current-state))
-                                             (keys (:service-id->unhealthy-instances current-state)))
-                                     (apply sorted-set)))
-            retrieve-instance-counts (fn retrieve-instance-counts [service-id]
-                                       {:healthy-instances (count (get-in current-state [:service-id->healthy-instances service-id]))
-                                        :unhealthy-instances (count (get-in current-state [:service-id->unhealthy-instances service-id]))})
-            service-id->metrics (service-id->metrics-fn)
-            include-effective-parameters? (utils/request-flag request-params "effective-parameters")
-            response-data (map
-                            (fn service-id->service-info [service-id]
-                              (let [service-description (service-id->service-description-fn service-id :effective? false)]
-                                (cond->
-                                  {:instance-counts (retrieve-instance-counts service-id)
-                                   :last-request-time (get-in service-id->metrics [service-id "last-request-time"])
-                                   :service-id service-id
-                                   :service-description service-description
-                                   :url (prepend-waiter-url (str "/apps/" service-id))}
-                                  include-effective-parameters? (assoc :effective-parameters
-                                                                       (service-id->service-description-fn
-                                                                         service-id :effective? true)))))
-                            viewable-services)]
-        (utils/map->streaming-json-response response-data)))))
+  [entitlement-manager query-state-fn prepend-waiter-url service-id->service-description-fn service-id->metrics-fn request]
+  (let [current-state (query-state-fn)]
+    (let [request-params (-> request ru/query-params-request :query-params)
+          auth-user (get request :authorization/user)
+          run-as-user-param (get request-params "run-as-user")
+          viewable-services (filter
+                              #(let [{:strs [run-as-user] :as service-description} (service-id->service-description-fn % :effective? false)]
+                                 (and service-description
+                                      (if run-as-user-param
+                                        (= run-as-user run-as-user-param)
+                                        (authz/manage-service? entitlement-manager auth-user % service-description))))
+                              (->> (concat (keys (:service-id->healthy-instances current-state))
+                                           (keys (:service-id->unhealthy-instances current-state)))
+                                   (apply sorted-set)))
+          retrieve-instance-counts (fn retrieve-instance-counts [service-id]
+                                     {:healthy-instances (count (get-in current-state [:service-id->healthy-instances service-id]))
+                                      :unhealthy-instances (count (get-in current-state [:service-id->unhealthy-instances service-id]))})
+          service-id->metrics (service-id->metrics-fn)
+          include-effective-parameters? (utils/request-flag request-params "effective-parameters")
+          response-data (map
+                          (fn service-id->service-info [service-id]
+                            (let [service-description (service-id->service-description-fn service-id :effective? false)]
+                              (cond->
+                                {:instance-counts (retrieve-instance-counts service-id)
+                                 :last-request-time (get-in service-id->metrics [service-id "last-request-time"])
+                                 :service-id service-id
+                                 :service-description service-description
+                                 :url (prepend-waiter-url (str "/apps/" service-id))}
+                                include-effective-parameters? (assoc :effective-parameters
+                                                                     (service-id->service-description-fn
+                                                                       service-id :effective? true)))))
+                          viewable-services)]
+      (utils/map->streaming-json-response response-data))))
 
 (defn delete-service-handler
   "Deletes the service from the scheduler (after authorization checks)."
@@ -518,35 +512,33 @@
 
 (defn get-router-state
   "Outputs the state of the router as json."
-  [router-id state-chan request]
-  (async/go
-    (try
-      (let [routers (-> state-chan retrieve-channel-state async/<! :routers)
-            host (get-in request [:headers "host"])
-            scheme (some-> request utils/request->scheme name)
-            make-url (fn make-url [path]
-                       (str (when scheme (str scheme "://")) host "/state/" path))]
-        (-> {:details (->> ["fallback" "interstitial" "kv-store" "launch-metrics" "leader"
-                            "local-usage" "maintainer" "router-metrics" "scheduler" "statsd"]
-                           (pc/map-from-keys make-url))
-             :router-id router-id
-             :routers routers}
-            (utils/map->streaming-json-response)))
-      (catch Exception ex
-        (utils/exception->response ex request)))))
+  [router-id query-state-fn request]
+  (try
+    (let [{:keys [routers]} (query-state-fn)
+          host (get-in request [:headers "host"])
+          scheme (some-> request utils/request->scheme name)
+          make-url (fn make-url [path]
+                     (str (when scheme (str scheme "://")) host "/state/" path))]
+      (-> {:details (->> ["fallback" "interstitial" "kv-store" "launch-metrics" "leader"
+                          "local-usage" "maintainer" "router-metrics" "scheduler" "statsd"]
+                         (pc/map-from-keys make-url))
+           :router-id router-id
+           :routers routers}
+          (utils/map->streaming-json-response)))
+    (catch Exception ex
+      (utils/exception->response ex request))))
 
 (defn get-chan-latest-state-handler
   "Outputs the latest state of the channel."
-  [router-id state-chan request]
-  (async/go
-    (try
-      (log/info (str "Waiting for response from state channel"))
-      (let [data (-> state-chan retrieve-channel-state async/<!)
-            state (or data {:message "Request timeout"})]
-        (-> {:router-id router-id :state state}
-            (utils/map->streaming-json-response)))
-      (catch Exception ex
-        (utils/exception->response ex request)))))
+  [router-id query-state-fn request]
+  (try
+    (log/info (str "Waiting for response from state channel"))
+    (let [data (query-state-fn)
+          state (or data {:message "Request timeout"})]
+      (-> {:router-id router-id :state state}
+          (utils/map->streaming-json-response)))
+    (catch Exception ex
+      (utils/exception->response ex request))))
 
 (defn get-query-chan-state-handler
   "Outputs the state by sending a standard query to the channel."

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -459,7 +459,7 @@
                                                               (available? instance health-check-path http-client))
                                                             service-id->service-description-fn))]
       (let [available-services (keys service->service-instances)
-            available-service-ids (->> available-services (map :id ) (set ))]
+            available-service-ids (->> available-services (map :id) (set))]
         (log/debug "scheduler-syncer:" (count service->service-instances) "available services:" available-service-ids)
         (doseq [service available-services]
           (when (->> (select-keys (:task-stats service) [:staged :running :healthy :unhealthy])

--- a/waiter/src/waiter/state.clj
+++ b/waiter/src/waiter/state.clj
@@ -1204,7 +1204,8 @@
     {:state-chan state-chan
      :router-state-push-mult (async/mult router-state-push-chan)
      :query-chan query-chan
-     :query-fn (fn router-state-maintainer-query-fn [] @state-atom)
+     :query-state-fn (fn router-state-maintainer-query-state-fn []
+                       (assoc @state-atom :router-id router-id))
      :go-chan
      (async/go
        (try

--- a/waiter/src/waiter/state.clj
+++ b/waiter/src/waiter/state.clj
@@ -1180,9 +1180,9 @@
 
 (defn start-router-state-maintainer
   "Start the instance state maintainer.
-   Maintains the state of the router as well as the state of marathon
-   and the existence of other routers. Acts as the central access point
-   for modifying this data for the router."
+   Maintains the state of the router as well as the state of marathon and the existence of other routers.
+   Acts as the central access point for modifying this data for the router.
+   Exposes the state of the router via a `query-state-fn` no-args function that is returned."
   [scheduler-state-chan router-chan router-id exit-chan service-id->service-description-fn deployment-error-config]
   (let [initial-state {:all-available-service-ids #{}
                        :service-id->healthy-instances {}
@@ -1198,11 +1198,9 @@
                        :routers []
                        :time (t/now)}
         state-atom (atom initial-state)
-        state-chan (async/chan)
         router-state-push-chan (au/latest-chan)
         query-chan (async/chan)]
-    {:state-chan state-chan
-     :router-state-push-mult (async/mult router-state-push-chan)
+    {:router-state-push-mult (async/mult router-state-push-chan)
      :query-chan query-chan
      :query-state-fn (fn router-state-maintainer-query-state-fn []
                        (assoc @state-atom :router-id router-id))
@@ -1345,10 +1343,7 @@
                                  (update-router-state router-id current-state candidate-state service-id->service-description-fn))
                                current-state)]
                          (async/put! router-state-push-chan new-state)
-                         new-state)))
-
-                   [[state-chan current-state]]
-                   (assoc current-state :router-id router-id))]
+                         new-state))))]
              (if next-state
                (recur next-state)
                (log/info "Stopping router-state-maintainer as next state is nil"))))

--- a/waiter/src/waiter/state.clj
+++ b/waiter/src/waiter/state.clj
@@ -1184,29 +1184,32 @@
    and the existence of other routers. Acts as the central access point
    for modifying this data for the router."
   [scheduler-state-chan router-chan router-id exit-chan service-id->service-description-fn deployment-error-config]
-  (let [state-chan (async/chan)
+  (let [initial-state {:all-available-service-ids #{}
+                       :service-id->healthy-instances {}
+                       :service-id->unhealthy-instances {}
+                       :service-id->my-instance->slots {} ; updated in update-router-state
+                       :service-id->expired-instances {}
+                       :service-id->starting-instances {}
+                       :service-id->failed-instances {}
+                       :service-id->instance-counts {}
+                       :service-id->deployment-error {}
+                       :service-id->instability-issue {}
+                       :iteration 0
+                       :routers []
+                       :time (t/now)}
+        state-atom (atom initial-state)
+        state-chan (async/chan)
         router-state-push-chan (au/latest-chan)
         query-chan (async/chan)]
     {:state-chan state-chan
      :router-state-push-mult (async/mult router-state-push-chan)
      :query-chan query-chan
+     :query-fn (fn router-state-maintainer-query-fn [] @state-atom)
      :go-chan
      (async/go
        (try
-         (loop [{:keys [iteration routers] :as current-state}
-                {:all-available-service-ids #{}
-                 :service-id->healthy-instances {}
-                 :service-id->unhealthy-instances {}
-                 :service-id->my-instance->slots {} ; updated in update-router-state
-                 :service-id->expired-instances {}
-                 :service-id->starting-instances {}
-                 :service-id->failed-instances {}
-                 :service-id->instance-counts {}
-                 :service-id->deployment-error {}
-                 :service-id->instability-issue {}
-                 :iteration 0
-                 :routers []
-                 :time (t/now)}]
+         (loop [{:keys [iteration routers] :as current-state} @state-atom]
+           (reset! state-atom current-state)
            (let [next-state
                  (async/alt!
                    exit-chan

--- a/waiter/src/waiter/state.clj
+++ b/waiter/src/waiter/state.clj
@@ -1194,7 +1194,8 @@
      (async/go
        (try
          (loop [{:keys [iteration routers] :as current-state}
-                {:service-id->healthy-instances {}
+                {:all-available-service-ids #{}
+                 :service-id->healthy-instances {}
                  :service-id->unhealthy-instances {}
                  :service-id->my-instance->slots {} ; updated in update-router-state
                  :service-id->expired-instances {}
@@ -1227,15 +1228,16 @@
                                (case message-type
                                  :update-available-services
                                  (let [{:keys [available-service-ids scheduler-sync-time]} message-data
-                                       services-without-instances (remove #(contains? service-id->my-instance->slots %) available-service-ids)
-                                       service-id->healthy-instances' (select-keys service-id->healthy-instances available-service-ids)
-                                       service-id->unhealthy-instances' (select-keys service-id->unhealthy-instances available-service-ids)
-                                       service-id->expired-instances' (select-keys service-id->expired-instances available-service-ids)
-                                       service-id->starting-instances' (select-keys service-id->starting-instances available-service-ids)
-                                       service-id->failed-instances' (select-keys service-id->failed-instances available-service-ids)
-                                       service-id->instance-counts' (select-keys service-id->instance-counts available-service-ids)
-                                       service-id->deployment-error' (select-keys service-id->deployment-error available-service-ids)
-                                       service-id->instability-issue' (select-keys service-id->instability-issue available-service-ids)]
+                                       all-available-service-ids' available-service-ids
+                                       services-without-instances (remove #(contains? service-id->my-instance->slots %) all-available-service-ids')
+                                       service-id->healthy-instances' (select-keys service-id->healthy-instances all-available-service-ids')
+                                       service-id->unhealthy-instances' (select-keys service-id->unhealthy-instances all-available-service-ids')
+                                       service-id->expired-instances' (select-keys service-id->expired-instances all-available-service-ids')
+                                       service-id->starting-instances' (select-keys service-id->starting-instances all-available-service-ids')
+                                       service-id->failed-instances' (select-keys service-id->failed-instances all-available-service-ids')
+                                       service-id->instance-counts' (select-keys service-id->instance-counts all-available-service-ids')
+                                       service-id->deployment-error' (select-keys service-id->deployment-error all-available-service-ids')
+                                       service-id->instability-issue' (select-keys service-id->instability-issue all-available-service-ids')]
                                    (when (or (not= service-id->healthy-instances service-id->healthy-instances')
                                              (not= service-id->unhealthy-instances service-id->unhealthy-instances')
                                              (seq services-without-instances))
@@ -1244,6 +1246,7 @@
                                                (count services-without-instances) "services without instances:"
                                                (vec services-without-instances)))
                                    (assoc loop-state
+                                     :all-available-service-ids all-available-service-ids'
                                      :service-id->healthy-instances service-id->healthy-instances'
                                      :service-id->unhealthy-instances service-id->unhealthy-instances'
                                      :service-id->expired-instances service-id->expired-instances'

--- a/waiter/src/waiter/state.clj
+++ b/waiter/src/waiter/state.clj
@@ -1184,20 +1184,19 @@
    Acts as the central access point for modifying this data for the router.
    Exposes the state of the router via a `query-state-fn` no-args function that is returned."
   [scheduler-state-chan router-chan router-id exit-chan service-id->service-description-fn deployment-error-config]
-  (let [initial-state {:all-available-service-ids #{}
-                       :service-id->healthy-instances {}
-                       :service-id->unhealthy-instances {}
-                       :service-id->my-instance->slots {} ; updated in update-router-state
-                       :service-id->expired-instances {}
-                       :service-id->starting-instances {}
-                       :service-id->failed-instances {}
-                       :service-id->instance-counts {}
-                       :service-id->deployment-error {}
-                       :service-id->instability-issue {}
-                       :iteration 0
-                       :routers []
-                       :time (t/now)}
-        state-atom (atom initial-state)
+  (let [state-atom (atom {:all-available-service-ids #{}
+                          :service-id->healthy-instances {}
+                          :service-id->unhealthy-instances {}
+                          :service-id->my-instance->slots {} ; updated in update-router-state
+                          :service-id->expired-instances {}
+                          :service-id->starting-instances {}
+                          :service-id->failed-instances {}
+                          :service-id->instance-counts {}
+                          :service-id->deployment-error {}
+                          :service-id->instability-issue {}
+                          :iteration 0
+                          :routers []
+                          :time (t/now)})
         router-state-push-chan (au/latest-chan)
         query-chan (async/chan)]
     {:router-state-push-mult (async/mult router-state-push-chan)

--- a/waiter/test/waiter/state_test.clj
+++ b/waiter/test/waiter/state_test.clj
@@ -1104,7 +1104,8 @@
                       (recur (inc index) (conj scheduler-messages service-instances-message))))))
               (let [expected-services (services-fn n)
                     expected-state (let [index-fn #(Integer/parseInt (subs % (inc (.lastIndexOf ^String % "-"))))]
-                                     {:service-id->healthy-instances
+                                     {:all-available-service-ids (set expected-services)
+                                      :service-id->healthy-instances
                                       (pc/map-from-keys #(healthy-instances-fn % (index-fn %) n) expected-services)
                                       :service-id->unhealthy-instances
                                       (pc/map-from-keys #(unhealthy-instances-fn % (index-fn %)) expected-services)
@@ -1141,7 +1142,7 @@
                     state (async/<!! router-state-push-chan)
                     actual-state (dissoc state :iteration :service-id->instance-counts)]
                 (when (not= expected-state actual-state)
-                  (clojure.pprint/pprint (clojure.data/diff expected-state actual-state)))
+                  (clojure.pprint/pprint (take 2 (clojure.data/diff expected-state actual-state))))
                 (is (= expected-state actual-state) (str (clojure.data/diff expected-state actual-state))))))
           (async/>!! exit-chan :exit)))))
 
@@ -1216,7 +1217,8 @@
                       (recur (inc index) (conj scheduler-messages service-instances-message))))))
               (let [expected-services (services-fn n)
                     expected-state (let [index-fn #(Integer/parseInt (subs % (inc (.lastIndexOf ^String % "-"))))]
-                                     {:service-id->unhealthy-instances
+                                     {:all-available-service-ids (set expected-services)
+                                      :service-id->unhealthy-instances
                                       (zipmap expected-services
                                               (map #(unhealthy-instances-fn % (index-fn %)) expected-services))
                                       :service-id->failed-instances
@@ -1231,8 +1233,8 @@
                     actual-state (dissoc state :iteration :service-id->healthy-instances :service-id->expired-instances :service-id->starting-instances
                                           :service-id->instance-counts :service-id->my-instance->slots :routers :time)]
                 (when (not= expected-state actual-state)
-                  (clojure.pprint/pprint (clojure.data/diff expected-state actual-state)))
-                (is (= expected-state actual-state) (str (clojure.data/diff expected-state actual-state))))))
+                  (clojure.pprint/pprint (take 2 (clojure.data/diff expected-state actual-state))))
+                (is (= expected-state actual-state) (str (take 2 (clojure.data/diff expected-state actual-state)))))))
           (async/>!! exit-chan :exit))))))
 
 (deftest test-retrieve-peer-routers


### PR DESCRIPTION
## Changes proposed in this PR

- adds `all-available-service-ids` in router state maintainer
- adds support for `query-fn` in router-state-maintainer
- includes `router-id` in router-state-maintainer `query-state-fn` output
- removes `state-chan` from router-state-maintainer and consumers use `query-state-fn` instead

## Why are we making these changes?

Two goals:
1. Avoid using go-blocks to read daemon states.
2. Enable a future where the router state is obtained from the maintainer instead of from the scheduler syncer.

