### PR TITLE
adds support for naming schedulers

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -613,11 +613,13 @@
                        service-id->password-fn*
                        service-id->service-description-fn*]
                 (let [is-waiter-app?-fn (fn is-waiter-app? [^String service-id]
-                                          (str/starts-with? service-id service-id-prefix))]
-                  (utils/create-component scheduler-config :context {:is-waiter-app?-fn is-waiter-app?-fn
-                                                                     :leader?-fn leader?-fn
-                                                                     :service-id->password-fn service-id->password-fn*
-                                                                     :service-id->service-description-fn service-id->service-description-fn*})))
+                                          (str/starts-with? service-id service-id-prefix))
+                      scheduler-context {:is-waiter-app?-fn is-waiter-app?-fn
+                                         :leader?-fn leader?-fn
+                                         :service-id->password-fn service-id->password-fn*
+                                         :service-id->service-description-fn service-id->service-description-fn*}]
+                  (-> (utils/create-component scheduler-config :context scheduler-context)
+                      (scheduler/attach-name (-> scheduler-config :kind name)))))
    ; This function is only included here for initializing the scheduler above.
    ; Prefer accessing the non-starred version of this function through the routines map.
    :service-id->password-fn* (pc/fnk [[:state passwords]]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -619,7 +619,7 @@
                                          :service-id->password-fn service-id->password-fn*
                                          :service-id->service-description-fn service-id->service-description-fn*}]
                   (-> (utils/create-component scheduler-config :context scheduler-context)
-                      (scheduler/attach-name (-> scheduler-config :kind name)))))
+                      (scheduler/attach-name (-> scheduler-config :kind utils/keyword->str)))))
    ; This function is only included here for initializing the scheduler above.
    ; Prefer accessing the non-starred version of this function through the routines map.
    :service-id->password-fn* (pc/fnk [[:state passwords]]

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -73,7 +73,7 @@
 (defn make-ServiceInstance [value-map]
   (map->ServiceInstance (merge {:extra-ports [] :flags #{}} value-map)))
 
-(let [name-key :waiter/scheduler-name]
+(let [name-key :waiter.scheduler/name]
   (defn attach-name
     "Attaches the name metadata to the scheduler."
     [scheduler scheduler-name]

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -73,6 +73,18 @@
 (defn make-ServiceInstance [value-map]
   (map->ServiceInstance (merge {:extra-ports [] :flags #{}} value-map)))
 
+(let [name-key :waiter/scheduler-name]
+  (defn attach-name
+    "Attaches the name metadata to the scheduler."
+    [scheduler scheduler-name]
+    {:pre [(not (str/blank? scheduler-name))]}
+    (vary-meta scheduler assoc name-key scheduler-name))
+
+  (defn scheduler->name
+    "Retrieves the scheduler name."
+    [scheduler]
+    (some-> scheduler meta name-key)))
+
 (defprotocol ServiceScheduler
 
   (get-service->instances [this]
@@ -451,7 +463,7 @@
   (let [^DateTime request-apps-time (t/now)
         timing-message-fn (fn [] (let [^DateTime now (t/now)]
                                    (str "scheduler-syncer: sync took " (- (.getMillis now) (.getMillis request-apps-time)) " ms")))]
-    (log/trace "scheduler-syncer: querying scheduler")
+    (log/trace "scheduler-syncer: querying" (scheduler->name scheduler) "scheduler")
     (if-let [service->service-instances (timers/start-stop-time!
                                           (metrics/waiter-timer "core" "scheduler" "app->available-tasks")
                                           (do-health-checks (request-available-waiter-apps scheduler)
@@ -460,14 +472,16 @@
                                                             service-id->service-description-fn))]
       (let [available-services (keys service->service-instances)
             available-service-ids (->> available-services (map :id) (set))]
-        (log/debug "scheduler-syncer:" (count service->service-instances) "available services:" available-service-ids)
+        (log/debug "scheduler-syncer:" (scheduler->name scheduler) "scheduler has" (count service->service-instances)
+                   "available services:" available-service-ids)
         (doseq [service available-services]
           (when (->> (select-keys (:task-stats service) [:staged :running :healthy :unhealthy])
                      vals
                      (filter number?)
                      (reduce + 0)
                      zero?)
-            (log/info "scheduler-syncer:" (:id service) "has no live instances!" (:task-stats service))))
+            (log/info "scheduler-syncer:" (:id service) "in" (scheduler->name scheduler) "scheduler"
+                      "has no live instances!" (:task-stats service))))
         (loop [service-id->health-check-context' {}
                healthy-service-ids #{}
                scheduler-messages []

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -73,17 +73,16 @@
 (defn make-ServiceInstance [value-map]
   (map->ServiceInstance (merge {:extra-ports [] :flags #{}} value-map)))
 
-(let [name-key :waiter.scheduler/name]
-  (defn attach-name
-    "Attaches the name metadata to the scheduler."
-    [scheduler scheduler-name]
-    {:pre [(not (str/blank? scheduler-name))]}
-    (vary-meta scheduler assoc name-key scheduler-name))
+(defn attach-name
+  "Attaches the name metadata to the scheduler."
+  [scheduler scheduler-name]
+  {:pre [(not (str/blank? scheduler-name))]}
+  (vary-meta scheduler assoc ::name scheduler-name))
 
-  (defn scheduler->name
-    "Retrieves the scheduler name."
-    [scheduler]
-    (some-> scheduler meta name-key)))
+(defn scheduler->name
+  "Retrieves the scheduler name."
+  [scheduler]
+  (some-> scheduler meta ::name))
 
 (defprotocol ServiceScheduler
 

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -118,7 +118,7 @@
     (log/debug "generate-secret-word" [src-id dest-id] "->" secret-word)
     secret-word))
 
-(defn- keyword->str
+(defn keyword->str
   "Converts keyword to string including the namespace."
   [k]
   (str (.-sym k)))

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -806,10 +806,5 @@
           (is (= expected-state-2 actual-state-2)))))))
 
 (deftest test-scheduler-naming
-  (let [scheduler (reify ServiceScheduler)]
-    (is (nil? (scheduler->name scheduler)))
-    (let [scheduler (attach-name scheduler "foo")]
-      (is (= "foo" (scheduler->name scheduler)))
-      (let [scheduler (attach-name scheduler "bar")]
-        (is (= "bar" (scheduler->name scheduler))))
-      (is (= "foo" (scheduler->name scheduler))))))
+  (is (-> (reify ServiceScheduler) scheduler->name nil?))
+  (is (-> (reify ServiceScheduler) (attach-name "foo") scheduler->name (= "foo"))))

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -804,3 +804,12 @@
           (is (= expected-state-1 actual-state-1')))
         (testing "applied router state update"
           (is (= expected-state-2 actual-state-2)))))))
+
+(deftest test-scheduler-naming
+  (let [scheduler (reify ServiceScheduler)]
+    (is (nil? (scheduler->name scheduler)))
+    (let [scheduler (attach-name scheduler "foo")]
+      (is (= "foo" (scheduler->name scheduler)))
+      (let [scheduler (attach-name scheduler "bar")]
+        (is (= "bar" (scheduler->name scheduler))))
+      (is (= "foo" (scheduler->name scheduler))))))

--- a/waiter/test/waiter/util/utils_test.clj
+++ b/waiter/test/waiter/util/utils_test.clj
@@ -106,6 +106,12 @@
     (is (not (str/includes? actual "dest")))
     (is (not (str/includes? actual "pass")))))
 
+(deftest test-keyword->str
+  (is (= "foo" (keyword->str :foo)))
+  (is (= "foo-bar" (keyword->str :foo-bar)))
+  (is (= "foo/bar" (keyword->str :foo/bar)))
+  (is (= "foo.bar/fuu-baz" (keyword->str :foo.bar/fuu-baz))))
+
 (deftest test-clj->json-response
   (testing "Conversion from map to JSON response"
 


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for naming schedulers

## Why are we making these changes?

Naming scheduler simplifies the path to debugging multiple schedulers with the ability to identify individual schedulers by name.
