### PR TITLE
stores source-tokens as a separate entity in the kv-store

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -812,17 +812,13 @@
                                            (partial sd/service-id->source-tokens-entries kv-store))
    :start-new-service-fn (pc/fnk [[:scheduler scheduler]
                                   [:state authenticator start-app-cache-atom task-threadpool]
-                                  store-service-description-fn store-source-tokens-fn]
-                           (fn start-new-service [{:keys [service-id source-tokens] :as descriptor}]
+                                  store-service-description-fn]
+                           (fn start-new-service [{:keys [service-id] :as descriptor}]
                              (let [run-as-user (get-in descriptor [:service-description "run-as-user"])]
                                (auth/check-user authenticator run-as-user service-id))
-                             (let [pre-start-fn (fn pre-start-new-service-fn []
-                                                  (when (seq source-tokens)
-                                                    (store-source-tokens-fn service-id source-tokens))
-                                                  (store-service-description-fn descriptor))]
-                               (service/start-new-service
-                                 scheduler descriptor start-app-cache-atom task-threadpool
-                                 :pre-start-fn pre-start-fn))))
+                             (service/start-new-service
+                               scheduler descriptor start-app-cache-atom task-threadpool
+                               :pre-start-fn #(store-service-description-fn descriptor))))
    :start-work-stealing-balancer-fn (pc/fnk [[:settings [:work-stealing offer-help-interval-ms reserve-timeout-ms]]
                                              [:state instance-rpc-chan router-id]
                                              make-inter-router-requests-async-fn router-metrics-helpers]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -776,12 +776,16 @@
    :request->descriptor-fn (pc/fnk [[:curator kv-store]
                                     [:settings [:token-config history-length token-defaults] metric-group-mappings service-description-defaults]
                                     [:state fallback-state-atom service-description-builder service-id-prefix waiter-hostnames]
-                                    assoc-run-as-user-approved? can-run-as?-fn]
+                                    assoc-run-as-user-approved? can-run-as?-fn store-source-tokens-fn]
                              (fn request->descriptor-fn [request]
-                               (descriptor/request->descriptor
-                                 assoc-run-as-user-approved? can-run-as?-fn fallback-state-atom kv-store metric-group-mappings
-                                 history-length service-description-builder service-description-defaults service-id-prefix
-                                 token-defaults waiter-hostnames request)))
+                               (let [{:keys [latest-descriptor] :as result}
+                                     (descriptor/request->descriptor
+                                       assoc-run-as-user-approved? can-run-as?-fn fallback-state-atom kv-store metric-group-mappings
+                                       history-length service-description-builder service-description-defaults service-id-prefix
+                                       token-defaults waiter-hostnames request)]
+                                 (when-let [source-tokens (-> latest-descriptor :source-tokens seq)]
+                                   (store-source-tokens-fn (:service-id latest-descriptor) source-tokens))
+                                 result)))
    :router-metrics-helpers (pc/fnk [[:state passwords router-metrics-agent]]
                              (let [password (first passwords)]
                                {:decryptor (fn router-metrics-decryptor [data] (utils/compressed-bytes->map data password))
@@ -794,24 +798,31 @@
                                       (fn service-description->service-id [service-description]
                                         (sd/service-description->service-id service-id-prefix service-description)))
    :service-id->idle-timeout (pc/fnk [[:settings [:token-config token-defaults]]
-                                      service-id->service-description-fn token->token-hash token->token-metadata]
+                                      service-id->service-description-fn service-id->source-tokens-entries-fn
+                                      token->token-hash token->token-metadata]
                                (fn service-id->idle-timeout [service-id]
                                  (sd/service-id->idle-timeout
-                                   service-id->service-description-fn token->token-hash token->token-metadata
-                                   token-defaults service-id)))
+                                   service-id->service-description-fn service-id->source-tokens-entries-fn
+                                   token->token-hash token->token-metadata token-defaults service-id)))
    :service-id->password-fn (pc/fnk [[:scheduler service-id->password-fn*]]
                               service-id->password-fn*)
    :service-id->service-description-fn (pc/fnk [[:scheduler service-id->service-description-fn*]]
                                          service-id->service-description-fn*)
