### PR TITLE
Add support for content-length bigger than an int

### DIFF
--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -222,7 +222,7 @@
         waiter-debug-enabled? (utils/request->debug-enabled? request)]
     (try
       (let [content-length-str (get passthrough-headers "content-length")
-            content-length (if content-length-str (Integer/parseInt content-length-str) 0)]
+            content-length (if content-length-str (Long/parseLong content-length-str) 0)] ;xxx
         (when (and (integer? content-length) (pos? content-length))
           ; computing the actual bytes will currently require synchronously reading all data in the request body
           (histograms/update! (metrics/service-histogram service-id "request-size") content-length)


### PR DESCRIPTION
## Changes proposed in this PR

Add support for content-length bigger than an int. Use Long.parseLong when parsing content-length header string

## Why are we making these changes?

We can get a request with content-length bigger than int can hold

