### PR TITLE
renders user metadata keys by default in token output

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1195,6 +1195,13 @@
               post-response (post-token waiter-url token-description-1)
               _ (assert-response-status post-response 200)
               service-id-1 (retrieve-service-id waiter-url service-id-headers)]
+
+          (testing "token response contains fallback and owner"
+            (let [{:keys [body] :as response} (get-token waiter-url token :query-params {})]
+              (assert-response-status response 200)
+              (is (= (assoc service-description-1 :owner (retrieve-username))
+                     (-> body json/read-str walk/keywordize-keys)))))
+
           (with-service-cleanup
             service-id-1
 

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -124,9 +124,9 @@
         (is (contains? token-description# :owner))
         (is (contains? token-description# :root)))
       (is (= (cond-> {:health-check-url "/probe"
-                      :name ~service-id-prefix}
+                      :name ~service-id-prefix
+                      :owner (retrieve-username)}
                      ~include-metadata (assoc :last-update-user (retrieve-username)
-                                              :owner (retrieve-username)
                                               :root ~token-root)
                      (and ~deleted ~include-metadata) (assoc :deleted ~deleted))
              (dissoc token-description# :last-update-time :previous))))))

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -287,9 +287,10 @@
       (let [epoch-time->date-time (fn [epoch-time] (DateTime. epoch-time))]
         (log/info "successfully retrieved token " token)
         (utils/clj->json-response
-          (cond-> service-parameter-template
+          (cond-> (merge service-parameter-template
+                         (select-keys token-metadata sd/user-metadata-keys))
                   show-metadata
-                  (merge (cond-> (loop [loop-token-metadata token-metadata
+                  (merge (cond-> (loop [loop-token-metadata (select-keys token-metadata sd/system-metadata-keys)
                                         nested-last-update-time-path ["last-update-time"]]
                                    (if (get-in loop-token-metadata nested-last-update-time-path)
                                      (recur (update-in loop-token-metadata nested-last-update-time-path epoch-time->date-time)


### PR DESCRIPTION
## Changes proposed in this PR

- renders user metadata keys by default in token output

## Why are we making these changes?

Rendering user modifiable metadata entries by default in token output avoids confusion, e.g. when using fallback support. One side-effect of this change is that the `owner` entry is always displayed, even if the user did not provide it explicitly, as it is generated and stored when not provided.

**Example output:**
<img width="822" alt="screen shot 2018-08-29 at 1 14 50 pm" src="https://user-images.githubusercontent.com/6611249/44806823-91397380-ab8d-11e8-9ae2-6a1c4d11f7b9.png">
