### PR TITLE
Add waiter-init script for K8s pods

### DIFF
--- a/kitchen/Dockerfile
+++ b/kitchen/Dockerfile
@@ -2,3 +2,4 @@ FROM containersol/mesos-agent:1.0.0-0.1.0
 
 RUN mkdir -p /opt/kitchen
 COPY bin/kitchen /opt/kitchen
+COPY bin/waiter-init /usr/bin/waiter-init

--- a/kitchen/bin/waiter-init
+++ b/kitchen/bin/waiter-init
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# A wrapper script for the Waiter-specific setup for a user command in a Waiter-K8s pod.
+# The script is usually invoked by prepending it to the user's Waiter command.
+#
+# A single argument is expected, the user's command string,
+# which is executed as its own bash shell process.
+
+# Ignore SIGTERM sent by Kubernetes on pod deletion,
+# waiting for SIGKILL (force delete) before exiting.
+trap : SIGTERM
+
+# Run the user's Waiter app command,
+# copying stdout and stderr to respectively named files.
+# We tee the output so that stdout and stderr are still accessible
+# via the Kubernetes `kubectl logs <pod-name>` command.
+/bin/bash -c "$1" 1> >(tee stdout) 2> >(tee stderr 1>&2)
+exit_code=$?
+
+# If the sub-command exited 143 (usually indicated it was killed via SIGTERM),
+# then sleep for a long time (15 minutes) awaiting a SIGKILL from Kubernetes.
+# This delay gives Waiter time to safely update the desired replica count
+# before the pod actually terminates, avoiding a race to replace this pod.
+if [ $exit_code -eq 143 ]; then
+    sleep 900
+fi
+
+# Propagate the user's command's exit code
+exit $exit_code

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -567,7 +567,7 @@
                                                 :waiter/service-id service-id}
                                   :labels {:app k8s-name
                                            :managed-by orchestrator-name}}
-                       :spec {:containers [{:command ["/bin/sh" "-c" cmd]
+                       :spec {:containers [{:command ["/usr/bin/waiter-init" cmd]
                                             :env env
                                             :image default-container-image
                                             :imagePullPolicy "IfNotPresent"


### PR DESCRIPTION
## Changes proposed in this PR

Add `waiter-init` script into our Kitchen image for use in K8s pods.

## Why are we making these changes?

We need a wrapper script for the user's command in order to cleanly support the combination of the following:

* SIGTERM capture to keep pods from exiting too early and causing a race in Waiter's scale-down code.
* Redirecting stdout and stderr to files (mimicking Mesos+Marathon behavior).
* Supporting `dumb-init` in pods to get correct zombie handling (todo).