### PR TITLE
adds class name check in addition to instanceof check

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -70,7 +70,7 @@
                  [org.apache.curator/curator-x-discovery "2.11.0"
                   :exclusions [io.netty/netty org.slf4j/slf4j-api]]
                  [org.clojure/clojure "1.8.0"]
-                 [org.clojure/core.async "0.3.465"
+                 [org.clojure/core.async "0.4.474"
                   :exclusions [org.clojure/clojure org.clojure/tools.reader]]
                  [org.clojure/core.memoize "0.7.1"
                   :exclusions [org.clojure/clojure]]

--- a/waiter/src/waiter/util/async_utils.clj
+++ b/waiter/src/waiter/util/async_utils.clj
@@ -186,4 +186,6 @@
 (defn chan?
   "Determines if v is a channel."
   [v]
-  (instance? ManyToManyChannel v))
+  (or (instance? ManyToManyChannel v)
+      (= (.getName ManyToManyChannel)
+         (some-> v .getClass .getName))))

--- a/waiter/src/waiter/util/async_utils.clj
+++ b/waiter/src/waiter/util/async_utils.clj
@@ -187,5 +187,6 @@
   "Determines if v is a channel."
   [v]
   (or (instance? ManyToManyChannel v)
+      ;; instance? is flaky here (possible classloader issue), so we fall back to checking the class name
       (= (.getName ManyToManyChannel)
          (some-> v .getClass .getName))))


### PR DESCRIPTION
 to avoid classloading issues

## Changes proposed in this PR

- adds class name check in addition to instanceof check to avoid classloading issues

## Why are we making these changes?

Waiter fails to startup when the `chan?` calls fail.

