### PR TITLE
Use router state to retrieve instance breakdown

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1032,11 +1032,13 @@
                               (wrap-secure-request-fn
                                 (fn async-status-handler-fn [request]
                                   (handler/async-status-handler async-trigger-terminate-fn make-http-request-fn service-id->service-description-fn request))))
-   :blacklist-instance-handler-fn (pc/fnk [[:state instance-rpc-chan]
+   :blacklist-instance-handler-fn (pc/fnk [[:daemons router-state-maintainer]
+                                           [:state instance-rpc-chan]
                                            wrap-router-auth-fn]
-                                    (wrap-router-auth-fn
-                                      (fn blacklist-instance-handler-fn [request]
-                                        (handler/blacklist-instance instance-rpc-chan request))))
+                                    (let [{{:keys [notify-instance-killed-fn]} :maintainer} router-state-maintainer]
+                                      (wrap-router-auth-fn
+                                        (fn blacklist-instance-handler-fn [request]
+                                          (handler/blacklist-instance notify-instance-killed-fn instance-rpc-chan request)))))
    :blacklisted-instances-list-handler-fn (pc/fnk [[:state instance-rpc-chan]]
                                             (fn blacklisted-instances-list-handler-fn [{{:keys [service-id]} :route-params :as request}]
                                               (handler/get-blacklisted-instances instance-rpc-chan service-id request)))

--- a/waiter/src/waiter/state.clj
+++ b/waiter/src/waiter/state.clj
@@ -1184,7 +1184,8 @@
    Acts as the central access point for modifying this data for the router.
    Exposes the state of the router via a `query-state-fn` no-args function that is returned."
   [scheduler-state-chan router-chan router-id exit-chan service-id->service-description-fn deployment-error-config]
-  (let [state-atom (atom {:all-available-service-ids #{}
+  (let [killed-instances-to-keep 10
+        state-atom (atom {:all-available-service-ids #{}
                           :iteration 0
                           :routers []
                           :service-id->deployment-error {}
@@ -1193,12 +1194,14 @@
                           :service-id->healthy-instances {}
                           :service-id->instability-issue {}
                           :service-id->instance-counts {}
+                          :service-id->killed-instances {}
                           :service-id->my-instance->slots {} ; updated in update-router-state
                           :service-id->starting-instances {}
                           :service-id->unhealthy-instances {}
                           :time (t/now)})
         router-state-push-chan (au/latest-chan)
         query-chan (async/chan)
+        kill-notification-chan (async/chan 16)
         go-chan
         (async/go
           (try
@@ -1218,7 +1221,8 @@
                           (str "router-state-maintainer-" iteration)
                           (loop [{:keys [service-id->healthy-instances service-id->unhealthy-instances service-id->my-instance->slots
                                          service-id->expired-instances service-id->starting-instances service-id->failed-instances
-                                         service-id->instance-counts service-id->deployment-error service-id->instability-issue] :as loop-state} current-state
+                                         service-id->instance-counts service-id->deployment-error service-id->instability-issue
+                                         service-id->killed-instances] :as loop-state} current-state
                                  [[message-type message-data] & remaining] scheduler-messages]
                             (log/trace "scheduler-state-chan received, type:" message-type)
                             (let [loop-state'
@@ -1228,6 +1232,7 @@
                                           all-available-service-ids' available-service-ids
                                           services-without-instances (remove #(contains? service-id->my-instance->slots %) all-available-service-ids')
                                           service-id->healthy-instances' (select-keys service-id->healthy-instances all-available-service-ids')
+                                          service-id->killed-instances' (select-keys service-id->killed-instances all-available-service-ids')
                                           service-id->unhealthy-instances' (select-keys service-id->unhealthy-instances all-available-service-ids')
                                           service-id->expired-instances' (select-keys service-id->expired-instances all-available-service-ids')
                                           service-id->starting-instances' (select-keys service-id->starting-instances all-available-service-ids')
@@ -1252,6 +1257,7 @@
                                         :service-id->instance-counts service-id->instance-counts'
                                         :service-id->deployment-error service-id->deployment-error'
                                         :service-id->instability-issue service-id->instability-issue'
+                                        :service-id->killed-instances service-id->killed-instances'
                                         :time scheduler-sync-time))
 
                                     :update-service-instances
@@ -1318,6 +1324,22 @@
                                   new-state)
                                 (recur loop-state' remaining))))))
 
+                      kill-notification-chan
+                      ([message]
+                        (cid/with-correlation-id
+                          (str "router-state-maintainer-" iteration)
+                          (let [{{:keys [id service-id] :as instance} :instance} message]
+                            (log/info "tracking killed instance" id "of service" service-id)
+                            (-> current-state
+                                (update-in [:service-id->killed-instances service-id]
+                                           (fn [killed-instances]
+                                             (vec
+                                               (take
+                                                 killed-instances-to-keep
+                                                 (conj
+                                                   (filterv (fn [i] (not= (:id i) id)) killed-instances)
+                                                   instance)))))))))
+
                       query-chan
                       ([response-chan]
                         (async/put! response-chan current-state)
@@ -1346,6 +1368,9 @@
               (log/error e "Fatal error in router-state-maintainer!")
               (System/exit 1))))]
     {:go-chan go-chan
+     :notify-instance-killed-fn (fn notify-router-state-maintainer-of-instance-killed [instance]
+                                  (async/go
+                                    (async/>! kill-notification-chan {:instance instance})))
      :query-chan query-chan
      :query-state-fn (fn router-state-maintainer-query-state-fn []
                        (assoc @state-atom :router-id router-id))

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -29,10 +29,10 @@
             [waiter.interstitial :as interstitial]
             [waiter.kv :as kv]
             [waiter.scheduler :as scheduler]
+            [waiter.service :as service]
             [waiter.service-description :as sd]
             [waiter.statsd :as statsd]
             [waiter.test-helpers :refer :all]
-            [waiter.util.async-utils :as au]
             [waiter.util.utils :as utils])
   (:import (clojure.core.async.impl.channels ManyToManyChannel)
            (clojure.lang ExceptionInfo)
@@ -1182,14 +1182,15 @@
           (is (= body "template:some-content")))))))
 
 (deftest test-blacklist-instance-cannot-find-channel
-  (let [instance-rpc-chan (async/chan)
+  (let [notify-instance-killed-fn (fn [instance] (throw (ex-info "Unexpected call" {:instance instance})))
+        instance-rpc-chan (async/chan)
         test-service-id "test-service-id"
         request {:body (StringBufferInputStream.
                          (utils/clj->json
                            {"instance" {"id" "test-instance-id", "service-id" test-service-id}
                             "period-in-ms" 1000
                             "reason" "blacklist"}))}
-        response-chan (blacklist-instance instance-rpc-chan request)]
+        response-chan (blacklist-instance notify-instance-killed-fn instance-rpc-chan request)]
     (async/thread
       (let [{:keys [cid method response-chan service-id]} (async/<!! instance-rpc-chan)]
         (is (= :blacklist method))
@@ -1199,6 +1200,38 @@
         (async/close! response-chan)))
     (let [{:keys [status]} (async/<!! response-chan)]
       (is (= 400 status)))))
+
+(deftest test-blacklist-killed-instance
+  (let [notify-instance-chan (async/promise-chan)
+        notify-instance-killed-fn (fn [instance] (async/>!! notify-instance-chan instance))
+        instance-rpc-chan (async/chan)
+        test-service-id "test-service-id"
+        instance {:id "test-instance-id"
+                  :service-id test-service-id
+                  :started-at nil}
+        request {:body (StringBufferInputStream.
+                         (utils/clj->json
+                           {"instance" instance
+                            "period-in-ms" 1000
+                            "reason" "killed"}))}]
+    (with-redefs []
+      (let [response-chan (blacklist-instance notify-instance-killed-fn instance-rpc-chan request)
+            blacklist-chan (async/promise-chan)]
+        (async/thread
+          (let [{:keys [cid method response-chan service-id]} (async/<!! instance-rpc-chan)]
+            (is (= :blacklist method))
+            (is (= test-service-id service-id))
+            (is cid)
+            (is (instance? ManyToManyChannel response-chan))
+            (async/>!! response-chan blacklist-chan)))
+        (async/thread
+          (let [[{:keys [blacklist-period-ms instance-id]} repsonse-chan] (async/<!! blacklist-chan)]
+            (is (= 1000 blacklist-period-ms))
+            (is (= (:id instance) instance-id))
+            (async/>!! repsonse-chan :blacklisted)))
+        (let [{:keys [status]} (async/<!! response-chan)]
+          (is (= 200 status))
+          (is (= instance (async/<!! notify-instance-chan))))))))
 
 (deftest test-get-blacklisted-instances-cannot-find-channel
   (let [instance-rpc-chan (async/chan)


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for tracking killed instances in router-state-maintainer
- adds kill instance notification to handler/blacklist-instance
- uses notify-instance-killed-fn in scaling.clj after successfully killing instances

## Why are we making these changes?

1. This avoids any inconsistency between Waiter's internal state and the output displayed in `/apps/<service-id>`
2. Removes the `atom` that stores killed instances and related functions (e.g. `preserve-only-killed-instances-for-services!`, `remove-killed-instances-for-service!`, ...)
3. Shrinks the `scheduler/ServiceScheduler` interface by removing the `get-instances` function


