### PR TITLE
Cook scheduler error logging

### DIFF
--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -142,6 +142,7 @@
     (let [{:strs [backend-proto cmd cmd-type cpus health-check-url instance-expiry-mins mem name ports
                   run-as-user version]} service-description
           job-uuid (str (UUID/randomUUID)) ;; TODO Use "less random" UUIDs for better Cook cache performance.
+          _ (log/info "creating a new job for" service-id "with uuid" job-uuid)
           home-path (str home-path-prefix run-as-user)
           environment (scheduler/environment service-id service-description service-id->password-fn home-path)
           container-mode? (= "docker" cmd-type)
@@ -194,7 +195,6 @@
   "Create and start a new Cook job specified by the service-description."
   [cook-api service-id service-description service-id->password-fn home-path-prefix instance-priority
    backend-port]
-  (log/info "creating a new job for" service-id)
   (->> (create-job-description service-id service-description service-id->password-fn home-path-prefix
                                instance-priority backend-port)
        (post-jobs cook-api)))

--- a/waiter/src/waiter/util/http_utils.clj
+++ b/waiter/src/waiter/util/http_utils.clj
@@ -45,7 +45,7 @@
         {:keys [error status] :as response} (async/<!! raw-response)]
     (when error
       (throw error))
-    (let [response (assoc response :body async/<!!)]
+    (let [response (update response :body async/<!!)]
       (when (and throw-exceptions (not (<= 200 status 299)))
         (ss/throw+ response))
       (let [{:keys [body]} response]

--- a/waiter/src/waiter/util/http_utils.clj
+++ b/waiter/src/waiter/util/http_utils.clj
@@ -45,15 +45,16 @@
         {:keys [error status] :as response} (async/<!! raw-response)]
     (when error
       (throw error))
-    (when (and throw-exceptions (not (<= 200 status 299)))
-      (ss/throw+ response))
-    (let [response-body (-> response :body async/<!!)]
-      (try
-        (cond-> response-body
-          (not-empty response-body)
-          (-> json/read-str walk/keywordize-keys))
-        (catch Exception _
-          response-body)))))
+    (let [response (assoc response :body async/<!!)]
+      (when (and throw-exceptions (not (<= 200 status 299)))
+        (ss/throw+ response))
+      (let [{:keys [body]} response]
+        (try
+          (cond-> body
+            (not-empty body)
+            (-> json/read-str walk/keywordize-keys))
+          (catch Exception _
+            body))))))
 
 (defn ^HttpClient http-client-factory
   "Creates a HttpClient."

--- a/waiter/test/waiter/util/http_utils_test.clj
+++ b/waiter/test/waiter/util/http_utils_test.clj
@@ -63,7 +63,11 @@
       (with-redefs [http/request (constantly
                                    (let [response-chan (async/promise-chan)
                                          body-chan (async/promise-chan)]
-                                     (async/>!! body-chan (utils/clj->json {}))
+                                     (async/>!! body-chan (utils/clj->json {:error :response}))
                                      (async/>!! response-chan {:body body-chan, :status 400})
                                      response-chan))]
-        (is (thrown? ExceptionInfo (http-request http-client "some-url")))))))
+        (try
+          (http-request http-client "some-url")
+          (is false "exception not thrown")
+          (catch ExceptionInfo ex
+            (is (= {:body "{\"error\":\"response\"}" :status 400} (ex-data ex)))))))))


### PR DESCRIPTION
## Changes proposed in this PR

- includes response body in thrown exception
- includes job uuid in log statement while creating cook job

## Why are we making these changes?

Improves Cook error logging.
