### PR TITLE
Update Kitchen SSL certificate environment variables

### DIFF
--- a/kitchen/bin/ci/run.sh
+++ b/kitchen/bin/ci/run.sh
@@ -2,6 +2,8 @@
 
 set -x
 
+source ./bin/ci/ssl-env.sh
+
 python --version
 pytest --version
 

--- a/kitchen/bin/ci/setup.sh
+++ b/kitchen/bin/ci/setup.sh
@@ -2,9 +2,29 @@
 
 set -x
 
+################################
+# Python environment setup
+
 pyenv global 3.6
 
 python --version
 python3 --version
 
 pip install -r requirements_test.txt
+
+################################
+# SSL certificate setup
+
+source ./bin/ci/ssl-env.sh
+
+# Generate CA certificate for self-signing
+openssl genrsa -out $CA_KEY_PATH 4096
+openssl req -new -x509 -key $CA_KEY_PATH -out $CA_CERT_PATH -subj '/CN=Kitchen Test CA/O=Waiter Kitchen/C=US'
+
+# Generate self-signed certificate for HTTPS server
+openssl req -newkey rsa:4096 -keyout $KEY_PATH -passout "pass:$KEY_PASSWORD" -out temp.csr -subj '/CN=localhost/O=Waiter Kitchen/C=US'
+openssl x509 -req -in temp.csr -CA $CA_CERT_PATH -CAkey $CA_KEY_PATH -CAcreateserial -out $CERT_PATH -extfile <(printf "subjectAltName=DNS:localhost")
+
+# Set up current directory for certificate verification
+# (needed for the Python requests verify='.' option)
+c_rehash .

--- a/kitchen/bin/ci/ssl-env.sh
+++ b/kitchen/bin/ci/ssl-env.sh
@@ -1,0 +1,5 @@
+export CERT_PATH=./kitchen.crt
+export KEY_PATH=./kitchen.key
+export KEY_PASSWORD='Kitchen Private Key Password'
+export CA_KEY_PATH=./kitchen-ca.key
+export CA_CERT_PATH=./kitchen-ca.crt

--- a/kitchen/bin/kitchen
+++ b/kitchen/bin/kitchen
@@ -932,10 +932,11 @@ if __name__ == '__main__':
         _auth_handler = BasicAuthHandler(username, password)
 
     if args.ssl:
-        keystore_path = os.environ.get('KEYSTORE')
-        keystore_password = os.environ.get('KEYSTORE_PASSWORD')
-        if not (keystore_path and keystore_password):
-            error_msg = 'Must set both KEYSTORE and KEYSTORE_PASSWORD environment variables for HTTPS mode.'
+        cert_path = os.environ.get('CERT_PATH')
+        key_path = os.environ.get('KEY_PATH')
+        key_password = os.environ.get('KEY_PASSWORD')
+        if not cert_path:
+            error_msg = 'Must set CERT_PATH environment variable for HTTPS mode. KEY_PATH and KEY_PASSWORD are optional.'
             kitchen_logger.error(error_msg)
             sys.exit(error_msg)
 
@@ -955,7 +956,7 @@ if __name__ == '__main__':
             except AttributeError:
                 ssl_protocol = ssl.PROTOCOL_TLSv1_2
             ssl_context = ssl.SSLContext(ssl_protocol)
-            ssl_context.load_cert_chain(keystore_path, password=keystore_password)
+            ssl_context.load_cert_chain(cert_path, key_path, key_password)
             kitchen.socket = ssl_context.wrap_socket(kitchen.socket, server_side=True)
             protocol = 'HTTPS'
         else:

--- a/kitchen/tests/kitchen/test_basic_http.py
+++ b/kitchen/tests/kitchen/test_basic_http.py
@@ -23,6 +23,13 @@ class TestBasicHttp:
         assert req.headers.get('Content-Type') == 'text/plain'
         assert req.text == 'Hello World'
 
+    def test_hello_https(self, kitchen_ssl_server):
+        """Test default 'Hello World' response with HTTPS"""
+        req = requests.get(kitchen_ssl_server.url(), verify='.')
+        assert req.status_code == requests.codes.ok
+        assert req.headers.get('Content-Type') == 'text/plain'
+        assert req.text == 'Hello World'
+
     def test_content_type(self, kitchen_server):
         """Test default 'Hello World' response"""
         req = requests.get(kitchen_server.url(), headers={'x-kitchen-content-type': 'text/html'})


### PR DESCRIPTION
## Changes proposed in this PR

- Changes the environment variables used for providing SSL certificates files
  + `KEYSTORE` → `CERT_PATH`
  + Add optional separate `KEY_PATH` variable
  + `KEYSTORE_PASSWORD` → `KEY_PASSWORD`
- Adds a Kitchen unit test for Kitchen using HTTPS
- Adds self-signed certificate generation to the Travis-CI setup script

## Why are we making these changes?

Since Python does not have built-in support for Java keystores, it's more accurate to use environment variable names corresponding to separate certificate, private key, and password settings. We previously called the combined certificate+private-key PEM file a "keystore", but now we use the same terms as the Python function handling the SSL-related files.
