### PR TITLE
Stop using deprecated-2017Q4 Travis-CI image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: trusty
-group: deprecated-2017Q4
 language: java
 jdk: oraclejdk8
 


### PR DESCRIPTION
## Changes proposed in this PR

Drop `deprecated-2017Q4` from our travis.yml spec.

## Why are we making these changes?

Fixes #468, and gets us onto a non-deprecated image.