### PR TITLE
Add async requirement to K8s scheduler

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -10,6 +10,7 @@
 ;;
 (ns waiter.scheduler.kubernetes
   (:require [clj-time.core :as t]
+            [clojure.core.async :as async]
             [clojure.java.io :as io]
             [clojure.string :as string]
             [clojure.tools.logging :as log]


### PR DESCRIPTION
## Changes proposed in this PR

Require core.async in the K8s scheduler module.

## Why are we making these changes?

This is a workaround for a very strange class-loading error that we've seen when deploying to our production clusters.
