### PR TITLE
token syncer: adds ping-token sub-command

### DIFF
--- a/token-syncer/bin/ci/run-integration-tests.sh
+++ b/token-syncer/bin/ci/run-integration-tests.sh
@@ -15,6 +15,7 @@ TEST_SELECTOR=${2:-integration}
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 WAITER_DIR=${DIR}/../../../waiter
+KITCHEN_DIR=${DIR}/../../../kitchen
 SYNCER_DIR=${WAITER_DIR}/../token-syncer
 
 pushd ${WAITER_DIR}
@@ -33,6 +34,7 @@ done
 popd
 
 # Run the integration tests
+export WAITER_TEST_KITCHEN_CMD="${KITCHEN_DIR}/bin/kitchen"
 export WAITER_URIS="${WAITER_URIS%?}"
 ${SYNCER_DIR}/bin/test.sh ${TEST_COMMAND} ${TEST_SELECTOR} || {
   # If there were failures, dump the logs

--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -524,6 +524,7 @@
 (deftest ^:integration test-ping-tokens
   (testing "token ping on clusters"
     (let [waiter-urls (waiter-urls)
+          queue-timeout-ms 120000
           {:keys [store-token] :as waiter-api} (waiter-api)]
 
       (testing "successful health check"
@@ -541,7 +542,7 @@
                    waiter-urls))
 
             ;; ACT
-            (let [actual-result (ping/ping-token waiter-api waiter-urls token-name)]
+            (let [actual-result (ping/ping-token waiter-api waiter-urls token-name queue-timeout-ms)]
 
               ;; ASSERT
               (let [expected-result {:details
@@ -574,7 +575,7 @@
                    waiter-urls))
 
             ;; ACT
-            (let [actual-result (ping/ping-token waiter-api waiter-urls token-name)]
+            (let [actual-result (ping/ping-token waiter-api waiter-urls token-name queue-timeout-ms)]
 
               ;; ASSERT
               (let [expected-result {:details

--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -43,7 +43,7 @@
 
 (deftest ^:integration test-environment
   (log/info "Running: test-environment")
-  (testing "presence of environment variables"
+  (testing "verifies presence of environment variables for running integration tests"
     (testing "waiter cluster uris"
       (log/info "env.WAITER_URIS" (System/getenv "WAITER_URIS"))
       (is (System/getenv "WAITER_URIS"))
@@ -549,13 +549,14 @@
                                      (pc/map-from-keys
                                        (fn [cluster-url]
                                          {:exit-code 0
-                                          :message (str "Successfully pinged token " token-name " on " cluster-url
+                                          :message (str "successfully pinged token " token-name " on " cluster-url
                                                         ", reason: health check returned status code 200")})
                                        waiter-urls)
                                      :exit-code 0
                                      :message (str "pinging token " token-name " on "
                                                    (-> waiter-urls vec println with-out-str str/trim)
-                                                   " was successful")}]
+                                                   " was successful")
+                                     :token token-name}]
                 (is (= expected-result actual-result))))
             (finally
               (cleanup-token waiter-api waiter-urls token-name)))))
@@ -588,7 +589,8 @@
                                      :exit-code (count waiter-urls)
                                      :message (str "pinging token " token-name " on "
                                                    (-> waiter-urls vec println with-out-str str/trim)
-                                                   " failed")}]
+                                                   " failed")
+                                     :token token-name}]
                 (is (= expected-result actual-result))))
             (finally
               (cleanup-token waiter-api waiter-urls token-name))))))))

