### PR TITLE
Use watch-based updates for Kubernetes scheduler

### DIFF
--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -1,0 +1,38 @@
+(ns waiter.kubernetes-scheduler-integration-test
+  (:require [clojure.test :refer :all]
+            [waiter.util.client-tools :refer :all]))
+
+(deftest ^:parallel ^:integration-fast test-kubernetes-watch-state-update
+  (testing-using-waiter-url
+    (when (using-k8s? waiter-url)
+      (let [{:keys [body] :as response} (make-request waiter-url "/state/scheduler" :method :get)
+            _ (assert-response-status response 200)
+            body-json (-> body str try-parse-json)
+            watch-state-json (get-in body-json ["state" "watch-state"])
+            initial-pods-snapshot-version (get-in watch-state-json ["pods-metadata" "version" "snapshot"])
+            initial-pods-watch-version (get-in watch-state-json ["pods-metadata" "version" "watch"])
+            initial-rs-snapshot-version (get-in watch-state-json ["rs-metadata" "version" "snapshot"])
+            initial-rs-watch-version (get-in watch-state-json ["rs-metadata" "version" "watch"])
+            {:keys [service-id request-headers]} (make-request-with-debug-info
+                                                   {:x-waiter-name (rand-name)}
+                                                   #(make-kitchen-request waiter-url % :path "/hello"))]
+        (with-service-cleanup
+          service-id
+          (let [{:keys [body] :as response} (make-request waiter-url "/state/scheduler" :method :get)
+                _ (assert-response-status response 200)
+                body-json (-> body str try-parse-json)
+                watch-state-json (get-in body-json ["state" "watch-state"])
+                pods-snapshot-version' (get-in watch-state-json ["pods-metadata" "version" "snapshot"])
+                pods-watch-version' (get-in watch-state-json ["pods-metadata" "version" "watch"])
+                rs-snapshot-version' (get-in watch-state-json ["rs-metadata" "version" "snapshot"])
+                rs-watch-version' (get-in watch-state-json ["rs-metadata" "version" "watch"])]
+            (is (or (nil? initial-pods-watch-version)
+                    (< initial-pods-snapshot-version initial-pods-watch-version)))
+            (is (<= initial-pods-snapshot-version pods-snapshot-version'))
+            (is (< pods-snapshot-version' pods-watch-version'))
+            (is (or (nil? initial-rs-watch-version)
+                    (< initial-rs-snapshot-version initial-rs-watch-version)))
+            (is (<= initial-rs-snapshot-version rs-snapshot-version'))
+            (is (< rs-snapshot-version' rs-watch-version'))))))))
+
+

--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -34,5 +34,3 @@
                     (< initial-rs-snapshot-version initial-rs-watch-version)))
             (is (<= initial-rs-snapshot-version rs-snapshot-version'))
             (is (< rs-snapshot-version' rs-watch-version'))))))))
-
-

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -712,6 +712,7 @@
                   (update-fn json-object))))
             (catch Exception e
               (log/error e "error in" resource-key "state watch thread"))))))
+    (.setDaemon true)
     (.start)))
 
 (defn- global-state-query

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -711,8 +711,7 @@
                 (when json-object
                   (update-fn json-object))))
             (catch Exception e
-              (log/error e "error in" resource-key "state watch thread"))))
-        (log/info "exiting Kubernetes watcher thread" resource-name)))
+              (log/error e "error in" resource-key "state watch thread"))))))
     (.start)))
 
 (defn- global-state-query

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -870,6 +870,6 @@
                                            watch-state)
           pod-watch-thread (start-pods-watch! scheduler)
           rs-watch-thread (start-replicasets-watch! scheduler)]
-      (reset! daemon-state {:pod-watch-cancel #(.stop pod-watch-thread)
-                            :rs-watch-cancel #(.stop rs-watch-thread)})
+      (reset! daemon-state {:pod-watch-daemon pod-watch-thread
+                            :rs-watch-daemon rs-watch-thread})
       scheduler)))

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -9,7 +9,9 @@
 ;;       actual or intended publication of such source code.
 ;;
 (ns waiter.scheduler.kubernetes
-  (:require [clj-time.core :as t]
+  (:require [cheshire.core :as cheshire]
+            [clj-http.client :as clj-http]
+            [clj-time.core :as t]
             [clojure.core.async :as async]
             [clojure.java.io :as io]
             [clojure.string :as string]
@@ -24,7 +26,8 @@
             [waiter.util.date-utils :as du]
             [waiter.util.http-utils :as http-utils]
             [waiter.util.utils :as utils])
-  (:import (org.joda.time.format DateTimeFormat)))
+  (:import (java.io InputStreamReader)
+           (org.joda.time.format DateTimeFormat)))
 
 (defn authorization-from-environment []
   "Sample implementation of the authentication string refresh function.
@@ -100,14 +103,24 @@
     (catch Throwable t
       (log/error t "error converting ReplicaSet to Waiter Service"))))
 
