### PR TITLE
Statsd router state maintainer

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -589,7 +589,11 @@
 
           ;; Waiter aggregates metrics locally and publishes
           ;; to StatsD on the following interval (milliseconds):
-          :publish-interval-ms 10000}
+          :publish-interval-ms 10000
+
+          ;; Waiter aggregates metrics locally for instances and resource usage and
+          ;; maintains them locally on the following interval (milliseconds):
+          :sync-instances-interval-ms 5000}
 
  ;; Waiter allows a "metric group" string to be associated with a service so that related
  ;; services can be grouped together in the Waiter Stats environment. One or multiple

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -591,8 +591,8 @@
           ;; to StatsD on the following interval (milliseconds):
           :publish-interval-ms 10000
 
-          ;; Waiter aggregates metrics locally for instances and resource usage and
-          ;; maintains them locally on the following interval (milliseconds):
+          ;; Waiter polls the router state for instances and resource
+          ;; usage on the following interval (milliseconds):
           :sync-instances-interval-ms 5000}
 
  ;; Waiter allows a "metric group" string to be associated with a service so that related

--- a/waiter/integration/waiter/statsd_support_test.clj
+++ b/waiter/integration/waiter/statsd_support_test.clj
@@ -32,6 +32,27 @@
   [waiter-url]
   (not= "disabled" (:statsd (waiter-settings waiter-url))))
 
+(deftest ^:parallel ^:integration-fast test-statsd-instance-metrics-aggregation
+  (testing-using-waiter-url
+    (let [metric-group (rand-name "foo")
+          headers {:x-waiter-name (rand-name)
+                   :x-waiter-metric-group metric-group}
+          {:keys [status service-id] :as response}
+          (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))]
+      (is (= 200 status))
+      (when (statsd-enabled? waiter-url)
+        (let [{:keys [metric-group]} (response->service-description waiter-url response)
+              metric-group-keyword (keyword metric-group)
+              {:keys [sync-instances-interval-ms]} (get (waiter-settings waiter-url) :statsd)]
+          (wait-for
+            (fn statsd-instance-metrics-predicate []
+              (let [metric-group-gauges (-> waiter-url statsd-state :state :gauge metric-group-keyword)]
+                (log/info metric-group "counts gauges:" metric-group-gauges)
+                (every? #(contains? metric-group-gauges %)
+                        [:cpus :instances.failed :instances.healthy :instances.unhealthy :mem])))
+            :interval 1 :timeout (* 2 (quot sync-instances-interval-ms 1000)))))
+      (delete-service waiter-url service-id))))
+
 (deftest ^:parallel ^:integration-fast test-statsd-disabled
   (testing-using-waiter-url
     (if (statsd-enabled? waiter-url)

--- a/waiter/integration/waiter/statsd_support_test.clj
+++ b/waiter/integration/waiter/statsd_support_test.clj
@@ -50,7 +50,8 @@
                 (log/info metric-group "counts gauges:" metric-group-gauges)
                 (every? #(contains? metric-group-gauges %)
                         [:cpus :instances.failed :instances.healthy :instances.unhealthy :mem])))
-            :interval 1 :timeout (* 2 (quot sync-instances-interval-ms 1000)))))
+            :interval 1
+            :timeout (-> sync-instances-interval-ms (quot 1000) (* 2)))))
       (delete-service waiter-url service-id))))
 
 (deftest ^:parallel ^:integration-fast test-statsd-disabled

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -137,7 +137,8 @@
                                        (s/required-key :host) schema/non-empty-string
                                        (s/required-key :port) schema/positive-int
                                        (s/required-key :publish-interval-ms) schema/positive-int
-                                       (s/required-key :server) schema/non-empty-string})
+                                       (s/required-key :server) schema/non-empty-string
+                                       (s/required-key :sync-instances-interval-ms) schema/positive-int})
    (s/required-key :support-info) [{(s/required-key :label) schema/non-empty-string
                                     (s/required-key :link) {(s/required-key :type) s/Keyword
                                                             (s/required-key :value) schema/non-empty-string}}]

