### PR TITLE
handles NPE due to empty service description being returned

### DIFF
--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -427,7 +427,7 @@
     (when (str/blank? service-id)
       (throw (ex-info "Missing service-id" {:status 400})))
     ; throw exception if no service description for service-id exists
-    (sd/fetch-core kv-store service-id :nil-on-missing? false)
+    (sd/fetch-core kv-store service-id :refresh true :nil-on-missing? false)
     (let [auth-user (get request :authorization/user)
           mode-str (name mode)]
       (log/info auth-user "wants to" mode-str " " service-id)
@@ -456,7 +456,7 @@
   (when (str/blank? service-id)
     (throw (ex-info "Missing service-id" {:status 400})))
   ; throw exception if no service description for service-id exists
-  (sd/fetch-core kv-store service-id :nil-on-missing? false)
+  (sd/fetch-core kv-store service-id :refresh true :nil-on-missing? false)
   (let [auth-user (get request :authorization/user)]
     (case request-method
       :delete

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -375,7 +375,7 @@
         request-params (-> request ru/query-params-request :query-params)
         include-effective-parameters? (utils/request-flag request-params "effective-parameters")
         result-map (cond-> {:router-id router-id, :num-routers (count router->metrics)}
-                     include-effective-parameters?
+                     (and (not-empty core-service-description) include-effective-parameters?)
                      (assoc :effective-parameters (service-id->service-description-fn service-id :effective? true))
                      (not-empty service-instance-maps)
                      (assoc :instances service-instance-maps

--- a/waiter/src/waiter/kv.clj
+++ b/waiter/src/waiter/kv.clj
@@ -49,7 +49,7 @@
 
 (defn fetch
   "Wrapper to work around Clojure's limitation of not supporting variable argument lists in defprotocol.
-  This method supports optional arguments and delegates to the protocl retrieve method."
+  This method supports optional arguments and delegates to the protocol retrieve method."
   [kv-protocol key & {:keys [refresh] :or {refresh false}}]
   (retrieve kv-protocol key refresh))
 

--- a/waiter/src/waiter/scaling.clj
+++ b/waiter/src/waiter/scaling.clj
@@ -191,7 +191,9 @@
   "Computes the new scale amount subject to quanta restrictions.
    The returned value is guaranteed to be at least 1."
   [service-description quanta-constraints scale-amount]
-  {:pre [(pos? scale-amount) (integer? scale-amount)]
+  {:pre [(seq service-description)
+         (pos? scale-amount)
+         (integer? scale-amount)]
    :post [(pos? %) (<= % scale-amount)]}
   (-> scale-amount
       (min (quot (:cpus quanta-constraints) (get service-description "cpus"))

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -836,8 +836,7 @@
 (defn service-id->service-description
   "Loads the service description for the specified service-id including any overrides."
   [kv-store service-id service-description-defaults metric-group-mappings & {:keys [effective?] :or {effective? true}}]
-  (cond-> (or (fetch-core kv-store service-id :refresh false)
-              (fetch-core kv-store service-id :refresh true))
+  (cond-> (fetch-core kv-store service-id :refresh false)
     effective? (default-and-override metric-group-mappings kv-store service-description-defaults service-id)))
 
 (defn can-manage-service?

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -653,6 +653,14 @@
         (when-not nil-on-missing?
           (throw (ex-info "No description found!" {:service-id service-id})))))))
 
+(defn refresh-service-descriptions
+  "Refreshes missing service descriptions for the specified service ids."
+  [kv-store service-ids]
+  (doseq [service-id service-ids]
+    (when-not (fetch-core kv-store service-id :refresh false)
+      (log/info "refreshing the service description for" service-id)
+      (fetch-core kv-store service-id :nil-on-missing? false :refresh true))))
+
 (let [service-id->key #(str "^STATUS#" %)]
   (defn suspend-service
     "Stores an entry in the key-value store marking the service as suspended."

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -833,13 +833,12 @@
 
 (defn service-id->service-description
   "Loads the service description for the specified service-id including any overrides."
-  [kv-store service-id service-description-defaults metric-group-mappings &
-   {:keys [effective? nil-on-missing? refresh] :or {effective? true nil-on-missing? true refresh false}}]
-  (let [service-description (fetch-core kv-store service-id :nil-on-missing? nil-on-missing? :refresh refresh)
-        service-description (if (and (empty? service-description) (not refresh))
+  [kv-store service-id service-description-defaults metric-group-mappings & {:keys [effective?] :or {effective? true}}]
+  (let [service-description (fetch-core kv-store service-id :refresh false)
+        service-description (if (and (empty? service-description))
                               (do
                                 (log/info "force refreshing fetch of service description for" service-id)
-                                (fetch-core kv-store service-id :nil-on-missing? nil-on-missing? :refresh true))
+                                (fetch-core kv-store service-id :refresh true))
                               service-description)]
     (cond-> service-description
       effective? (default-and-override metric-group-mappings kv-store service-description-defaults service-id))))

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -1770,14 +1770,14 @@
 
     (testing "no data available"
       (let [kv-store (kv/->LocalKeyValueStore (atom {}))]
-        (is (empty? (kv/fetch kv-store service-key)))
-        (is (empty? (fetch-core kv-store service-id :refresh false)))
-        (is (empty? (kv/fetch kv-store service-key)))))
+        (is (nil? (kv/fetch kv-store service-key)))
+        (is (nil? (fetch-core kv-store service-id :refresh false)))
+        (is (nil? (kv/fetch kv-store service-key)))))
 
     (testing "data without refresh"
       (let [kv-store (kv/->LocalKeyValueStore (atom {}))
             service-description {"cmd" "tc" "cpus" 1 "mem" 200 "version" "a1b2c3"}]
-        (is (empty? (kv/fetch kv-store service-key)))
+        (is (nil? (kv/fetch kv-store service-key)))
         (kv/store kv-store service-key service-description)
         (is (= service-description (fetch-core kv-store service-id :refresh false)))
         (is (= service-description (kv/fetch kv-store service-key)))))
@@ -1788,12 +1788,12 @@
             cache-kv-store (kv/->CachedKeyValueStore kv-store cache)
             service-id "test-service-1"
             service-description {"cmd" "tc" "cpus" 1 "mem" 200 "version" "a1b2c3"}]
-        (kv/store kv-store service-key {})
-        (is (empty? (fetch-core cache-kv-store service-id :refresh false)))
+        (is (nil? (fetch-core kv-store service-id :refresh false)))
+        (is (nil? (fetch-core cache-kv-store service-id :refresh false)))
         (kv/store kv-store service-key service-description)
-        (is (empty? (kv/fetch cache-kv-store (str "^SERVICE-ID#" service-id))))
-        (is (empty? (fetch-core cache-kv-store service-id :refresh false)))
-        (is (empty? (kv/fetch cache-kv-store (str "^SERVICE-ID#" service-id))))
+        (is (nil? (kv/fetch cache-kv-store (str "^SERVICE-ID#" service-id))))
+        (is (nil? (fetch-core cache-kv-store service-id :refresh false)))
+        (is (nil? (kv/fetch cache-kv-store (str "^SERVICE-ID#" service-id))))
         (is (= service-description (fetch-core cache-kv-store service-id :refresh true)))
         (is (= service-description (kv/fetch cache-kv-store (str "^SERVICE-ID#" service-id))))))))
 
@@ -1805,14 +1805,14 @@
 
     (testing "no data available"
       (let [kv-store (kv/->LocalKeyValueStore (atom {}))]
-        (is (empty? (kv/fetch kv-store service-key)))
-        (is (empty? (fetch-service-description kv-store)))
-        (is (empty? (kv/fetch kv-store service-key)))))
+        (is (nil? (kv/fetch kv-store service-key)))
+        (is (nil? (fetch-service-description kv-store)))
+        (is (nil? (kv/fetch kv-store service-key)))))
 
     (testing "data without refresh"
       (let [kv-store (kv/->LocalKeyValueStore (atom {}))
             service-description {"cmd" "tc" "cpus" 1 "mem" 200 "version" "a1b2c3"}]
-        (is (empty? (kv/fetch kv-store service-key)))
+        (is (nil? (kv/fetch kv-store service-key)))
         (kv/store kv-store service-key service-description)
         (is (= service-description (fetch-service-description kv-store)))
         (is (= service-description (kv/fetch kv-store service-key)))))
@@ -1823,10 +1823,9 @@
             cache-kv-store (kv/->CachedKeyValueStore kv-store cache)
             service-id "test-service-1"
             service-description {"cmd" "tc" "cpus" 1 "mem" 200 "version" "a1b2c3"}]
-        (kv/store kv-store service-key {})
-        (is (empty? (fetch-service-description cache-kv-store)))
+        (is (nil? (fetch-service-description cache-kv-store)))
         (kv/store kv-store service-key service-description)
-        (is (empty? (kv/fetch cache-kv-store (str "^SERVICE-ID#" service-id))))
+        (is (nil? (kv/fetch cache-kv-store (str "^SERVICE-ID#" service-id))))
         (is (= service-description (fetch-service-description cache-kv-store)))
         (is (= service-description (kv/fetch cache-kv-store (str "^SERVICE-ID#" service-id))))))))
 

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -1826,6 +1826,9 @@
         (is (nil? (fetch-service-description cache-kv-store)))
         (kv/store kv-store service-key service-description)
         (is (nil? (kv/fetch cache-kv-store (str "^SERVICE-ID#" service-id))))
+        (is (nil? (fetch-service-description cache-kv-store)))
+        (is (nil? (kv/fetch cache-kv-store (str "^SERVICE-ID#" service-id))))
+        (is (= service-description (kv/fetch cache-kv-store (str "^SERVICE-ID#" service-id) :refresh true)))
         (is (= service-description (fetch-service-description cache-kv-store)))
         (is (= service-description (kv/fetch cache-kv-store (str "^SERVICE-ID#" service-id))))))))
 


### PR DESCRIPTION
## Changes proposed in this PR

- ensures a refreshed copy is retrieved before returning an empty service description

## Why are we making these changes?

We would like to avoid NPEs in our code paths that assume that a service description is always available for a service-id. An empty map can be returned by `service-id->service-description` due to an existing cached value from a previous lookup when the service description did not exist. This can lead to an NPE in the autoscaler for a newly created service.

Most code paths that use `service-id->service-description` expect a service description to be available. The other uses perform the lookup before performing some scheduler operation on the service. Since these invocation expect a service description to be available, we perform the force refresh to avoid returning an empty map for a service description if it exists in the kv store.

