### PR TITLE
Preserve keyword namespace on /apps endpoint

### DIFF
--- a/waiter/integration/waiter/new_app_test.clj
+++ b/waiter/integration/waiter/new_app_test.clj
@@ -16,7 +16,8 @@
 (ns waiter.new-app-test
   (:require [clojure.test :refer :all]
             [clojure.tools.logging :as log]
-            [waiter.util.client-tools :refer :all]))
+            [waiter.util.client-tools :refer :all]
+            [waiter.util.utils :as utils]))
 
 (deftest ^:parallel ^:integration-fast test-new-app
   (testing-using-waiter-url
@@ -37,7 +38,7 @@
             (is (= 1 (get-in settings [:state :autoscaler-state :healthy-instances])) (str settings))))
 
         (testing "service state with invalid service-id"
-          (let [settings (service-state router-endpoint (str "invalid-" service-id) :cookies cookies)]
+          (let [settings (utils/deep-sort-map (service-state router-endpoint (str "invalid-" service-id) :cookies cookies))]
             (is (= router-id (get settings :router-id)) (str settings))
             (is (not (get-in settings [:state :app-maintainer-state :maintainer-chan-available])) (str settings))
             (is (empty? (get-in settings [:state :autoscaler-state])) (str settings)))))

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -498,7 +498,7 @@
                                        (not show-metadata)
                                        (dissoc :deleted :etag)))))))
                   flatten
-                  utils/map->streaming-json-response))
+                  utils/clj->streaming-json-response))
       (throw (ex-info "Only GET supported" {:request-method request-method
                                             :status 405})))
     (catch Exception ex

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -162,7 +162,7 @@
    :status status
    :headers (assoc headers "content-type" "application/json")})
 
-(defn map->streaming-json-response
+(defn clj->streaming-json-response
   "Converts the data into a json response which can be streamed back to the client."
   [data-map & {:keys [status] :or {status 200}}]
   (let [data-map (doall data-map)]
@@ -171,7 +171,12 @@
      :body (fn [^ServletResponse resp]
              (let [writer (OutputStreamWriter. (.getOutputStream resp))]
                (try
-                 (json/write data-map writer :key-fn stringify-keys :value-fn stringify-elements)
+                 (json/write
+                   data-map
+                   writer
+                   :escape-slash false
+                   :key-fn stringify-keys
+                   :value-fn stringify-elements)
                  (catch Exception e
                    (log/error e "Exception creating streaming json response")
                    (throw e))

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -513,7 +513,9 @@
                                          "host" "10.141.141.11"
                                          "log-url" "http://www.example.com/apps/test-service-1/logs?instance-id=test-service-1.A&host=10.141.141.11"
                                          "port" 31045,
-                                         "started-at" (du/date-to-str started-time du/formatter-iso8601)}]}))
+                                         "started-at" (du/date-to-str started-time du/formatter-iso8601)}]
+                    "failed-instances" nil
+                    "killed-instances" nil}))
             (is (= (get body-json "metrics")
                    {"aggregate" {"routers-sent-requests-to" 0}}))
             (is (= (get body-json "num-active-instances") 1))

--- a/waiter/test/waiter/util/utils_test.clj
+++ b/waiter/test/waiter/util/utils_test.clj
@@ -122,26 +122,26 @@
       (is (= (json/write-str {"bar" ["foo" "baz"]}) (:body (clj->json-response {:bar ["foo" #"baz"]}))))
       (is (= (json/write-str {"bar" [["foo" "baz"]]}) (:body (clj->json-response {:bar [["foo" #"baz"]]})))))))
 
-(deftest test-map->streaming-json-response
+(deftest test-clj->streaming-json-response
   (testing "convert empty map"
-    (let [{:keys [body headers status]} (map->streaming-json-response {})]
+    (let [{:keys [body headers status]} (clj->streaming-json-response {})]
       (is (= 200 status))
       (is (= {"content-type" "application/json"} headers))
       (is (= {} (json/read-str (json-response->str body))))))
   (testing "consumes status argument"
-    (let [{:keys [status]} (map->streaming-json-response {} :status 404)]
+    (let [{:keys [status]} (clj->streaming-json-response {} :status 404)]
       (is (= status 404))))
   (testing "converts regex patters to strings"
     (is (= {"foo" ["bar"]}
            (-> {:foo [#"bar"]}
-               map->streaming-json-response
+               clj->streaming-json-response
                :body
                json-response->str
                json/read-str))))
   (testing "converts namespaced keywords"
     (is (= {"foo/bar" "fuu/baz"}
            (-> {:foo/bar :fuu/baz}
-               map->streaming-json-response
+               clj->streaming-json-response
                :body
                json-response->str
                json/read-str)))))


### PR DESCRIPTION
## Changes proposed in this PR

- Rename `utils/map->streaming-json-response` → `utils/clj->streaming-json-response`
- Don't call `walk/stringify-keys` on the `/apps` endpoint, since the utility function does the conversion for us, and because `walk/stringify-keys` drops the keyword namespaces.

## Why are we making these changes?

Same reasons as #406, but I missed a few spots last time.
