### PR TITLE
Make K8s fileserver container command configurable

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -341,7 +341,8 @@
                                  ;; The sidecar container is only added to Waiter-managed pods if the :port number is set in this map,
                                  ;; otherwise, the file browsing API is disabled (always returning an empty array).
                                  ;; You must ensure that the fileserver port number does not intersect with the pod-base-port range.
-                                 :fileserver {:image "twosigma/waiter-fileserver:latest"
+                                 :fileserver {:cmd ["/bin/fileserver-start"]
+                                              :image "twosigma/waiter-fileserver:latest"
                                               :port 9090
                                               :resources {:cpu 0.1 :mem 128}
                                               :scheme "http"}

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -629,9 +629,9 @@
       (update-in
         [:spec :template :spec :containers]
         conj
-        (let [{:keys [image port] {:keys [cpu mem]} :resources} fileserver
+        (let [{:keys [cmd image port] {:keys [cpu mem]} :resources} fileserver
               memory (str mem "Mi")]
-          {:command ["/bin/fileserver-start"]
+          {:command cmd
            :env [{:name "WAITER_FILESERVER_PORT"
                   :value (str port)}]
            :image image

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -291,7 +291,8 @@
                       :kubernetes {; Default values are not provided below for the following keys:
                                    ; :authentication [:fileserver :port] :url
                                    :factory-fn 'waiter.scheduler.kubernetes/kubernetes-scheduler
-                                   :fileserver {:image "twosigma/waiter-fileserver:latest"
+                                   :fileserver {:cmd ["/bin/fileserver-start"]
+                                                :image "twosigma/waiter-fileserver:latest"
                                                 :resources {:cpu 0.1 :mem 128}
                                                 :scheme "http"}
                                    :http-options {:conn-timeout 10000


### PR DESCRIPTION
## Changes proposed in this PR

Allow setting the Waiter-Kubernetes fileserver container's command via the config file. (Previously it was hard-coded into the replicaset spec factory function.)

## Why are we making these changes?

Since the container is set in the config file, it doesn't make sense to not set the container's startup command in the same place.