--- a/token-syncer/src/token_syncer/commands/ping.clj
+++ b/token-syncer/src/token_syncer/commands/ping.clj
@@ -1,0 +1,98 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns token-syncer.commands.ping
+  (:require [clojure.pprint :as pp]
+            [clojure.string :as str]
+            [clojure.tools.logging :as log]
+            [plumbing.core :as pc]))
+
+(defn ping-token
+  "Pings the specified tokens across provided clusters based on cluster-urls and returns the result.
+   Throws an exception if there was an error while pinging the clusters with the provided token."
+  [{:keys [health-check-token]} cluster-urls token]
+  (try
+    (log/info "pinging token" token "on clusters:" cluster-urls)
+    (let [cluster-url->result
+          (pc/map-from-keys
+            (fn [cluster-url]
+              (try
+                (let [{:keys [body headers status]} (health-check-token cluster-url token)]
+                  (log/info "health check repsonse:"
+                            {:body (str/trim (str body))
+                             :headers headers
+                             :status status})
+                  (if (and (integer? status) (<= 200 status 299))
+                    {:exit-code 0
+                     :message (str "Successfully pinged token " token " on " cluster-url
+                                   ", reason: health check returned status code " status)}
+                    {:exit-code 1
+                     :message (str "unable to ping token " token " on " cluster-url
+                                   ", reason: health check returned status code " status)}))
+                (catch Throwable th
+                  (log/error th "unable to ping token" token "on" cluster-url)
+                  {:exit-code 1
+                   :message (str "unable to ping token " token " on " cluster-url
+                                 ", reason: " (.getMessage th))})))
+            (set cluster-urls))
+          exit-code (reduce + 0 (->> cluster-url->result vals (map :exit-code)))]
+      {:details cluster-url->result
+       :exit-code exit-code
+       :message (str "pinging token " token " on " (-> cluster-urls vec println with-out-str str/trim)
+                     " " (if (zero? exit-code) "was successful" "failed"))})
+    (catch Throwable th
+      (log/error th "unable to ping token")
+      (throw th))))
+
+(def ^:const valid-token-re #"[a-zA-Z]([a-zA-Z0-9\-_$\.])+")
+
+(def ping-token-config
+  {:execute-command (fn execute-ping-token-command
+                      [{:keys [waiter-api]} _ arguments]
+                      (let [token (first arguments)
+                            cluster-urls-set (-> arguments rest set)]
+                        (cond
+                          (empty? arguments)
+                          {:exit-code 1
+                           :message "no arguments provided, usage TOKEN URL..."}
+
+                          (str/blank? token)
+                          {:exit-code 1
+                           :message (str "token is required, none provided: " (vec arguments))}
+
+                          (not (re-matches valid-token-re token))
+                          {:exit-code 1
+                           :message (str "token is not valid: "
+                                         (-> {:arguments (vec arguments)
+                                              :pattern (str valid-token-re)
+                                              :token token}
+                                             println
+                                             with-out-str
+                                             str/trim))}
+
+                          (-> cluster-urls-set set seq not)
+                          {:exit-code 1
+                           :message (str "at least one cluster url required, provided: " (vec cluster-urls-set))}
+
+                          :else
+                          (let [{:keys [exit-code] :as ping-result} (ping-token waiter-api cluster-urls-set token)]
+                            (log/info (-> ping-result pp/pprint with-out-str str/trim))
+                            {:exit-code exit-code
+                             :message (str "exiting with code " exit-code)}))))
+   :option-specs []
+   :retrieve-documentation (fn retrieve-ping-token-documentation
+                             [command-name _]
+                             {:description (str "Pings the specified TOKEN across Waiter cluster(s) specified in the URL(s)")
+                              :usage (str command-name " TOKEN URL...")})})

--- a/token-syncer/src/token_syncer/waiter.clj
+++ b/token-syncer/src/token_syncer/waiter.clj
@@ -198,15 +198,15 @@
 
 (defn health-check-token
   "Performs health check on a token on a specific cluster."
-  [^HttpClient http-client cluster-url token]
-  (log/info "health-check-token" token "on" cluster-url)
+  [^HttpClient http-client cluster-url token queue-timeout-ms]
+  (log/info "health-check-token" token "on" cluster-url "with queue timeout of" queue-timeout-ms "ms")
   (let [{:keys [description]} (load-token http-client cluster-url token)
         {:strs [deleted health-check-url]} description]
     (if (and (not deleted) (not (str/blank? health-check-url)))
       (do
         (log/info "health-check-token" token "on" (str cluster-url health-check-url))
         (-> (make-http-request http-client (str cluster-url health-check-url)
-                               :headers {"x-waiter-queue-timeout" (-> 2 t/minutes t/in-millis)
+                               :headers {"x-waiter-queue-timeout" queue-timeout-ms
                                          "x-waiter-token" token}
                                :method :get
                                :query-params {})
@@ -217,4 +217,4 @@
                    :deleted deleted
                    :health-check-url health-check-url
                    :token token})
-        (comment "return nil")))))
+        nil))))

--- a/token-syncer/src/token_syncer/waiter.clj
+++ b/token-syncer/src/token_syncer/waiter.clj
@@ -211,10 +211,8 @@
                                :method :get
                                :query-params {})
             (update :body async/<!!)))
-      (do
-        (log/info "health-check-token not performed"
-                  {:cluster-url cluster-url
-                   :deleted deleted
-                   :health-check-url health-check-url
-                   :token token})
-        nil))))
+      (log/info "health-check-token not performed"
+                {:cluster-url cluster-url
+                 :deleted deleted
+                 :health-check-url health-check-url
+                 :token token}))))

