### PR TITLE
Use guava cache instead of clojure.core.cache

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -64,7 +64,8 @@
                  [org.apache.curator/curator-recipes "2.11.0"
                   :exclusions [io.netty/netty org.slf4j/slf4j-api]]
                  [org.apache.curator/curator-test "2.11.0"
-                  :exclusions [io.netty/netty]]
+                  :exclusions [com.google.guava/guava
+                               io.netty/netty]]
                  [org.apache.curator/curator-x-discovery "2.11.0"
                   :exclusions [io.netty/netty org.slf4j/slf4j-api]]
                  [org.clojure/clojure "1.8.0"]

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -36,8 +36,8 @@
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-io org.clojure/tools.reader potemkin slingshot]]
                  [clj-time "0.12.0"
-                  :exclusions
-                  [joda-time]]
+                  :exclusions [joda-time]]
+                 [com.google.guava/guava "20.0"]
                  [com.taoensso/nippy "2.12.2"
                   :exclusions [org.clojure/clojure org.clojure/tools.reader]]
                  [comb "0.1.0"
@@ -70,7 +70,6 @@
                  [org.clojure/clojure "1.8.0"]
                  [org.clojure/core.async "0.3.442"
                   :exclusions [org.clojure/clojure org.clojure/tools.reader]]
-                 [org.clojure/core.cache "0.7.1"]
                  [org.clojure/core.memoize "0.7.1"
                   :exclusions [org.clojure/clojure]]
                  [org.clojure/data.codec "0.1.0"]

--- a/waiter/src/waiter/cookie_support.clj
+++ b/waiter/src/waiter/cookie_support.clj
@@ -93,6 +93,6 @@
   (defn decode-cookie-cached
     "Decode Waiter encoded cookie."
     [^String waiter-cookie password]
-    (cu/atom-cache-get-or-load
+    (cu/cache-get-or-load
       cookie-cache waiter-cookie
       (fn [] (decode-cookie waiter-cookie password)))))

--- a/waiter/src/waiter/cookie_support.clj
+++ b/waiter/src/waiter/cookie_support.clj
@@ -20,8 +20,8 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [taoensso.nippy :as nippy]
-            [waiter.util.ring-utils :as ru]
-            [waiter.util.utils :as utils])
+            [waiter.util.cache-utils :as cu]
+            [waiter.util.ring-utils :as ru])
   (:import clojure.lang.ExceptionInfo
            org.eclipse.jetty.util.UrlEncoded))
 
@@ -96,6 +96,6 @@
   (defn decode-cookie-cached
     "Decode Waiter encoded cookie."
     [^String waiter-cookie password]
-    (utils/atom-cache-get-or-load
+    (cu/atom-cache-get-or-load
       cookie-cache waiter-cookie
       (fn [] (decode-cookie waiter-cookie password)))))

--- a/waiter/src/waiter/cookie_support.clj
+++ b/waiter/src/waiter/cookie_support.clj
@@ -15,7 +15,6 @@
 ;;
 (ns waiter.cookie-support
   (:require [clj-time.core :as t]
-            [clojure.core.cache :as cache]
             [clojure.data.codec.base64 :as b64]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
@@ -90,9 +89,7 @@
                       (-> (ex-data e)
                           (update-in [:opts :password] (fn [password] (when password "***")))))))))
 
