### PR TITLE
updates core.cache and core.memoize versions to 0.7.1

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -70,8 +70,8 @@
                  [org.clojure/clojure "1.8.0"]
                  [org.clojure/core.async "0.3.442"
                   :exclusions [org.clojure/clojure org.clojure/tools.reader]]
-                 [org.clojure/core.cache "0.6.5"]
-                 [org.clojure/core.memoize "0.5.9"
+                 [org.clojure/core.cache "0.7.1"]
+                 [org.clojure/core.memoize "0.7.1"
                   :exclusions [org.clojure/clojure]]
                  [org.clojure/data.codec "0.1.0"]
                  [org.clojure/data.json "0.2.6"]


### PR DESCRIPTION
## Changes proposed in this PR

- updates core.cache and core.memoize versions to 0.7.1

## Why are we making these changes?

core.cache version 0.7.1 (transitive dependency in core.memoize) avoids the stack overflow error. Please see https://dev.clojure.org/jira/browse/CCACHE-40 for details on the error.
