### PR TITLE
Log file access in K8s pods

### DIFF
--- a/kubernetes/fileserver-container/Dockerfile
+++ b/kubernetes/fileserver-container/Dockerfile
@@ -1,0 +1,6 @@
+FROM nginx:1.15-alpine
+
+COPY fileserver-start /bin/
+COPY nginx.conf /root/nginx.conf.template
+RUN mkdir -p /srv/www && echo 'Hello!' > /srv/www/hello.txt
+CMD ["fileserver-start"]

--- a/kubernetes/fileserver-container/README.md
+++ b/kubernetes/fileserver-container/README.md
@@ -1,0 +1,19 @@
+# Waiter-Kubernetes Fileserver Sidecar Container
+
+Waiter on Marathon+Mesos uses the Mesos file-browsing REST API
+to give users access to their service instances' local files (e.g., logs).
+To provide a similar experience for Waiter on Kubernetes users,
+we add a fileserver as a sidecar-container in each Waiter-managed pod.
+The sidecar-container runs an nginx server,
+mounting the same home directory volume used in the main app container,
+and serving that mounted directory using automatic JSON directory indexing.
+
+## Settings
+
+By default, the nginx server binds to port 9090 in its container.
+The default port can be overridden by setting `WAITER_FILESERVER_PORT`
+in the container's environment to the desired port number.
+
+## Building the Docker image
+
+    docker build -t twosigma/waiter-fileserver .

--- a/kubernetes/fileserver-container/fileserver-start
+++ b/kubernetes/fileserver-container/fileserver-start
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Set default server port
+: ${WAITER_FILESERVER_PORT:=9090}
+export WAITER_FILESERVER_PORT
+
+# Generate server config from template
+envsubst </root/nginx.conf.template >/root/nginx.conf
+
+# Start server in non-daemon mode
+nginx -c /root/nginx.conf

--- a/kubernetes/fileserver-container/nginx.conf
+++ b/kubernetes/fileserver-container/nginx.conf
@@ -1,0 +1,20 @@
+daemon off;
+worker_processes 1;
+
+events {
+  use epoll;
+}
+
+http {
+  server {
+    gzip on;
+    gzip_min_length 512;
+    gzip_types *;
+    listen ${WAITER_FILESERVER_PORT};
+    root /srv/www;
+    location / {
+      autoindex on;
+      autoindex_format json;
+    }
+  }
+}

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -334,6 +334,17 @@
                                                            ;; The default factory function accepts an option for the docker container to use in the pod.
                                                            :default-container-image "twosigma/kitchen:latest"}
 
+                                 ;; Configuration for creating and querying a sidecar container in each Waiter Service Instance's Kuberentes pod
+                                 ;; running a server for directory listings (in JSON) and serving file contents.
+                                 ;; Waiter expects the directory listings in the format returned by nginx's autoindex module when configured for JSON.
+                                 ;; See the behavior of the default container image below for reference.
+                                 ;; The sidecar container is only added to Waiter-managed pods if the :port number is set in this map,
+                                 ;; otherwise, the file browsing API is disabled (always returning an empty array).
+                                 :fileserver {:image "twosigma/waiter-fileserver:latest"
+                                              :port 9090
+                                              :resources {:cpu 0.1 :mem 128}
+                                              :scheme "http"}
+
                                  ;; HTTP options that will be used when accessing the Kubernetes API:
                                  :http-options {:conn-timeout 10000
                                                 :socket-timeout 10000}

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -340,6 +340,7 @@
                                  ;; See the behavior of the default container image below for reference.
                                  ;; The sidecar container is only added to Waiter-managed pods if the :port number is set in this map,
                                  ;; otherwise, the file browsing API is disabled (always returning an empty array).
+                                 ;; You must ensure that the fileserver port number does not intersect with the pod-base-port range.
                                  :fileserver {:image "twosigma/waiter-fileserver:latest"
                                               :port 9090
                                               :resources {:cpu 0.1 :mem 128}

--- a/waiter/config-k8s.edn
+++ b/waiter/config-k8s.edn
@@ -21,8 +21,8 @@
  ; ---------- Scheduling ----------
 
  :scheduler-config {:kind :kubernetes
-                    :kubernetes {:url "http://localhost:8001"
-                                 :replicaset-spec-file-path "./specs/k8s-default-pod.edn"}}
+                    :kubernetes {:fileserver {:port 591}
+                                 :url "http://localhost:8001"}}
 
  ; ---------- Error Handling ----------
 

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -184,7 +184,7 @@
 
 (deftest ^:parallel ^:integration-fast test-basic-logs
   (testing-using-waiter-url
-    (if (or (using-cook? waiter-url) (using-marathon? waiter-url))
+    (if (contains? #{"cook" "kubernetes" "marathon"} (scheduler-kind waiter-url))
       (let [waiter-headers {:x-waiter-name (rand-name)}
             {:keys [cookies router-id service-id]} (make-request-with-debug-info waiter-headers #(make-kitchen-request waiter-url %))
             router-url (get (routers waiter-url) router-id)]

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -289,8 +289,11 @@
                              :mesos-slave-port 5051
                              :search-interval-days 10}
                       :kubernetes {; Default values are not provided below for the following keys:
-                                   ; :authentication :url
+                                   ; :authentication [:fileserver :port] :url
                                    :factory-fn 'waiter.scheduler.kubernetes/kubernetes-scheduler
+                                   :fileserver {:image "twosigma/waiter-fileserver:latest"
+                                                :resources {:cpu 0.1 :mem 128}
+                                                :scheme "http"}
                                    :http-options {:conn-timeout 10000
                                                   :socket-timeout 10000}
                                    :max-patch-retries 5

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -850,7 +850,7 @@
     (log/debug "router url with slots assigned:" router-url)
     router-url))
 
-(defn- scheduler-kind
+(defn scheduler-kind
   "Returns the configured :scheduler-config :kind"
   [waiter-url & {:keys [verbose] :or {verbose false}}]
   (setting waiter-url [:scheduler-config :kind] :verbose verbose))
@@ -865,9 +865,14 @@
     (:gracePeriodSeconds (first (:healthChecks (:app app-info-map))))))
 
 (defn using-cook?
-  "Returns true if Waiter is configured to use Marathon for scheduling"
+  "Returns true if Waiter is configured to use Cook for scheduling"
   [waiter-url]
   (= "cook" (scheduler-kind waiter-url :verbose true)))
+
+(defn using-k8s?
+  "Returns true if Waiter is configured to use Kubernetes for scheduling"
+  [waiter-url]
+  (= "kubernetes" (scheduler-kind waiter-url :verbose true)))
 
 (defn using-marathon?
   "Returns true if Waiter is configured to use Marathon for scheduling"

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -629,7 +629,7 @@
                      :size 1
                      :type "file"})
         make-dir (fn [dir-name]
-                   {:url (str "http://" host ":" port path dir-name "/")
+                   {:path (str path dir-name)
                     :name dir-name
                     :type "directory"})
         strip-links (partial mapv #(dissoc % :url))


### PR DESCRIPTION
## Changes proposed in this PR

Adds support for the Waiter service-instance file-browsing API, mimicking the functionality we have with Waiter-Marathon. This is achieved by adding a sidecar-app running nginx and serving the contents of the main working directory (shared between the two containers).

## Why are we making these changes?

Closes #357.