### PR TITLE
Rebalance k8s tests

### DIFF
--- a/waiter/bin/ci/monitor-pods.sh
+++ b/waiter/bin/ci/monitor-pods.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+: ${cycle_delay_secs:=${1:-30}}
+
+while true; do
+    sleep ${cycle_delay_secs}
+    printf '\n***** Kubernetes pod state at %s *****\n%s\n\n' \
+        "$(date +'%H:%M:%S')" \
+        "$(kubectl --namespace=${USER} get pods 2>&1)"
+done

--- a/waiter/bin/ci/run-integration-tests-k8s-scheduler.sh
+++ b/waiter/bin/ci/run-integration-tests-k8s-scheduler.sh
@@ -32,7 +32,8 @@ ${WAITER_DIR}/bin/run-using-k8s.sh ${WAITER_PORT} &
 bash +x ${DIR}/monitor-pods.sh &
 
 # Run the integration tests
-WAITER_TEST_KITCHEN_CMD=/opt/kitchen/kitchen \
+LEIN_TEST_THREADS=4 \
+    WAITER_TEST_KITCHEN_CMD=/opt/kitchen/kitchen \
     WAITER_AUTH_RUN_AS_USER=${USER} \
     WAITER_URI=127.0.0.1:${WAITER_PORT} \
     ${WAITER_DIR}/bin/test.sh ${TEST_COMMAND} ${TEST_SELECTOR} || test_failures=true

--- a/waiter/bin/ci/run-integration-tests-k8s-scheduler.sh
+++ b/waiter/bin/ci/run-integration-tests-k8s-scheduler.sh
@@ -28,6 +28,9 @@ ${KITCHEN_DIR}/bin/build-docker-image.sh
 WAITER_PORT=9091
 ${WAITER_DIR}/bin/run-using-k8s.sh ${WAITER_PORT} &
 
+# Start monitoring state of Kubernetes pods
+bash +x ${DIR}/monitor-pods.sh &
+
 # Run the integration tests
 WAITER_TEST_KITCHEN_CMD=/opt/kitchen/kitchen \
     WAITER_AUTH_RUN_AS_USER=${USER} \

--- a/waiter/integration/waiter/async_request_integration_test.clj
+++ b/waiter/integration/waiter/async_request_integration_test.clj
@@ -187,7 +187,7 @@
             (assert-response-status response 200))))
       (delete-service waiter-url service-id))))
 
-(deftest ^:parallel ^:integration-slow test-multiple-async-requests
+(deftest ^:parallel ^:integration-slow ^:resource-heavy test-multiple-async-requests
   ;; tests the metrics and state flow associated with a multiple concurrent async requests.
   (testing-using-waiter-url
     (let [metrics-sync-interval-ms (-> (waiter-settings waiter-url)

--- a/waiter/integration/waiter/autoscaling_test.clj
+++ b/waiter/integration/waiter/autoscaling_test.clj
@@ -142,7 +142,7 @@
             waiter-url cookies request-fn requests-per-thread delay-secs service-id
             num-threads expected-instances))))))
 
-(deftest ^:parallel ^:integration-slow ^:resource-heavy test-expired-instance
+(deftest ^:parallel ^:integration-slow test-expired-instance
   (testing-using-waiter-url
     (let [extra-headers {:x-waiter-instance-expiry-mins 1 ;; can't set it any lower :(
                          :x-waiter-name (rand-name)}
@@ -185,7 +185,7 @@
             (is (contains? killed-instances instance-id)
                 (str {:instance-id instance-id :killed-instances killed-instances}))))))))
 