+(defn k8s-object->id
+  "Get the id (name) from a ReplicaSet or Pod's metadata"
+  [k8s-obj]
+  (get-in k8s-obj [:metadata :name]))
+
+(defn k8s-object->service-id
+  "Get the Waiter service-id from a ReplicaSet or Pod's annotations"
+  [k8s-obj]
+  (get-in k8s-obj [:metadata :annotations :waiter/service-id]))
+
 (defn- pod->instance-id
   "Construct the Waiter instance-id for the given Kubernetes pod incarnation.
    Note that a new Waiter Service Instance is created each time a pod restarts,
    and that we generate a unique instance-id by including the pod's restartCount value."
   ([scheduler pod] (pod->instance-id scheduler pod (get-in pod [:status :containerStatuses 0 :restartCount])))
   ([{:keys [pod-suffix-length] :as scheduler} pod restart-count]
-   (let [pod-name (get-in pod [:metadata :name])
-         service-id (get-in pod [:metadata :annotations :waiter/service-id])]
+   (let [pod-name (k8s-object->id pod)
+         service-id (k8s-object->service-id pod)]
      (str service-id \. pod-name \- restart-count))))
 
 (defn- killed-by-k8s?
@@ -156,18 +169,33 @@
          :id (pod->instance-id scheduler pod)
          :k8s/app-name (get-in pod [:metadata :labels :app])
          :k8s/namespace (get-in pod [:metadata :namespace])
-         :k8s/pod-name (get-in pod [:metadata :name])
+         :k8s/pod-name (k8s-object->id pod)
          :k8s/restart-count (get-in pod [:status :containerStatuses 0 :restartCount])
          :log-directory (str "/home/" (get-in pod [:metadata :namespace]))
          :port port0
          :protocol (get-in pod [:metadata :annotations :waiter/protocol])
-         :service-id (get-in pod [:metadata :annotations :waiter/service-id])
+         :service-id (k8s-object->service-id pod)
          :started-at (-> pod
                          (get-in [:status :startTime])
                          (timestamp-str->datetime))}))
     (catch Throwable e
       (log/error e "error converting pod to waiter service instance" pod)
       (comment "Returning nil on failure."))))
+
+(defn streaming-api-request
+  "Make a long-lived HTTP request to the Kubernetes API server using the configured authentication.
+   If data is provided via :body, the application/json content type is added automatically.
+   The response payload (if any) is returned as a lazy seq of parsed JSON objects."
+  ([url] (streaming-api-request url {}))
+  ([url {:keys [keyword-keys?] :or {keyword-keys? true}}]
+   (let [auth-str @k8s-api-auth-str
+         request-options (cond-> {:as :stream}
+                           auth-str (assoc :headers {"Authorization" auth-str}))]
+     (-> url
+         (clj-http/get request-options)
+         :body
+         InputStreamReader.
+         (cheshire/parsed-seq keyword-keys?)))))
 
 (defn api-request
   "Make an HTTP request to the Kubernetes API server using the configured authentication.
@@ -196,26 +224,13 @@
 
 (defn- get-services
   "Get all Waiter Services (reified as ReplicaSets) running in this Kubernetes cluster."
-  [{:keys [api-server-url http-client orchestrator-name replicaset-api-version] :as scheduler}]
-  (->> (str api-server-url "/apis/" replicaset-api-version
-            "/replicasets?labelSelector=managed-by="
-            orchestrator-name)
-       (api-request http-client)
-       :items
-       (map replicaset->Service)
-       (filterv some?)))
+  [{:keys [watch-state] :as scheduler}]
+  (-> watch-state deref :services vals))
 
 (defn- get-replicaset-pods
   "Get all Kubernetes pods associated with the given Waiter Service's corresponding ReplicaSet."
-  [{:keys [api-server-url http-client service-id->service-description-fn] :as scheduler}
-   {:keys [k8s/app-name k8s/namespace]}]
-  (->> (str api-server-url
-            "/api/v1/namespaces/"
-            namespace
-            "/pods?labelSelector=app="
-            app-name)
-       (api-request http-client)
-       :items))
+  [{:keys [watch-state] :as scheduler} {service-id :id}]
+  (-> watch-state deref :service-id->pods (get service-id) vals))
 
 (defn- live-pod?
   "Returns true if the pod has started, but has not yet been deleted."
@@ -256,10 +271,9 @@
                       {:op :replace :path "/spec/replicas" :value replicas'}]))
 
 (defn- get-replica-count
-  "Query the current replica count for the given Kubernetes object."
-  [{:keys [http-client] :as scheduler} replicaset-url]
-  (-> (api-request http-client replicaset-url)
-      (get-in [:spec :replicas])))
+  "Query the current requested replica count for the given Kubernetes object."
+  [{:keys [watch-state] :as scheduler} service-id]
+  (-> watch-state deref :services (get service-id) :instances))
 
 (defmacro k8s-patch-with-retries
   "Query the current replica count for the given Kubernetes object,
@@ -286,17 +300,17 @@
 (defn- scale-service-up-to
   "Scale the number of instances for a given service to a specific number.
    Only used for upward scaling. No-op if it would result in downward scaling."
-  [{:keys [http-client max-patch-retries] :as scheduler} service instances']
+  [{:keys [http-client max-patch-retries] :as scheduler} {service-id :id :as service} instances']
   (let [replicaset-url (build-replicaset-url scheduler service)]
     (loop [attempt 1
            instances (:instances service)]
       (if (<= instances' instances)
-        (log/warn "skipping non-upward scale-up request on" (:id service)
+        (log/warn "skipping non-upward scale-up request on" service-id
                   "from" instances "to" instances')
         (k8s-patch-with-retries
           (patch-object-replicas http-client replicaset-url instances instances')
           (<= attempt max-patch-retries)
-          (recur (inc attempt) (get-replica-count scheduler replicaset-url)))))))
+          (recur (inc attempt) (get-replica-count scheduler service-id)))))))
 
 (defn- scale-service-by-delta
   "Scale the number of instances for a given service by a given delta.
@@ -389,24 +403,9 @@
      :result :deleted}))
 
 (defn service-id->service
-  "Look up the Kubernetes ReplicaSet associated with a given Waiter service-id,
-   and return a corresponding Waiter Service record."
-  [{:keys [api-server-url http-client orchestrator-name replicaset-api-version
-           service-id->service-description-fn] :as scheduler}
-   service-id]
-  (when-let [service-ns (-> service-id service-id->service-description-fn service-description->namespace)]
-    (some->> (str api-server-url "/apis/" replicaset-api-version
-                  "/namespaces/" service-ns
-                  "/replicasets?labelSelector=managed-by=" orchestrator-name
-                  ",app=" (service-id->k8s-app-name scheduler service-id))
-             (api-request http-client)
-             :items
-             ;; It's possible that multiple Waiter services in different namespaces
-             ;; have service-ids mapping to the same Kubernetes object name,
-             ;; so we filter to match the full service-id as well.
-             (filter #(= service-id (get-in % [:metadata :annotations :waiter/service-id])))
-             first
-             replicaset->Service)))
+  "Look up a Waiter Service record via its service-id."
+  [{:keys [watch-state] :as scheduler} service-id]
+  (-> watch-state deref :services (get service-id)))
 
 (defn get-service->instances
   "Returns a map of scheduler/Service records -> map of scheduler/ServiceInstance records."
@@ -429,7 +428,8 @@
                                 retrieve-syncer-state-fn
                                 service-id->failed-instances-transient-store
                                 service-id->password-fn
-                                service-id->service-description-fn]
+                                service-id->service-description-fn
+                                watch-state]
   scheduler/ServiceScheduler
 
   (get-services [this]
@@ -550,8 +550,9 @@
     {:failed-instances (vals (get @service-id->failed-instances-transient-store service-id))
      :syncer (retrieve-syncer-state-fn service-id)})
 
