### PR TITLE
Correct task-stats numbers for K8s scheduler

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -86,7 +86,7 @@
         [:status {replicas 0} {availableReplicas 0} {readyReplicas 0} {unavailableReplicas 0}]]
        replicaset-json
        requested (get spec :replicas 0)
-       staged (- (+ availableReplicas unavailableReplicas) replicas)]
+       staged (- replicas (+ availableReplicas unavailableReplicas))]
         (scheduler/make-Service
           {:id service-id
            :instances requested
@@ -94,7 +94,7 @@
            :k8s/namespace namespace
            :task-count replicas
            :task-stats {:healthy readyReplicas
-                        :running replicas
+                        :running (- replicas staged)
                         :staged staged
                         :unhealthy (- replicas readyReplicas staged)}}))
     (catch Throwable t

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -215,6 +215,25 @@
          {:api-server-response
           {:kind "ReplicaSetList"
            :apiVersion "extensions/v1beta1"
+           :items [{:metadata {:name "test-app-4321"
+                               :namespace "myself"
+                               :labels {:app "test-app-4321"
+                                        :managed-by "waiter"}
+                               :annotations {:waiter/service-id "test-app-4321"}}
+                    :spec {:replicas 3
+                           :selector {:matchLabels {:app "test-app-4321"
+                                                    :managed-by "waiter"}}}
+                    :status {:replicas 3
+                             :readyReplicas 1
+                             :availableReplicas 1
+                             :unavailableReplicas 1}}]}
+          :expected-result
+          [(scheduler/make-Service {:id "test-app-4321" :instances 3 :task-count 3
+                                    :task-stats {:running 2 :healthy 1 :unhealthy 1 :staged 1}})]}
+
+         {:api-server-response
+          {:kind "ReplicaSetList"
+           :apiVersion "extensions/v1beta1"
            :items [{:metadata {:name "test-app-9999"
                                :namespace "myself"
                                :labels {:app "test-app-9999"


### PR DESCRIPTION
## Changes proposed in this PR

- Negate the `staged` task count for K8s (currently comes out negative)
- Don't include `staged` tasks in the `running` count

## Why are we making these changes?

Negative staged counts were obviously wrong, and staged tasks shouldn't be included in the running-task count.

The counts make more sense now:
```
running == healthy + unhealthy
replicas == running + staged
```