-(deftest ^:parallel ^:integration-fast test-minmax-instances
+(deftest ^:parallel ^:integration-fast ^:resource-heavy test-minmax-instances
   (testing-using-waiter-url
     (let [min-instances 2
           max-instances 5

--- a/waiter/integration/waiter/busy_instance_test.clj
+++ b/waiter/integration/waiter/busy_instance_test.clj
@@ -20,7 +20,7 @@
             [waiter.util.client-tools :refer :all]
             [waiter.util.utils :as utils]))
 
-(deftest ^:parallel ^:integration-slow test-busy-instance-not-reserved
+(deftest ^:parallel ^:integration-slow ^:resource-heavy test-busy-instance-not-reserved
   (testing-using-waiter-url
     (let [extra-headers {:x-waiter-name (rand-name)
                          :x-waiter-scale-up-factor 0.99}

--- a/waiter/integration/waiter/content_encoding_test.clj
+++ b/waiter/integration/waiter/content_encoding_test.clj
@@ -75,7 +75,7 @@
 (deftest ^:parallel ^:integration-fast test-support-success-gzip-response
   (testing-using-waiter-url
     (log/info "Test successful gzip response")
-    (let [service-headers (assoc (kitchen-request-headers) :x-waiter-name (rand-name "testgzipsuccesschunked"))
+    (let [service-headers (assoc (kitchen-request-headers) :x-waiter-name (rand-name "testgzipsuccessunchunked"))
           {:keys [service-id]} (make-request-with-debug-info service-headers #(make-kitchen-request waiter-url %))]
       (try
         (let [response-size 2000000
@@ -103,7 +103,7 @@
 (deftest ^:parallel ^:integration-fast test-support-failed-gzip-response
   (testing-using-waiter-url
     (log/info "Test failed gzip response")
-    (let [service-headers (assoc (kitchen-request-headers) :x-waiter-name (rand-name "testgzipfailedchunked"))
+    (let [service-headers (assoc (kitchen-request-headers) :x-waiter-name (rand-name "testgzipfailedunchunked"))
           {:keys [service-id]} (make-request-with-debug-info service-headers #(make-kitchen-request waiter-url %))]
       (try
         (let [req-headers (assoc service-headers

--- a/waiter/integration/waiter/killed_instance_test.clj
+++ b/waiter/integration/waiter/killed_instance_test.clj
@@ -67,7 +67,7 @@
     (when (some #(= "blacklisted" %) (:status-tags instance-state))
       (get-in responder-state [:instance-id->blacklist-expiry-time instance-keyword]))))
 
-(deftest ^:parallel ^:integration-slow ^:resource-heavy test-blacklisted-instance-not-reserved
+(deftest ^:parallel ^:integration-slow test-blacklisted-instance-not-reserved
   ;; Verifies that a blacklisted instance is not used to process a request.
   ;; The test first blacklists an instance on all routers.
   ;; It then makes a few requests and verifies if they responded inside the blacklist

--- a/waiter/integration/waiter/metrics_output_test.clj
+++ b/waiter/integration/waiter/metrics_output_test.clj
@@ -173,7 +173,7 @@
       (get-in ["state" "service-id->launch-tracker" service-id])
       some?))
 
-(deftest ^:parallel ^:integration-slow ^:resource-heavy test-launch-metrics-output
+(deftest ^:parallel ^:integration-slow test-launch-metrics-output
   (testing-using-waiter-url
     (let [waiter-settings (waiter-settings waiter-url)
           metrics-sync-interval-ms (get-in waiter-settings [:metrics-config :metrics-sync-interval-ms])

--- a/waiter/integration/waiter/new_app_test.clj
+++ b/waiter/integration/waiter/new_app_test.clj
@@ -45,7 +45,7 @@
 
       (delete-service waiter-url service-id))))
 
-(deftest ^:parallel ^:integration-slow ^:resource-heavy test-new-app-gc
+(deftest ^:parallel ^:integration-slow test-new-app-gc
   (testing-using-waiter-url
     (let [idle-timeout-in-mins 1
           {:keys [service-id]} (make-request-with-debug-info

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -294,7 +294,7 @@
             (assert-response-status response 404)
             (is (str/includes? (str body) "Couldn't find token") (str body))))))))
 
-(deftest ^:parallel ^:integration-fast test-service-list-filtering
+(deftest ^:parallel ^:integration-fast ^:resource-heavy test-service-list-filtering
   (testing-using-waiter-url
     (let [service-name (rand-name)
           token-1 (create-token-name waiter-url (str "www." service-name ".t1"))


### PR DESCRIPTION
## Changes proposed in this PR

- Add a small script to periodically print the current Kubernetes pod state in our K8s integration tests.
- Fix incorrect service names for two content-encoding tests. (These were duplicate names. Looks like a copy/paste error.)
- Shuffle some tests between K8s the heavy/lite test jobs. These changes are based on the observed pod state in the integration tests. (We moved tests that obviously created many pods to *heavy*, and moved a couple tests that only created one or two pods back to *lite*.)

## Why are we making these changes?

- The periodic printing of the Kubernetes pod state helps to diagnose why some tests fail. Specifically, it's more obvious when a 503 error is due to our minikube cluster being oversubscribed.
- Correctly marking `:resource-heavy` tests makes the tests more reliable, and helps the corresponding Travis build to finish as quickly as possible.