### PR TITLE
makes fallback maintainer rely on router-state-maintainer state updates

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -860,10 +860,10 @@
                                     quanta-constraints scaling-timeout-config))
                                 {}))
    :fallback-maintainer (pc/fnk [[:state fallback-state-atom]
-                                 scheduler-maintainer]
-                          (let [scheduler-state-mult-chan (:scheduler-state-mult-chan scheduler-maintainer)
-                                scheduler-state-chan (async/tap scheduler-state-mult-chan (au/latest-chan))]
-                            (descriptor/fallback-maintainer scheduler-state-chan fallback-state-atom)))
+                                 router-state-maintainer]
+                          (let [{{:keys [router-state-push-mult]} :maintainer} router-state-maintainer
+                                router-state-chan (async/tap router-state-push-mult (au/latest-chan))]
+                            (descriptor/fallback-maintainer router-state-chan fallback-state-atom)))
    :gc-for-transient-metrics (pc/fnk [[:routines router-metrics-helpers]
                                       [:settings metrics-config]
                                       [:state clock local-usage-agent]


### PR DESCRIPTION
## Changes proposed in this PR

- makes fallback maintainer rely on router-state-maintainer state updates

## Why are we making these changes?

Enable a state where the router state is obtained from the maintainer instead of from the scheduler syncer.