--- a/token-syncer/test/token_syncer/commands/ping_test.clj
+++ b/token-syncer/test/token_syncer/commands/ping_test.clj
@@ -1,0 +1,152 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns token-syncer.commands.ping-test
+  (:require [clojure.test :refer :all]
+            [token-syncer.cli :as cli]
+            [token-syncer.commands.ping :refer :all]))
+
+(deftest test-ping-token
+  (let [test-token "test-token"]
+
+    (testing "exception on health check"
+      (let [test-cluster-urls ["http://c1.com"]
+            waiter-api {:health-check-token (fn [cluster-url token]
+                                              (is (= (first test-cluster-urls) cluster-url))
+                                              (is (= test-token token))
+                                              (throw (ex-info "thrown from test" {:cluster-url cluster-url})))}]
+        (is (= {:details {"http://c1.com"
+                          {:exit-code 1
+                           :message (str "unable to ping token test-token on http://c1.com, "
+                                         "reason: thrown from test")}}
+                :exit-code 1
+                :message "pinging token test-token on [http://c1.com] failed"}
+               (ping-token waiter-api test-cluster-urls test-token)))))
+
+    (testing "unsuccessful health check"
+      (let [test-cluster-urls ["http://c1.com"]
+            waiter-api {:health-check-token (fn [cluster-url token]
+                                              (is (= (first test-cluster-urls) cluster-url))
+                                              (is (= test-token token))
+                                              {:body "failure" :status 400})}]
+        (is (= {:details {"http://c1.com"
+                          {:exit-code 1
+                           :message (str "unable to ping token test-token on http://c1.com, "
+                                         "reason: health check returned status code 400")}}
+                :exit-code 1
+                :message "pinging token test-token on [http://c1.com] failed"}
+               (ping-token waiter-api test-cluster-urls test-token)))))
+
+    (testing "unsuccessful health check"
+      (let [test-cluster-urls ["http://c1.com" "http://c2.com"]
+            waiter-api {:health-check-token (fn [cluster-url token]
+                                              (is (= test-token token))
+                                              {:body (str "failure " cluster-url) :status 400})}]
+        (is (= {:details {"http://c1.com"
+                          {:exit-code 1
+                           :message (str "unable to ping token test-token on http://c1.com, "
+                                         "reason: health check returned status code 400")}
+                          "http://c2.com"
+                          {:exit-code 1
+                           :message (str "unable to ping token test-token on http://c2.com, "
+                                         "reason: health check returned status code 400")}}
+                :exit-code 2
+                :message "pinging token test-token on [http://c1.com http://c2.com] failed"}
+               (ping-token waiter-api test-cluster-urls test-token)))))
+
+    (testing "single unsuccessful health check"
+      (let [test-cluster-urls ["http://c1.com" "http://c2.com"]
+            waiter-api {:health-check-token (fn [cluster-url token]
+                                              (is (= test-token token))
+                                              (if (= cluster-url "http://c1.com")
+                                                {:body (str "success " cluster-url) :status 200}
+                                                {:body (str "failure " cluster-url) :status 400}))}]
+        (is (= {:details {"http://c1.com"
+                          {:exit-code 0
+                           :message (str "Successfully pinged token test-token on http://c1.com, "
+                                         "reason: health check returned status code 200")}
+                          "http://c2.com"
+                          {:exit-code 1
+                           :message (str "unable to ping token test-token on http://c2.com, "
+                                         "reason: health check returned status code 400")}}
+                :exit-code 1
+                :message "pinging token test-token on [http://c1.com http://c2.com] failed"}
+               (ping-token waiter-api test-cluster-urls test-token)))))
+
+    (testing "successful health check"
+      (let [test-cluster-urls ["http://c1.com" "http://c2.com"]
+            waiter-api {:health-check-token (fn [cluster-url token]
+                                              (is (= test-token token))
+                                              {:body (str "success " cluster-url) :status 200})}]
+        (is (= {:details {"http://c1.com"
+                          {:exit-code 0
+                           :message (str "Successfully pinged token test-token on http://c1.com, "
+                                         "reason: health check returned status code 200")}
+                          "http://c2.com"
+                          {:exit-code 0
+                           :message (str "Successfully pinged token test-token on http://c2.com, "
+                                         "reason: health check returned status code 200")}}
+                :exit-code 0
+                :message "pinging token test-token on [http://c1.com http://c2.com] was successful"}
+               (ping-token waiter-api test-cluster-urls test-token)))))))
+
+(deftest test-ping-token-config
+  (let [test-command-config (assoc ping-token-config :command-name "test-command")
+        waiter-api {:health-check-token (constantly {})}
+        context {:waiter-api waiter-api}]
+    (testing "sub-command token config"
+      (let [args []]
+        (is (= {:exit-code 1
+                :message "test-command: no arguments provided, usage TOKEN URL..."}
+               (cli/process-command test-command-config context args))))
+      (with-out-str
+        (let [args ["-h"]]
+          (is (= {:exit-code 0
+                  :message "test-command: displayed documentation"}
+                 (cli/process-command test-command-config context args)))))
+      (let [args ["http://c1.com" "http://c2.com"]]
+        (is (= {:exit-code 1
+                :message (str "test-command: token is not valid: "
+                              "{:arguments [http://c1.com http://c2.com],"
+                              " :pattern [a-zA-Z]([a-zA-Z0-9\\-_$\\.])+,"
+                              " :token http://c1.com}")}
+               (cli/process-command test-command-config context args))))
+      (let [args ["my-token"]]
+        (with-redefs [ping-token (fn [in-waiter-api in-cluster-urls token]
+                                   (is (= waiter-api in-waiter-api))
+                                   (is (= #{"http://c1.com"} in-cluster-urls))
+                                   (is (= "my-token" token))
+                                   {:exit-code 0})]
+          (is (= {:exit-code 1
+                  :message "test-command: at least one cluster url required, provided: []"}
+                 (cli/process-command test-command-config context args)))))
+      (let [args ["my-token" "http://c1.com"]]
+        (with-redefs [ping-token (fn [in-waiter-api in-cluster-urls token]
+                                   (is (= waiter-api in-waiter-api))
+                                   (is (= #{"http://c1.com"} in-cluster-urls))
+                                   (is (= "my-token" token))
+                                   {:exit-code 0})]
+          (is (= {:exit-code 0
+                  :message "test-command: exiting with code 0"}
+                 (cli/process-command test-command-config context args)))))
+      (let [args ["my-token" "http://c1.com" "http://c2.com"]]
+        (with-redefs [ping-token (fn [in-waiter-api in-cluster-urls token]
+                                   (is (= waiter-api in-waiter-api))
+                                   (is (= #{"http://c1.com" "http://c2.com"} in-cluster-urls))
+                                   (is (= "my-token" token))
+                                   {:exit-code 0})]
+          (is (= {:exit-code 0
+                  :message "test-command: exiting with code 0"}
+                 (cli/process-command test-command-config context args))))))))

--- a/token-syncer/test/token_syncer/waiter_test.clj
+++ b/token-syncer/test/token_syncer/waiter_test.clj
@@ -242,7 +242,8 @@
   (let [http-client-wrapper (Object.)
         test-cluster-url "http://www.test.com:1234"
         test-token "lorem-ipsum"
-        expected-options {:headers {"x-waiter-queue-timeout" 120000
+        queue-timeout-ms 120000
+        expected-options {:headers {"x-waiter-queue-timeout" queue-timeout-ms
                                     "x-waiter-token" test-token}
                           :method :get
                           :query-params {}}]
@@ -257,7 +258,7 @@
                       make-http-request (fn [& _]
                                           (throw (Exception. "unexpected call")))]
           (is (thrown-with-msg? Exception #"exception from test"
-                                (health-check-token http-client-wrapper test-cluster-url test-token))))))
+                                (health-check-token http-client-wrapper test-cluster-url test-token queue-timeout-ms))))))
 
     (testing "deleted token"
       (let [error (Exception. "exception from test")]
@@ -269,7 +270,7 @@
                                     "health-check-url" "/health-check"})
                       make-http-request (fn [& _]
                                           (throw (Exception. "unexpected call")))]
