### PR TITLE
Swap use -> require in resolve-symbol helper

### DIFF
--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -436,10 +436,10 @@
   "Resolve the given symbol to the corresponding Var."
   [sym]
   {:pre [(symbol? sym)]}
-  (let [target-ns (namespace sym)]
-    (when-not (str/blank? target-ns)
-      (-> target-ns symbol require))
-    (resolve sym)))
+  (if-let [target-ns (namespace sym)]
+    (-> target-ns symbol require)
+    (log/warn "Unable to load namespace for symbol" sym))
+  (resolve sym))
 
 (defn create-component
   "Creates a component based on the specified :kind"

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -435,7 +435,11 @@
 (defn resolve-symbol
   "Resolve the given symbol to the corresponding Var."
   [sym]
-  (resolve (some-> sym namespace symbol use) sym))
+  {:pre [(symbol? sym)]}
+  (let [target-ns (namespace sym)]
+    (when-not (str/blank? target-ns)
+      (-> target-ns symbol require))
+    (resolve sym)))
 
 (defn create-component
   "Creates a component based on the specified :kind"

--- a/waiter/test/waiter/util/utils_test.clj
+++ b/waiter/test/waiter/util/utils_test.clj
@@ -534,10 +534,13 @@
                             (create-component {:kind :x
                                                :x {:factory-fn 'bar}}))))
 
-    (testing "should call use on namespace before attempting to resolve"
-      (is (= :bar
-             (create-component {:kind :x
-                                :x {:factory-fn 'waiter.util.utils-test-ns/foo}}))))))
+    (let [test-component {:kind :x
+                          :x {:factory-fn 'waiter.util.utils-test-ns/foo}}]
+      (testing "should call use on namespace before attempting to resolve"
+        (is (= :bar (create-component test-component))))
+
+      (testing "create-component calls should be repeatable"
+        (is (= :bar (create-component test-component)))))))
 
 (deftest test-port-available?
   (let [port (first (filter port-available? (shuffle (range 10000 11000))))]


### PR DESCRIPTION
## Changes proposed in this PR

Use `require` rather than `symbol` for our our dynamic "class-loading" logic in the `resolve-symbol` helper (the function that we use for loading `:factory-fn`s for Waiter components.)

## Why are we making these changes?

Since `use` imports all members into the current namespace, that was causing errors when we `use` the `waiter.auth.kerberos` namespace twice: once for `Authentication`, and once for `Authorization`. The conflicts were causing fatal errors on Waiter startup.