-(let [cookie-cache (-> {}
-                       (cache/ttl-cache-factory :ttl (-> 300 t/seconds t/in-millis))
-                       atom)]
+(let [cookie-cache (cu/cache-factory {:ttl (-> 300 t/seconds t/in-millis)})]
   (defn decode-cookie-cached
     "Decode Waiter encoded cookie."
     [^String waiter-cookie password]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -535,10 +535,10 @@
                                   (utils/create-component
                                     service-description-builder-config :context {:constraints service-description-constraints}))
    :service-id-prefix (pc/fnk [[:settings [:cluster-config service-prefix]]] service-prefix)
-   :start-service-cache-atom (pc/fnk []
-                               (cu/cache-factory {:threshold 100
-                                                  :ttl (-> 1 t/minutes t/in-millis)}))
-   :task-threadpool (pc/fnk [] (Executors/newFixedThreadPool 20))
+   :start-service-cache (pc/fnk []
+                          (cu/cache-factory {:threshold 100
+                                             :ttl (-> 1 t/minutes t/in-millis)}))
+   :task-thread-pool (pc/fnk [] (Executors/newFixedThreadPool 20))
    :token-root (pc/fnk [[:settings [:cluster-config name]]] name)
    :waiter-hostnames (pc/fnk [[:settings hostname]]
                        (set (if (sequential? hostname)
@@ -814,13 +814,13 @@
    :service-id->source-tokens-entries-fn (pc/fnk [[:curator kv-store]]
                                            (partial sd/service-id->source-tokens-entries kv-store))
    :start-new-service-fn (pc/fnk [[:scheduler scheduler]
-                                  [:state authenticator start-service-cache-atom task-threadpool]
+                                  [:state authenticator start-service-cache task-thread-pool]
                                   store-service-description-fn]
                            (fn start-new-service [{:keys [service-id] :as descriptor}]
                              (let [run-as-user (get-in descriptor [:service-description "run-as-user"])]
                                (auth/check-user authenticator run-as-user service-id))
                              (service/start-new-service
-                               scheduler descriptor start-service-cache-atom task-threadpool
+                               scheduler descriptor start-service-cache task-thread-pool
                                :pre-start-fn #(store-service-description-fn descriptor))))
    :start-work-stealing-balancer-fn (pc/fnk [[:settings [:work-stealing offer-help-interval-ms reserve-timeout-ms]]
                                              [:state instance-rpc-chan router-id]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -17,7 +17,6 @@
   (:require [bidi.bidi :as bidi]
             [clj-time.core :as t]
             [clojure.core.async :as async]
-            [clojure.core.cache :as cache]
             [clojure.java.io :as io]
             [clojure.set :as set]
             [clojure.string :as str]
@@ -58,6 +57,7 @@
             [waiter.statsd :as statsd]
             [waiter.token :as token]
             [waiter.util.async-utils :as au]
+            [waiter.util.cache-utils :as cu]
             [waiter.util.date-utils :as du]
             [waiter.util.ring-utils :as ru]
             [waiter.util.utils :as utils]
@@ -536,10 +536,8 @@
                                     service-description-builder-config :context {:constraints service-description-constraints}))
    :service-id-prefix (pc/fnk [[:settings [:cluster-config service-prefix]]] service-prefix)
    :start-service-cache-atom (pc/fnk []
-                               (-> {}
-                                   (cache/fifo-cache-factory :threshold 100)
-                                   (cache/ttl-cache-factory :ttl (-> 1 t/minutes t/in-millis))
-                                   atom))
+                               (cu/cache-factory {:threshold 100
+                                                  :ttl (-> 1 t/minutes t/in-millis)}))
    :task-threadpool (pc/fnk [] (Executors/newFixedThreadPool 20))
    :token-root (pc/fnk [[:settings [:cluster-config name]]] name)
    :waiter-hostnames (pc/fnk [[:settings hostname]]

--- a/waiter/src/waiter/kv.clj
+++ b/waiter/src/waiter/kv.clj
@@ -197,21 +197,21 @@
       (if (cu/cache-contains? cache key)
         (do
           (log/info "evicting entry for" key "from cache")
-          (cu/atom-cache-evict cache key))
+          (cu/cache-evict cache key))
         (log/info "refresh is a no-op as cache does not contain" key)))
-    (cu/atom-cache-get-or-load cache key #(retrieve inner-kv-store key refresh)))
+    (cu/cache-get-or-load cache key #(retrieve inner-kv-store key refresh)))
   (store [_ key value]
-    (cu/atom-cache-evict cache key)
+    (cu/cache-evict cache key)
     (store inner-kv-store key value))
   (delete [_ key]
     (log/info "evicting deleted entry" key "from cache")
-    (cu/atom-cache-evict cache key)
+    (cu/cache-evict cache key)
     (delete inner-kv-store key))
   (state [_]
-    (let [cache-data (into (hash-map) @cache)]
-      {:cache {:count (count cache-data), :data cache-data}
-       :inner-state (state inner-kv-store)
-       :variant "cache"})))
+    {:cache {:count (cu/cache-size cache)
+             :data (cu/cache->map cache)}
+     :inner-state (state inner-kv-store)
+     :variant "cache"}))
 
 (defn new-cached-kv-store [{:keys [threshold ttl]} kv-store]
   (->> {:threshold threshold

--- a/waiter/src/waiter/kv.clj
+++ b/waiter/src/waiter/kv.clj
@@ -23,6 +23,7 @@
             [taoensso.nippy.compression :as compression]
             [waiter.curator :as curator]
             [waiter.metrics :as metrics]
+            [waiter.util.cache-utils :as cu]
             [waiter.util.utils :as utils])
   (:import java.util.Arrays
            org.apache.curator.framework.CuratorFramework))
@@ -197,15 +198,15 @@
       (if (cache/has? @cache key)
         (do
           (log/info "evicting entry for" key "from cache")
-          (utils/atom-cache-evict cache key))
+          (cu/atom-cache-evict cache key))
         (log/info "refresh is a no-op as cache does not contain" key)))
-    (utils/atom-cache-get-or-load cache key #(retrieve inner-kv-store key refresh)))
+    (cu/atom-cache-get-or-load cache key #(retrieve inner-kv-store key refresh)))
   (store [_ key value]
-    (utils/atom-cache-evict cache key)
+    (cu/atom-cache-evict cache key)
     (store inner-kv-store key value))
   (delete [_ key]
     (log/info "evicting deleted entry" key "from cache")
-    (utils/atom-cache-evict cache key)
+    (cu/atom-cache-evict cache key)
     (delete inner-kv-store key))
   (state [_]
     (let [cache-data (into (hash-map) @cache)]

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -16,7 +16,6 @@
 (ns waiter.scheduler.cook
   (:require [clj-time.coerce :as tc]
             [clj-time.core :as t]
-            [clojure.core.cache :as cache]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [metrics.timers :as timers]
@@ -89,10 +88,8 @@
                                                    :socket-timeout 10000
                                                    :spnego-auth false})
       ;; TODO make this cache configurable
-      healthy-instance-cache (-> {}
-                                 (cache/fifo-cache-factory :threshold 5000)
-                                 (cache/ttl-cache-factory :ttl (-> 10 t/seconds t/in-millis))
-                                 atom)]
+      healthy-instance-cache (cu/cache-factory {:threshold 5000
+                                                :ttl (-> 10 t/seconds t/in-millis)})]
   (defn- instance-healthy?
     "Performs health check if an entry does not exist in the healthy-instance-cache."
     [task-id health-check-url]

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -94,7 +94,7 @@
     "Performs health check if an entry does not exist in the healthy-instance-cache."
     [task-id health-check-url]
     ;; TODO Move health check out of critical path, e.g. by storing a future in the cache
-    (let [health-result (cu/atom-cache-get-or-load
+    (let [health-result (cu/cache-get-or-load
                           healthy-instance-cache
                           task-id
                           (fn perform-instance-health-check []
@@ -108,7 +108,7 @@
                                 false))))]
       ;; Do not track unhealthy instances in the cache
       (when-not health-result
-        (cu/atom-cache-evict healthy-instance-cache task-id))
+        (cu/cache-evict healthy-instance-cache task-id))
       health-result)))
 
 (defn- job->port

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -26,6 +26,7 @@
             [waiter.metrics :as metrics]
             [waiter.scheduler :as scheduler]
             [waiter.util.async-utils :as au]
+            [waiter.util.cache-utils :as cu]
             [waiter.util.date-utils :as du]
             [waiter.util.http-utils :as http-utils]
             [waiter.util.utils :as utils])
@@ -96,7 +97,7 @@
     "Performs health check if an entry does not exist in the healthy-instance-cache."
     [task-id health-check-url]
     ;; TODO Move health check out of critical path, e.g. by storing a future in the cache
-    (let [health-result (utils/atom-cache-get-or-load
+    (let [health-result (cu/atom-cache-get-or-load
                           healthy-instance-cache
                           task-id
                           (fn perform-instance-health-check []
@@ -110,7 +111,7 @@
                                 false))))]
       ;; Do not track unhealthy instances in the cache
       (when-not health-result
-        (utils/atom-cache-evict healthy-instance-cache task-id))
+        (cu/atom-cache-evict healthy-instance-cache task-id))
       health-result)))
 
 (defn- job->port

--- a/waiter/src/waiter/util/cache_utils.clj
+++ b/waiter/src/waiter/util/cache_utils.clj
@@ -16,17 +16,33 @@
 (ns waiter.util.cache-utils
   (:require [clojure.core.cache :as cache]))
 
+(defn cache-factory
+  "Creates a cache wrapped in an atom.
+   The argument to the method is a map that contains the threshold and ttl keys.
+   The threshold argument defines the maximum number of elements in the cache.
+   The ttl argument that defines the time (in millis) that entries are allowed to reside in the cache."
+  [{:keys [threshold ttl]}]
+  (cond-> {}
+    threshold (cache/fifo-cache-factory :threshold threshold)
+    ttl (cache/ttl-cache-factory :ttl ttl)
+    true atom))
+
+(defn cache-contains?
+  "Checks if the cache contains a value associated with cache-key."
+  [cache-atom cache-key]
+  (cache/has? @cache-atom cache-key))
+
 (defn atom-cache-get-or-load
   "Gets a value from a cache based upon the key.
    On cache miss, call get-fn with the key and place result into the cache in {:data value} form.
    This allows us to handle nil values as results of the get-fn."
-  [cache key get-fn]
+  [cache-atom key get-fn]
   (let [d (delay (get-fn))
-        _ (swap! cache #(cache/through (fn [_] {:data @d}) % key))
-        out (cache/lookup @cache key)]
+        _ (swap! cache-atom #(cache/through (fn [_] {:data @d}) % key))
+        out (cache/lookup @cache-atom key)]
     (if-not (nil? out) (:data out) @d)))
 
 (defn atom-cache-evict
   "Evicts a key from an atom-based cache."
-  [cache key]
-  (swap! cache #(cache/evict % key)))
+  [cache-atom key]
+  (swap! cache-atom #(cache/evict % key)))

--- a/waiter/src/waiter/util/cache_utils.clj
+++ b/waiter/src/waiter/util/cache_utils.clj
@@ -1,0 +1,32 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns waiter.util.cache-utils
+  (:require [clojure.core.cache :as cache]))
+
+(defn atom-cache-get-or-load
+  "Gets a value from a cache based upon the key.
+   On cache miss, call get-fn with the key and place result into the cache in {:data value} form.
+   This allows us to handle nil values as results of the get-fn."
+  [cache key get-fn]
+  (let [d (delay (get-fn))
+        _ (swap! cache #(cache/through (fn [_] {:data @d}) % key))
+        out (cache/lookup @cache key)]
+    (if-not (nil? out) (:data out) @d)))
+
+(defn atom-cache-evict
+  "Evicts a key from an atom-based cache."
+  [cache key]
+  (swap! cache #(cache/evict % key)))

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -14,8 +14,7 @@
 ;; limitations under the License.
 ;;
 (ns waiter.util.utils
-  (:require [clojure.core.cache :as cache]
-            [clojure.data.json :as json]
+  (:require [clojure.data.json :as json]
             [clojure.java.io :as io]
             [clojure.pprint :as pprint]
             [clojure.string :as str]
@@ -80,22 +79,6 @@
       (UUID/fromString s)
       (catch Exception _
         nil))))
-
-
-(defn atom-cache-get-or-load
-  "Gets a value from a cache based upon the key.
-   On cache miss, call get-fn with the key and place result into the cache in {:data value} form.
-   This allows us to handle nil values as results of the get-fn."
-  [cache key get-fn]
-  (let [d (delay (get-fn))
-        _ (swap! cache #(cache/through (fn [_] {:data @d}) % key))
-        out (cache/lookup @cache key)]
-    (if-not (nil? out) (:data out) @d)))
-
-(defn atom-cache-evict
-  "Evicts a key from an atom-based cache."
-  [cache key]
-  (swap! cache #(cache/evict % key)))
 
 (defn truncate [in-str max-len]
   (let [ellipsis "..."

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -15,7 +15,6 @@
 ;;
 (ns waiter.service-description-test
   (:require [clj-time.core :as t]
-            [clojure.core.cache :as cache]
             [clojure.set :as set]
             [clojure.string :as str]
             [clojure.test :refer :all]
@@ -23,7 +22,8 @@
             [schema.core :as s]
             [waiter.authorization :as authz]
             [waiter.kv :as kv]
-            [waiter.service-description :refer :all])
+            [waiter.service-description :refer :all]
+            [waiter.util.cache-utils :as cu])
   (:import (clojure.lang ExceptionInfo)
            (org.joda.time DateTime)))
 
@@ -1784,7 +1784,7 @@
 
     (testing "cached empty data"
       (let [kv-store (kv/->LocalKeyValueStore (atom {}))
-            cache (atom (cache/fifo-cache-factory {} :threshold 10))
+            cache (cu/cache-factory {:threshold 10})
             cache-kv-store (kv/->CachedKeyValueStore kv-store cache)
             service-id "test-service-1"
             service-description {"cmd" "tc" "cpus" 1 "mem" 200 "version" "a1b2c3"}]
@@ -1799,7 +1799,7 @@
 
 (deftest test-refresh-service-descriptions
   (let [raw-kv-store (kv/->LocalKeyValueStore (atom {}))
-        cache (atom (cache/fifo-cache-factory {} :threshold 10))
+        cache (cu/cache-factory {:threshold 10})
         cache-kv-store (kv/->CachedKeyValueStore raw-kv-store cache)
         service-id->key (fn [service-id] (str "^SERVICE-ID#" service-id))
         service-id->service-description (fn [service-id] {"cmd" "tc" "cpus" 1 "mem" 200 "version" service-id})
@@ -1849,7 +1849,7 @@
 
     (testing "cached empty data"
       (let [kv-store (kv/->LocalKeyValueStore (atom {}))
-            cache (atom (cache/fifo-cache-factory {} :threshold 10))
+            cache (cu/cache-factory {:threshold 10})
             cache-kv-store (kv/->CachedKeyValueStore kv-store cache)
             service-id "test-service-1"
             service-description {"cmd" "tc" "cpus" 1 "mem" 200 "version" "a1b2c3"}]

--- a/waiter/test/waiter/service_test.clj
+++ b/waiter/test/waiter/service_test.clj
@@ -177,42 +177,42 @@
         descriptor {:service-id "test-service-id"}]
 
     (testing "start-new-service"
-      (let [cache-atom (make-cache-fn 100 20)
+      (let [cache (make-cache-fn 100 20)
             start-called-atom (atom false)
             start-fn (fn [] (reset! start-called-atom (not @start-called-atom)))
-            start-service-result (start-new-service scheduler descriptor cache-atom start-service-thread-pool :start-fn start-fn)]
+            start-service-result (start-new-service scheduler descriptor cache start-service-thread-pool :start-fn start-fn)]
         (is (not (nil? start-service-result)))
         (.get ^Future start-service-result)
         (is @start-called-atom)))
 
     (testing "service-already-starting"
-      (let [cache-atom (make-cache-fn 100 1000)
+      (let [cache (make-cache-fn 100 1000)
             start-called-atom (atom false)
             start-fn (fn [] (reset! start-called-atom (not @start-called-atom)))]
-        (let [start-service-result-1 (start-new-service scheduler descriptor cache-atom start-service-thread-pool :start-fn start-fn)]
+        (let [start-service-result-1 (start-new-service scheduler descriptor cache start-service-thread-pool :start-fn start-fn)]
           (is (not (nil? start-service-result-1)))
           (.get ^Future start-service-result-1)
           (is @start-called-atom))
-        (let [start-service-result-2 (start-new-service scheduler descriptor cache-atom start-service-thread-pool :start-fn start-fn)]
+        (let [start-service-result-2 (start-new-service scheduler descriptor cache start-service-thread-pool :start-fn start-fn)]
           (is (nil? start-service-result-2)))))
 
     (testing "service-starting-after-cache-eviction"
-      (let [cache-atom (make-cache-fn 100 20)
+      (let [cache (make-cache-fn 100 20)
             start-called-atom (atom 0)]
         (let [start-fn (fn [] (reset! start-called-atom 1))
-              start-service-result-1 (start-new-service scheduler descriptor cache-atom start-service-thread-pool :start-fn start-fn)]
+              start-service-result-1 (start-new-service scheduler descriptor cache start-service-thread-pool :start-fn start-fn)]
           (is (not (nil? start-service-result-1)))
           (.get ^Future start-service-result-1)
           (is (= 1 @start-called-atom)))
         (Thread/sleep 30)
         (let [start-fn (fn [] (reset! start-called-atom 2))
-              start-service-result-2 (start-new-service scheduler descriptor cache-atom start-service-thread-pool :start-fn start-fn)]
+              start-service-result-2 (start-new-service scheduler descriptor cache start-service-thread-pool :start-fn start-fn)]
           (is (not (nil? start-service-result-2)))
           (.get ^Future start-service-result-2))
         (is (= 2 @start-called-atom))))
 
     (testing "tens-of-services-starting-simultaneously"
-      (let [cache-atom (make-cache-fn 100 15000)
+      (let [cache (make-cache-fn 100 15000)
             start-called-atom (atom {})
             individual-call-result-atom (atom {})]
         (doall
@@ -222,7 +222,7 @@
                     service-id (str "test-service-id-" service-num)
                     descriptor {:service-id service-id}
                     start-fn (fn [] (swap! start-called-atom assoc service-id (not (get @start-called-atom service-id))))
-                    start-service-result (start-new-service scheduler descriptor cache-atom start-service-thread-pool :start-fn start-fn)]
+                    start-service-result (start-new-service scheduler descriptor cache start-service-thread-pool :start-fn start-fn)]
                 (if-not (nil? start-service-result)
                   (do
                     (.get ^Future start-service-result)

--- a/waiter/test/waiter/util/utils_test.clj
+++ b/waiter/test/waiter/util/utils_test.clj
@@ -26,6 +26,7 @@
             [full.async :refer (<?? <? go-try)]
             [waiter.password-store]
             [waiter.test-helpers :refer :all]
+            [waiter.util.cache-utils :refer :all]
             [waiter.util.date-utils :refer :all]
             [waiter.util.utils :refer :all])
   (:import clojure.lang.ExceptionInfo


### PR DESCRIPTION
## Changes proposed in this PR

- introduces cache-utils.clj
- ensures use of cache-utils over clojure.core.cache in the codebase
- uses guava cache instead of clojure.core cache

## Why are we making these changes?

The guava cache is simpler to use (and more performant) than the Clojure cache library.

In addition, we had some StackOverflowExceptions due to a [known bug](https://dev.clojure.org/jira/browse/CCACHE-40) in clojure.core.cache's FIFO caches, where `concat` was used incorrectly and easily lead to blown stacks.

I settled at version 20.0 as using newer versions of guava results in the following error:
```
ERROR in (test-zk-keys) (ListenerContainer.java:41)                                                                                                                                                       
Uncaught exception, not in assertion.                                                                                                                                     
expected: nil                                                                                                                                                                                             
  actual:  #error {                                                                                                                                                                           
 :cause "com.google.common.util.concurrent.MoreExecutors.sameThreadExecutor()Lcom/google/common/util/concurrent/ListeningExecutorService;"                                                                
 :via                                                                                                                                                                        
 [{:type java.lang.NoSuchMethodError                                                                                                                                                                      
   :message "com.google.common.util.concurrent.MoreExecutors.sameThreadExecutor()Lcom/google/common/util/concurrent/ListeningExecutorService;"                                                         
   :at [org.apache.curator.framework.listen.ListenerContainer addListener "ListenerContainer.java" 41]}]                                                                                                  
 :trace                                                                                                                                                                                                 
 [[org.apache.curator.framework.listen.ListenerContainer addListener "ListenerContainer.java" 41]                                                                                                         
  [org.apache.curator.framework.imps.CuratorFrameworkImpl start "CuratorFrameworkImpl.java" 257]                                                                                                          
  [waiter.kv_test$fn__60335 invokeStatic "kv_test.clj" 205]                                                                                                                                               
  [waiter.kv_test$fn__60335 invoke "kv_test.clj" 193]                                                                                                                                          
  [clojure.test$test_var$fn__7983 invoke "test.clj" 716]                  
```