### PR TITLE
Service gc pop push issue

### DIFF
--- a/waiter/src/waiter/async_request.clj
+++ b/waiter/src/waiter/async_request.clj
@@ -48,62 +48,61 @@
    A request is not complete as long as the backend keeps returning a 200 response.
    The request is forcefully completed at timeout."
   [make-http-request complete-async-request request-still-active? status-endpoint check-interval-ms request-timeout-ms correlation-id exit-chan]
-  (let [correlation-id (str correlation-id "|status-check")]
-    (cid/with-correlation-id
-      correlation-id
-      (async/go
-        (loop [ttl request-timeout-ms]
-          (if-not (pos? ttl)
-            (do
-              (log/info "request has timed out, releasing allocated instance")
-              (complete-async-request :success)
-              :monitor-timed-out)
-            (let [timeout-chan (async/timeout (min check-interval-ms ttl))
-                  [message trigger-chan] (async/alts! [exit-chan timeout-chan] :priority true)
-                  continue-looping (if (= trigger-chan timeout-chan) (request-still-active?) (not= message :exit))]
-              (if-not continue-looping
+  (cid/with-correlation-id
+    (str correlation-id "|status-check")
+    (async/go
+      (loop [ttl request-timeout-ms]
+        (if-not (pos? ttl)
+          (do
+            (log/info "request has timed out, releasing allocated instance")
+            (complete-async-request :success)
+            :monitor-timed-out)
+          (let [timeout-chan (async/timeout (min check-interval-ms ttl))
+                [message trigger-chan] (async/alts! [exit-chan timeout-chan] :priority true)
+                continue-looping (if (= trigger-chan timeout-chan) (request-still-active?) (not= message :exit))]
+            (if-not continue-looping
+              (do
+                (log/info "request has been cleared from store, exiting monitoring loop")
+                (complete-async-request :success)
+                (if (= trigger-chan exit-chan) :request-terminated :request-no-longer-active))
+              (let [{:keys [body headers error status]} (async/<! (make-http-request))]
+                (when body (async/close! body))
                 (do
-                  (log/info "request has been cleared from store, exiting monitoring loop")
-                  (complete-async-request :success)
-                  (if (= trigger-chan exit-chan) :request-terminated :request-no-longer-active))
-                (let [{:keys [body headers error status]} (async/<! (make-http-request))]
-                  (when body (async/close! body))
-                  (do
-                    (if error
+                  (if error
+                    (do
+                      (condp instance? error
+                        ConnectException (log/debug error "error in performing status check")
+                        SocketTimeoutException (log/debug error "timeout in performing status check")
+                        TimeoutException (log/debug error "timeout in performing status check")
+                        Throwable (log/warn error "unexpected error in performing status check"))
+                      (log/info (.getMessage error) "releasing allocated instance")
+                      (complete-async-request :instance-error)
+                      :make-request-error)
+                    (case (int status)
+                      200
                       (do
-                        (condp instance? error
-                          ConnectException (log/debug error "error in performing status check")
-                          SocketTimeoutException (log/debug error "timeout in performing status check")
-                          TimeoutException (log/debug error "timeout in performing status check")
-                          Throwable (log/warn error "unexpected error in performing status check"))
-                        (log/info (.getMessage error) "releasing allocated instance")
-                        (complete-async-request :instance-error)
-                        :make-request-error)
-                      (case (int status)
-                        200
-                        (do
-                          (cid/cdebug correlation-id "async request has not yet completed")
-                          (recur (max 0 (- ttl check-interval-ms))))
-                        303
-                        (do
-                          (log/info "async request has completed, result headers" headers)
-                          (let [location-header (get headers "location")
-                                location (normalize-location-header status-endpoint location-header)]
-                            (if (str/starts-with? (str location) "/")
-                              (recur (max 0 (- ttl check-interval-ms)))
-                              (do
-                                (log/info "completing async request as result location is not a relative path:" location)
-                                (complete-async-request :success)
-                                :status-see-other))))
-                        410
-                        (do
-                          (log/info "async request has completed, result is no longer available!")
-                          (complete-async-request :success)
-                          :status-gone)
-                        (do
-                          (log/warn "status check returned unsupported status" status ", releasing reserved instance")
-                          (complete-async-request :success)
-                          :unknown-status-code)))))))))))))
+                        (cid/cdebug correlation-id "async request has not yet completed")
+                        (recur (max 0 (- ttl check-interval-ms))))
+                      303
+                      (do
+                        (log/info "async request has completed, result headers" headers)
+                        (let [location-header (get headers "location")
+                              location (normalize-location-header status-endpoint location-header)]
+                          (if (str/starts-with? (str location) "/")
+                            (recur (max 0 (- ttl check-interval-ms)))
+                            (do
+                              (log/info "completing async request as result location is not a relative path:" location)
+                              (complete-async-request :success)
+                              :status-see-other))))
+                      410
+                      (do
+                        (log/info "async request has completed, result is no longer available!")
+                        (complete-async-request :success)
+                        :status-gone)
+                      (do
+                        (log/warn "status check returned unsupported status" status ", releasing reserved instance")
+                        (complete-async-request :success)
+                        :unknown-status-code))))))))))))
 
 (defn complete-async-request-locally
   "Helper function that stops tracking an async request locally and releases the instance associated with it.

--- a/waiter/src/waiter/websocket.clj
+++ b/waiter/src/waiter/websocket.clj
@@ -150,10 +150,8 @@
               (async/put! response {:error error})))))
       (ws-client/connect! websocket-client instance-endpoint
                           (fn [request]
-                            (cid/with-correlation-id
-                              correlation-id
-                              (log/info "successfully connected with backend")
-                              (async/put! response {:ctrl-mult control-mult, :request request})))
+                            (cid/cinfo correlation-id "successfully connected with backend")
+                            (async/put! response {:ctrl-mult control-mult, :request request}))
                           ws-request-properties)
       (let [{:keys [requests-waiting-to-stream]} (metrics/stream-metric-map service-id)]
         (counters/inc! requests-waiting-to-stream))


### PR DESCRIPTION
## Changes proposed in this PR

- moves cid/with-correlation-id outside the go-block creation in service-gc-go-routine
- moves cid/with-correlation-id outside the go-block creation in transient-metrics-data-producer
- reformats handle-blacklist-request
- avoid with-correlation-id call in make-request
- moves cid/with-correlation-id outside the go-block creation in start-router-state-maintainer
- refactors monitor-async-request
- avoids cid/with-correlation-id call in service-scaling-multiplexer

## Why are we making these changes?

We want to avoid push/pop errors due to mixing of dynamic binding and async-go blocks.

