### PR TITLE
Fix metric-group setting for Kitchen-based integration tests

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -176,8 +176,8 @@
           (let [response (make-request 24000)]
             (assert-response-status response 200))))
 
-      (testing "metric group should be waiter_kitchen"
-        (is (= "waiter_kitchen" (service-id->metric-group waiter-url service-id))
+      (testing "metric group should be waiter_kitchen_test"
+        (is (= "waiter_kitchen_test" (service-id->metric-group waiter-url service-id))
             (str "Invalid metric group for " service-id)))
 
       (delete-service waiter-url service-id))))
@@ -753,7 +753,7 @@
                                          (assoc
                                            :concurrency-level 20
                                            :interstitial-secs interstitial-secs
-                                           :metric-group "waiter_kitchen"
+                                           :metric-group "waiter_kitchen_test"
                                            :name token
                                            :permitted-user (retrieve-username)
                                            :run-as-user (retrieve-username)

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -411,8 +411,9 @@
           (log/info "basic hostname as token test")
           (let [current-user (retrieve-username)
                 service-description (assoc (kitchen-request-headers)
-                                      :x-waiter-permitted-user "*"
-                                      :x-waiter-run-as-user current-user)]
+                                           :x-waiter-metric-group token-prefix
+                                           :x-waiter-permitted-user "*"
+                                           :x-waiter-run-as-user current-user)]
             (testing "hostname-token-creation"
               (log/info "creating configuration using token" token)
               (let [{:keys [body status]}

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -315,6 +315,7 @@
    :health-check-url "/status"
    :idle-timeout-mins 10
    :mem 256
+   :metric-group "waiter_kitchen_test"
    :version "version-does-not-matter"})
 
 (defn kitchen-request-headers
@@ -371,7 +372,7 @@
     waiter-url
     (merge
       {:x-waiter-cmd (kitchen-cmd "-p $PORT0")
-       :x-waiter-metric-group "waiter_kitchen"}
+       :x-waiter-metric-group "waiter_kitchen_test"}
       custom-headers)
     :body body
     :cookies cookies


### PR DESCRIPTION
## Changes proposed in this PR

- Add `metric-group` to `kitchen-request-headers` output.
- Remove `metric-group` from service-description in token-hostname test.

## Why are we making these changes?

Not having the `metric-group` set was causing a mismatch in all of the content-encoding tests between the "canary" request and the "real" request (i.e., it was causing two different services to be created for each, but we of course only wanted one).

Adding the `metric-group` caused `test-token-hostname` to fail, so we simply `dissoc` it there.