-          (is (nil? (health-check-token http-client-wrapper test-cluster-url test-token))))))
+          (is (nil? (health-check-token http-client-wrapper test-cluster-url test-token queue-timeout-ms))))))
 
     (testing "error in health check"
       (let [error (Exception. "exception from test")]
@@ -284,7 +285,7 @@
                                           (is (= expected-options (apply hash-map in-options)))
                                           (throw error))]
           (is (thrown-with-msg? Exception #"exception from test"
-                                (health-check-token http-client-wrapper test-cluster-url test-token))))))
+                                (health-check-token http-client-wrapper test-cluster-url test-token queue-timeout-ms))))))
 
     (testing "error in status code"
       (with-redefs [load-token (fn [in-http-client-wrapper in-cluster-url in-token]
@@ -300,7 +301,7 @@
         (is (= {:body "{\"message\":\"failed\"}"
                 :headers {}
                 :status 400}
-               (health-check-token http-client-wrapper test-cluster-url test-token)))))
+               (health-check-token http-client-wrapper test-cluster-url test-token queue-timeout-ms)))))
 
     (testing "successful response"
       (with-redefs [load-token (fn [in-http-client-wrapper in-cluster-url in-token]
@@ -316,4 +317,4 @@
         (is (= {:body "{\"message\":\"success\"}"
                 :headers {}
                 :status 200}
-               (health-check-token http-client-wrapper test-cluster-url test-token)))))))
+               (health-check-token http-client-wrapper test-cluster-url test-token queue-timeout-ms)))))))

