### PR TITLE
Skip token-syncer tests when untouched

### DIFF
--- a/token-syncer/bin/ci/run-all-tests.sh
+++ b/token-syncer/bin/ci/run-all-tests.sh
@@ -6,6 +6,15 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if [ "$TRAVIS" ]; then
+    # Don't run for PRs that didn't modify the Token-Syncer
+    if [ "${TRAVIS_PULL_REQUEST}" != false ]; then
+        PR_URL="https://api.github.com/repos/${TRAVIS_REPO_SLUG}/pulls/${TRAVIS_PULL_REQUEST}/files"
+        if !(curl -s $PR_URL | jq '.[].filename' | grep -qE '^"(\.travis|token-syncer)'); then
+            echo "Skipping Token-Syncer tests on this build (project unmodified)."
+            exit 0
+        fi
+    fi
+
     # Don't exceed the Travis container 4GB max
     export JVM_OPTS="-Xmx700m"
     export LEIN_JVM_OPTS="-Xmx200m"


### PR DESCRIPTION
## Changes proposed in this PR

Skip the token-syncer tests in Travis-CI if both the `token-syncer` directory and the `.travis.yml` file are untouched. Only applies to PRs (i.e., all tests always run on master builds).

## Why are we making these changes?

We waste 5 or 6 minutes on almost all of our Travis builds running the tests for the independent token syncer project, which is almost never modified.

In the unlikely event that we manage to break the token syncer behavior by modifying something in Waiter, we should still catch it when the Travis master build breaks.