-  (state [_]
-    {:service-id->failed-instances @service-id->failed-instances-transient-store
+  (state [{:keys [watch-state]}]
+    {:watch-state @watch-state
+     :service-id->failed-instances @service-id->failed-instances-transient-store
      :syncer (retrieve-syncer-state-fn)})
 
   (validate-service [_ service-id]
@@ -671,6 +672,107 @@
         auth-update-task
         :delay-ms (* 60000 refresh-delay-mins)))))
 
+
+(defn- reset-watch-state!
+  [{:keys [watch-state] :as scheduler}
+   {:keys [resource-key resource-url query-fn version-key]}]
+  (let [{:keys [version] :as initial-state} (query-fn scheduler resource-url)]
+    (swap! watch-state assoc
+           resource-key (get initial-state resource-key)
+           version-key version)
+    version))
+
+(defn start-k8s-watch!
+  "Start a thread to continuously update the watch-state atom based on watched K8s events."
+  [{:keys [api-server-url watch-state] :as scheduler}
+   {:keys [resource-key resource-url update-fn] :as options}]
+  (let [initial-version (reset-watch-state! scheduler options)]
+    (when-not initial-version
+      (log/error "Unable to get initial watch state for" resource-key)
+      (throw (ex-info "Unable to get initial watch state" options)))
+    (->
+      (fn k8s-watch []
+        (loop [v initial-version]
+          (try
+            (let [watch-url (str resource-url "&watch=true&resourceVersion=" v)]
+              ;; process updates forever (unless there's an exception)
+              (doseq [json-object (streaming-api-request watch-url)]
+                (update-fn json-object)))
+            (catch Exception e
+              (log/error e "error in" resource-key "state watch thread")))
+          (when-let [version' (try
+                                (reset-watch-state! scheduler options)
+                                (catch Exception e
+                                  (log/error e "error recovering" resource-key "state watch thread")))]
+            (recur version'))))
+      Thread.
+      .start)))
+
+(defn- global-state-query
+  [{:keys [http-client] :as scheduler} objects-url]
+  (let [{:keys [items] :as response} (api-request http-client objects-url)
+        resource-version (get-in response [:metadata :resourceVersion])]
+    {:items items
+     :version resource-version}))
+
+(defn global-pods-state-query
+  "Query K8s for all Waiter-managed Pods"
+  [scheduler pods-url]
+  (let [{:keys [items version]} (global-state-query scheduler pods-url)
+        grouped-pods (->> items
+                          (group-by k8s-object->service-id)
+                          (pc/map-vals (partial pc/map-from-vals k8s-object->id)))]
+    {:service-id->pods grouped-pods
+     :version version}))
+
+(defn start-pods-watch!
+  "Start a thread to continuously update the watch-state atom based on watched Pod events."
+  [{:keys [api-server-url watch-state orchestrator-name] :as scheduler}]
+  (start-k8s-watch!
+    scheduler
+    {:resource-key :service-id->pods
+     :resource-url (str api-server-url "/api/v1/pods?labelSelector=managed-by=" orchestrator-name)
+     :query-fn global-pods-state-query
+     :version-key :pods-version
+     :update-fn (fn pods-watch-update [{pod :object update-type :type}]
+                  (let [id (k8s-object->id pod)
+                        service-id (k8s-object->service-id pod)]
+                    (scheduler/log "pod state update:" update-type pod)
+                    (case update-type
+                      "ADDED" (swap! watch-state assoc-in [:service-id->pods service-id id] pod)
+                      "MODIFIED" (swap! watch-state assoc-in [:service-id->pods service-id id] pod)
+                      "DELETED" (swap! watch-state utils/dissoc-in [:service-id->pods service-id id]))))}))
+
+(defn global-rs-state-query
+  "Query K8s for all Waiter-managed ReplicaSets"
+  [scheduler rs-url]
+  (let [{:keys [items version]} (global-state-query scheduler rs-url)
+        services (->> items
+                      (map replicaset->Service)
+                      (filter some?)
+                      (pc/map-from-vals :id))]
+    {:services services
+     :version version}))
+
+(defn start-replicasets-watch!
+  "Start a thread to continuously update the watch-state atom based on watched ReplicaSet events."
+  [{:keys [api-server-url watch-state orchestrator-name replicaset-api-version] :as scheduler}]
+  (start-k8s-watch!
+    scheduler
+    {:resource-key :services
+     :resource-url (str api-server-url "/apis/" replicaset-api-version
+                        "/replicasets?labelSelector=managed-by="
+                        orchestrator-name)
+     :query-fn global-rs-state-query
+     :version-key :rs-version
+     :update-fn (fn rs-watch-update [{rs :object update-type :type}]
+                  (when-let [{:keys [id] :as service} (replicaset->Service rs)]
+                    (scheduler/log "rs state update:" update-type service)
+                    (case update-type
+                      "ADDED" (swap! watch-state assoc-in [:services id] service)
+                      "MODIFIED" (swap! watch-state assoc-in [:services id] service)
+                      "DELETED" (swap! watch-state utils/dissoc-in [:services id]))))}))
+
 (defn kubernetes-scheduler
   "Returns a new KubernetesScheduler with the provided configuration. Validates the
    configuration against kubernetes-scheduler-schema and throws if it's not valid."
@@ -711,28 +813,37 @@
                                      (assert (fn? f) "ReplicaSet spec function must be a Clojure fn")
                                      (fn [scheduler service-id service-description]
                                        (f scheduler service-id service-description replicaset-spec-builder)))
+        watch-state (atom nil)
         scheduler-config {:api-server-url url
+                          :watch-state watch-state
                           :http-client http-client
                           :orchestrator-name orchestrator-name
                           :replicaset-api-version replicaset-api-version
                           :service-id->failed-instances-transient-store service-id->failed-instances-transient-store}
         get-service->instances-fn #(get-service->instances scheduler-config)
-        {:keys [retrieve-syncer-state-fn]}
-        (start-scheduler-syncer-fn scheduler-name get-service->instances-fn scheduler-state-chan scheduler-syncer-interval-secs)]
+        {:keys [retrieve-syncer-state-fn]} (start-scheduler-syncer-fn
+                                             scheduler-name
+                                             get-service->instances-fn
+                                             scheduler-state-chan
+                                             scheduler-syncer-interval-secs)]
     (when authentication
       (start-auth-renewer authentication))
-    (->KubernetesScheduler url
-                           authorizer
-                           fileserver
-                           http-client
-                           max-patch-retries
-                           max-name-length
-                           orchestrator-name
-                           pod-base-port
-                           pod-suffix-length
-                           replicaset-api-version
-                           replicaset-spec-builder-fn
-                           retrieve-syncer-state-fn
-                           service-id->failed-instances-transient-store
-                           service-id->password-fn
-                           service-id->service-description-fn)))
+    (let [scheduler (->KubernetesScheduler url
+                                           authorizer
+                                           fileserver
+                                           http-client
+                                           max-patch-retries
+                                           max-name-length
+                                           orchestrator-name
+                                           pod-base-port
+                                           pod-suffix-length
+                                           replicaset-api-version
+                                           replicaset-spec-builder-fn
+                                           retrieve-syncer-state-fn
+                                           service-id->failed-instances-transient-store
+                                           service-id->password-fn
+                                           service-id->service-description-fn
+                                           watch-state)]
+      (start-pods-watch! scheduler)
+      (start-replicasets-watch! scheduler)
+      scheduler)))

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -606,7 +606,7 @@
   (let [instances' 4
         service-id "test-service-id"
         service (scheduler/make-Service {:id service-id :instances 1 :k8s/app-name service-id :k8s/namespace "myself"})
-        service-state (atom {:services {service-id service}})
+        service-state (atom {:service-id->service {service-id service}})
         dummy-scheduler (-> (make-dummy-scheduler [service-id])
                             (assoc :watch-state service-state))]
     (with-redefs [service-id->service (constantly service)]

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -41,6 +41,7 @@
    (->
      {:authorizer {:kind :default
                    :default {:factory-fn 'waiter.authorization/noop-authorizer}}
+      :daemon-state (atom nil)
       :fileserver {:port 9090
                    :scheme "http"}
       :max-patch-retries 5
@@ -713,7 +714,8 @@
                                               :default-container-image "twosigma/kitchen:latest"}
                     :url "http://127.0.0.1:8001"}
         base-config (merge context k8s-config)]
-    (with-redefs [start-k8s-watch! (constantly nil)]
+    (with-redefs [api-request (constantly nil)
+                  streaming-api-request (constantly (repeat nil))]
       (testing "Creating a KubernetesScheduler"
 
         (testing "should throw on invalid configuration"

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -14,6 +14,7 @@
             [clojure.pprint]
             [clojure.string :as string]
             [clojure.test :refer :all]
+            [clojure.tools.logging :as log]
             [clojure.walk :as walk]
             [plumbing.core :as pc]
             [slingshot.slingshot :as ss]
@@ -264,6 +265,7 @@
                                     :instances 0
                                     :task-count 0
                                     :task-stats {:running 0, :healthy 0, :unhealthy 0, :staged 0}})]}]]
+    (log/info "Expecting Key error due to bad :mismatched-replicaset in API server response...")
     (doseq [{:keys [api-server-response expected-result]} test-cases]
       (let [dummy-scheduler (make-dummy-scheduler ["test-app-1234" "test-app-6789"])
             _ (reset-scheduler-watch-state! dummy-scheduler api-server-response)
@@ -304,71 +306,71 @@
         {:kind "PodList"
          :apiVersion "v1"
          :items [{:metadata {:name "test-app-1234-abcd1"
-                       :namespace "myself"
-                       :labels {:app "test-app-1234"
-                                :managed-by "waiter"}
-                       :annotations {:waiter/port-count "1"
-                                     :waiter/protocol "https"
-                                     :waiter/service-id "test-app-1234"}}
-            :spec {:containers [{:ports [{:containerPort 8080 :protocol "TCP"}]}]}
-            :status {:podIP "10.141.141.11"
-                     :startTime "2014-09-13T00:24:46Z"
-                     :containerStatuses [{:name "test-app-1234"
-                                          :ready true
-                                          :restartCount 0}]}}
-           {:metadata {:name "test-app-1234-abcd2"
-                       :namespace "myself"
-                       :labels {:app "test-app-1234"
-                                :managed-by "waiter"}
-                       :annotations {:waiter/port-count "1"
-                                     :waiter/protocol "https"
-                                     :waiter/service-id "test-app-1234"}}
-            :spec {:containers [{:ports [{:containerPort 8080 :protocol "TCP"}]}]}
-            :status {:podIP "10.141.141.12"
-                     :startTime "2014-09-13T00:24:47Z"
-                     :containerStatuses [{:name "test-app-1234"
-                                          :ready true
-                                          :restartCount 0}]}}
-           {:metadata {:name "test-app-6789-abcd1"
-                       :namespace "myself"
-                       :labels {:app "test-app-6789"
-                                :managed-by "waiter"}
-                       :annotations {:waiter/port-count "1"
-                                     :waiter/protocol "http"
-                                     :waiter/service-id "test-app-6789"}}
-            :spec {:containers [{:ports [{:containerPort 8080 :protocol "TCP"}]}]}
-            :status {:podIP "10.141.141.13"
-                     :startTime "2014-09-13T00:24:35Z"
-                     :containerStatuses [{:name "test-app-6789"
-                                          :ready true
-                                          :restartCount 0}]}}
-           {:metadata {:name "test-app-6789-abcd2"
-                       :namespace "myself"
-                       :labels {:app "test-app-6789"
-                                :managed-by "waiter"}
-                       :annotations {:waiter/port-count "1"
-                                     :waiter/protocol "http"
-                                     :waiter/service-id "test-app-6789"}}
-            :spec {:containers [{:ports [{:containerPort 8080 :protocol "TCP"}]}]}
-            :status {:podIP "10.141.141.14"
-                     :startTime "2014-09-13T00:24:37Z"
-                     :containerStatuses [{:name "test-app-6789"
-                                          :lastState {:terminated {:exitCode 255
-                                                                   :reason "Error"
-                                                                   :startedAt "2014-09-13T00:24:36Z"}}
-                                          :restartCount 1}]}}
-           {:metadata {:name "test-app-6789-abcd3"
-                       :namespace "myself"
-                       :labels {:app "test-app-6789"
-                                :managed-by "waiter"}
-                       :annotations {:waiter/port-count "1"
-                                     :waiter/protocol "http"
-                                     :waiter/service-id "test-app-6789"}}
-            :spec {:containers [{:ports [{:containerPort 8080 :protocol "TCP"}]}]}
-            :status {:podIP "10.141.141.15"
-                     :startTime "2014-09-13T00:24:38Z"
-                     :containerStatuses [{:name "test-app-6789"
-                                          :restartCount 0}]}}]}
+                             :namespace "myself"
+                             :labels {:app "test-app-1234"
+                                      :managed-by "waiter"}
+                             :annotations {:waiter/port-count "1"
+                                           :waiter/protocol "https"
+                                           :waiter/service-id "test-app-1234"}}
+                  :spec {:containers [{:ports [{:containerPort 8080 :protocol "TCP"}]}]}
+                  :status {:podIP "10.141.141.11"
+                           :startTime "2014-09-13T00:24:46Z"
+                           :containerStatuses [{:name "test-app-1234"
+                                                :ready true
+                                                :restartCount 0}]}}
+                 {:metadata {:name "test-app-1234-abcd2"
+                             :namespace "myself"
+                             :labels {:app "test-app-1234"
+                                      :managed-by "waiter"}
+                             :annotations {:waiter/port-count "1"
+                                           :waiter/protocol "https"
+                                           :waiter/service-id "test-app-1234"}}
+                  :spec {:containers [{:ports [{:containerPort 8080 :protocol "TCP"}]}]}
+                  :status {:podIP "10.141.141.12"
+                           :startTime "2014-09-13T00:24:47Z"
+                           :containerStatuses [{:name "test-app-1234"
+                                                :ready true
+                                                :restartCount 0}]}}
+                 {:metadata {:name "test-app-6789-abcd1"
+                             :namespace "myself"
+                             :labels {:app "test-app-6789"
+                                      :managed-by "waiter"}
+                             :annotations {:waiter/port-count "1"
+                                           :waiter/protocol "http"
+                                           :waiter/service-id "test-app-6789"}}
+                  :spec {:containers [{:ports [{:containerPort 8080 :protocol "TCP"}]}]}
+                  :status {:podIP "10.141.141.13"
+                           :startTime "2014-09-13T00:24:35Z"
+                           :containerStatuses [{:name "test-app-6789"
+                                                :ready true
+                                                :restartCount 0}]}}
+                 {:metadata {:name "test-app-6789-abcd2"
+                             :namespace "myself"
+                             :labels {:app "test-app-6789"
+                                      :managed-by "waiter"}
+                             :annotations {:waiter/port-count "1"
+                                           :waiter/protocol "http"
+                                           :waiter/service-id "test-app-6789"}}
+                  :spec {:containers [{:ports [{:containerPort 8080 :protocol "TCP"}]}]}
+                  :status {:podIP "10.141.141.14"
+                           :startTime "2014-09-13T00:24:37Z"
+                           :containerStatuses [{:name "test-app-6789"
+                                                :lastState {:terminated {:exitCode 255
+                                                                         :reason "Error"
+                                                                         :startedAt "2014-09-13T00:24:36Z"}}
+                                                :restartCount 1}]}}
+                 {:metadata {:name "test-app-6789-abcd3"
+                             :namespace "myself"
+                             :labels {:app "test-app-6789"
+                                      :managed-by "waiter"}
+                             :annotations {:waiter/port-count "1"
+                                           :waiter/protocol "http"
+                                           :waiter/service-id "test-app-6789"}}
+                  :spec {:containers [{:ports [{:containerPort 8080 :protocol "TCP"}]}]}
+                  :status {:podIP "10.141.141.15"
+                           :startTime "2014-09-13T00:24:38Z"
+                           :containerStatuses [{:name "test-app-6789"
+                                                :restartCount 0}]}}]}
 
         expected (hash-map
                    (scheduler/make-Service {:id "test-app-1234"
@@ -445,7 +447,7 @@
     (assert-data-equal expected actual)))
 
 (deftest test-kill-instance
-  (let [service-id "test-service-id"
+  (let [service-id "test-kill-service-id"
         service (scheduler/make-Service {:id service-id :instances 1 :k8s/namespace "myself"})
         instance-id "instance-id"
         instance (scheduler/make-ServiceInstance
@@ -460,6 +462,18 @@
                     :service-id service-id
                     :started-at (du/str-to-date "2014-09-13T00:24:56Z" k8s-timestamp-format)})
         dummy-scheduler (make-dummy-scheduler [service-id])
+        api-server-response {:kind "ReplicaSetList"
+                             :apiVersion "extensions/v1beta1"
+                             :items [{:metadata {:name service-id
+                                                 :namespace "myself"
+                                                 :labels {:app service-id
+                                                          :managed-by "waiter"}
+                                                 :annotations {:waiter/service-id service-id}}
+                                      :spec {:replicas 1}
+                                      :status {:replicas 1
+                                               :readyReplicas 1
+                                               :availableReplicas 1}}]}
+        _ (reset-scheduler-watch-state! dummy-scheduler api-server-response)
         partial-expected {:instance-id instance-id :killed? false :service-id service-id}]
     (with-redefs [service-id->service (constantly service)]
       (testing "successful-delete"
@@ -481,10 +495,10 @@
                    :status 404)
                  actual))))
       (testing "successful-delete: terminated, but had patch conflict"
+        (log/info "Expecting 409 patch-conflict error when deleting service instance...")
         (let [actual (with-redefs [api-request (fn mocked-api-request [_ _ & {:keys [request-method]}]
-                                                 (if (= request-method :patch)
-                                                   (ss/throw+ {:status 409})
-                                                   {:spec {:replicas 1}}))]
+                                                 (when (= request-method :patch)
+                                                   (ss/throw+ {:status 409})))]
                        (scheduler/kill-instance dummy-scheduler instance))]
           (is (= (assoc partial-expected
                    :killed? true
@@ -714,8 +728,8 @@
                                               :default-container-image "twosigma/kitchen:latest"}
                     :url "http://127.0.0.1:8001"}
         base-config (merge context k8s-config)]
-    (with-redefs [api-request (constantly nil)
-                  streaming-api-request (constantly (repeat nil))]
+    (with-redefs [start-pods-watch! (constantly nil)
+                  start-replicasets-watch! (constantly nil)]
       (testing "Creating a KubernetesScheduler"
 
         (testing "should throw on invalid configuration"
@@ -755,3 +769,237 @@
               (is (ct/wait-for #(= secret-value @k8s-api-auth-str) :interval 1 :timeout 10))
               (finally
                 (@kill-task-fn)))))))))
