### PR TITLE
Trigger Travis-CI on branches with "build/" prefix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ addons:
   artifacts: true
 
 branches:
-  only: master
+  only:
+    - master
+    - /^build\/.*$/
 
 cache:
   directories:


### PR DESCRIPTION
## Changes proposed in this PR

- Trigger Travis-CI on branches with the `build/` prefix.

## Why are we making these changes?

This makes it easier for developers to trigger Travis-CI on branches in their personal GitHub forks of the Waiter project.