### PR TITLE
avoid cid bindings in parkable core.async code blocks in async_request.clj and scaling.clj

### DIFF
--- a/waiter/src/waiter/async_request.clj
+++ b/waiter/src/waiter/async_request.clj
@@ -49,11 +49,11 @@
    The request is forcefully completed at timeout."
   [make-http-request complete-async-request request-still-active? status-endpoint check-interval-ms request-timeout-ms correlation-id exit-chan]
   (async/go
-    (cid/with-correlation-id
-      (str correlation-id "|status-check")
+    (let [correlation-id (str correlation-id "|status-check")]
       (loop [ttl request-timeout-ms]
         (if-not (pos? ttl)
-          (do
+          (cid/with-correlation-id
+            correlation-id
             (log/info "request has timed out, releasing allocated instance")
             (complete-async-request :success)
             :monitor-timed-out)
@@ -61,47 +61,53 @@
                 [message trigger-chan] (async/alts! [exit-chan timeout-chan] :priority true)
                 continue-looping (if (= trigger-chan timeout-chan) (request-still-active?) (not= message :exit))]
             (if-not continue-looping
-              (do
+              (cid/with-correlation-id
+                correlation-id
                 (log/info "request has been cleared from store, exiting monitoring loop")
                 (complete-async-request :success)
                 (if (= trigger-chan exit-chan) :request-terminated :request-no-longer-active))
               (let [{:keys [body headers error status]} (async/<! (make-http-request))]
                 (when body (async/close! body))
-                (if error
-                  (do
-                    (condp instance? error
-                      ConnectException (log/debug error "error in performing status check")
-                      SocketTimeoutException (log/debug error "timeout in performing status check")
-                      TimeoutException (log/debug error "timeout in performing status check")
-                      Throwable (log/warn error "unexpected error in performing status check"))
-                    (log/info (.getMessage error) "releasing allocated instance")
-                    (complete-async-request :instance-error)
-                    :make-request-error)
-                  (case (int status)
-                    200
-                    (do
-                      (log/debug "async request has not yet completed")
-                      (recur (max 0 (- ttl check-interval-ms))))
-                    303
-                    (do
-                      (log/info "async request has completed, result headers" headers)
-                      (let [location-header (get headers "location")
-                            location (normalize-location-header status-endpoint location-header)]
-                        (if (str/starts-with? (str location) "/")
-                          (recur (max 0 (- ttl check-interval-ms)))
-                          (do
-                            (log/info "completing async request as result location is not a relative path:" location)
-                            (complete-async-request :success)
-                            :status-see-other))))
-                    410
-                    (do
-                      (log/info "async request has completed, result is no longer available!")
-                      (complete-async-request :success)
-                      :status-gone)
-                    (do
-                      (log/warn "status check returned unsupported status" status ", releasing reserved instance")
-                      (complete-async-request :success)
-                      :unknown-status-code)))))))))))
+                (do
+                  (if error
+                    (cid/with-correlation-id
+                      correlation-id
+                      (condp instance? error
+                        ConnectException (log/debug error "error in performing status check")
+                        SocketTimeoutException (log/debug error "timeout in performing status check")
+                        TimeoutException (log/debug error "timeout in performing status check")
+                        Throwable (log/warn error "unexpected error in performing status check"))
+                      (log/info (.getMessage error) "releasing allocated instance")
+                      (complete-async-request :instance-error)
+                      :make-request-error)
+                    (case (int status)
+                      200
+                      (do
+                        (cid/cdebug correlation-id "async request has not yet completed")
+                        (recur (max 0 (- ttl check-interval-ms))))
+                      303
+                      (do
+                        (log/info "async request has completed, result headers" headers)
+                        (let [location-header (get headers "location")
+                              location (normalize-location-header status-endpoint location-header)]
+                          (if (str/starts-with? (str location) "/")
+                            (recur (max 0 (- ttl check-interval-ms)))
+                            (cid/with-correlation-id
+                              correlation-id
+                              (log/info "completing async request as result location is not a relative path:" location)
+                              (complete-async-request :success)
+                              :status-see-other))))
+                      410
+                      (cid/with-correlation-id
+                        correlation-id
+                        (log/info "async request has completed, result is no longer available!")
+                        (complete-async-request :success)
+                        :status-gone)
+                      (cid/with-correlation-id
+                        correlation-id
+                        (log/warn "status check returned unsupported status" status ", releasing reserved instance")
+                        (complete-async-request :success)
+                        :unknown-status-code))))))))))))
 
 (defn complete-async-request-locally
   "Helper function that stops tracking an async request locally and releases the instance associated with it.

--- a/waiter/test/waiter/scaling_test.clj
+++ b/waiter/test/waiter/scaling_test.clj
@@ -282,7 +282,8 @@
             quanta-constraints {:cpus 64 :mem 100000}
             equilibrium-state {}
             make-scaling-message (fn [service-id scale-amount scale-to-instances task-count total-instances response-chan]
-                                   {:service-id service-id, :scale-amount scale-amount, :scale-to-instances scale-to-instances,
+                                   {:correlation-id (first *testing-contexts*)
+                                    :service-id service-id, :scale-amount scale-amount, :scale-to-instances scale-to-instances,
                                     :task-count task-count, :total-instances total-instances, :response-chan response-chan})
             run-service-scaling-executor (fn [scheduler instance-rpc-chan &
                                               {:keys [delegate-instance-kill-request-fn
@@ -305,7 +306,7 @@
                   scheduler instance-rpc-chan
                   :peers-acknowledged-blacklist-requests-fn peers-acknowledged-blacklist-requests-fn)]
             (mock-reservation-system instance-rpc-chan [])
-            (async/>!! executor-chan {:service-id test-service-id, :scale-amount 0})
+            (async/>!! executor-chan {:correlation-id (first *testing-contexts*) :service-id test-service-id, :scale-amount 0})
             (is (= equilibrium-state (retrieve-state-fn query-chan)))
             (async/>!! exit-chan :exit)))
 


### PR DESCRIPTION
## Changes proposed in this PR

- avoid cid bindings in parkable core.async code blocks

## Why are we making these changes?

We want to reduce instances of #204 occurring.
