### PR TITLE
adds support for filtering by token and version in /apps endpoint

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -292,6 +292,78 @@
             (assert-response-status response 404)
             (is (str/includes? (str body) "Couldn't find token") (str body))))))))
 
+(deftest ^:parallel ^:integration-fast test-service-list-filtering
+  (testing-using-waiter-url
+    (let [service-name (rand-name)
+          token-1 (create-token-name waiter-url (str service-name ".t1"))
+          token-2 (create-token-name waiter-url (str service-name ".t2"))
+          service-ids-atom (atom #{})
+          token->version->etag-atom (atom {})
+          all-tokens [token-1 token-2]
+          all-version-suffixes ["v1" "v2" "v3"]]
+      (doseq [version-suffix all-version-suffixes]
+        (doseq [token all-tokens]
+          (let [token-description (merge
+                                    (kitchen-request-headers :prefix "")
+                                    {:fallback-period-secs 0
+                                     :name service-name
+                                     :token token
+                                     :version (str service-name "." version-suffix)})
+                {:keys [headers] :as response} (post-token waiter-url token-description)]
+            (assert-response-status response 200)
+            (let [token-etag (get headers "etag")]
+              (log/info token "->" token-etag)
+              (is (-> token-etag str/blank? not))
+              (let [{:keys [service-id] :as response} (make-request-with-debug-info
+                                                        {:x-waiter-token token}
+                                                        #(make-request waiter-url "/environment" :headers %))]
+                (assert-response-status response 200)
+                (is (-> service-id str/blank? not))
+                (swap! service-ids-atom conj service-id))
+              (swap! token->version->etag-atom assoc-in [token version-suffix] token-etag)))))
+      (is (= (* (count all-tokens) (count all-version-suffixes)) (count @service-ids-atom))
+          (str {:service-ids @service-ids-atom}))
+
+      (doseq [loop-token all-tokens]
+        (let [query-params {"token" loop-token}
+              _ (log/info query-params)
+              {:keys [body] :as response} (make-request waiter-url "/apps" :query-params query-params)
+              services (json/read-str body)
+              service-tokens (mapcat (fn [entry]
+                                       (some->> entry
+                                                walk/keywordize-keys
+                                                :service-description
+                                                :source-tokens
+                                                (map :token)))
+                                     services)]
+          (assert-response-status response 200)
+          (is (= 3 (count service-tokens))
+              (str {:query-params query-params
+                    :service-count (count services)
+                    :service-tokens service-tokens})))
+
+        (doseq [version-suffix all-version-suffixes]
+          (let [loop-etag (get-in @token->version->etag-atom [loop-token version-suffix])
+                query-params {"token-version" loop-etag}
+                _ (log/info query-params)
+                {:keys [body] :as response} (make-request waiter-url "/apps" :query-params query-params)
+                services (json/read-str body)
+                service-token-versions (mapcat (fn [entry]
+                                                 (some->> entry
+                                                          walk/keywordize-keys
+                                                          :service-description
+                                                          :source-tokens
+                                                          (map :version)))
+                                               services)]
+            (assert-response-status response 200)
+            (is (= 1 (count service-token-versions))
+                (str {:query-params query-params
+                      :service-count (count services)
+                      :service-token-verisons service-token-versions})))))
+
+      (doseq [service-id @service-ids-atom]
+        (delete-service waiter-url service-id)))))
+
 (deftest ^:parallel ^:integration-fast test-hostname-token
   (testing-using-waiter-url
     (let [service-id-prefix (rand-name)

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -231,7 +231,10 @@
 (defn- str->filter-fn
   "Returns a name-filtering function given a user-provided name filter string"
   [name]
-  (let [pattern (re-pattern (str/replace (str name) #"\*+" ".*"))]
+  (let [pattern (-> (str name)
+                    (str/replace #"\." "\\\\.")
+                    (str/replace #"\*+" ".*")
+                    re-pattern)]
     #(re-matches pattern %)))
 
 (defn list-services-handler

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -18,6 +18,7 @@
             [clojure.core.async :as async]
             [clojure.data.json :as json]
             [clojure.java.io :as io]
+            [clojure.set :as set]
             [clojure.string :as str]
             [clojure.test :refer :all]
             [clojure.walk :as walk]
@@ -407,9 +408,20 @@
 
 (deftest test-list-services-handler
   (let [test-user "test-user"
-        test-user-services ["service1" "service2" "service3"]
-        state-atom (atom nil)
-        query-state-fn (fn [] @state-atom)
+        test-user-services #{"service1" "service2" "service3" "service7" "service8" "service9"}
+        other-user-services #{"service4" "service5" "service6"}
+        healthy-services #{"service1" "service2" "service4" "service6" "service7" "service8" "service9"}
+        unhealthy-services #{"service2" "service3" "service5"}
+        service-id->source-tokens {"service1" [{:token "t1" :version "v1"} {:token "t2" :version "v2"}]
+                                   "service3" [{:token "t2" :version "v2"} {:token "t3" :version "v3"}]
+                                   "service4" [{:token "t1" :version "v1"} {:token "t2" :version "v2"}]
+                                   "service5" [{:token "t1" :version "v1"} {:token "t3" :version "v3"}]
+                                   "service7" [{:token "t1" :version "v2"} {:token "t2" :version "v1"}]
+                                   "service9" [{:token "t2" :version "v3"}]}
+        all-services (set/union other-user-services test-user-services)
+        query-state-fn (constantly {:all-available-service-ids all-services
+                                    :service-id->healthy-instances (pc/map-from-keys (constantly []) healthy-services)
+                                    :service-id->unhealthy-instances (pc/map-from-keys (constantly []) unhealthy-services)})
         request {:authorization/user test-user}
         instance-counts-present (fn [body]
                                   (let [parsed-body (-> body (str) (json/read-str) (walk/keywordize-keys))]
@@ -424,46 +436,32 @@
                                 (and (= user test-user)
                                      (= action :manage)
                                      (some #(= % service-id) test-user-services))))
-        list-services-handler (wrap-handler-json-response list-services-handler)]
+        list-services-handler (wrap-handler-json-response list-services-handler)
+        assert-successful-json-response (fn [{:keys [body headers status]}]
+                                          (is (= 200 status))
+                                          (is (= "application/json" (get headers "content-type")))
+                                          (is (instance-counts-present body)))]
     (letfn [(service-id->service-description-fn [service-id & _]
-              {"run-as-user" (if (some #(= service-id %) test-user-services) test-user "another-user")})
+              (cond-> {"run-as-user" (if (contains? test-user-services service-id) test-user "another-user")}
+                (contains? service-id->source-tokens service-id)
+                (assoc "source-tokens" (-> service-id service-id->source-tokens walk/stringify-keys))))
             (service-id->metrics-fn []
               {})]
 
       (testing "list-services-handler:success-regular-user"
-        (reset! state-atom {:service-id->healthy-instances {"service1" []
-                                                            "service2" []
-                                                            "service3" []
-                                                            "service4" []
-                                                            "service6" []}
-                            :service-id->unhealthy-instances {"service3" []
-                                                              "service5" []}})
-        (let [{:keys [body headers status]}
+        (let [{:keys [body] :as response}
               (list-services-handler entitlement-manager query-state-fn prepend-waiter-url
                                      service-id->service-description-fn service-id->metrics-fn request)]
-          (is (= 200 status))
-          (is (= "application/json" (get headers "content-type")))
-          (is (every? #(str/includes? (str body) (str "service" %)) (range 1 4)))
-          (is (not-any? #(str/includes? (str body) (str "service" %)) (range 4 7)))
-          (is (instance-counts-present body))))
+          (assert-successful-json-response response)
+          (is (= test-user-services (->> body json/read-str walk/keywordize-keys (map :service-id) set)))))
 
       (testing "list-services-handler:success-regular-user-with-filter-for-another-user"
         (let [request (assoc request :query-string "run-as-user=another-user")]
-          (reset! state-atom {:service-id->healthy-instances {"service1" []
-                                                              "service2" []
-                                                              "service3" []
-                                                              "service4" []
-                                                              "service6" []}
-                              :service-id->unhealthy-instances {"service3" []
-                                                                "service5" []}})
-          (let [{:keys [body headers status]}
+          (let [{:keys [body] :as response}
                 (list-services-handler entitlement-manager query-state-fn prepend-waiter-url
                                        service-id->service-description-fn service-id->metrics-fn request)]
-            (is (= 200 status))
-            (is (= "application/json" (get headers "content-type")))
-            (is (not-any? #(str/includes? (str body) (str "service" %)) (range 1 4)))
-            (is (every? #(str/includes? (str body) (str "service" %)) (range 4 7)))
-            (is (instance-counts-present body)))))
+            (assert-successful-json-response response)
+            (is (= other-user-services (->> body json/read-str walk/keywordize-keys (map :service-id) set))))))
 
       (testing "list-services-handler:success-regular-user-with-filter-for-same-user"
         (let [entitlement-manager (reify authz/EntitlementManager
@@ -471,58 +469,110 @@
                                       ; use (constantly true) for authorized? to verify that filter still applies
                                       true))
               request (assoc request :authorization/user "another-user" :query-string "run-as-user=another-user")]
-          (reset! state-atom {:service-id->healthy-instances {"service1" []
-                                                              "service2" []
-                                                              "service3" []
-                                                              "service4" []
-                                                              "service6" []}
-                              :service-id->unhealthy-instances {"service3" []
-                                                                "service5" []}})
-          (let [{:keys [body headers status]}
-
+          (let [{:keys [body] :as response}
                 (list-services-handler entitlement-manager query-state-fn prepend-waiter-url
                                        service-id->service-description-fn service-id->metrics-fn request)]
-            (is (= 200 status))
-            (is (= "application/json" (get headers "content-type")))
-            (is (not-any? #(str/includes? (str body) (str "service" %)) (range 1 4)))
-            (is (every? #(str/includes? (str body) (str "service" %)) (range 4 7)))
-            (is (instance-counts-present body)))))
+            (assert-successful-json-response response)
+            (is (= other-user-services (->> body json/read-str walk/keywordize-keys (map :service-id) set))))))
 
       (testing "list-services-handler:failure"
-        (reset! state-atom {:service-id->healthy-instances {"service1" []}})
-        (let [request {:authorization/user test-user}
+        (let [query-state-fn (constantly {:all-available-service-ids #{"service1"}
+                                          :service-id->healthy-instances {"service1" []}})
+              request {:authorization/user test-user}
               exception-message "Custom message from test case"
               prepend-waiter-url (fn [_] (throw (ex-info exception-message {:status 400})))
               list-services-handler (core/wrap-error-handling
                                       #(list-services-handler entitlement-manager query-state-fn prepend-waiter-url
                                                               service-id->service-description-fn service-id->metrics-fn %))
-              {:keys [body headers status]}
-              (list-services-handler request)]
+              {:keys [body headers status]} (list-services-handler request)]
           (is (= 400 status))
           (is (= "text/plain" (get headers "content-type")))
           (is (str/includes? (str body) exception-message))))
 
       (testing "list-services-handler:success-super-user-sees-all-apps"
-        (reset! state-atom {:service-id->healthy-instances {"service1" []
-                                                            "service2" []
-                                                            "service3" []
-                                                            "service4" []
-                                                            "service6" []}
-                            :service-id->unhealthy-instances {"service3" []
-                                                              "service5" []}})
         (let [entitlement-manager (reify authz/EntitlementManager
                                     (authorized? [_ user action {:keys [service-id]}]
                                       (and (= user test-user)
                                            (= :manage action)
-                                           (some #(= (str "service" %) service-id) (range 1 7)))))
-              {:keys [body headers status]}
+                                           (contains? all-services service-id))))
+              {:keys [body] :as response}
               ; without a run-as-user, should return all apps
               (list-services-handler entitlement-manager query-state-fn prepend-waiter-url
                                      service-id->service-description-fn service-id->metrics-fn request)]
-          (is (= 200 status))
-          (is (= "application/json" (get headers "content-type")))
-          (is (every? #(str/includes? (str body) (str "service" %)) (range 1 7)))
-          (is (instance-counts-present body)))))))
+          (assert-successful-json-response response)
+          (is (= all-services (->> body json/read-str walk/keywordize-keys (map :service-id) set)))))
+
+      (testing "list-services-handler:success-filter-tokens"
+        (let [request (assoc request :query-string "token=t1")
+              {:keys [body] :as response}
+              ; without a run-as-user, should return all apps
+              (list-services-handler entitlement-manager query-state-fn prepend-waiter-url
+                                     service-id->service-description-fn service-id->metrics-fn request)]
+          (assert-successful-json-response response)
+          (is (= (->> service-id->source-tokens
+                      (filter (fn [[_ source-tokens]]
+                                (->> source-tokens (map :token) (some #(= % "t1")))))
+                      keys
+                      set
+                      (set/intersection test-user-services))
+                 (->> body json/read-str walk/keywordize-keys (map :service-id) set))))
+        (let [request (assoc request :query-string "token=t2")
+              {:keys [body] :as response}
+              ; without a run-as-user, should return all apps
+              (list-services-handler entitlement-manager query-state-fn prepend-waiter-url
+                                     service-id->service-description-fn service-id->metrics-fn request)]
+          (assert-successful-json-response response)
+          (is (= (->> service-id->source-tokens
+                      (filter (fn [[_ source-tokens]]
+                                (->> source-tokens (map :token) (some #(= % "t2")))))
+                      keys
+                      set
+                      (set/intersection test-user-services))
+                 (->> body json/read-str walk/keywordize-keys (map :service-id) set)))))
+
+      (testing "list-services-handler:success-filter-version"
+        (let [request (assoc request :query-string "token-version=v1")
+              {:keys [body] :as response}
+              ; without a run-as-user, should return all apps
+              (list-services-handler entitlement-manager query-state-fn prepend-waiter-url
+                                     service-id->service-description-fn service-id->metrics-fn request)]
+          (assert-successful-json-response response)
+          (is (= (->> service-id->source-tokens
+                      (filter (fn [[_ source-tokens]]
+                                (->> source-tokens (map :version) (some #(= % "v1")))))
+                      keys
+                      set
+                      (set/intersection test-user-services))
+                 (->> body json/read-str walk/keywordize-keys (map :service-id) set))))
+        (let [request (assoc request :query-string "token-version=v2")
+              {:keys [body] :as response}
+              ; without a run-as-user, should return all apps
+              (list-services-handler entitlement-manager query-state-fn prepend-waiter-url
+                                     service-id->service-description-fn service-id->metrics-fn request)]
+          (assert-successful-json-response response)
+          (is (= (->> service-id->source-tokens
+                      (filter (fn [[_ source-tokens]]
+                                (->> source-tokens (map :version) (some #(= % "v2")))))
+                      keys
+                      set
+                      (set/intersection test-user-services))
+                 (->> body json/read-str walk/keywordize-keys (map :service-id) set)))))
+
+      (testing "list-services-handler:success-filter-token-and-version"
+        (let [request (assoc request :query-string "token=t1&token-version=v1")
+              {:keys [body] :as response}
+              ; without a run-as-user, should return all apps
+              (list-services-handler entitlement-manager query-state-fn prepend-waiter-url
+                                     service-id->service-description-fn service-id->metrics-fn request)]
+          (assert-successful-json-response response)
+          (is (= (->> service-id->source-tokens
+                      (filter (fn [[_ source-tokens]]
+                                (and (->> source-tokens (map :token) (some #(= % "t1")))
+                                     (->> source-tokens (map :version) (some #(= % "v1"))))))
+                      keys
+                      set
+                      (set/intersection test-user-services))
+                 (->> body json/read-str walk/keywordize-keys (map :service-id) set))))))))
 
 (deftest test-delete-service-handler
   (let [test-user "test-user"
@@ -1046,8 +1096,8 @@
                                                               "interstitial-secs" 10)
                                       nil)]
             (cond-> service-description
-                    (seq service-description)
-                    (assoc "source-tokens" [(sd/source-tokens-entry token service-description)]))
+              (seq service-description)
+              (assoc "source-tokens" [(sd/source-tokens-entry token service-description)]))
             service-description))
         service-description->service-id (fn [service-description]
                                           (str "service-" (count service-description) "." (count (str service-description))))

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -412,12 +412,12 @@
         other-user-services #{"service4" "service5" "service6"}
         healthy-services #{"service1" "service2" "service4" "service6" "service7" "service8" "service9"}
         unhealthy-services #{"service2" "service3" "service5"}
-        service-id->source-tokens {"service1" [{:token "t1" :version "v1"} {:token "t2" :version "v2"}]
-                                   "service3" [{:token "t2" :version "v2"} {:token "t3" :version "v3"}]
-                                   "service4" [{:token "t1" :version "v1"} {:token "t2" :version "v2"}]
-                                   "service5" [{:token "t1" :version "v1"} {:token "t3" :version "v3"}]
-                                   "service7" [{:token "t1" :version "v2"} {:token "t2" :version "v1"}]
-                                   "service9" [{:token "t2" :version "v3"}]}
+        service-id->source-tokens {"service1" [{:token "t1.org" :version "v1"} {:token "t2.com" :version "v2"}]
+                                   "service3" [{:token "t2.com" :version "v2"} {:token "t3.edu" :version "v3"}]
+                                   "service4" [{:token "t1.org" :version "v1"} {:token "t2.com" :version "v2"}]
+                                   "service5" [{:token "t1.org" :version "v1"} {:token "t3.edu" :version "v3"}]
+                                   "service7" [{:token "t1.org" :version "v2"} {:token "t2.com" :version "v1"}]
+                                   "service9" [{:token "t2.com" :version "v3"}]}
         all-services (set/union other-user-services test-user-services)
         query-state-fn (constantly {:all-available-service-ids all-services
                                     :service-id->healthy-instances (pc/map-from-keys (constantly []) healthy-services)
@@ -504,12 +504,14 @@
 
       (testing "list-services-handler:success-filter-tokens"
         (doseq [[query-param filter-fn]
-                {"t1" #(= % "t1")
-                 "t2" #(= % "t2")
+                {"t1.com" #(= % "t1.com")
+                 "t2.org" #(= % "t2.org")
+                 "tn.none" #(= % "tn.none")
+                 "*o*" #(str/includes? % "o")
                  "*t*" #(str/includes? % "t")
                  "t*" #(str/starts-with? % "t")
-                 "*1" #(str/ends-with? % "1")
-                 "*2" #(str/ends-with? % "2")}]
+                 "*com" #(str/ends-with? % "com")
+                 "*org" #(str/ends-with? % "org")}]
           (let [request (assoc request :query-string (str "token=" query-param))
                 {:keys [body] :as response}
                 ; without a run-as-user, should return all apps
@@ -528,6 +530,7 @@
         (doseq [[query-param filter-fn]
                 {"v1" #(= % "v1")
                  "v2" #(= % "v2")
+                 "vn" #(= % "vn")
                  "*v*" #(str/includes? % "v")
                  "v*" #(str/starts-with? % "v")
                  "*1" #(str/ends-with? % "1")


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for filtering by token and version

## Why are we making these changes?

Allows users to filter the running services by token and token version.

Example search for token:
<img width="1041" alt="screen shot 2018-08-22 at 10 14 52 am" src="https://user-images.githubusercontent.com/6611249/44510723-0df2bc00-a67b-11e8-8407-a6fadd3c8d4b.png">

Example search for token version:
<img width="1023" alt="screen shot 2018-08-22 at 10 15 17 am" src="https://user-images.githubusercontent.com/6611249/44510724-0df2bc00-a67b-11e8-8bc5-9d3a72dd1b17.png">

