### PR TITLE
Use latest resourceVersion on successive watch connections

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -734,17 +734,17 @@
               (fn k8s-watch-retried-thunk []
                 (try
                   (loop [version (reset-watch-state! scheduler options)
-                         watch-url (str resource-url "&watch=true&resourceVersion=" version)
                          iter 0]
-                    ;; process updates forever (unless there's an exception)
-                    (doseq [json-object (streaming-api-request-fn watch-url)]
-                      (when json-object
-                        (update-fn json-object)))
+                    (let [watch-url (str resource-url "&watch=true&resourceVersion=" version)]
+                      ;; process updates forever (unless there's an exception)
+                      (doseq [json-object (streaming-api-request-fn watch-url)]
+                        (when json-object
+                          (update-fn json-object))))
                     ;; when the watch connection closed normally (i.e., no HTTP error code response),
                     ;; retry the watch (before falling back to the global query again) `watch-retries` times.
                     (when (< iter watch-retries)
                       (when-let [version' (latest-watch-state-version scheduler options)]
-                        (recur version' watch-url (inc iter)))))
+                        (recur version' (inc iter)))))
                   (catch Exception e
                     (log/error e "error in" resource-key "state watch thread")
                     (throw e))))))


### PR DESCRIPTION
## Changes proposed in this PR

- Rebuild the watch-url on each iteration of the watch-retry loop, using the latest `resourceVersion`.
- Add new unit test that confirms the retry behavior in the pods watch thread.

## Why are we making these changes?

Not using the latest `resourceVersion` in the watch url can result in repeated messages, which may cause Waiter to observe an inconsistent state.

The new unit test helps ensure that the watch-thread's retry logic is behaving as expected.
