### PR TITLE
marks a service as stale conservatively

### DIFF
--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -892,8 +892,9 @@
     (if (and (seq source-tokens-set)
              (some (fn [source-tokens]
                      (and (seq source-tokens)
-                          (some (fn [{:strs [token version]}]
-                                  (not= (token->token-hash token) version))
+                          ;; safe assumption mark a service stale when every token used to access it is stale
+                          (every? (fn [{:strs [token version]}]
+                                    (not= (token->token-hash token) version))
                                 source-tokens)))
                    source-tokens-set))
       (do

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -2294,12 +2294,12 @@
                                                   (is (= service-id in-service-id))
                                                   #{[{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash0"}]})
             token->token-metadata (token->token-metadata-fn token->token-data)]
-        (is (= (-> 300 t/seconds t/in-minutes (+ stale-timeout-mins))
+        (is (= idle-timeout-mins
                (service-id->idle-timeout
                  service-id->service-description-fn service-id->source-token-entries-fn token->token-hash
                  token->token-metadata token-defaults service-id)))))
 
-    (testing "service outdated and fallback and timeout configured on all tokens"
+    (testing "service outdated on some tokens and fallback and timeout configured on all tokens"
       (let [stale-timeout-mins 45
             token->token-data {"t1" {"cpus" 123 "fallback-period-secs" 300}
                                "t2" {"cmd" "tc" "fallback-period-secs" 600 "stale-timeout-mins" stale-timeout-mins}
@@ -2310,6 +2310,25 @@
             service-id->source-token-entries-fn (fn [in-service-id]
                                                   (is (= service-id in-service-id))
                                                   #{[{"token" "t1" "version" "t1.hash1"}
+                                                     {"token" "t2" "version" "t2.hash0"}
+                                                     {"token" "t3" "version" "t3.hash0"}]})
+            token->token-metadata (token->token-metadata-fn token->token-data)]
+        (is (= idle-timeout-mins
+               (service-id->idle-timeout
+                 service-id->service-description-fn service-id->source-token-entries-fn token->token-hash
+                 token->token-metadata token-defaults service-id)))))
+
+    (testing "service outdated on every token and fallback and timeout configured on all tokens"
+      (let [stale-timeout-mins 45
+            token->token-data {"t1" {"cpus" 123 "fallback-period-secs" 300}
+                               "t2" {"cmd" "tc" "fallback-period-secs" 600 "stale-timeout-mins" stale-timeout-mins}
+                               "t3" {"cmd" "tc" "fallback-period-secs" 900}}
+            service-id->service-description-fn (fn [in-service-id]
+                                                 (is (= service-id in-service-id))
+                                                 {"idle-timeout-mins" idle-timeout-mins})
+            service-id->source-token-entries-fn (fn [in-service-id]
+                                                  (is (= service-id in-service-id))
+                                                  #{[{"token" "t1" "version" "t1.hash0"}
                                                      {"token" "t2" "version" "t2.hash0"}
                                                      {"token" "t3" "version" "t3.hash0"}]})
             token->token-metadata (token->token-metadata-fn token->token-data)]


### PR DESCRIPTION

## Changes proposed in this PR

- a service is stale only when all tokens used to access the service are outdated

## Why are we making these changes?

We would like to prevent eagerly GC-ing a service which might still be in use via a fresh token.

