### PR TITLE
Add retry/backoff logic to k8s watches

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -385,7 +385,12 @@
 
                                  ;; Base URL for accessing the Kubernetes API server.
                                  ;; The URL used below is the default proxy URL bound to by the `kubectl proxy` command:
-                                 :url "http://localhost:8001"}
+                                 :url "http://localhost:8001"
+
+                                 ;; Number of times to retry a watch before falling back to a global state query.
+                                 ;; These retries only apply to a closed watch connection, not to connections returning an HTTP error code.
+                                 ;; Defaults to 0 (one attempt, no retries) if not provided.
+                                 :watch-retries 10}
 
                     ;; :kind :marathon uses Marathon (https://mesosphere.github.io/marathon/) for scheduling instances:
                     ;:kind :marathon


### PR DESCRIPTION
## Changes proposed in this PR

- Add retry logic to the watch query.
- Add exponential backoff logic to the retries.

## Why are we making these changes?

Currently, if the API server is having issues, we spam the global pod/rs query until it responds. We should have a backoff there. Also, we should be trying the watch query multiple times before we fall back to the global query again, since the global query is much more expensive.