+   :service-id->source-tokens-entries-fn (pc/fnk [[:curator kv-store]]
+                                           (partial sd/service-id->source-tokens-entries kv-store))
    :start-new-service-fn (pc/fnk [[:scheduler scheduler]
                                   [:state authenticator start-app-cache-atom task-threadpool]
-                                  store-service-description-fn]
-                           (fn start-new-service [{:keys [service-id] :as descriptor}]
+                                  store-service-description-fn store-source-tokens-fn]
+                           (fn start-new-service [{:keys [service-id source-tokens] :as descriptor}]
                              (let [run-as-user (get-in descriptor [:service-description "run-as-user"])]
                                (auth/check-user authenticator run-as-user service-id))
-                             (service/start-new-service
-                               scheduler descriptor start-app-cache-atom task-threadpool
-                               :pre-start-fn #(store-service-description-fn descriptor))))
+                             (let [pre-start-fn (fn pre-start-new-service-fn []
+                                                  (when (seq source-tokens)
+                                                    (store-source-tokens-fn service-id source-tokens))
+                                                  (store-service-description-fn descriptor))]
+                               (service/start-new-service
+                                 scheduler descriptor start-app-cache-atom task-threadpool
+                                 :pre-start-fn pre-start-fn))))
    :start-work-stealing-balancer-fn (pc/fnk [[:settings [:work-stealing offer-help-interval-ms reserve-timeout-ms]]
                                              [:state instance-rpc-chan router-id]
                                              make-inter-router-requests-async-fn router-metrics-helpers]
@@ -830,6 +841,10 @@
                                           validate-service-description-fn]
                                    (fn store-service-description [{:keys [core-service-description service-id]}]
                                      (sd/store-core kv-store service-id core-service-description validate-service-description-fn)))
