### PR TITLE
adds logs to track why /state/service-id requests were blocked

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -97,6 +97,8 @@
                      "settings" :display-settings-handler-fn
                      "sim" :sim-request-handler
                      "state" [["" :state-all-handler-fn]
+                              ["/autoscaler" :state-autoscaler-handler-fn]
+                              ["/autoscaling-multiplexer" :state-autoscaling-multiplexer-handler-fn]
                               ["/fallback" :state-fallback-handler-fn]
                               ["/interstitial" :state-interstitial-handler-fn]
                               ["/launch-metrics" :state-launch-metrics-handler-fn]
@@ -1214,6 +1216,20 @@
                              (wrap-secure-request-fn
                                (fn state-all-handler-fn [request]
                                  (handler/get-router-state router-id query-state-fn request)))))
+   :state-autoscaler-handler-fn (pc/fnk [[:daemons autoscaler]
+                                         [:state router-id]
+                                         wrap-secure-request-fn]
+                                  (let [{:keys [query-state-fn]} autoscaler]
+                                    (wrap-secure-request-fn
+                                      (fn state-autoscaler-handler-fn [request]
+                                        (handler/get-autoscaler-state router-id query-state-fn request)))))
+   :state-autoscaling-multiplexer-handler-fn (pc/fnk [[:daemons autoscaling-multiplexer]
+                                                      [:state router-id]
+                                                      wrap-secure-request-fn]
+                                               (let [{:keys [query-chan]} autoscaling-multiplexer]
+                                                 (wrap-secure-request-fn
+                                                   (fn state-autoscaling-multiplexer-handler-fn [request]
+                                                     (handler/get-query-chan-state-handler router-id query-chan request)))))
    :state-fallback-handler-fn (pc/fnk [[:daemons fallback-maintainer]
                                        [:state router-id]
                                        wrap-secure-request-fn]

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -555,8 +555,8 @@
           scheme (some-> request utils/request->scheme name)
           make-url (fn make-url [path]
                      (str (when scheme (str scheme "://")) host "/state/" path))]
-      (-> {:details (->> ["fallback" "interstitial" "kv-store" "launch-metrics" "leader"
-                          "local-usage" "maintainer" "router-metrics" "scheduler" "statsd"]
+      (-> {:details (->> ["autoscaler" "autoscaling-multiplexer" "fallback" "interstitial" "kv-store"
+                          "launch-metrics" "leader" "local-usage" "maintainer" "router-metrics" "scheduler" "statsd"]
                          (pc/map-from-keys make-url))
            :router-id router-id
            :routers routers}
@@ -601,6 +601,11 @@
         (utils/clj->streaming-json-response))
     (catch Exception ex
       (utils/exception->response ex request))))
+
+(defn get-autoscaler-state
+  "Outputs the autoscaler state."
+  [router-id query-state-fn request]
+  (get-function-state query-state-fn router-id request))
 
 (defn get-kv-store-state
   "Outputs the kv-store state."

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -675,7 +675,7 @@
                                     (let [state (let [response-chan (async/promise-chan)]
                                                   (async/>! query-response-or-chan
                                                             (assoc query-params :response-chan response-chan))
-                                                  (log/info (str "waiting on response from " key " channel"))
+                                                  (log/info "waiting on response from" key "channel")
                                                   (async/alt!
                                                     response-chan ([state] state)
                                                     (async/timeout timeout-ms) ([_] {:message "Request timeout"})))]

--- a/waiter/src/waiter/scaling.clj
+++ b/waiter/src/waiter/scaling.clj
@@ -575,5 +575,6 @@
             (System/exit 1)))))
     {:exit exit-chan
      :query query-chan
+     :query-state-fn (fn query-state-fn [] @state-atom)
      :query-service-state-fn (fn query-service-state-fn [query-params]
                                (query-autoscaler-service-state @state-atom query-params))}))

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -735,6 +735,22 @@
               (str "Body did not include necessary JSON keys:\n" body))
           (is (= 200 status)))))))
 
+(deftest test-get-autoscaler-state
+  (let [router-id "test-router-id"
+        test-fn (wrap-handler-json-response get-autoscaler-state)]
+    (testing "successful response"
+      (let [state {"autoscaler" "state"}
+            query-state-fn (constantly state)
+            {:keys [body status]} (test-fn router-id query-state-fn {})]
+        (is (= 200 status))
+        (is (= (-> body json/read-str) {"router-id" router-id, "state" state}))))
+
+    (testing "exception response"
+      (let [query-state-fn (fn [] (throw (Exception. "from test")))
+            {:keys [body status]} (test-fn router-id query-state-fn {})]
+        (is (= 500 status))
+        (is (str/includes? body "Waiter Error 500"))))))
+
 (deftest test-get-kv-store-state
   (let [router-id "test-router-id"
         test-fn (wrap-handler-json-response get-kv-store-state)]


### PR DESCRIPTION
## Changes proposed in this PR

- adds logs to track why /state requests were blocked
- adds endpoints to introspect autoscaler state

## Why are we making these changes?

We would like to debug why requests were being blocked indefinitely.
