### PR TITLE
Use correct copyright header in k8s scheduler and test files

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2017 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.scheduler.kubernetes
   (:require [clj-time.core :as t]

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -1,12 +1,17 @@
 ;;
-;;       Copyright (c) 2018 Two Sigma Investments, LP.
-;;       All Rights Reserved
+;; Copyright (c) Two Sigma Open Source, LLC
 ;;
-;;       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-;;       Two Sigma Investments, LP.
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
 ;;
-;;       The copyright notice above does not evidence any
-;;       actual or intended publication of such source code.
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 (ns waiter.scheduler.kubernetes-test
   (:require [clojure.core.async :as async]


### PR DESCRIPTION
## Changes proposed in this PR

Use correct copyright header in k8s scheduler and test files.

## Why are we making these changes?

We should be using the Two Sigma Open Source copyright header consistently in all of our Clojure files.