--- a/waiter/src/waiter/statsd.clj
+++ b/waiter/src/waiter/statsd.clj
@@ -360,7 +360,7 @@
                 (gauge! metric-group "mem" mem))
               metric-group->counts)))
 
-(defn process-service-instance-state
+(defn merge-service-state
   "Merges the current map of resources by metric group with service data from a router state update message."
   [service-id->service-description-fn service-id healthy-instances unhealthy-instances failed-instances
    metric-group->counts]
@@ -396,7 +396,7 @@
             healthy-instances (get service-id->healthy-instances service-id)
             unhealthy-instances (get service-id->unhealthy-instances service-id)]
         (recur remaining-service-ids
-               (process-service-instance-state
+               (merge-service-state
                  service-id->service-description-fn service-id healthy-instances unhealthy-instances failed-instances
                  metric-group->counts))))))
 

--- a/waiter/src/waiter/statsd.clj
+++ b/waiter/src/waiter/statsd.clj
@@ -348,22 +348,22 @@
               {}
               @aggregation-agent))))
 
-(defn publish-instance-counts-by-metric-group
-  "Publishes a gauge for  the number healthy, unhealthy, and failed
-  instances corresponding to each metric group in the provided map"
-  [counts-by-metric-group]
+(defn publish-metric-group->counts
+  "Publishes a gauge for the number of cpus, mem, healthy instances, unhealthy instances, and
+   failed instances corresponding to each metric group in the provided map."
+  [metric-group->counts]
   (dorun (map (fn [[metric-group {:keys [healthy-instances unhealthy-instances failed-instances cpus mem]}]]
                 (gauge! metric-group "instances.healthy" healthy-instances)
                 (gauge! metric-group "instances.unhealthy" unhealthy-instances)
                 (gauge! metric-group "instances.failed" failed-instances)
                 (gauge! metric-group "cpus" cpus)
                 (gauge! metric-group "mem" mem))
-              counts-by-metric-group)))
+              metric-group->counts)))
 
-(defn process-update-service-instances-message
-  "Merges the current map of resources by metric group with data from a :update-service-instances scheduler message"
-  [counts-by-metric-group {:keys [service-id healthy-instances unhealthy-instances failed-instances] :as message-data}
-   service-id->service-description-fn]
+(defn process-service-instance-state
+  "Merges the current map of resources by metric group with service data from a router state update message."
+  [service-id->service-description-fn service-id healthy-instances unhealthy-instances failed-instances
+   metric-group->counts]
   (try
     (if-let [{:strs [metric-group cpus mem]} (service-id->service-description-fn service-id)]
       (let [healthy (count healthy-instances)
@@ -375,53 +375,51 @@
                     :failed-instances failed
                     :cpus (* active (or cpus 0))
                     :mem (* active (or mem 0))}]
-        (merge-with #(merge-with + %1 %2) counts-by-metric-group {metric-group counts}))
+        (merge-with #(merge-with + %1 %2) metric-group->counts {metric-group counts}))
       (do
-        (log/warn "No service description found for service id" service-id)
-        counts-by-metric-group))
+        (log/warn "no service description found for service id" service-id)
+        metric-group->counts))
     (catch Throwable e
-      (log/error e "Error processing update-service-instances message" message-data)
-      counts-by-metric-group)))
+      (log/error e "error processing service metrics for" service-id)
+      metric-group->counts)))
 
