### PR TITLE
Deep merge all default config values

### DIFF
--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -281,7 +281,7 @@
                              :home-path-prefix "/home/"
                              :http-options {:conn-timeout 10000
                                             :socket-timeout 10000
-                                            :spnego-auth true}
+                                            :spnego-auth false}
                              :impersonate false
                              :instance-priorities {:delta 5
                                                    :max 75
@@ -305,7 +305,7 @@
                                  :home-path-prefix "/home/"
                                  :http-options {:conn-timeout 10000
                                                 :socket-timeout 10000
-                                                :spnego-auth true}
+                                                :spnego-auth false}
                                  :force-kill-after-ms 60000
                                  :framework-id-ttl 900000
                                  :sync-deployment {:interval-ms (-> 15 t/seconds t/in-millis)
@@ -386,7 +386,7 @@
                   y-sub-map (get y kind)]
               (-> x
                   (merge y)
-                  (assoc kind (merge x-sub-map y-sub-map))))
+                  (assoc kind (deep-merge-settings x-sub-map y-sub-map))))
             (deep-merge-settings x y)))
         y))
     map-1 map-2))

--- a/waiter/test/waiter/settings_test.clj
+++ b/waiter/test/waiter/settings_test.clj
@@ -226,6 +226,22 @@
                                    :foo {:other 3}
                                    :qux {:one "a"
                                          :two "c"}}}
+               (deep-merge-settings defaults configured)))))
+
+    (testing "should merge sub-sub-maps within the configured :kind"
+      (let [defaults {:scheduler-config {:kind :foo
+                                         :foo {:bar 1
+                                               :baz {:x 2
+                                                     :y 3}}}}
+            configured {:scheduler-config {:kind :foo
+                                           :foo {:bar 1
+                                                 :baz {:y 4
+                                                       :z 4}}}}]
+        (is (= {:scheduler-config {:kind :foo
+                                   :foo {:bar 1
+                                         :baz {:x 2
+                                               :y 4
+                                               :z 4}}}}
                (deep-merge-settings defaults configured)))))))
 
 (deftest test-validate-minimesos-settings


### PR DESCRIPTION
## Changes proposed in this PR

- Use `deep-merge-settings` function on `:kind` maps (they were previously excluded).
- Change `:use-spnego` default to `false` under `:http-options` for Marathon and Kubernetes schedulers.

## Why are we making these changes?

We would like to get default values for maps nested within a `:kind` map. However, defaulting to using Kerberos doesn't seem like a good default, so we're switching that to `false`.