### PR TITLE
makes interstitial maintainer rely on router-state-maintainer state updates

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -881,12 +881,12 @@
                                  metrics-gc-chans))
    :interstitial-maintainer (pc/fnk [[:routines service-id->service-description-fn]
                                      [:state interstitial-state-atom]
-                                     scheduler-maintainer]
-                              (let [scheduler-state-mult-chan (:scheduler-state-mult-chan scheduler-maintainer)
-                                    scheduler-state-chan (async/tap scheduler-state-mult-chan (au/latest-chan))
+                                     router-state-maintainer]
+                              (let [{{:keys [router-state-push-mult]} :maintainer} router-state-maintainer
+                                    router-state-chan (async/tap router-state-push-mult (au/latest-chan))
                                     initial-state {}]
                                 (interstitial/interstitial-maintainer
-                                  service-id->service-description-fn scheduler-state-chan interstitial-state-atom initial-state)))
+                                  service-id->service-description-fn router-state-chan interstitial-state-atom initial-state)))
    :launch-metrics-maintainer (pc/fnk [[:curator leader?-fn]
                                        [:routines service-id->service-description-fn]
                                        router-state-maintainer]


### PR DESCRIPTION
## Changes proposed in this PR

- makes interstitial maintainer rely on router-state-maintainer state updates

## Why are we making these changes?

Enable a state where the router state is obtained from the maintainer instead of from the scheduler syncer.


