### PR TITLE
filters jobs by waiter source in cook scheduler

### DIFF
--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -215,10 +215,10 @@
 (defn available?
   "Async go block which returns the status code and success of a health check.
   Returns false if such a connection cannot be established."
-  [http-client {:keys [port] :as service-instance} health-check-path]
+  [http-client {:keys [host port] :as service-instance} health-check-path]
   (async/go
     (try
-      (if (pos? port)
+      (if (and (pos? port) host)
         (let [instance-health-check-url (health-check-url service-instance health-check-path)
               {:keys [status error]} (async/<! (http/get http-client instance-health-check-url))
               error-flag (cond

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -68,19 +68,19 @@
   (let [end-time (or end-time (t/now))
         end-time-str (du/date-to-str end-time)
         start-time (or start-time (t/minus end-time search-interval))
-        start-time-str (du/date-to-str start-time)]
-    (http-utils/http-request
-      http-client
-      (str url "/jobs")
-      :accept "application/json"
-      :content-type "application/json"
-      :query-string (cond-> {:end end-time-str
-                             :start start-time-str
-                             :state states
-                             :user user}
-                      service-id (assoc :name (str service-id "*")))
-      :request-method :get
-      :spnego-auth spnego-auth)))
+        start-time-str (du/date-to-str start-time)
+        jobs (http-utils/http-request
+               http-client (str url "/jobs")
+               :accept "application/json"
+               :content-type "application/json"
+               :query-string (cond-> {:end end-time-str
+                                      :start start-time-str
+                                      :state states
+                                      :user user}
+                               service-id (assoc :name (str service-id "*")))
+               :request-method :get
+               :spnego-auth spnego-auth)]
+    (filter (fn [job] (= "waiter" (-> job :labels :source))) jobs)))
 
 ;; Instance health checks
 

--- a/waiter/test/waiter/scheduler/cook_test.clj
+++ b/waiter/test/waiter/scheduler/cook_test.clj
@@ -122,6 +122,12 @@
         test-user "test-user"
         current-time (t/now)
         service-id "test-service-id"
+        cook-job-1 {:application {:name "test-job" :version "123456"}
+                    :labels {:user test-user}}
+        cook-job-2 {:application {:name "test-service-1" :version "123456"}
+                    :labels {:source "waiter" :user test-user}}
+        cook-job-3 {:application {:name "test-service-3" :version "238723"}
+                    :labels {:source "waiter" :user test-user}}
         http-request-fn-factory (fn [expected-query-string]
                                   (fn [in-http-client in-request-url & {:as options}]
                                     (is (= http-client in-http-client))
@@ -131,71 +137,77 @@
                                             :query-string expected-query-string
                                             :request-method :get
                                             :spnego-auth "test-spnego-auth"}
-                                           options))))]
+                                           options))
+                                    [cook-job-1 cook-job-2 cook-job-3]))]
     (with-redefs [t/now (constantly current-time)]
 
       (testing "no optional arguments"
-        (let [end-time current-time
-              search-interval (t/days 7)
-              start-time (t/minus end-time search-interval)
-              states ["running"]
-              query-string {:end (du/date-to-str end-time)
-                            :start (du/date-to-str start-time)
-                            :state states
-                            :user test-user}]
-          (with-redefs [http-utils/http-request (http-request-fn-factory query-string)]
-            (get-jobs cook-api test-user states))))
+               (let [end-time current-time
+                     search-interval (t/days 7)
+                     start-time (t/minus end-time search-interval)
+                     states ["running"]
+                     query-string {:end (du/date-to-str end-time)
+                                   :start (du/date-to-str start-time)
+                                   :state states
+                                   :user test-user}]
+                 (with-redefs [http-utils/http-request (http-request-fn-factory query-string)]
+                   (is (= [cook-job-2 cook-job-3]
+                          (get-jobs cook-api test-user states))))))
 
       (testing "only search interval argument"
-        (let [end-time current-time
-              search-interval (t/days 4)
-              start-time (t/minus end-time search-interval)
-              states ["running"]
-              query-string {:end (du/date-to-str end-time)
-                            :start (du/date-to-str start-time)
-                            :state states
-                            :user test-user}]
-          (with-redefs [http-utils/http-request (http-request-fn-factory query-string)]
-            (get-jobs cook-api test-user states :search-interval search-interval))))
+               (let [end-time current-time
+                     search-interval (t/days 4)
+                     start-time (t/minus end-time search-interval)
+                     states ["running"]
+                     query-string {:end (du/date-to-str end-time)
+                                   :start (du/date-to-str start-time)
+                                   :state states
+                                   :user test-user}]
+                 (with-redefs [http-utils/http-request (http-request-fn-factory query-string)]
+                   (is (= [cook-job-2 cook-job-3]
+                          (get-jobs cook-api test-user states :search-interval search-interval))))))
 
       (testing "only end-time argument"
-        (let [end-time (t/minus current-time (t/days 1))
-              search-interval (t/days 7)
-              start-time (t/minus end-time search-interval)
-              states ["running"]
-              query-string {:end (du/date-to-str end-time)
-                            :start (du/date-to-str start-time)
-                            :state states
-                            :user test-user}]
-          (with-redefs [http-utils/http-request (http-request-fn-factory query-string)]
-            (get-jobs cook-api test-user states :end-time end-time))))
+               (let [end-time (t/minus current-time (t/days 1))
+                     search-interval (t/days 7)
+                     start-time (t/minus end-time search-interval)
+                     states ["running"]
+                     query-string {:end (du/date-to-str end-time)
+                                   :start (du/date-to-str start-time)
+                                   :state states
+                                   :user test-user}]
+                 (with-redefs [http-utils/http-request (http-request-fn-factory query-string)]
+                   (is (= [cook-job-2 cook-job-3]
+                          (get-jobs cook-api test-user states :end-time end-time))))))
 
       (testing "only service-id argument"
-        (let [end-time current-time
-              search-interval (t/days 7)
-              start-time (t/minus end-time search-interval)
-              states ["running"]
-              query-string {:end (du/date-to-str end-time)
-                            :name (str service-id "*")
-                            :start (du/date-to-str start-time)
-                            :state states
-                            :user test-user}]
-          (with-redefs [http-utils/http-request (http-request-fn-factory query-string)]
-            (get-jobs cook-api test-user states :service-id service-id))))
+               (let [end-time current-time
+                     search-interval (t/days 7)
+                     start-time (t/minus end-time search-interval)
+                     states ["running"]
+                     query-string {:end (du/date-to-str end-time)
+                                   :name (str service-id "*")
+                                   :start (du/date-to-str start-time)
+                                   :state states
+                                   :user test-user}]
+                 (with-redefs [http-utils/http-request (http-request-fn-factory query-string)]
+                   (is (= [cook-job-2 cook-job-3]
+                          (get-jobs cook-api test-user states :service-id service-id))))))
 
       (testing "all arguments"
-        (let [end-time current-time
-              search-interval (t/days 2)
-              start-time (t/minus end-time search-interval)
-              states ["running" "waiting"]
-              query-string {:end (du/date-to-str end-time)
-                            :start (du/date-to-str start-time)
-                            :state states
-                            :user test-user}]
-          (with-redefs [http-utils/http-request (http-request-fn-factory query-string)]
-            (get-jobs cook-api test-user states
-                      :end-time end-time
-                      :start-time start-time)))))))
+               (let [end-time current-time
+                     search-interval (t/days 2)
+                     start-time (t/minus end-time search-interval)
+                     states ["running" "waiting"]
+                     query-string {:end (du/date-to-str end-time)
+                                   :start (du/date-to-str start-time)
+                                   :state states
+                                   :user test-user}]
+                 (with-redefs [http-utils/http-request (http-request-fn-factory query-string)]
+                   (is (= [cook-job-2 cook-job-3]
+                          (get-jobs cook-api test-user states
+                                    :end-time end-time
+                                    :start-time start-time)))))))))
 
 (deftest test-job-healthy?
   (with-redefs [http-utils/http-request (fn [_ in-health-check-url]


### PR DESCRIPTION
## Changes proposed in this PR

- filters jobs by waiter source in cook scheduler
- avoids triggering health checks when host is missing

## Why are we making these changes?

The cook scheduler should only process jobs it launched using the waiter source label.

Since the cook scheduler can have explicit backend ports, we have to modify the health check logic to include check for presence of host (instead of just checking the presence of port).

