### PR TITLE
Simplify stringify-elements json helper fn

### DIFF
--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -133,17 +133,15 @@
 (defn stringify-elements
   [k v]
   (cond
-    (vector? v) (mapv (partial stringify-elements k) v)
+    (sequential? v) (mapv (partial stringify-elements k) v)
     (keyword? v) (keyword->str v)
     (instance? DateTime v) (du/date-to-str v)
     (instance? UUID v) (str v)
     (instance? Pattern v) (str v)
-    (instance? PersistentQueue v) (vec v)
     (instance? ManyToManyChannel v) (str v)
     (instance? Process v) (str v)
     (instance? ValidationError v) (str v)
-    (= k :time) (str v)
-    (symbol? v) (str/join "/" ((juxt namespace name) v))
+    (symbol? v) (str v)
     :else v))
 
 (defn clj->json


### PR DESCRIPTION
## Changes proposed in this PR

Modifications to `waiter.util.utils/stringify-elements`:

- Swap `vector?` predicate for more general `sequential?`.
- Simplify stringification of symbols.
- Remove special handling of `:time` and `PersistentQueue`  values.

## Why are we making these changes?

Switching from `(vector? v)` to `(sequential? v)` was is the main motivation for this PR. I was tired of accidentally passing sequences into `clj->json`, only to get a nasty error due to this helper not being applied recursively to the sequence's elements.

## Notes

### sequential?

`sequental?` matches vectors, lists, lazy sequences, and persistent queues.
It doesn't match sets, maps or `nil`.
http://clojuredocs.org/clojure.core/sequential_q

The `mapv` will convert any sequential-type into a vector (which becomes a JSON array), and ensures all elements of the sequence are also recursively processed. We weren't converting `PersistentQueue` elements in the old code, but we do cover that case now.

However, neither the old nor new code has special handling for sets.

### symbols

Simply calling `str` on a symbol seems better than the current more complex conversion.

`(str 'x/y)` → `"x/y"`
`(str 'z)` → `"z"`
`(str/join "/" ((juxt namespace name) 'z))` → `"/z"`

I can't see any reason why we'd want to prepend `/` in the last case. That just seems wrong.

### :time 

I searched our source code, and the `:time` key appears to always be associated with a `DateTime` object. The most common case is `{... :time (t/now) ...}`. We don't need this case anymore since we added an explicit conversion for `DateTime` objects to ISO8601 (UTC) format.