+   :store-source-tokens-fn (pc/fnk [[:curator kv-store]
+                                    synchronize-fn]
+                             (fn store-source-tokens-fn [service-id source-tokens]
+                               (sd/store-source-tokens! synchronize-fn kv-store service-id source-tokens)))
    :synchronize-fn (pc/fnk [[:curator curator]
                             [:settings [:zookeeper base-path mutex-timeout-ms]]]
                      (fn synchronize-fn [path f]
@@ -1129,7 +1144,7 @@
    :service-handler-fn (pc/fnk [[:curator kv-store]
                                 [:daemons router-state-maintainer]
                                 [:routines allowed-to-manage-service?-fn generate-log-url-fn make-inter-router-requests-sync-fn
-                                 service-id->service-description-fn]
+                                 service-id->service-description-fn service-id->source-tokens-entries-fn]
                                 [:scheduler scheduler]
                                 [:state router-id]
                                 wrap-secure-request-fn]
@@ -1138,7 +1153,8 @@
                              (fn service-handler-fn [{:as request {:keys [service-id]} :route-params}]
                                (handler/service-handler router-id service-id scheduler kv-store allowed-to-manage-service?-fn
                                                         generate-log-url-fn make-inter-router-requests-sync-fn
-                                                        service-id->service-description-fn query-state-fn request)))))
+                                                        service-id->service-description-fn service-id->source-tokens-entries-fn
+                                                        query-state-fn request)))))
    :service-id-handler-fn (pc/fnk [[:curator kv-store]
                                    [:routines store-service-description-fn]
                                    wrap-descriptor-fn wrap-secure-request-fn]
@@ -1147,7 +1163,8 @@
                                 wrap-descriptor-fn
                                 wrap-secure-request-fn))
    :service-list-handler-fn (pc/fnk [[:daemons router-state-maintainer]
-                                     [:routines prepend-waiter-url router-metrics-helpers service-id->service-description-fn]
+                                     [:routines prepend-waiter-url router-metrics-helpers
+                                      service-id->service-description-fn service-id->source-tokens-entries-fn]
                                      [:state entitlement-manager]
                                      wrap-secure-request-fn]
                               (let [{{:keys [query-state-fn]} :maintainer} router-state-maintainer
@@ -1156,7 +1173,7 @@
                                   (fn service-list-handler-fn [request]
                                     (handler/list-services-handler entitlement-manager query-state-fn prepend-waiter-url
                                                                    service-id->service-description-fn service-id->metrics-fn
-                                                                   request)))))
+                                                                   service-id->source-tokens-entries-fn request)))))
    :service-override-handler-fn (pc/fnk [[:curator kv-store]
                                          [:routines allowed-to-manage-service?-fn make-inter-router-requests-sync-fn]
                                          wrap-secure-request-fn]

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -240,14 +240,17 @@
 (defn list-services-handler
   "Retrieves the list of services viewable by the currently logged in user.
    A service is viewable by the run-as-user or a waiter super-user."
-  [entitlement-manager query-state-fn prepend-waiter-url service-id->service-description-fn service-id->metrics-fn request]
+  [entitlement-manager query-state-fn prepend-waiter-url service-id->service-description-fn service-id->metrics-fn
+   service-id->source-tokens-entries-fn request]
   (let [{:keys [all-available-service-ids service-id->healthy-instances service-id->unhealthy-instances]} (query-state-fn)]
     (let [{:strs [run-as-user token token-version] :as request-params} (-> request ru/query-params-request :query-params)
           auth-user (get request :authorization/user)
           viewable-services (filter
                               (fn [service-id]
-                                (let [{:strs [source-tokens] :as service-description}
-                                      (service-id->service-description-fn service-id :effective? false)]
+                                (let [service-description (service-id->service-description-fn service-id :effective? false)
+                                      source-tokens (-> (service-id->source-tokens-entries-fn service-id)
+                                                        vec
+                                                        flatten)]
                                   (and (if (str/blank? run-as-user)
                                          (authz/manage-service? entitlement-manager auth-user service-id service-description)
                                          (= run-as-user (get service-description "run-as-user")))
@@ -269,16 +272,19 @@
           include-effective-parameters? (utils/request-flag request-params "effective-parameters")
           response-data (map
                           (fn service-id->service-info [service-id]
-                            (let [service-description (service-id->service-description-fn service-id :effective? false)]
+                            (let [service-description (service-id->service-description-fn service-id :effective? false)
+                                  source-tokens-entries (service-id->source-tokens-entries-fn service-id)]
                               (cond->
                                 {:instance-counts (retrieve-instance-counts service-id)
                                  :last-request-time (get-in service-id->metrics [service-id "last-request-time"])
                                  :service-id service-id
                                  :service-description service-description
                                  :url (prepend-waiter-url (str "/apps/" service-id))}
-                                include-effective-parameters? (assoc :effective-parameters
-                                                                     (service-id->service-description-fn
-                                                                       service-id :effective? true)))))
+                                include-effective-parameters?
+                                (assoc :effective-parameters
+                                       (service-id->service-description-fn service-id :effective? true))
+                                (seq source-tokens-entries)
+                                (assoc :source-tokens source-tokens-entries))))
                           viewable-services)]
       (utils/clj->streaming-json-response response-data))))
 
@@ -327,7 +333,7 @@
 (defn- get-service-handler
   "Returns details about the service such as the service description, metrics, instances, etc."
   [router-id service-id core-service-description kv-store generate-log-url-fn make-inter-router-requests-fn
-   service-id->service-description-fn query-state-fn request]
+   service-id->service-description-fn service-id->source-tokens-entries-fn query-state-fn request]
   (let [service-instance-maps (try
                                 (let [assoc-log-url-to-instances
                                       (fn assoc-log-url-to-instances [instances]
@@ -365,6 +371,7 @@
                                   (sd/service-id->suspended-state kv-store service-id :refresh true)
                                   (catch Exception e
                                     (log/error e "Error in retrieving service suspended state for" service-id)))
+        source-tokens-entries (service-id->source-tokens-entries-fn service-id)
         request-params (-> request ru/query-params-request :query-params)
         include-effective-parameters? (utils/request-flag request-params "effective-parameters")
         result-map (cond-> {:router-id router-id, :num-routers (count router->metrics)}
@@ -382,7 +389,9 @@
                      (not-empty (or (:overrides service-description-overrides) {}))
                      (assoc :service-description-overrides service-description-overrides)
                      (:time service-suspended-state)
-                     (assoc :service-suspended-state service-suspended-state))]
+                     (assoc :service-suspended-state service-suspended-state)
+                     (seq source-tokens-entries)
+                     (assoc :source-tokens source-tokens-entries))]
     (utils/clj->streaming-json-response result-map)))
 
 (defn service-handler
@@ -391,7 +400,7 @@
      :delete deletes the service from the scheduler (after authorization checks).
      :get returns details about the service such as the service description, metrics, instances, etc."
   [router-id service-id scheduler kv-store allowed-to-manage-service?-fn generate-log-url-fn make-inter-router-requests-fn
-   service-id->service-description-fn query-state-fn request]
+   service-id->service-description-fn service-id->source-tokens-entries-fn query-state-fn request]
   (try
     (when (not service-id)
       (throw (ex-info "Missing service-id" {:status 400})))
@@ -401,8 +410,8 @@
         (case (:request-method request)
           :delete (delete-service-handler service-id core-service-description scheduler allowed-to-manage-service?-fn request)
           :get (get-service-handler router-id service-id core-service-description kv-store generate-log-url-fn
-                                    make-inter-router-requests-fn service-id->service-description-fn  query-state-fn
-                                    request))))
+                                    make-inter-router-requests-fn service-id->service-description-fn
+                                    service-id->source-tokens-entries-fn query-state-fn request))))
     (catch Exception ex
       (utils/exception->response ex request))))
 

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -411,7 +411,8 @@
                        :routines {:allowed-to-manage-service?-fn allowed-to-manage-service?
                                   :generate-log-url-fn nil
                                   :make-inter-router-requests-sync-fn nil
-                                  :service-id->service-description-fn (constantly {})}
+                                  :service-id->service-description-fn (constantly {})
+                                  :service-id->source-tokens-entries-fn (constantly #{})}
                        :scheduler {:scheduler (Object.)}
                        :state {:router-id "router-id"}
                        :wrap-secure-request-fn utils/wrap-identity}