-(defn scheduler-messages->instance-counts-by-metric-group
-  "Converts messages from the scheduler to a map of metric-group -> [healthy unhealthy failed],
-  where each element in the array is the count of instances in that metric group with that status"
-  [messages service-id->service-description-fn]
-  (loop [[[message-type message-data] & remaining] messages
-         counts-by-metric-group {}]
-    (let [counts-by-metric-group'
-          (cond-> counts-by-metric-group
-                  (= message-type :update-service-instances)
-                  (process-update-service-instances-message message-data service-id->service-description-fn))]
-      (if (some? remaining)
-        (recur remaining counts-by-metric-group')
-        counts-by-metric-group'))))
+(defn router-state->metric-group->counts
+  "Converts messages from the router state update to a map of metric-group -> [healthy unhealthy failed],
+   where each element in the array is the count of instances in that metric group with that status."
+  [service-id->service-description-fn
+   {:keys [all-available-service-ids service-id->failed-instances service-id->healthy-instances service-id->unhealthy-instances]}]
+  (loop [[service-id & remaining-service-ids] (seq all-available-service-ids)
+         metric-group->counts {}]
+    (if-not service-id
+      metric-group->counts
+      (let [failed-instances (get service-id->failed-instances service-id)
+            healthy-instances (get service-id->healthy-instances service-id)
+            unhealthy-instances (get service-id->unhealthy-instances service-id)]
+        (recur remaining-service-ids
+               (process-service-instance-state
+                 service-id->service-description-fn service-id healthy-instances unhealthy-instances failed-instances
+                 metric-group->counts))))))
 
-(defn process-scheduler-messages
+(defn process-router-state
   "Publishes all gauges produced from the provided scheduler messages"
-  [messages service-id->service-description-fn]
+  [router-state service-id->service-description-fn]
   (try
-    (->
-      messages
-      (scheduler-messages->instance-counts-by-metric-group service-id->service-description-fn)
-      (publish-instance-counts-by-metric-group))
+    (->> router-state
+         (router-state->metric-group->counts service-id->service-description-fn)
+         publish-metric-group->counts)
     (catch Throwable e
-      (log/error e "Error processing scheduler messages"))))
+      (log/error e "error processing router state"))))
 
-(defn start-scheduler-metrics-publisher
-  "Go loop to continuously publish stats based on scheduler messages"
-  [scheduler-state-chan exit-chan service-id->service-description-fn]
-  (log/info "Starting scheduler-metrics-publisher")
-  (async/go-loop []
-    (let [continue
-          (async/alt!
-            exit-chan
-            ([_] false)
-
-            scheduler-state-chan
-            ([messages]
-              (process-scheduler-messages messages service-id->service-description-fn)
-              true))]
-      (if continue
-        (recur)
-        (log/info "Stopping scheduler-metrics-publisher")))))
+(defn start-service-instance-metrics-publisher
+  "Go loop to continuously publish stats based on router state updates."
+  [service-id->service-description-fn query-state-fn sync-instances-interval-ms]
+  (log/info "service-instance-metrics-publisher starting")
+  (let [cancel-fn (du/start-timer-task
+                    (t/millis sync-instances-interval-ms)
+                    (fn run-instance-metrics-publisher []
+                      (log/info "service-instance-metrics-publisher publishing router state")
+                      (-> (query-state-fn)
+                          (process-router-state service-id->service-description-fn))))]
+    (fn cancel-instance-metrics-publisher []
+      (log/info "service-instance-metrics-publisher stopping")
+      (cancel-fn))))

--- a/waiter/src/waiter/statsd.clj
+++ b/waiter/src/waiter/statsd.clj
@@ -411,7 +411,8 @@
       (log/error e "error processing router state"))))
 
 (defn start-service-instance-metrics-publisher
-  "Go loop to continuously publish stats based on router state updates."
+  "Launches a timer task, running at intervals of sync-instances-interval-ms milliseconds,
+   to continuously publish stats based on router state updates."
   [service-id->service-description-fn query-state-fn sync-instances-interval-ms]
   (log/info "service-instance-metrics-publisher starting")
   (let [cancel-fn (du/start-timer-task

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -416,7 +416,7 @@
     (try-parse-json state-body)))
 
 (defn fallback-state
-  "Fetches and returns the statsd state."
+  "Fetches and returns the fallback state."
   [waiter-url & {:keys [cookies] :or {cookies {}}}]
   (retrieve-state-helper waiter-url "/state/fallback" :cookies cookies))
 

--- a/waiter/test/waiter/statsd_test.clj
+++ b/waiter/test/waiter/statsd_test.clj
@@ -68,45 +68,54 @@
 
 (deftest test-start-scheduler-metrics-publisher
   (testing "Scheduler metrics publishing loop"
-    (testing "should terminate via exit channel"
-      (let [exit-chan (async/chan 1)
-            return-chan (statsd/start-scheduler-metrics-publisher (async/chan) exit-chan nil)]
-        (is (async/>!! exit-chan :foo))
-        (async/alt!!
-          return-chan
-          ([returned] (is (nil? returned)))
+    (testing "should terminate via cancel call"
+      (let [service-id->service-description-fn (constantly {})
+            query-state-call-counter (atom 0)
+            query-call-started (promise)
+            cancel-triggered (promise)
+            query-state-fn (fn []
+                             (swap! query-state-call-counter inc)
+                             (deliver query-call-started :called)
+                             {:call-count @query-state-call-counter
+                              :cancel-triggered (deref cancel-triggered 1000 :not-called)})
+            sync-instances-interval-ms 10
+            cancel-fn (statsd/start-service-instance-metrics-publisher
+                        service-id->service-description-fn query-state-fn sync-instances-interval-ms)]
+        (is (= :called (deref query-call-started 1000 :not-called)))
+        (is (= 1 @query-state-call-counter))
+        (cancel-fn)
+        (deliver cancel-triggered :called)
+        (is (= {:call-count 2
+                :cancel-triggered :called}
+               (query-state-fn)))
+        ;; since publisher has been cancelled, we should not have any intervening calls to query state
+        (Thread/sleep (* 2 sync-instances-interval-ms))
+        (is (= {:call-count 3
+                :cancel-triggered :called}
+               (query-state-fn)))))))
 
-          (async/timeout 1000)
-          ([_] (throw (Exception. "Timed out waiting for publisher to terminate"))))))))
-
-(deftest test-scheduler-messages->instance-counts-by-metric-group
+(deftest test-router-state->metric-group->counts
   (testing "Conversion of scheduler messages to instance counts by metric group"
     (testing "should produce aggregate instance counts by metric group"
-      (let [messages [[:update-available-services {}]
-                      [:update-service-instances {:service-id :fee
-                                                  :healthy-instances [:i]
-                                                  :unhealthy-instances [:i :i]
-                                                  :failed-instances [:i :i :i]}]
-                      [:update-service-instances {:service-id :fie
-                                                  :healthy-instances [:i]
-                                                  :unhealthy-instances [:i :i]
-                                                  :failed-instances [:i :i :i]}]
-                      [:update-service-instances {:service-id :foe
-                                                  :healthy-instances [:i :i :i]
-                                                  :unhealthy-instances [:i :i :i]
-                                                  :failed-instances [:i :i :i]}]
-                      [:update-service-instances {:service-id :fum
-                                                  :healthy-instances [:i :i :i]
-                                                  :unhealthy-instances [:i :i :i]
-                                                  :failed-instances [:i :i :i]}]
-                      [:update-service-instances {:service-id :qux
-                                                  :healthy-instances [:i :i :i]
-                                                  :unhealthy-instances [:i :i :i]
-                                                  :failed-instances [:i :i :i]}]
-                      [:update-service-instances {:service-id :eek
-                                                  :healthy-instances [:i]
-                                                  :unhealthy-instances [:i :i]
-                                                  :failed-instances [:i :i :i]}]]
+      (let [router-state {:all-available-service-ids #{:eek :fee :fie :foe :fum :qux}
+                          :service-id->failed-instances {:eek [:i :i :i]
+                                                         :fee [:i :i :i]
+                                                         :fie [:i :i :i]
+                                                         :foe [:i :i :i]
+                                                         :fum [:i :i :i]
+                                                         :qux [:i :i :i]}
+                          :service-id->healthy-instances {:eek [:i]
+                                                          :fee [:i]
+                                                          :fie [:i]
+                                                          :foe [:i :i :i]
+                                                          :fum [:i :i :i]
+                                                          :qux [:i :i :i]}
+                          :service-id->unhealthy-instances {:eek [:i :i]
+                                                            :fee [:i :i]
+                                                            :fie [:i :i]
+                                                            :foe [:i :i :i]
+                                                            :fum [:i :i :i]
+                                                            :qux [:i :i :i]}}
             service-id->service-description #(% {:fee {"metric-group" "foo", "cpus" 0.1, "mem" 128}
                                                  :fie {"metric-group" "bar", "cpus" 0.2, "mem" 256}
                                                  :foe {"metric-group" "bar", "cpus" 0.4, "mem" 512}
@@ -128,44 +137,45 @@
                        :failed-instances 9
                        :cpus (+ (* 6 0.8) (* 6 1.6) (* 3 3.2))
                        :mem 30720}}
-               (statsd/scheduler-messages->instance-counts-by-metric-group messages service-id->service-description)))))
+               (statsd/router-state->metric-group->counts service-id->service-description router-state)))))
 
     (testing "should be resilient to empty service description"
       (is (= {nil {:healthy-instances 1, :unhealthy-instances 2, :failed-instances 3, :cpus 0, :mem 0}}
-             (statsd/scheduler-messages->instance-counts-by-metric-group
-               [[:update-service-instances {:service-id :fee
-                                            :healthy-instances [:i]
-                                            :unhealthy-instances [:i :i]
-                                            :failed-instances [:i :i :i]}]]
-               (constantly {})))))))
+             (statsd/router-state->metric-group->counts
+               (constantly {})
+               {:all-available-service-ids #{:fee}
+                :service-id->failed-instances {:fee [:i :i :i]}
+                :service-id->healthy-instances {:fee [:i]}
+                :service-id->unhealthy-instances {:fee [:i :i]}}))))))
 
