### PR TITLE
More flaky integ tests

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -186,8 +186,10 @@
   (testing-using-waiter-url
     (if (or (using-cook? waiter-url) (using-marathon? waiter-url))
       (let [waiter-headers {:x-waiter-name (rand-name)}
-            {:keys [service-id]} (make-request-with-debug-info waiter-headers #(make-kitchen-request waiter-url %))]
-        (let [active-instances (get-in (service-settings waiter-url service-id) [:instances :active-instances])
+            {:keys [cookies router-id service-id]} (make-request-with-debug-info waiter-headers #(make-kitchen-request waiter-url %))
+            router-url (get (routers waiter-url) router-id)]
+        (let [active-instances (get-in (service-settings router-url service-id :cookies cookies)
+                                       [:instances :active-instances])
               log-url (:log-url (first active-instances))
               _ (log/debug "Log Url:" log-url)
               make-request-fn (fn [url] (make-request url "" :verbose true))

--- a/waiter/integration/waiter/statsd_support_test.clj
+++ b/waiter/integration/waiter/statsd_support_test.clj
@@ -36,7 +36,7 @@
   (testing-using-waiter-url
     (let [router-id->router-url (routers waiter-url)
           {:keys [cookies]} (make-request waiter-url "/waiter-auth")
-          metric-group (rand-name "foo")
+          metric-group (str "test-" (rand-int 3000000))
           headers {:x-waiter-concurrency-level (count router-id->router-url)
                    :x-waiter-name (rand-name)
                    :x-waiter-metric-group metric-group}


### PR DESCRIPTION
## Changes proposed in this PR

- ensures metric-group is inside length limits
- queries router with instance info in test-basic-logs

## Why are we making these changes?

Reduce flakiness in tests.