@@ -486,7 +487,8 @@
                        :routines {:allowed-to-manage-service?-fn (constantly true)
                                   :generate-log-url-fn (partial handler/generate-log-url #(str "http://www.example.com" %))
                                   :make-inter-router-requests-sync-fn nil
-                                  :service-id->service-description-fn (constantly {})}
+                                  :service-id->service-description-fn (constantly {})
+                                  :service-id->source-tokens-entries-fn (constantly #{})}
                        :scheduler {:scheduler (Object.)}
                        :state {:router-id "router-id"}
                        :wrap-secure-request-fn utils/wrap-identity}

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -389,12 +389,12 @@
                                        "owner" "token-owner"
                                        "previous" {}
                                        "version" "token"}
-                                      (str/includes? token "allowed") (assoc "allowed-params" #{"BAR" "FOO"})
-                                      (str/includes? token "cpus") (assoc "cpus" "1")
-                                      (str/includes? token "fall") (assoc "fallback-period-secs" 600)
-                                      (str/includes? token "mem") (assoc "mem" "2")
-                                      (str/includes? token "per") (assoc "permitted-user" "puser")
-                                      (str/includes? token "run") (assoc "run-as-user" "ruser"))
+                                (str/includes? token "allowed") (assoc "allowed-params" #{"BAR" "FOO"})
+                                (str/includes? token "cpus") (assoc "cpus" "1")
+                                (str/includes? token "fall") (assoc "fallback-period-secs" 600)
+                                (str/includes? token "mem") (assoc "mem" "2")
+                                (str/includes? token "per") (assoc "permitted-user" "puser")
+                                (str/includes? token "run") (assoc "run-as-user" "ruser"))
                               {}))
         build-source-tokens (fn [& tokens]
                               (mapv (fn [token] (source-tokens-entry token (create-token-data token))) tokens))]
@@ -424,8 +424,8 @@
                                                "run-as-user" test-user}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-host"
-                                                                    "source-tokens" (build-source-tokens "test-host")
                                                                     "version" "token"}
+                                     :source-tokens (build-source-tokens "test-host")
                                      :token->token-data {"test-host" (create-token-data "test-host")}
                                      :token-authentication-disabled false
                                      :token-preauthorized false
@@ -449,6 +449,7 @@
                                                "version" "test-version"
                                                "run-as-user" test-user}
                                      :service-description-template {},
+                                     :source-tokens []
                                      :token->token-data {},
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
@@ -473,8 +474,8 @@
                                                "run-as-user" test-user}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-host"
-                                                                    "source-tokens" (build-source-tokens "test-host")
                                                                     "version" "token"}
+                                     :source-tokens (build-source-tokens "test-host")
                                      :token->token-data {"test-host" (create-token-data "test-host")}
                                      :token-authentication-disabled false
                                      :token-preauthorized false
@@ -497,6 +498,7 @@
                                                "version" "test-version"
                                                "run-as-user" test-user}
                                      :service-description-template {},
+                                     :source-tokens []
                                      :token->token-data {},
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
@@ -512,8 +514,8 @@
                                      :headers {}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-host"
-                                                                    "source-tokens" (build-source-tokens "test-host")
                                                                     "version" "token"}
+                                     :source-tokens (build-source-tokens "test-host")
                                      :token->token-data {"test-host" (create-token-data "test-host")}
                                      :token-authentication-disabled false
                                      :token-preauthorized false
@@ -529,8 +531,8 @@
                                      :headers {}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-token"
-                                                                    "source-tokens" (build-source-tokens "test-token")
                                                                     "version" "token"}
+                                     :source-tokens (build-source-tokens "test-token")
                                      :token->token-data {"test-token" (create-token-data "test-token")}
                                      :token-authentication-disabled false
                                      :token-preauthorized false
@@ -547,8 +549,8 @@
                                      :headers {}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-token2"
-                                                                    "source-tokens" (build-source-tokens "test-token" "test-token2")
                                                                     "version" "token"}
+                                     :source-tokens (build-source-tokens "test-token" "test-token2")
                                      :token->token-data {"test-token" (create-token-data "test-token")
                                                          "test-token2" (create-token-data "test-token2")}
                                      :token-authentication-disabled false
@@ -566,8 +568,8 @@
                                                                     "cpus" "1"
                                                                     "mem" "2"
                                                                     "name" "test-mem-token"
-                                                                    "source-tokens" (build-source-tokens "test-token" "test-token2" "test-cpus-token" "test-mem-token")
                                                                     "version" "token"}
+                                     :source-tokens (build-source-tokens "test-token" "test-token2" "test-cpus-token" "test-mem-token")
                                      :token->token-data {"test-cpus-token" (create-token-data "test-cpus-token")
                                                          "test-mem-token" (create-token-data "test-mem-token")
                                                          "test-token" (create-token-data "test-token")
@@ -585,8 +587,8 @@
                                      :headers {}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-host"
-                                                                    "source-tokens" (build-source-tokens "test-host")
                                                                     "version" "token"}