-(deftest test-process-update-service-instances-message
+(deftest test-process-service-instance-state
   (testing "Processing of an :update-service-instances scheduler message"
 
     (testing "should not let exceptions bubble out"
-      (let [misbehaving-fn (fn [_] (throw (Exception. "I'm misbehaving")))]
-        (is (= {} (statsd/process-update-service-instances-message {} {} misbehaving-fn)))
+      (let [misbehaving-fn (fn [_] (throw (Exception. "I'm misbehaving")))
+            healthy-instances [:i]
+            unhealthy-instances [:i :i]
+            failed-instances [:i :i :i]]
+        (is (= {} (statsd/process-service-instance-state
+                    misbehaving-fn "foo" healthy-instances unhealthy-instances failed-instances {})))
         (is (= {"foo" {:healthy-instances 1, :unhealthy-instances 2, :failed-instances 3, :cpus 0.5, :mem 384}}
-               (statsd/process-update-service-instances-message
-                 {"foo" {:healthy-instances 1, :unhealthy-instances 2, :failed-instances 3, :cpus 0.5, :mem 384}}
-                 {:service-id "bar"}
-                 misbehaving-fn)))))
+               (statsd/process-service-instance-state
+                 misbehaving-fn "bar" healthy-instances unhealthy-instances failed-instances
+                 {"foo" {:healthy-instances 1, :unhealthy-instances 2, :failed-instances 3, :cpus 0.5, :mem 384}})))))
 
     (testing "should not include instance counts when service description is nil"
-      (is (= {} (statsd/process-update-service-instances-message {}
-                                                                 {:service-id :fee
-                                                                  :healthy-instances [:i]
-                                                                  :unhealthy-instances [:i :i]
-                                                                  :failed-instances [:i :i :i]}
-                                                                 (constantly nil)))))))
+      (is (= {} (statsd/process-service-instance-state
+                  (constantly nil)
+                  "fee" [:i] [:i :i] [:i :i :i]
+                  {}))))))
 