+
+(deftest test-start-k8s-watch!
+  (let [service-id "test-app-1234"
+
+        rs-response
+        {:kind "ReplicaSetList"
+         :apiVersion "extensions/v1beta1"
+         :metadata {:resourceVersion "1000"}
+         :items [{:metadata {:name "test-app-1234"
+                             :namespace "myself"
+                             :labels {:app "test-app-1234"
+                                      :managed-by "waiter"}
+                             :annotations {:waiter/service-id "test-app-1234"}}
+                  :spec {:replicas 2
+                         :selector {:matchLabels {:app "test-app-1234"
+                                                  :managed-by "waiter"}}}
+                  :status {:replicas 2
+                           :readyReplicas 1
+                           :availableReplicas 2}}]}
+
+        rs-watch-updates
+        [{:type "MODIFIED"
+          :object {:metadata {:name "test-app-1234"
+                              :namespace "myself"
+                              :labels {:app "test-app-1234"
+                                       :managed-by "waiter"}
+                              :annotations {:waiter/service-id "test-app-1234"}
+                              :resourceVersion "1001"}
+                   :spec {:replicas 2
+                          :selector {:matchLabels {:app "test-app-1234"
+                                                   :managed-by "waiter"}}}
+                   :status {:replicas 2
+                            :readyReplicas 2
+                            :availableReplicas 2}}}
+         {:type "MODIFIED"
+          :object {:metadata {:name "test-app-1234"
+                              :namespace "myself"
+                              :labels {:app "test-app-1234"
+                                       :managed-by "waiter"}
+                              :annotations {:waiter/service-id "test-app-1234"}
+                              :resourceVersion "1002"}
+                   :spec {:replicas 3
+                          :selector {:matchLabels {:app "test-app-1234"
+                                                   :managed-by "waiter"}}}
+                   :status {:replicas 3
+                            :readyReplicas 2
+                            :availableReplicas 3}}}
+         {:type "MODIFIED"
+          :object {:metadata {:name "test-app-1234"
+                              :namespace "myself"
+                              :labels {:app "test-app-1234"
+                                       :managed-by "waiter"}
+                              :annotations {:waiter/service-id "test-app-1234"}
+                              :resourceVersion "1003"}
+                   :spec {:replicas 2
+                          :selector {:matchLabels {:app "test-app-1234"
+                                                   :managed-by "waiter"}}}
+                   :status {:replicas 2
+                            :readyReplicas 1
+                            :availableReplicas 2}}}]
+
+        pods-response
+        {:kind "PodList"
+         :apiVersion "v1"
+         :metadata {:resourceVersion "1000"}
+         :items [{:metadata {:name "test-app-1234-abcd1"
+                             :namespace "myself"
+                             :labels {:app "test-app-1234"
+                                      :managed-by "waiter"}
+                             :annotations {:waiter/port-count "1"
+                                           :waiter/protocol "https"
+                                           :waiter/service-id "test-app-1234"}}
+                  :spec {:containers [{:ports [{:containerPort 8080 :protocol "TCP"}]}]}
+                  :status {:podIP "10.141.141.11"
+                           :startTime "2014-09-13T00:24:46Z"
+                           :containerStatuses [{:name "test-app-1234"
+                                                :ready true
+                                                :restartCount 0}]}}
+                 {:metadata {:name "test-app-1234-abcd2"
+                             :namespace "myself"
+                             :labels {:app "test-app-1234"
+                                      :managed-by "waiter"}
+                             :annotations {:waiter/port-count "1"
+                                           :waiter/protocol "https"
+                                           :waiter/service-id "test-app-1234"}}
+                  :spec {:containers [{:ports [{:containerPort 8080 :protocol "TCP"}]}]}
+                  :status {:podIP "10.141.141.12"
+                           :startTime "2014-09-13T00:24:47Z"
+                           :containerStatuses [{:name "test-app-1234"
+                                                :restartCount 0}]}}]}
+
+        pods-watch-updates
+        [{:type "MODIFIED"
+          :object {:metadata {:name "test-app-1234-abcd2"
+                              :namespace "myself"
+                              :labels {:app "test-app-1234"
+                                       :managed-by "waiter"}
+                              :annotations {:waiter/port-count "1"
+                                            :waiter/protocol "https"
+                                            :waiter/service-id "test-app-1234"}
+                              :resourceVersion "1001"}
+                   :spec {:containers [{:ports [{:containerPort 8080 :protocol "TCP"}]}]}
+                   :status {:podIP "10.141.141.12"
+                            :startTime "2014-09-13T00:24:47Z"
+                            :containerStatuses [{:name "test-app-1234"
+                                                 :ready true
+                                                 :restartCount 0}]}}}
+         {:type "ADDED"
+          :object {:metadata {:name "test-app-1234-abcd3"
+                              :namespace "myself"
+                              :labels {:app "test-app-1234"
+                                       :managed-by "waiter"}
+                              :annotations {:waiter/port-count "1"
+                                            :waiter/protocol "https"
+                                            :waiter/service-id "test-app-1234"}
+                              :resourceVersion "1002"}
+                   :spec {:containers [{:ports [{:containerPort 8080 :protocol "TCP"}]}]}
+                   :status {:podIP "10.141.141.13"
+                            :startTime "2014-09-13T00:24:48Z"
+                            :containerStatuses [{:name "test-app-1234"
+                                                 :restartCount 0}]}}}
+         {:type "DELETED"
+          :object {:metadata {:name "test-app-1234-abcd1"
+                              :annotations {:waiter/port-count "1"
+                                            :waiter/protocol "https"
+                                            :waiter/service-id "test-app-1234"}
+                              :resourceVersion "1003"}}}]
+
+        watch-update-signals (vec (repeatedly (count rs-watch-updates) promise))
+
+        make-watch-stream (fn [updates signals]
+                            (assert (== (count updates) (count signals)))
+                            (map (fn [data signal] @signal data)
+                                 (concat updates ["hang after last update"])
+                                 (concat signals [(promise)])))
+
+        pods-watch-stream (make-watch-stream pods-watch-updates watch-update-signals)
+        rs-watch-stream (make-watch-stream rs-watch-updates watch-update-signals)
+
+        {:keys [watch-state] :as dummy-scheduler} (make-dummy-scheduler ["test-app-1234"])
+
+        rs-watch-thread (-> dummy-scheduler
+                            (assoc :api-request-fn (constantly rs-response)
+                                   :streaming-api-request-fn (constantly rs-watch-stream))
+                            (start-replicasets-watch!))
+
+        pods-watch-thread (-> dummy-scheduler
+                             (assoc :api-request-fn (constantly pods-response)
+                                    :streaming-api-request-fn (constantly pods-watch-stream))
+                            (start-pods-watch!))
+
+        get-instance (fn [{:keys [watch-state] :as scheduler} index]
+                       (let [pod-id (str "test-app-1234-abcd" index)
+                             pod (get-in @watch-state [:service-id->pod-id->pod service-id pod-id])]
+                         (when pod
+                           (pod->ServiceInstance scheduler pod))))
+        wait-for-version (fn [version-tag value]
+                           (ct/wait-for
+                             #(= value
+                                 (get-in @watch-state [:rs-metadata :version version-tag])
+                                 (get-in @watch-state [:pods-metadata :version version-tag]))
+                             :interval 500 :timeout 5000 :unit-multiplier 1))]
+
+    ;; Verify base state
+    (is (wait-for-version :snapshot 1000))
+    (let [task-stats (get-in @watch-state [:service-id->service service-id :task-stats])
+          {:keys [healthy running staged unhealthy]} task-stats
+          inst1 (get-instance dummy-scheduler 1)
+          inst2 (get-instance dummy-scheduler 2)
+          inst3 (get-instance dummy-scheduler 3)]
+      (is (== healthy 1))
+      (is (== running 2))
+      (is (== staged 0))
+      (is (== unhealthy 1))
+      (is (:healthy? inst1))
+      (is (some? inst2))
+      (is (not (:healthy? inst2)))
+      (is (nil? inst3)))
+
+    ;; Verify state after update 1:
+    ;; instance 2 should now be healthy
+    (deliver (get watch-update-signals 0) true)
+    (is (wait-for-version :watch 1001))
+    (let [task-stats (get-in @watch-state [:service-id->service service-id :task-stats])
+          {:keys [healthy running staged unhealthy]} task-stats
+          inst1 (get-instance dummy-scheduler 1)
+          inst2 (get-instance dummy-scheduler 2)
+          inst3 (get-instance dummy-scheduler 3)]
+      (is (== healthy 2))
+      (is (== running 2))
+      (is (== staged unhealthy 0))
+      (is (:healthy? inst1))
+      (is (:healthy? inst2))
+      (is (nil? inst3)))
+
+    ;; Verify state after update 2:
+    ;; instance 3 should now be available
+    (deliver (get watch-update-signals 1) true)
+    (is (wait-for-version :watch 1002))
+    (let [task-stats (get-in @watch-state [:service-id->service service-id :task-stats])
+          {:keys [healthy running staged unhealthy]} task-stats
+          inst1 (get-instance dummy-scheduler 1)
+          inst2 (get-instance dummy-scheduler 2)
+          inst3 (get-instance dummy-scheduler 3)]
+      (is (== healthy 2))
+      (is (== running 3))
+      (is (== staged 0))
+      (is (== unhealthy 1))
+      (is (:healthy? inst1))
+      (is (:healthy? inst2))
+      (is (some? inst3))
+      (is (not (:healthy? inst3))))
+
+    ;; Verify state after update 3:
+    ;; instance 1 should now be gone
+    (deliver (get watch-update-signals 2) true)
+    (is (wait-for-version :watch 1003))
+    (let [task-stats (get-in @watch-state [:service-id->service service-id :task-stats])
+          {:keys [healthy running staged unhealthy]} task-stats
+          inst1 (get-instance dummy-scheduler 1)
+          inst2 (get-instance dummy-scheduler 2)
+          inst3 (get-instance dummy-scheduler 3)]
+      (is (== healthy 1))
+      (is (== running 2))
+      (is (== staged 0))
+      (is (== unhealthy 1))
+      (is (nil? inst1))
+      (is (:healthy? inst2))
+      (is (some? inst3))
+      (is (not (:healthy? inst3))))
+
+    ;; Kill the watch threads
+    (.stop rs-watch-thread)
+    (.stop pods-watch-thread)))


### PR DESCRIPTION
## Changes proposed in this PR

For the Kuberentes scheduler, switch from polling-based scheduler updates to push-based updates on ReplicaSets and Pods via "watches" (K8s' event subscription mechanism).

## Why are we making these changes?

Using watches is more efficient than polling on Kubernetes. This should get us the updates faster, and help avoid performance issues with bottlenecks on the central API server.