### PR TITLE
adds logging if we detect that with-correlation-id binding executed on different threads

### DIFF
--- a/waiter/src/waiter/correlation_id.clj
+++ b/waiter/src/waiter/correlation_id.clj
@@ -45,7 +45,14 @@
   "Executes the body with the specified value of correlation-id."
   [correlation-id & body]
   `(binding [dynamic-correlation-id ~correlation-id]
-     ~@body))
+     (let [start-thread-id# (.getId (Thread/currentThread))
+           result# (do ~@body)
+           end-thread-id# (.getId (Thread/currentThread))]
+       (when (not= start-thread-id# end-thread-id#)
+         (log/warn "with-correlation-id binding executed on different threads"
+                   {:correlation-id ~correlation-id
+                    :thread-ids {:end end-thread-id# :start start-thread-id#}}))
+       result#)))
 
 (defn get-correlation-id
   "Retrieve the value of the current correlation-id."


### PR DESCRIPTION

## Changes proposed in this PR

- adds logging if we detect that with-correlation-id binding executed on different threads

## Why are we making these changes?
2018-09-06 10:23:37,363 WARN  waiter.async-request [async-dispatch-4] -  with-correlation-id binding executed on different threads {:thread-ids {:start 23, :end 26}, :correlation-id test-monitor-async-request-cid|status-check}

Addresses #204.
We would like to detect scenarios where the `binding` block executes on different threads.

From the unit tests already identified two locations which will be fixed in subsequent PRs:
```
2018-09-06 10:32:17,492 WARN  waiter.async-request [async-dispatch-4] -  with-correlation-id binding executed on different threads {:threads {:start {:name async-dispatch-1, :id 23}, :end {:name async-dispatch-4, :id 26}}, :correlation-id test-monitor-async-request-cid|status-check}

2018-09-06 10:32:39,822 WARN  waiter.scaling [async-dispatch-61] -  with-correlation-id binding executed on different threads {:threads {:start {:name async-dispatch-38, :id 60}, :end {:name async-dispatch-61, :id 83}}, :correlation-id scaling-executor-test-service-id.}
```