-(deftest test-process-scheduler-messages
-  (testing "Processing a batch of scheduler messages"
+(deftest test-process-router-state
+  (testing "Processing a batch of router-state messages"
     (testing "should not let exceptions bubble out"
-      (with-redefs [statsd/publish-instance-counts-by-metric-group (fn [_] (throw (Exception. "I'm misbehaving")))]
-        (statsd/process-scheduler-messages [] (constantly {}))))))
+      (with-redefs [statsd/publish-metric-group->counts (fn [_] (throw (Exception. "I'm misbehaving")))]
+        (is (nil? (statsd/process-router-state (constantly {}) {})))))))
 
-(deftest test-publish-instance-counts-by-metric-group
+(deftest test-publish-instance-metric-group->counts
   (testing "Publishing instance counts"
     (testing "should send a gauge for each of healthy, unhealthy, failed"
       (teardown-setup)
@@ -173,21 +183,21 @@
         (with-redefs [statsd/add-value (fn [_ metric-group metric value metric-type]
                                          (swap! metrics #(conj %1 [metric-group metric value metric-type]))
                                          {})]
-          (statsd/publish-instance-counts-by-metric-group {"foo" {:healthy-instances 1
-                                                                  :unhealthy-instances 2
-                                                                  :failed-instances 3
-                                                                  :cpus (* 3 0.1)
-                                                                  :mem 384}
-                                                           "bar" {:healthy-instances 4
-                                                                  :unhealthy-instances 5
-                                                                  :failed-instances 6
-                                                                  :cpus (+ (* 3 0.2) (* 6 0.4))
-                                                                  :mem 3840}
-                                                           "baz" {:healthy-instances 7
-                                                                  :unhealthy-instances 8
-                                                                  :failed-instances 9
-                                                                  :cpus (+ (* 6 0.8) (* 6 1.6) (* 3 3.2))
-                                                                  :mem 30720}}))
+          (statsd/publish-metric-group->counts {"foo" {:healthy-instances 1
+                                                       :unhealthy-instances 2
+                                                       :failed-instances 3
+                                                       :cpus (* 3 0.1)
+                                                       :mem 384}
+                                                "bar" {:healthy-instances 4
+                                                       :unhealthy-instances 5
+                                                       :failed-instances 6
+                                                       :cpus (+ (* 3 0.2) (* 6 0.4))
+                                                       :mem 3840}
+                                                "baz" {:healthy-instances 7
+                                                       :unhealthy-instances 8
+                                                       :failed-instances 9
+                                                       :cpus (+ (* 6 0.8) (* 6 1.6) (* 3 3.2))
+                                                       :mem 30720}}))
         (statsd/drain)
         (is (= 15 (count @metrics)))
         (is (= ["foo" "instances.healthy" 1 statsd/gauge-metric] (nth @metrics 0)))

--- a/waiter/test/waiter/statsd_test.clj
+++ b/waiter/test/waiter/statsd_test.clj
@@ -148,7 +148,7 @@
                 :service-id->healthy-instances {:fee [:i]}
                 :service-id->unhealthy-instances {:fee [:i :i]}}))))))
 