+                                     :source-tokens (build-source-tokens "test-host")
                                      :token->token-data {"test-host" (create-token-data "test-host")}
                                      :token-authentication-disabled false
                                      :token-preauthorized false
@@ -601,8 +603,8 @@
                                      :headers {}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-host"
-                                                                    "source-tokens" (build-source-tokens "test-host")
                                                                     "version" "token"}
+                                     :source-tokens (build-source-tokens "test-host")
                                      :token->token-data {"test-host" (create-token-data "test-host")}
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
@@ -618,8 +620,8 @@
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-token-run"
                                                                     "run-as-user" "ruser"
-                                                                    "source-tokens" (build-source-tokens "test-token-run")
                                                                     "version" "token"}
+                                     :source-tokens (build-source-tokens "test-token-run")
                                      :token->token-data {"test-token-run" (create-token-data "test-token-run")}
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
@@ -634,8 +636,8 @@
                                      :headers {}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-token-per-fall"
-                                                                    "source-tokens" (build-source-tokens "test-token-per-fall")
                                                                     "version" "token" "permitted-user" "puser"}
+                                     :source-tokens (build-source-tokens "test-token-per-fall")
                                      :token->token-data {"test-token-per-fall" (create-token-data "test-token-per-fall")}
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
@@ -652,8 +654,8 @@
                                                                     "name" "test-token-per-run"
                                                                     "permitted-user" "puser"
                                                                     "run-as-user" "ruser"
-                                                                    "source-tokens" (build-source-tokens "test-token-per-run")
                                                                     "version" "token"}
+                                     :source-tokens (build-source-tokens "test-token-per-run")
                                      :token->token-data {"test-token-per-run" (create-token-data "test-token-per-run")}
                                      :token-authentication-disabled false
                                      :token-preauthorized true
@@ -671,8 +673,8 @@
                                                                     "name" "test-cpus-token"
                                                                     "permitted-user" "puser"
                                                                     "run-as-user" "ruser"
-                                                                    "source-tokens" (build-source-tokens "test-token-per-run" "test-cpus-token")
                                                                     "version" "token"}
+                                     :source-tokens (build-source-tokens "test-token-per-run" "test-cpus-token")
                                      :token->token-data {"test-cpus-token" (create-token-data "test-cpus-token")
                                                          "test-token-per-run" (create-token-data "test-token-per-run")}
                                      :token-authentication-disabled false
@@ -690,6 +692,7 @@
                                                            "baz" "quux"}
                                                "cpus" "1"}
                                      :service-description-template {},
+                                     :source-tokens []
                                      :token->token-data {},
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
@@ -706,6 +709,7 @@
                                                       "FOO_BAR" "bar"}
                                                "cpus" "1"}
                                      :service-description-template {},
+                                     :source-tokens []
                                      :token->token-data {},
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
@@ -726,8 +730,8 @@
                                                                     "name" "test-host-allowed-cpus-mem-per-run"
                                                                     "permitted-user" "puser"
                                                                     "run-as-user" "ruser"
-                                                                    "source-tokens" (build-source-tokens "test-host-allowed-cpus-mem-per-run")
                                                                     "version" "token"}
+                                     :source-tokens (build-source-tokens "test-host-allowed-cpus-mem-per-run")
                                      :token->token-data {"test-host-allowed-cpus-mem-per-run" (create-token-data "test-host-allowed-cpus-mem-per-run")}
                                      :token-authentication-disabled false
                                      :token-preauthorized true
@@ -750,8 +754,8 @@
                                                                     "name" "test-host-allowed-cpus-mem-per-run"
                                                                     "permitted-user" "puser"
                                                                     "run-as-user" "ruser"
-                                                                    "source-tokens" (build-source-tokens "test-host-allowed-cpus-mem-per-run")
                                                                     "version" "token"}
+                                     :source-tokens (build-source-tokens "test-host-allowed-cpus-mem-per-run")
                                      :token->token-data {"test-host-allowed-cpus-mem-per-run" (create-token-data "test-host-allowed-cpus-mem-per-run")}
                                      :token-authentication-disabled false
                                      :token-preauthorized true
@@ -773,8 +777,8 @@
                                                                     "name" "test-host-allowed-cpus-mem-per-run"
                                                                     "permitted-user" "puser"
                                                                     "run-as-user" "ruser"
-                                                                    "source-tokens" (build-source-tokens "test-host-allowed-cpus-mem-per-run")
                                                                     "version" "token"}
+                                     :source-tokens (build-source-tokens "test-host-allowed-cpus-mem-per-run")
                                      :token->token-data {"test-host-allowed-cpus-mem-per-run" (create-token-data "test-host-allowed-cpus-mem-per-run")}
                                      :token-authentication-disabled false
                                      :token-preauthorized true
@@ -791,6 +795,7 @@
                                                "param" {"BAZ" "quux"
                                                         "FOO_BAR" "bar"}}
                                      :service-description-template {},
