### PR TITLE
 Serialize dynamic loading of namespaces

### DIFF
--- a/waiter/src/waiter/util/async_utils.clj
+++ b/waiter/src/waiter/util/async_utils.clj
@@ -186,7 +186,4 @@
 (defn chan?
   "Determines if v is a channel."
   [v]
-  (or (instance? ManyToManyChannel v)
-      ;; instance? is flaky here (possible classloader issue), so we fall back to checking the class name
-      (= (.getName ManyToManyChannel)
-         (some-> v .getClass .getName))))
+  (instance? ManyToManyChannel v))

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -443,6 +443,7 @@
       (locking ns-loader-lock
         (require target-ns))
       (log/warn "Unable to load namespace for symbol" sym))
+    (log/info "Dynamically loading Clojure var:" sym)
     (resolve sym)))
 
 (defn create-component

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -434,14 +434,16 @@
     (when (and host origin scheme)
       (= origin (str (name scheme) "://" host)))))
 
-(defn resolve-symbol
-  "Resolve the given symbol to the corresponding Var."
-  [sym]
-  {:pre [(symbol? sym)]}
-  (if-let [target-ns (namespace sym)]
-    (-> target-ns symbol require)
-    (log/warn "Unable to load namespace for symbol" sym))
-  (resolve sym))
+(let [ns-loader-lock (Object.)]
+  (defn resolve-symbol
+    "Resolve the given symbol to the corresponding Var."
+    [sym]
+    {:pre [(symbol? sym)]}
+    (if-let [target-ns (some-> sym namespace symbol)]
+      (locking ns-loader-lock
+        (require target-ns))
+      (log/warn "Unable to load namespace for symbol" sym))
+    (resolve sym)))
 
 (defn create-component
   "Creates a component based on the specified :kind"


### PR DESCRIPTION
## Changes proposed in this PR

- Ensure our dynamic calls to `require` are serialized via `locking`.
- Revert the hacks we added to make the `chan?` predicate work.
- Add a logging message so we can see if our `resolve-symbol` is being called from multiple threads.

## Why are we making these changes?

It seems that ensuring all dynamic calls to `require` are serialized gets rid of all the weird class resolution errors we've been seeing recently in Waiter.