### PR TITLE
adds support for restoring shell scheduler state during restart

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -419,12 +419,9 @@
                             :factory-fn waiter.scheduler.shell/shell-scheduler
 
                             ;; The shell scheduler can persist its state and use this state when it restarts.
-                            :backup {
-                                     ;; The file in the work directory which contains the scheduler state:
-                                     :file-name "backup.json"
-
-                                     ;; The interval (milliseconds) at which to persist the scheduler state:
-                                     :interval-ms 5000}
+                            ;; This is an optional config, when not provided no backup state will be persisted.
+                            ;; The file in the work directory which contains the scheduler state:
+                            :backup-file-name "backup.json"
 
                             ;; The interval (milliseconds) at which instance health will be checked:
                             :health-check-interval-ms 10000

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -418,6 +418,14 @@
                     :shell {
                             :factory-fn waiter.scheduler.shell/shell-scheduler
 
+                            ;; The shell scheduler can persist its state and use this state when it restarts.
+                            :backup {
+                                     ;; The file in the work directory which contains the scheduler state:
+                                     :file-name "backup.json"
+
+                                     ;; The interval (milliseconds) at which to persist the scheduler state:
+                                     :interval-ms 5000}
+
                             ;; The interval (milliseconds) at which instance health will be checked:
                             :health-check-interval-ms 10000
 

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -332,7 +332,8 @@
 
 (defn- alive?
   "Returns true if the process is running.
-   It first tries to query the process handle, which is absent we fallback to the shell."
+   It first tries to query the process handle to check if the process is alive.
+   If the process handle is missing, we fallback to the shell to check the state of the process."
   [{:keys [:shell-scheduler/pid :shell-scheduler/process] :as instance}]
   (cond
     process (.isAlive process)

--- a/waiter/test-files/shell-scheduler-backup.json
+++ b/waiter/test-files/shell-scheduler-backup.json
@@ -37,6 +37,23 @@
           "shell-scheduler/pid": 76576,
           "shell-scheduler/working-directory": "/tmp/w8r-kitchen/w8r-kitchen.b2",
           "started-at": "2018-08-30T15:44:37.393Z"
+        },
+        "w8r-kitchen.c3": {
+          "exit-code": null,
+          "extra-ports": [],
+          "flags": [],
+          "health-check-status": null,
+          "healthy?": true,
+          "host": "127.0.0.8",
+          "id": "w8r-kitchen.c3",
+          "log-directory": "/tmp/w8r-kitchen/w8r-kitchen.c3",
+          "message": null,
+          "port": 10002,
+          "protocol": "http",
+          "service-id": "w8r-kitchen",
+          "shell-scheduler/pid": 82982,
+          "shell-scheduler/working-directory": "/tmp/w8r-kitchen/w8r-kitchen.c3",
+          "started-at": "2018-08-30T15:45:37.393Z"
         }
       },
       "service": {
@@ -89,10 +106,10 @@
           "version": "v1"
         },
         "shell-scheduler/mem": 256,
-        "task-count": 1,
+        "task-count": 2,
         "task-stats": {
-          "healthy": 1,
-          "running": 1,
+          "healthy": 2,
+          "running": 2,
           "staged": 0,
           "unhealthy": 0
         }

--- a/waiter/test-files/shell-scheduler-backup.json
+++ b/waiter/test-files/shell-scheduler-backup.json
@@ -1,0 +1,112 @@
+{
+  "id->service": {
+    "w8r-kitchen": {
+      "id->instance": {
+        "w8r-kitchen.a1": {
+          "exit-code": 1,
+          "extra-ports": [],
+          "failed?": true,
+          "flags": [],
+          "health-check-status": null,
+          "healthy?": false,
+          "host": "127.0.0.5",
+          "id": "w8r-kitchen.a1",
+          "killed?": true,
+          "log-directory": "/tmp/w8r-kitchen/w8r-kitchen.a1",
+          "message": "Exited with code 1",
+          "port": 10000,
+          "protocol": "http",
+          "service-id": "w8r-kitchen",
+          "shell-scheduler/pid": 32432,
+          "shell-scheduler/working-directory": "/tmp/w8r-kitchen/w8r-kitchen.a1",
+          "started-at": "2018-08-30T15:44:33.136Z"
+        },
+        "w8r-kitchen.b2": {
+          "exit-code": null,
+          "extra-ports": [],
+          "flags": [],
+          "health-check-status": null,
+          "healthy?": true,
+          "host": "127.0.0.10",
+          "id": "w8r-kitchen.b2",
+          "log-directory": "/tmp/w8r-kitchen/w8r-kitchen.b2",
+          "message": null,
+          "port": 10001,
+          "protocol": "http",
+          "service-id": "w8r-kitchen",
+          "shell-scheduler/pid": 76576,
+          "shell-scheduler/working-directory": "/tmp/w8r-kitchen/w8r-kitchen.b2",
+          "started-at": "2018-08-30T15:44:37.393Z"
+        }
+      },
+      "service": {
+        "environment": {
+          "HOME": "/home/w8r",
+          "LOGNAME": "w8r",
+          "USER": "w8r",
+          "WAITER_CPUS": "0.1",
+          "WAITER_MEM_MB": "256",
+          "WAITER_PASSWORD": "7e37af",
+          "WAITER_SERVICE_ID": "w8r-kitchen",
+          "WAITER_USERNAME": "waiter"
+        },
+        "id": "w8r-kitchen",
+        "instances": 1,
+        "service-description": {
+          "allowed-params": [],
+          "authentication": "standard",
+          "backend-proto": "http",
+          "blacklist-on-503": true,
+          "cmd": "/kitchen/bin/kitchen -p $PORT0",
+          "cmd-type": "shell",
+          "concurrency-level": 1,
+          "cpus": 0.1,
+          "distribution-scheme": "balanced",
+          "env": {},
+          "expired-instance-restart-rate": 0.1,
+          "grace-period-secs": 120,
+          "health-check-interval-secs": 10,
+          "health-check-max-consecutive-failures": 5,
+          "health-check-url": "/status",
+          "idle-timeout-mins": 10,
+          "instance-expiry-mins": 7200,
+          "interstitial-secs": 0,
+          "jitter-threshold": 0.5,
+          "max-instances": 500,
+          "max-queue-length": 1000000,
+          "mem": 256,
+          "metadata": {},
+          "metric-group": "waiter_kitchen",
+          "min-instances": 1,
+          "name": "kitchen-app",
+          "permitted-user": "w8r",
+          "ports": 1,
+          "restart-backoff-factor": 2,
+          "run-as-user": "w8r",
+          "scale-down-factor": 0.001,
+          "scale-factor": 1,
+          "scale-up-factor": 0.1,
+          "version": "v1"
+        },
+        "shell-scheduler/mem": 256,
+        "task-count": 1,
+        "task-stats": {
+          "healthy": 1,
+          "running": 1,
+          "staged": 0,
+          "unhealthy": 0
+        }
+      }
+    }
+  },
+  "port->reservation": {
+    "10000": {
+      "expiry-time": "2018-08-30T15:46:37.374Z",
+      "state": "in-grace-period-until-expiry"
+    },
+    "10001": {
+      "expiry-time": null,
+      "state": "in-use"
+    }
+  }
+}

--- a/waiter/test-files/shell-scheduler-backup.json
+++ b/waiter/test-files/shell-scheduler-backup.json
@@ -1,8 +1,8 @@
 {
   "id->service": {
-    "w8r-kitchen": {
+    "waiter-kitchen": {
       "id->instance": {
-        "w8r-kitchen.a1": {
+        "waiter-kitchen.a1": {
           "exit-code": 1,
           "extra-ports": [],
           "failed?": true,
@@ -10,64 +10,64 @@
           "health-check-status": null,
           "healthy?": false,
           "host": "127.0.0.5",
-          "id": "w8r-kitchen.a1",
+          "id": "waiter-kitchen.a1",
           "killed?": true,
-          "log-directory": "/tmp/w8r-kitchen/w8r-kitchen.a1",
+          "log-directory": "/tmp/waiter-kitchen/waiter-kitchen.a1",
           "message": "Exited with code 1",
           "port": 10000,
           "protocol": "http",
-          "service-id": "w8r-kitchen",
+          "service-id": "waiter-kitchen",
           "shell-scheduler/pid": 32432,
-          "shell-scheduler/working-directory": "/tmp/w8r-kitchen/w8r-kitchen.a1",
+          "shell-scheduler/working-directory": "/tmp/waiter-kitchen/waiter-kitchen.a1",
           "started-at": "2018-08-30T15:44:33.136Z"
         },
-        "w8r-kitchen.b2": {
+        "waiter-kitchen.b2": {
           "exit-code": null,
           "extra-ports": [],
           "flags": [],
           "health-check-status": null,
           "healthy?": true,
           "host": "127.0.0.10",
-          "id": "w8r-kitchen.b2",
-          "log-directory": "/tmp/w8r-kitchen/w8r-kitchen.b2",
+          "id": "waiter-kitchen.b2",
+          "log-directory": "/tmp/waiter-kitchen/waiter-kitchen.b2",
           "message": null,
           "port": 10001,
           "protocol": "http",
-          "service-id": "w8r-kitchen",
+          "service-id": "waiter-kitchen",
           "shell-scheduler/pid": 76576,
-          "shell-scheduler/working-directory": "/tmp/w8r-kitchen/w8r-kitchen.b2",
+          "shell-scheduler/working-directory": "/tmp/waiter-kitchen/waiter-kitchen.b2",
           "started-at": "2018-08-30T15:44:37.393Z"
         },
-        "w8r-kitchen.c3": {
+        "waiter-kitchen.c3": {
           "exit-code": null,
           "extra-ports": [],
           "flags": [],
           "health-check-status": null,
           "healthy?": true,
           "host": "127.0.0.8",
-          "id": "w8r-kitchen.c3",
-          "log-directory": "/tmp/w8r-kitchen/w8r-kitchen.c3",
+          "id": "waiter-kitchen.c3",
+          "log-directory": "/tmp/waiter-kitchen/waiter-kitchen.c3",
           "message": null,
           "port": 10002,
           "protocol": "http",
-          "service-id": "w8r-kitchen",
+          "service-id": "waiter-kitchen",
           "shell-scheduler/pid": 82982,
-          "shell-scheduler/working-directory": "/tmp/w8r-kitchen/w8r-kitchen.c3",
+          "shell-scheduler/working-directory": "/tmp/waiter-kitchen/waiter-kitchen.c3",
           "started-at": "2018-08-30T15:45:37.393Z"
         }
       },
       "service": {
         "environment": {
-          "HOME": "/home/w8r",
-          "LOGNAME": "w8r",
-          "USER": "w8r",
+          "HOME": "/home/waiter",
+          "LOGNAME": "hiro",
+          "USER": "hiro",
           "WAITER_CPUS": "0.1",
           "WAITER_MEM_MB": "256",
           "WAITER_PASSWORD": "7e37af",
-          "WAITER_SERVICE_ID": "w8r-kitchen",
+          "WAITER_SERVICE_ID": "waiter-kitchen",
           "WAITER_USERNAME": "waiter"
         },
-        "id": "w8r-kitchen",
+        "id": "waiter-kitchen",
         "instances": 1,
         "service-description": {
           "allowed-params": [],
@@ -96,10 +96,10 @@
           "metric-group": "waiter_kitchen",
           "min-instances": 1,
           "name": "kitchen-app",
-          "permitted-user": "w8r",
+          "permitted-user": "hiro",
           "ports": 1,
           "restart-backoff-factor": 2,
-          "run-as-user": "w8r",
+          "run-as-user": "hiro",
           "scale-down-factor": 0.001,
           "scale-factor": 1,
           "scale-up-factor": 0.1,

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -573,16 +573,16 @@
                      "s2" {:id->instance {"s2.a" {:killed? true :shell-scheduler/pid 3456}
                                           "s2.b" {:killed? false :shell-scheduler/pid 3434}
                                           "s2.c" {:killed? false :shell-scheduler/pid 3467}
-                                          "s2.d" {:killed? false :shell-scheduler/pid 5678}}}
+                                          "s2.d" {:killed? false :shell-scheduler/pid 3478}}}
                      "s3" {:id->instance {"s3.a" {:killed? false :shell-scheduler/pid 5656}
-                                          "s3.b" {:killed? false :shell-scheduler/pid 7878}}}}
-        running-pids #{1212 3434 5656 7878}
+                                          "s3.b" {:killed? false :shell-scheduler/pid 5678}}}}
+        running-pids #{1212 1245 3434 3467 3478 3489 4567 4578 5656 5678}
         killed-process-group-ids (atom #{})]
     (with-redefs [sh/sh (fn [command arg1 arg2 pgid]
                           (is (= ["pkill" "-9" "-g"] [command arg1 arg2]))
                           (swap! killed-process-group-ids conj pgid))]
       (kill-orphaned-processes! id->service running-pids))
-    (is (= #{"1245" "3467" "5678"} @killed-process-group-ids))))
+    (is (= #{"3489" "4567" "4578"} @killed-process-group-ids))))
 
 (defn- make-instance
   [service-id instance-id & {:as config}]


### PR DESCRIPTION
Addresses https://github.com/twosigma/waiter/issues/431

## Changes proposed in this PR

- adds support for backing up state whenever the `id->service-agent` state changes 
- restores shell scheduler state from backup file during restart

## Why are we making these changes?

When the Waiter restarts we would like to:
- retrieve all the running instances along with the following information:
-- the process id of the process running the instance
-- ports in use
-- associated flags on the instance
-- the host information
- state of allocated ports (in-use, blocked for certain duration, etc.)
- handle orphaned and lost processes
 
Another benefit of the backup strategy is that we also receive information on killed and failed instances.