+                                     :source-tokens []
                                      :token->token-data {},
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
@@ -811,6 +816,7 @@
                                                "param" {"BAZ" "quux"
                                                         "FOO_BAR" "bar"}}
                                      :service-description-template {},
+                                     :source-tokens []
                                      :token->token-data {},
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
@@ -831,6 +837,7 @@
                                                "param" {"BAZ" "quux"
                                                         "FOO_BAR" "bar2"}}
                                      :service-description-template {},
+                                     :source-tokens []
                                      :token->token-data {},
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
@@ -847,6 +854,7 @@
                                                "env" {"1" "quux"
                                                       "FOO-BAR" "bar"}}
                                      :service-description-template {},
+                                     :source-tokens []
                                      :token->token-data {},
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
@@ -894,9 +902,8 @@
                 expected {:defaults service-description-defaults
                           :fallback-period-secs 300
                           :headers {}
-                          :service-description-template (-> token-data
-                                                            (select-keys service-parameter-keys)
-                                                            (assoc "source-tokens" [(source-tokens-entry test-token token-data)]))
+                          :service-description-template (select-keys token-data service-parameter-keys)
+                          :source-tokens [(source-tokens-entry test-token token-data)]
                           :token->token-data {test-token token-data}
                           :token-authentication-disabled true
                           :token-preauthorized true
@@ -927,9 +934,8 @@
                 expected {:defaults service-description-defaults
                           :fallback-period-secs 300
                           :headers {}
-                          :service-description-template (-> token-data
-                                                            (select-keys service-parameter-keys)
-                                                            (assoc "source-tokens" [(source-tokens-entry test-token token-data)]))
+                          :service-description-template (select-keys token-data service-parameter-keys)
+                          :source-tokens [(source-tokens-entry test-token token-data)]
                           :token->token-data {test-token token-data}
                           :token-authentication-disabled false
                           :token-preauthorized true
@@ -968,6 +974,17 @@
     (is (nil? (compute-on-the-fly {"cmd" "on-the-fly-cmd", "run-as-user" "on-the-fly-ru"})))
     (is (compute-on-the-fly {"x-waiter-cmd" "on-the-fly-cmd", "x-waiter-run-as-user" "on-the-fly-ru"}))
     (is (compute-on-the-fly {"x-waiter-token" "value-does-not-matter"}))))