--- a/token-syncer/test/token_syncer/waiter_test.clj
+++ b/token-syncer/test/token_syncer/waiter_test.clj
@@ -28,7 +28,7 @@
          (async/put! body-chan))
     (cond-> {:body body-chan
              :headers (or headers {})}
-            status (assoc :status status))))
+      status (assoc :status status))))
 
 (deftest test-make-http-request
   (let [http-client-wrapper (Object.)
@@ -72,8 +72,8 @@
                                             (update :headers dissoc "x-cid"))))
                                  (let [response-chan (async/promise-chan)
                                        response (cond-> {}
-                                                        (not (:auth in-options))
-                                                        (assoc :status 401 :headers {"www-authenticate" "Negotiate"}))]
+                                                  (not (:auth in-options))
+                                                  (assoc :status 401 :headers {"www-authenticate" "Negotiate"}))]
                                    (async/put! response-chan response)
                                    response-chan))]
           (make-http-request http-client-wrapper test-endpoint
@@ -90,7 +90,7 @@
       (let [error (Exception. "exception from test")]
         (with-redefs [make-http-request (fn [in-http-client-wrapper in-endopint-url & in-options]
                                           (is (= http-client-wrapper in-http-client-wrapper))
-                                          (is (= (str test-cluster-url "/token")) in-endopint-url)
+                                          (is (= (str test-cluster-url "/tokens") in-endopint-url))
                                           (is (= [:headers {"accept" "application/json"}
                                                   :query-params {"include" ["deleted" "metadata"]}]
                                                  in-options))
@@ -104,7 +104,7 @@
                             {"last-update-time" 3000, "owner" "test-3", "token" "token-3"}]]
         (with-redefs [make-http-request (fn [in-http-client-wrapper in-endopint-url & in-options]
                                           (is (= http-client-wrapper in-http-client-wrapper))
-                                          (is (= (str test-cluster-url "/token")) in-endopint-url)
+                                          (is (= (str test-cluster-url "/tokens") in-endopint-url))
                                           (is (= [:headers {"accept" "application/json"}
                                                   :query-params {"include" ["deleted" "metadata"]}]
                                                  in-options))
@@ -123,7 +123,7 @@
       (let [error (Exception. "exception from test")]
         (with-redefs [make-http-request (fn [in-http-client-wrapper in-endopint-url & in-options]
                                           (is (= http-client-wrapper in-http-client-wrapper))
-                                          (is (= (str test-cluster-url "/token")) in-endopint-url)
+                                          (is (= (str test-cluster-url "/token") in-endopint-url))
                                           (is (= expected-options (apply hash-map in-options)))
                                           (throw error))]
           (is (= {:error error}
@@ -137,7 +137,7 @@
             last-modified-str current-time-ms]
         (with-redefs [make-http-request (fn [in-http-client-wrapper in-endopint-url & in-options]
                                           (is (= http-client-wrapper in-http-client-wrapper))
-                                          (is (= (str test-cluster-url "/token")) in-endopint-url)
+                                          (is (= (str test-cluster-url "/token") in-endopint-url))
                                           (is (= expected-options (apply hash-map in-options)))
                                           (send-json-response token-response
                                                               :headers {"etag" last-modified-str}
@@ -166,7 +166,7 @@
       (let [error (Exception. "exception from test")]
         (with-redefs [make-http-request (fn [in-http-client-wrapper in-endopint-url & in-options]
                                           (is (= http-client-wrapper in-http-client-wrapper))
-                                          (is (= (str test-cluster-url "/token")) in-endopint-url)
+                                          (is (= (str test-cluster-url "/token") in-endopint-url))
                                           (is (= expected-options (apply hash-map in-options)))
                                           (throw error))]
           (is (thrown-with-msg? Exception #"exception from test"
@@ -177,7 +177,7 @@
       (let [token-response {"message" "failed"}]
         (with-redefs [make-http-request (fn [in-http-client-wrapper in-endopint-url & in-options]
                                           (is (= http-client-wrapper in-http-client-wrapper))
-                                          (is (= (str test-cluster-url "/token")) in-endopint-url)
+                                          (is (= (str test-cluster-url "/token") in-endopint-url))
                                           (is (= expected-options (apply hash-map in-options)))
                                           (send-json-response token-response :status 300))]
           (is (thrown-with-msg? Exception #"Token store failed"
@@ -188,7 +188,7 @@
       (let [token-response {"message" "success"}]
         (with-redefs [make-http-request (fn [in-http-client-wrapper in-endopint-url & in-options]
                                           (is (= http-client-wrapper in-http-client-wrapper))
-                                          (is (= (str test-cluster-url "/token")) in-endopint-url)
+                                          (is (= (str test-cluster-url "/token") in-endopint-url))
                                           (is (= expected-options (apply hash-map in-options)))
                                           (send-json-response token-response :status 200))]
           (is (= {:body token-response, :headers {}, :status 200}
@@ -210,7 +210,7 @@
       (let [error (Exception. "exception from test")]
         (with-redefs [make-http-request (fn [in-http-client-wrapper in-endopint-url & in-options]
                                           (is (= http-client-wrapper in-http-client-wrapper))
-                                          (is (= (str test-cluster-url "/token")) in-endopint-url)
+                                          (is (= (str test-cluster-url "/token") in-endopint-url))
                                           (is (= expected-options (apply hash-map in-options)))
                                           (throw error))]
           (is (thrown-with-msg? Exception #"exception from test"
@@ -221,7 +221,7 @@
       (let [token-response {"message" "failed"}]
         (with-redefs [make-http-request (fn [in-http-client-wrapper in-endopint-url & in-options]
                                           (is (= http-client-wrapper in-http-client-wrapper))
-                                          (is (= (str test-cluster-url "/token")) in-endopint-url)
+                                          (is (= (str test-cluster-url "/token") in-endopint-url))
                                           (is (= expected-options (apply hash-map in-options)))
                                           (send-json-response token-response :status 300))]
           (is (thrown-with-msg? Exception #"Token hard-delete failed"
@@ -232,8 +232,88 @@
       (let [token-response {"message" "success"}]
         (with-redefs [make-http-request (fn [in-http-client-wrapper in-endopint-url & in-options]
                                           (is (= http-client-wrapper in-http-client-wrapper))
-                                          (is (= (str test-cluster-url "/token")) in-endopint-url)
+                                          (is (= (str test-cluster-url "/token") in-endopint-url))
                                           (is (= expected-options (apply hash-map in-options)))
                                           (send-json-response token-response :status 200))]
           (is (= {:body token-response, :headers {}, :status 200}
                  (hard-delete-token http-client-wrapper test-cluster-url test-token test-token-etag))))))))
+
+(deftest test-health-check-token
+  (let [http-client-wrapper (Object.)
+        test-cluster-url "http://www.test.com:1234"
+        test-token "lorem-ipsum"
+        expected-options {:headers {"x-waiter-queue-timeout" 120000
+                                    "x-waiter-token" test-token}
+                          :method :get
+                          :query-params {}}]
+
+    (testing "error in loading token"
+      (let [error (Exception. "exception from test")]
+        (with-redefs [load-token (fn [in-http-client-wrapper in-cluster-url in-token]
+                                   (is (= http-client-wrapper in-http-client-wrapper))
+                                   (is (= test-cluster-url in-cluster-url))
+                                   (is (= test-token in-token))
+                                   (throw error))
+                      make-http-request (fn [& _]
+                                          (throw (Exception. "unexpected call")))]
+          (is (thrown-with-msg? Exception #"exception from test"
+                                (health-check-token http-client-wrapper test-cluster-url test-token))))))
+
+    (testing "deleted token"
+      (let [error (Exception. "exception from test")]
+        (with-redefs [load-token (fn [in-http-client-wrapper in-cluster-url in-token]
+                                   (is (= http-client-wrapper in-http-client-wrapper))
+                                   (is (= test-cluster-url in-cluster-url))
+                                   (is (= test-token in-token))
+                                   {"deleted" true
+                                    "health-check-url" "/health-check"})
+                      make-http-request (fn [& _]
+                                          (throw (Exception. "unexpected call")))]
+          (is (nil? (health-check-token http-client-wrapper test-cluster-url test-token))))))
+
+    (testing "error in health check"
+      (let [error (Exception. "exception from test")]
+        (with-redefs [load-token (fn [in-http-client-wrapper in-cluster-url in-token]
+                                   (is (= http-client-wrapper in-http-client-wrapper))
+                                   (is (= test-cluster-url in-cluster-url))
+                                   (is (= test-token in-token))
+                                   {:description {"health-check-url" "/health-check"}})
+                      make-http-request (fn [in-http-client-wrapper in-endopint-url & in-options]
+                                          (is (= http-client-wrapper in-http-client-wrapper))
+                                          (is (= (str test-cluster-url "/health-check") in-endopint-url))
+                                          (is (= expected-options (apply hash-map in-options)))
+                                          (throw error))]
+          (is (thrown-with-msg? Exception #"exception from test"
+                                (health-check-token http-client-wrapper test-cluster-url test-token))))))
+
+    (testing "error in status code"
+      (with-redefs [load-token (fn [in-http-client-wrapper in-cluster-url in-token]
+                                 (is (= http-client-wrapper in-http-client-wrapper))
+                                 (is (= test-cluster-url in-cluster-url))
+                                 (is (= test-token in-token))
+                                 {:description {"health-check-url" "/health-check"}})
+                    make-http-request (fn [in-http-client-wrapper in-endopint-url & in-options]
+                                        (is (= http-client-wrapper in-http-client-wrapper))
+                                        (is (= (str test-cluster-url "/health-check") in-endopint-url))
+                                        (is (= expected-options (apply hash-map in-options)))
+                                        (send-json-response {"message" "failed"} :status 400))]
+        (is (= {:body "{\"message\":\"failed\"}"
+                :headers {}
+                :status 400}
+               (health-check-token http-client-wrapper test-cluster-url test-token)))))
+
+    (testing "successful response"
+      (with-redefs [load-token (fn [in-http-client-wrapper in-cluster-url in-token]
+                                 (is (= http-client-wrapper in-http-client-wrapper))
+                                 (is (= test-cluster-url in-cluster-url))
+                                 (is (= test-token in-token))
+                                 {:description {"health-check-url" "/health-check"}})
+                    make-http-request (fn [in-http-client-wrapper in-endopint-url & in-options]
+                                        (is (= http-client-wrapper in-http-client-wrapper))
+                                        (is (= (str test-cluster-url "/health-check") in-endopint-url))
+                                        (is (= expected-options (apply hash-map in-options)))
+                                        (send-json-response {"message" "success"} :status 200))]
+        (is (= {:body "{\"message\":\"success\"}"
+                :headers {}
+                :status 200}
+               (health-check-token http-client-wrapper test-cluster-url test-token)))))))


### PR DESCRIPTION
## Changes proposed in this PR

- adds health-check-token to waiter-api
- adds sub-command for pinging tokens on multiple clusters

## Why are we making these changes?

We would like the ability to ensure a token can be used to successfully launch services on multiple clusters.

### Example usage:

```
$ lein run -- ping-token -q 10000 test-healthy-1234 http://localhost:9091 http://localhost:9093
2018-08-27 17:06:56 INFO  token-syncer.main - command-line arguments: [ping-token -q 10000 test-healthy-1234 http://localhost:9091 http://localhost:9093]
2018-08-27 17:06:57 INFO  token-syncer.commands.ping - pinging token test-healthy-1234 on clusters: #{http://localhost:9093 http://localhost:9091}
2018-08-27 17:06:57 INFO  token-syncer.waiter - health-check-token test-healthy-1234 on http://localhost:9093 with queue timeout of 10000 ms
2018-08-27 17:06:57 INFO  token-syncer.waiter - token-syncer.569640a3-0a74-4f71-8e2c-734aca9f8ad7 making GET request to http://localhost:9093/token
2018-08-27 17:06:57 INFO  token-syncer.waiter - loading test-healthy-1234 on http://localhost:9093 responded with status 200 {content-type application/json, etag E-ed0d92d0c2b01f94fc813d03a4dc404d, x-cid token-syncer.569640a3-0a74-4f71-8e2c-734aca9f8ad7}
2018-08-27 17:06:57 INFO  token-syncer.waiter - health-check-token test-healthy-1234 on http://localhost:9093/status
2018-08-27 17:06:57 INFO  token-syncer.waiter - token-syncer.bf432023-7550-4e46-9fe5-c83d068cf5a7 making GET request to http://localhost:9093/status
2018-08-27 17:06:57 INFO  token-syncer.commands.ping - http://localhost:9093 health check response: {:body Hello World, :headers {..., content-length 11}, :status 200}
2018-08-27 17:06:57 INFO  token-syncer.waiter - health-check-token test-healthy-1234 on http://localhost:9091 with queue timeout of 10000 ms
2018-08-27 17:06:57 INFO  token-syncer.waiter - token-syncer.302433a6-345f-40c6-826f-826be97c3b48 making GET request to http://localhost:9091/token
2018-08-27 17:06:57 INFO  token-syncer.waiter - loading test-healthy-1234 on http://localhost:9091 responded with status 200 {content-type application/json, etag E-5aefd0ecd1261b5b4ee87883a3244de0, x-cid token-syncer.302433a6-345f-40c6-826f-826be97c3b48}
2018-08-27 17:06:57 INFO  token-syncer.waiter - health-check-token test-healthy-1234 on http://localhost:9091/status
2018-08-27 17:06:57 INFO  token-syncer.waiter - token-syncer.2e265000-daeb-4f77-aaf1-c8de8b498e4e making GET request to http://localhost:9091/status
2018-08-27 17:06:57 INFO  token-syncer.commands.ping - http://localhost:9091 health check response: {:body Hello World, :headers {..., content-length 11}, :status 200}
2018-08-27 17:06:57 INFO  token-syncer.commands.ping - {:details
 {"http://localhost:9093"
  {:exit-code 0,
   :message
   "successfully pinged token test-healthy-1234 on http://localhost:9093, reason: health check returned status code 200"},
  "http://localhost:9091"
  {:exit-code 0,
   :message
   "successfully pinged token test-healthy-1234 on http://localhost:9091, reason: health check returned status code 200"}},
 :exit-code 0,
 :message
 "pinging token test-healthy-1234 on [http://localhost:9093 http://localhost:9091] was successful",
 :token "test-healthy-1234"}
2018-08-27 17:06:57 INFO  token-syncer.main - token-syncer: ping-token: exiting with code 0

$ lein run -- ping-token -q 10000 test-fail-1234 http://localhost:9091 http://localhost:9093
2018-08-27 17:03:26 INFO  token-syncer.main - command-line arguments: [ping-token -q 10000 test-fail-1234 http://localhost:9091 http://localhost:9093]
2018-08-27 17:03:27 INFO  token-syncer.commands.ping - pinging token test-fail-1234 on clusters: #{http://localhost:9093 http://localhost:9091}
2018-08-27 17:03:27 INFO  token-syncer.waiter - health-check-token test-fail-1234 on http://localhost:9093 with queue timeout of 10000 ms
2018-08-27 17:03:27 INFO  token-syncer.waiter - token-syncer.ca10e9d9-4c26-477d-ba27-12ca1af5634a making GET request to http://localhost:9093/token
2018-08-27 17:03:27 INFO  token-syncer.waiter - loading test-fail-1234 on http://localhost:9093 responded with status 200 {content-type application/json, etag E-7890399a41a843c5c4cf84d33b567da4, x-cid token-syncer.ca10e9d9-4c26-477d-ba27-12ca1af5634a}
2018-08-27 17:03:27 INFO  token-syncer.waiter - health-check-token not performed {:cluster-url http://localhost:9093, :deleted nil, :health-check-url nil, :token test-fail-1234}
2018-08-27 17:03:27 INFO  token-syncer.commands.ping - http://localhost:9093 health check response: {:body , :headers nil, :status nil}
2018-08-27 17:03:27 INFO  token-syncer.waiter - health-check-token test-fail-1234 on http://localhost:9091 with queue timeout of 10000 ms
2018-08-27 17:03:27 INFO  token-syncer.waiter - token-syncer.1f559ea7-db51-49e0-9652-2c166c25cdc2 making GET request to http://localhost:9091/token
2018-08-27 17:03:27 INFO  token-syncer.waiter - loading test-fail-1234 on http://localhost:9091 responded with status 200 {content-type application/json, etag E-7890399a41a843c5c4cf84d33b567da4, x-cid token-syncer.1f559ea7-db51-49e0-9652-2c166c25cdc2}
2018-08-27 17:03:27 INFO  token-syncer.waiter - health-check-token not performed {:cluster-url http://localhost:9091, :deleted nil, :health-check-url nil, :token test-fail-1234}
2018-08-27 17:03:27 INFO  token-syncer.commands.ping - http://localhost:9091 health check response: {:body , :headers nil, :status nil}
2018-08-27 17:03:27 INFO  token-syncer.commands.ping - {:details
 {"http://localhost:9093"
  {:exit-code 1,
   :message
   "unable to ping token test-fail-1234 on http://localhost:9093, reason: health check returned status code "},
  "http://localhost:9091"
  {:exit-code 1,
   :message
   "unable to ping token test-fail-1234 on http://localhost:9091, reason: health check returned status code "}},
 :exit-code 2,
 :message
 "pinging token test-fail-1234 on [http://localhost:9093 http://localhost:9091] failed",
 :token
 "test-fail-1234"}
2018-08-27 17:03:27 ERROR token-syncer.main - token-syncer: ping-token: exiting with code 2
```