### PR TITLE
reduces info logging on the expected cache removal

### DIFF
--- a/waiter/src/waiter/util/cache_utils.clj
+++ b/waiter/src/waiter/util/cache_utils.clj
@@ -29,9 +29,9 @@
         ttl (.expireAfterWrite ttl TimeUnit/MILLISECONDS))
       (.removalListener (proxy [RemovalListener] []
                           (onRemoval [^RemovalNotification n]
-                            (log/info "cache entry removal notification"
-                                      {:evicted (.wasEvicted n)
-                                       :key (.getKey n)}))))
+                            (log/debug "cache entry removal notification"
+                                       {:evicted (.wasEvicted n)
+                                        :key (.getKey n)}))))
       (.build)))
 
 (defn cache-contains?


### PR DESCRIPTION
## Changes proposed in this PR

- reduces info logging on the expected cache removal

## Why are we making these changes?

We would like the log files to be less verbose.

