### PR TITLE
adds support to synchronously query the service state in the autoscaler daemon

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -992,17 +992,17 @@
                                 (async/tap state-chan-mult state-chan)
                                 (state/start-service-chan-maintainer
                                   {} instance-rpc-chan state-chan query-app-maintainer-chan start-service remove-service retrieve-channel)))
-   :state-query-chans (pc/fnk [[:state query-app-maintainer-chan]
-                               autoscaler autoscaling-multiplexer gc-for-transient-metrics interstitial-maintainer
-                               scheduler-broken-services-gc scheduler-maintainer scheduler-services-gc]
-                        {:app-maintainer-state query-app-maintainer-chan
-                         :autoscaler-state (:query autoscaler)
-                         :autoscaling-multiplexer-state (:query-chan autoscaling-multiplexer)
-                         :interstitial-maintainer-state (:query-chan interstitial-maintainer)
-                         :scheduler-broken-services-gc-state (:query scheduler-broken-services-gc)
-                         :scheduler-services-gc-state (:query scheduler-services-gc)
-                         :scheduler-state (:query-chan scheduler-maintainer)
-                         :transient-metrics-gc-state (:query gc-for-transient-metrics)})
+   :state-query-chans-or-fns (pc/fnk [[:state query-app-maintainer-chan]
+                                      autoscaler autoscaling-multiplexer gc-for-transient-metrics interstitial-maintainer
+                                      scheduler-broken-services-gc scheduler-maintainer scheduler-services-gc]
+                               {:app-maintainer-state query-app-maintainer-chan
+                                :autoscaler-state (:query-service-state-fn autoscaler)
+                                :autoscaling-multiplexer-state (:query-chan autoscaling-multiplexer)
+                                :interstitial-maintainer-state (:query-chan interstitial-maintainer)
+                                :scheduler-broken-services-gc-state (:query scheduler-broken-services-gc)
+                                :scheduler-services-gc-state (:query scheduler-services-gc)
+                                :scheduler-state (:query-chan scheduler-maintainer)
+                                :transient-metrics-gc-state (:query gc-for-transient-metrics)})
    :statsd (pc/fnk [[:routines service-id->service-description-fn]
                     [:settings statsd]
                     scheduler-maintainer]
@@ -1236,13 +1236,13 @@
                                    (wrap-secure-request-fn
                                      (fn scheduler-state-handler-fn [request]
                                        (handler/get-query-chan-state-handler router-id scheduler-query-chan request)))))
-   :state-service-handler-fn (pc/fnk [[:daemons state-query-chans]
+   :state-service-handler-fn (pc/fnk [[:daemons state-query-chans-or-fns]
                                       [:state instance-rpc-chan local-usage-agent router-id]
                                       wrap-secure-request-fn]
                                (wrap-secure-request-fn
                                  (fn service-state-handler-fn [{{:keys [service-id]} :route-params :as request}]
                                    (handler/get-service-state router-id instance-rpc-chan local-usage-agent
-                                                              service-id state-query-chans request))))
+                                                              service-id state-query-chans-or-fns request))))
    :state-statsd-handler-fn (pc/fnk [[:state router-id]
                                      wrap-secure-request-fn]
                               (wrap-secure-request-fn

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -992,17 +992,17 @@
                                 (async/tap state-chan-mult state-chan)
                                 (state/start-service-chan-maintainer
                                   {} instance-rpc-chan state-chan query-app-maintainer-chan start-service remove-service retrieve-channel)))
-   :state-query-chans-or-fns (pc/fnk [[:state query-app-maintainer-chan]
-                                      autoscaler autoscaling-multiplexer gc-for-transient-metrics interstitial-maintainer
-                                      scheduler-broken-services-gc scheduler-maintainer scheduler-services-gc]
-                               {:app-maintainer-state query-app-maintainer-chan
-                                :autoscaler-state (:query-service-state-fn autoscaler)
-                                :autoscaling-multiplexer-state (:query-chan autoscaling-multiplexer)
-                                :interstitial-maintainer-state (:query-chan interstitial-maintainer)
-                                :scheduler-broken-services-gc-state (:query scheduler-broken-services-gc)
-                                :scheduler-services-gc-state (:query scheduler-services-gc)
-                                :scheduler-state (:query-chan scheduler-maintainer)
-                                :transient-metrics-gc-state (:query gc-for-transient-metrics)})
+   :state-sources (pc/fnk [[:state query-app-maintainer-chan]
+                           autoscaler autoscaling-multiplexer gc-for-transient-metrics interstitial-maintainer
+                           scheduler-broken-services-gc scheduler-maintainer scheduler-services-gc]
+                    {:app-maintainer-state query-app-maintainer-chan
+                     :autoscaler-state (:query-service-state-fn autoscaler)
+                     :autoscaling-multiplexer-state (:query-chan autoscaling-multiplexer)
+                     :interstitial-maintainer-state (:query-chan interstitial-maintainer)
+                     :scheduler-broken-services-gc-state (:query scheduler-broken-services-gc)
+                     :scheduler-services-gc-state (:query scheduler-services-gc)
+                     :scheduler-state (:query-chan scheduler-maintainer)
+                     :transient-metrics-gc-state (:query gc-for-transient-metrics)})
    :statsd (pc/fnk [[:routines service-id->service-description-fn]
                     [:settings statsd]
                     scheduler-maintainer]
@@ -1236,13 +1236,13 @@
                                    (wrap-secure-request-fn
                                      (fn scheduler-state-handler-fn [request]
                                        (handler/get-query-chan-state-handler router-id scheduler-query-chan request)))))