-(deftest test-process-service-instance-state
+(deftest test-merge-service-state
   (testing "Processing of an :update-service-instances scheduler message"
 
     (testing "should not let exceptions bubble out"
@@ -156,15 +156,15 @@
             healthy-instances [:i]
             unhealthy-instances [:i :i]
             failed-instances [:i :i :i]]
-        (is (= {} (statsd/process-service-instance-state
+        (is (= {} (statsd/merge-service-state
                     misbehaving-fn "foo" healthy-instances unhealthy-instances failed-instances {})))
         (is (= {"foo" {:healthy-instances 1, :unhealthy-instances 2, :failed-instances 3, :cpus 0.5, :mem 384}}
-               (statsd/process-service-instance-state
+               (statsd/merge-service-state
                  misbehaving-fn "bar" healthy-instances unhealthy-instances failed-instances
                  {"foo" {:healthy-instances 1, :unhealthy-instances 2, :failed-instances 3, :cpus 0.5, :mem 384}})))))
 
     (testing "should not include instance counts when service description is nil"
-      (is (= {} (statsd/process-service-instance-state
+      (is (= {} (statsd/merge-service-state
                   (constantly nil)
                   "fee" [:i] [:i :i] [:i :i :i]
                   {}))))))


### PR DESCRIPTION
## Changes proposed in this PR

- uses messages from router-state-maintainer instead of scheduler-syncer for statsd metric group 
- integration tests for metric group gauges

## Why are we making these changes?

Two goals:
1. Avoid using go-blocks to read daemon states.
2. Enable a future where the router state is obtained from the maintainer instead of from the scheduler syncer.
