### PR TITLE
Corrects logic for determining healthy instances

### DIFF
--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -134,7 +134,10 @@
 
                     router-state-chan
                     (let [{:keys [all-available-service-ids service-id->healthy-instances]} message
-                          healthy-service-ids' (-> service-id->healthy-instances keys set)
+                          healthy-service-ids' (->> service-id->healthy-instances
+                                                    (filter #(-> % second seq))
+                                                    (map first)
+                                                    set)
                           current-state' (assoc current-state
                                            :available-service-ids all-available-service-ids
                                            :healthy-service-ids healthy-service-ids')]

--- a/waiter/src/waiter/interstitial.clj
+++ b/waiter/src/waiter/interstitial.clj
@@ -99,7 +99,10 @@
    It also removes from the interstitial state any resolved promises for services which are no longer available."
   [interstitial-state-atom service-id->service-description current-available-service-ids
    {:keys [all-available-service-ids service-id->healthy-instances]}]
-  (let [healthy-service-ids (-> service-id->healthy-instances keys set)
+  (let [healthy-service-ids (->> service-id->healthy-instances
+                                 (filter #(-> % second seq))
+                                 (map first)
+                                 set)
         service-ids-to-remove (set/difference current-available-service-ids all-available-service-ids)
         removed-service-ids (remove-resolved-interstitial-promises! interstitial-state-atom service-ids-to-remove)]
     (doseq [service-id all-available-service-ids]

--- a/waiter/test/waiter/descriptor_test.clj
+++ b/waiter/test/waiter/descriptor_test.clj
@@ -91,11 +91,13 @@
         new-healthy-service-ids (set/union current-available-service-ids #{"service-2" "service-4"})
         new-available-service-ids (set/union new-healthy-service-ids #{"service-6" "service-8"})
         scheduler-messages {:all-available-service-ids new-available-service-ids
-                            :service-id->healthy-instances (pc/map-from-keys
-                                                             (fn [service-id]
-                                                               {:id (str service-id ".instance-1")
-                                                                :service-id service-id})
-                                                             new-healthy-service-ids)}
+                            :service-id->healthy-instances (-> (pc/map-from-keys
+                                                                 (fn [service-id]
+                                                                   [{:id (str service-id ".instance-1")
+                                                                     :service-id service-id}])
+                                                                 new-healthy-service-ids)
+                                                               (assoc "service-9" []
+                                                                      "service-10" nil))}
         router-state-chan (au/latest-chan)
         {:keys [exit-chan query-chan]} (fallback-maintainer router-state-chan fallback-state-atom)]
 

--- a/waiter/test/waiter/interstitial_test.clj
+++ b/waiter/test/waiter/interstitial_test.clj
@@ -192,8 +192,10 @@
         available-service-ids #{"service-0" "service-7" "service-8" "service-9"}
         router-message {:all-available-service-ids available-service-ids
                         :service-id->healthy-instances {"service-0" [{:id "service-0.1"}]
+                                                        "service-4" nil
                                                         "service-6" [{:id "service-6.1"}]
-                                                        "service-8" [{:id "service-8.1"}]}}
+                                                        "service-8" [{:id "service-8.1"}]
+                                                        "service-9" []}}
         service-id->service-description (fn [service-id]
                                           {"interstitial-secs" (->> (str/last-index-of service-id "-")
                                                                     inc


### PR DESCRIPTION
## Changes proposed in this PR

- corrects logic for determining healthy instances

## Why are we making these changes?

Fallback 9and interstitial) logic is affected when we incorrectly (eagerly) determine a service to be healthy.

