### PR TITLE
uses image label as version string in cook scheduler

### DIFF
--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -160,7 +160,7 @@
             (log/info "container support enabled" container-data)
             (throw (ex-info "to use container support format version as namespace/name:label" container-data)))))
       {:jobs [(cond-> {:application {:name name
-                                     :version version}
+                                     :version (if image-label image-label version)}
                        :command cmd
                        :cpus cpus
                        :disable-mea-culpa-retries true

--- a/waiter/test/waiter/scheduler/cook_test.clj
+++ b/waiter/test/waiter/scheduler/cook_test.clj
@@ -325,7 +325,7 @@
             job-uuid (-> actual :jobs first :uuid)
             expected {:jobs [(assoc expected-job
                                :application {:name "test-service"
-                                             :version "foo/bar:baz"}
+                                             :version "baz"}
                                :container {:docker {:force-pull-image false
                                                     :image "namespace:foo,name:bar,label:baz"
                                                     :network "HOST"}


### PR DESCRIPTION
## Changes proposed in this PR

- uses image label as version string in cook scheduler

## Why are we making these changes?

Cook requires the version string to not contain `/` and `:`.