+
+(deftest test-compute-service-description-source-tokens
+  (let [defaults {"health-check-url" "/ping", "permitted-user" "bob"}
+        source-tokens (Object.)
+        sources {:defaults defaults
+                 :service-description-template {"cmd" "token-cmd"}
+                 :source-tokens source-tokens}
+        compute-source-tokens (fn compute-source-tokens [waiter-headers]
+                                (-> (compute-service-description-helper sources :waiter-headers waiter-headers)
+                                    :source-tokens))]
+    (is (= source-tokens (compute-source-tokens {})))))
 
 (deftest test-compute-service-description
   (testing "Service description computation"
@@ -1422,7 +1439,6 @@
             "current-request-user"
             {"scale-factor" 0.3})
           (is (= (-> basic-service-description
-                     (dissoc "source-tokens")
                      (assoc "health-check-url" "/ping" "permitted-user" "bob" "scale-factor" 0.3))
                  (service-description {:defaults {"health-check-url" "/ping"
                                                   "permitted-user" "bob"
@@ -1437,7 +1453,6 @@
             basic-service-id
             "current-request-user")
           (is (= (-> basic-service-description
-                     (dissoc "source-tokens")
                      (assoc "health-check-url" "/ping" "permitted-user" "bob"))
                  (service-description {:defaults {"health-check-url" "/ping"
                                                   "permitted-user" "bob"}
@@ -1918,17 +1933,10 @@
       (testing "should use mapping when metric group not specified"
         (is (= "mapped" (mg-filter {"name" "foo"}))))
 
-      (testing "should ignore source-tokens when single token specified"
-        (is (= "other" (mg-filter {"cpus" 1 "source-tokens" [{"token" "example-1.app.com" "version" "hash-1"}]}))))
+      (testing "should use 'other' when metric group not specified and name not mapped - 1"
+        (is (= "other" (mg-filter {"cpus" 1 "mem" 1024}))))
 
-      (testing "should use other when token in source-tokens does not validate"
-        (is (= "other" (mg-filter {"cpus" 1 "source-tokens" [{"token" "example-1@app.com" "version" "hash-1"}]}))))
-
-      (testing "should use other when source-tokens has multiple tokens"
-        (is (= "other" (mg-filter {"cpus" 1 "source-tokens" [{"token" "example-1.app.com" "version" "hash-1"}
-                                                             {"token" "example-2.app.com" "version" "hash-2"}]}))))
-
-      (testing "should use 'other' when metric group not specified and name not mapped"
+      (testing "should use 'other' when metric group not specified and name not mapped - 2"
         (is (= "other" (mg-filter {})))))))
 
 (deftest test-name->metric-group
@@ -2134,57 +2142,63 @@
       (let [token->token-data {"t1" {"cpus" 1}}
             service-id->service-description-fn (fn [in-service-id]
                                                  (is (= service-id in-service-id))
-                                                 {"idle-timeout-mins" idle-timeout-mins
-                                                  "source-tokens" [{"token" "t1" "version" "t1.hash1"}]})
+                                                 {"idle-timeout-mins" idle-timeout-mins})
+            service-id->source-token-entries-fn (fn [in-service-id]
+                                                  (is (= service-id in-service-id))
+                                                  #{[{"token" "t1" "version" "t1.hash1"}]})
             token->token-metadata (token->token-metadata-fn token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
-                 service-id->service-description-fn token->token-hash token->token-metadata
-                 token-defaults service-id)))))
+                 service-id->service-description-fn service-id->source-token-entries-fn token->token-hash
+                 token->token-metadata token-defaults service-id)))))
 
     (testing "service with multiple tokens is active"
       (let [token->token-data {"t1" {"cpus" 1}
                                "t2" {"mem" 2048}}
             service-id->service-description-fn (fn [in-service-id]
                                                  (is (= service-id in-service-id))
-                                                 {"idle-timeout-mins" idle-timeout-mins
-                                                  "source-tokens" [{"token" "t1" "version" "t1.hash1"}
-                                                                   {"token" "t2" "version" "t2.hash1"}]})
+                                                 {"idle-timeout-mins" idle-timeout-mins})
+            service-id->source-token-entries-fn (fn [in-service-id]
+                                                  (is (= service-id in-service-id))
+                                                  #{[{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash1"}]})
             token->token-metadata (token->token-metadata-fn token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
-                 service-id->service-description-fn token->token-hash token->token-metadata
-                 token-defaults service-id)))))
+                 service-id->service-description-fn service-id->source-token-entries-fn token->token-hash
+                 token->token-metadata token-defaults service-id)))))
 
     (testing "service outdated but fallback not configured"
       (let [token->token-data {"t1" {"cpus" 1}
                                "t2" {"mem" 2048}}
             service-id->service-description-fn (fn [in-service-id]
                                                  (is (= service-id in-service-id))
-                                                 {"idle-timeout-mins" idle-timeout-mins
-                                                  "source-tokens" [{"token" "t1" "version" "t1.hash0"}]})
+                                                 {"idle-timeout-mins" idle-timeout-mins})
+            service-id->source-token-entries-fn (fn [in-service-id]
+                                                  (is (= service-id in-service-id))
+                                                  #{[{"token" "t1" "version" "t1.hash0"}]})
             token->token-metadata (token->token-metadata-fn token->token-data)]
         (is (= (-> (+ fallback-period-secs (dec (-> 1 t/minutes t/in-seconds)))
                    t/seconds
                    t/in-minutes
                    (+ stale-timeout-mins))
                (service-id->idle-timeout
-                 service-id->service-description-fn token->token-hash token->token-metadata
-                 token-defaults service-id)))))
+                 service-id->service-description-fn service-id->source-token-entries-fn token->token-hash
+                 token->token-metadata token-defaults service-id)))))
 
     (testing "service outdated and fallback configured on one token"
       (let [token->token-data {"t1" {"cpus" 1 "fallback-period-secs" 300}
                                "t2" {"mem" 2048}}
             service-id->service-description-fn (fn [in-service-id]
                                                  (is (= service-id in-service-id))
-                                                 {"idle-timeout-mins" idle-timeout-mins
-                                                  "source-tokens" [{"token" "t1" "version" "t1.hash1"}
-                                                                   {"token" "t2" "version" "t2.hash0"}]})
+                                                 {"idle-timeout-mins" idle-timeout-mins})
+            service-id->source-token-entries-fn (fn [in-service-id]
+                                                  (is (= service-id in-service-id))
+                                                  #{[{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash0"}]})
             token->token-metadata (token->token-metadata-fn token->token-data)]
         (is (= (-> 300 t/seconds t/in-minutes (+ stale-timeout-mins))
                (service-id->idle-timeout
-                 service-id->service-description-fn token->token-hash token->token-metadata
-                 token-defaults service-id)))))
+                 service-id->service-description-fn service-id->source-token-entries-fn token->token-hash
+                 token->token-metadata token-defaults service-id)))))
 
     (testing "service outdated and fallback and timeout configured on all tokens"
       (let [stale-timeout-mins 45
@@ -2193,12 +2207,74 @@
                                "t3" {"cmd" "tc" "fallback-period-secs" 900}}
             service-id->service-description-fn (fn [in-service-id]
                                                  (is (= service-id in-service-id))
-                                                 {"idle-timeout-mins" idle-timeout-mins
-                                                  "source-tokens" [{"token" "t1" "version" "t1.hash1"}
-                                                                   {"token" "t2" "version" "t2.hash0"}
-                                                                   {"token" "t3" "version" "t3.hash0"}]})
+                                                 {"idle-timeout-mins" idle-timeout-mins})
+            service-id->source-token-entries-fn (fn [in-service-id]
+                                                  (is (= service-id in-service-id))
+                                                  #{[{"token" "t1" "version" "t1.hash1"}
+                                                     {"token" "t2" "version" "t2.hash0"}
+                                                     {"token" "t3" "version" "t3.hash0"}]})
             token->token-metadata (token->token-metadata-fn token->token-data)]
         (is (= (-> 900 t/seconds t/in-minutes (+ stale-timeout-mins))
                (service-id->idle-timeout
-                 service-id->service-description-fn token->token-hash token->token-metadata
-                 token-defaults service-id)))))))
+                 service-id->service-description-fn service-id->source-token-entries-fn token->token-hash
+                 token->token-metadata token-defaults service-id)))))
+
+    (testing "service outdated and fallback and timeout configured on multiple source tokens"
+      (let [stale-timeout-mins 45
+            token->token-data {"t1" {"cpus" 123 "fallback-period-secs" 300}
+                               "t2" {"cmd" "tc" "fallback-period-secs" 600 "stale-timeout-mins" stale-timeout-mins}
+                               "t3" {"cmd" "tc" "fallback-period-secs" 900}
+                               "t4" {"fallback-period-secs" 1200 "stale-timeout-mins" (+ stale-timeout-mins 15)}}
+            service-id->service-description-fn (fn [in-service-id]
+                                                 (is (= service-id in-service-id))
+                                                 {"idle-timeout-mins" idle-timeout-mins})
+            service-id->source-token-entries-fn (fn [in-service-id]
+                                                  (is (= service-id in-service-id))
+                                                  #{[{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash0"}]
+                                                    [{"token" "t3" "version" "t3.hash0"} {"token" "t4" "version" "t4.hash0"}]})
+            token->token-metadata (token->token-metadata-fn token->token-data)]
+        (is (= (max (-> 900 t/seconds t/in-minutes (+ stale-timeout-mins))
+                    (-> 1200 t/seconds t/in-minutes (+ stale-timeout-mins 15)))
+               (service-id->idle-timeout
+                 service-id->service-description-fn service-id->source-token-entries-fn token->token-hash
+                 token->token-metadata token-defaults service-id)))))))
+
+(defn- synchronize-fn
+  [lock f]
+  (locking lock
+    (f)))
+
+(deftest test-store-source-tokens!
+  (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+        service-id "test-service-id"
+        token-data-1 {"cmd" "ls" "cpus" 1 "mem" 32}
+        token-data-2 {"run-as-user" "ru1" "version" "foo"}
+        token-data-3 {"mem" 64 "run-as-user2" "ru" "version" "foo"}
+        source-tokens-1 [(source-tokens-entry "token-1" token-data-1)
+                         (source-tokens-entry "token-2" token-data-2)]
+        source-tokens-2 [(source-tokens-entry "token-1" token-data-1)
+                         (source-tokens-entry "token-2" token-data-2)]
+        source-tokens-3 [(source-tokens-entry "token-3" token-data-3)
+                         (source-tokens-entry "token-2" token-data-2)]
+        source-tokens-4 [(source-tokens-entry "token-2" token-data-2)
+                         (source-tokens-entry "token-3" token-data-3)]]
+
+    (store-source-tokens! synchronize-fn kv-store service-id source-tokens-1)
+    (is (= #{source-tokens-1}
+           (service-id->source-tokens-entries kv-store service-id)))
+
+    (store-source-tokens! synchronize-fn kv-store service-id source-tokens-2)
+    (is (= #{source-tokens-1}
+           (service-id->source-tokens-entries kv-store service-id)))
+
+    (store-source-tokens! synchronize-fn kv-store service-id source-tokens-3)
+    (is (= #{source-tokens-1 source-tokens-3}
+           (service-id->source-tokens-entries kv-store service-id)))
+
+    (store-source-tokens! synchronize-fn kv-store service-id source-tokens-1)
+    (is (= #{source-tokens-1 source-tokens-3}
+           (service-id->source-tokens-entries kv-store service-id)))
+
+    (store-source-tokens! synchronize-fn kv-store service-id source-tokens-4)
+    (is (= #{source-tokens-1 source-tokens-3 source-tokens-4}
+           (service-id->source-tokens-entries kv-store service-id)))))


### PR DESCRIPTION
## Changes proposed in this PR

- stores source-tokens as a separate entity in the `kv-store` instead of in the service description

## Why are we making these changes?

This re-allows services to be shared by on-the-fly requests and multiple tokens.

This PR only stores the `service-id` to source tokens mapping. We do not store the token to `service-id` mapping as it is not used currently.
