### PR TITLE
deflakes test-router-state-maintainer-removes-killed-instances

### DIFF
--- a/waiter/test/waiter/state_test.clj
+++ b/waiter/test/waiter/state_test.clj
@@ -1046,7 +1046,7 @@
         make-instance (fn [index]
                         {:id (str service-id "." index)
                          :service-id service-id
-                         :started-at (t/minus (t/now) (t/minutes index))})
+                         :started-at (t/minus (t/now) (t/seconds (+ (-> index t/minutes t/in-seconds) 10)))})
         deployment-error-config {:min-failed-instances 2
                                  :min-hosts 2}
         instance-0 (make-instance 0)


### PR DESCRIPTION
## Changes proposed in this PR

- deflakes `test-router-state-maintainer-removes-killed-instances`

## Why are we making these changes?

`test-router-state-maintainer-removes-killed-instances` is flaky.