-   :state-service-handler-fn (pc/fnk [[:daemons state-query-chans-or-fns]
+   :state-service-handler-fn (pc/fnk [[:daemons state-sources]
                                       [:state instance-rpc-chan local-usage-agent router-id]
                                       wrap-secure-request-fn]
                                (wrap-secure-request-fn
                                  (fn service-state-handler-fn [{{:keys [service-id]} :route-params :as request}]
                                    (handler/get-service-state router-id instance-rpc-chan local-usage-agent
-                                                              service-id state-query-chans-or-fns request))))
+                                                              service-id state-sources request))))
    :state-statsd-handler-fn (pc/fnk [[:state router-id]
                                      wrap-secure-request-fn]
                               (wrap-secure-request-fn

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -604,7 +604,7 @@
 
 (defn get-service-state
   "Retrieves the state for a particular service on the router."
-  [router-id instance-rpc-chan local-usage-agent service-id query-chans-or-fns request]
+  [router-id instance-rpc-chan local-usage-agent service-id query-sources request]
   (async/go
     (try
       (if (str/blank? service-id)
@@ -620,7 +620,7 @@
               query-params {:cid (cid/get-correlation-id) :service-id service-id}
               [query-chans initial-result]
               (loop [[[entry-key entry-value] & remaining]
-                     (concat query-chans-or-fns
+                     (concat query-sources
                        [[:responder-state responder-state-chan] [:work-stealing-state work-stealing-state-chan]])
                      query-chans {}
                      initial-result {:local-usage local-usage-state}]

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -826,15 +826,19 @@
       (start-instance-rpc-fn)
       (start-query-chan-fn)
       (start-maintainer-fn)
-      (let [response (async/<!! (get-service-state router-id instance-rpc-chan local-usage-agent
-                                                   service-id {:maintainer-state maintainer-state-chan} {}))
+      (let [query-chans-or-fns {:autoscaler-state (fn [{:keys [service-id]}]
+                                                    {:service-id service-id :source "autoscaler"})
+                                :maintainer-state maintainer-state-chan}
+            response (->> (get-service-state router-id instance-rpc-chan local-usage-agent service-id query-chans-or-fns {})
+                          (async/<!!))
             service-state (json/read-str (:body response) :key-fn keyword)]
         (is (= router-id (get-in service-state [:router-id])))
         (is (= responder-state (get-in service-state [:state :responder-state])))
         (is (= {:last-request-time "foo"}
                (get-in service-state [:state :local-usage])))
         (is (= work-stealing-state (get-in service-state [:state :work-stealing-state])))
-        (is (= (assoc maintainer-state :service-id service-id) (get-in service-state [:state :maintainer-state])))))))
+        (is (= (assoc maintainer-state :service-id service-id) (get-in service-state [:state :maintainer-state])))
+        (is (= {:service-id service-id :source "autoscaler"} (get-in service-state [:state :autoscaler-state])))))))
 
 (deftest test-acknowledge-consent-handler
   (let [current-time-ms (System/currentTimeMillis)

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -826,10 +826,10 @@
       (start-instance-rpc-fn)
       (start-query-chan-fn)
       (start-maintainer-fn)
-      (let [query-chans-or-fns {:autoscaler-state (fn [{:keys [service-id]}]
-                                                    {:service-id service-id :source "autoscaler"})
-                                :maintainer-state maintainer-state-chan}
-            response (->> (get-service-state router-id instance-rpc-chan local-usage-agent service-id query-chans-or-fns {})
+      (let [query-sources {:autoscaler-state (fn [{:keys [service-id]}]
+                                               {:service-id service-id :source "autoscaler"})
+                           :maintainer-state maintainer-state-chan}
+            response (->> (get-service-state router-id instance-rpc-chan local-usage-agent service-id query-sources {})
                           (async/<!!))
             service-state (json/read-str (:body response) :key-fn keyword)]
         (is (= router-id (get-in service-state [:router-id])))


### PR DESCRIPTION
## Changes proposed in this PR

- adds support to synchronously query the service state in the autoscaler daemon
- uses autoscaler query-service-state-fn to retrieve service state

## Why are we making these changes?

We want to reduce the pressure on go-blocks when synchronous calls to retrieve state suffice.
