### PR TITLE
Use "waiter-cluster" label to identify waiter-managed objects

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -342,6 +342,9 @@
                                  :authorizer {:kind :default
                                               :default {:factory-fn waiter.authorization/noop-authorizer}}
 
+                                 ;; String value used to annotate Kubernetes objects that are orchestrated by this Waiter instantiation:
+                                 :cluster-name "waiter"
+
                                  ;; Configuration for creating and querying a sidecar container in each Waiter Service Instance's Kuberentes pod
                                  ;; running a server for directory listings (in JSON) and serving file contents.
                                  ;; Waiter expects the directory listings in the format returned by nginx's autoindex module when configured for JSON.
@@ -364,9 +367,6 @@
 
                                  ;; Maximum number of characters allowed for a Kubernetes object name:
                                  :max-name-length 63
-
-                                 ;; String value used to annotate Kubernetes objects that are orchestrated by this Waiter instantiation:
-                                 :orchestrator-name "waiter"
 
                                  ;; Port number used to set the $PORT0 (service port) for Waiter service instances.
                                  ;; Waiter generates a random offset in the range [0, 990] each time it creates a service,

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -295,6 +295,7 @@
                                    :factory-fn 'waiter.scheduler.kubernetes/kubernetes-scheduler
                                    :authorizer {:kind :default
                                                 :default {:factory-fn 'waiter.authorization/noop-authorizer}}
+                                   :cluster-name "waiter"
                                    :fileserver {:cmd ["/bin/fileserver-start"]
                                                 :image "twosigma/waiter-fileserver:latest"
                                                 :resources {:cpu 0.1 :mem 128}
@@ -303,7 +304,6 @@
                                                   :socket-timeout 10000}
                                    :max-patch-retries 5
                                    :max-name-length 63
-                                   :orchestrator-name "waiter"
                                    :pod-base-port 31000
                                    :pod-suffix-length 5
                                    :replicaset-api-version "extensions/v1beta1"

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -48,11 +48,11 @@
      {:authorizer {:kind :default
                    :default {:factory-fn 'waiter.authorization/noop-authorizer}}
       :daemon-state (atom nil)
+      :cluster-name "waiter"
       :fileserver {:port 9090
                    :scheme "http"}
       :max-patch-retries 5
       :max-name-length 63
-      :orchestrator-name "waiter"
       :pod-base-port 8080
       :pod-suffix-length default-pod-suffix-length
       :replicaset-api-version "extensions/v1beta1"
@@ -170,22 +170,22 @@
            :items [{:metadata {:name "test-app-1234"
                                :namespace "myself"
                                :labels {:app "test-app-1234"
-                                        :managed-by "waiter"}
+                                        :waiter-cluster "waiter"}
                                :annotations {:waiter/service-id "test-app-1234"}}
                     :spec {:replicas 2
                            :selector {:matchLabels {:app "test-app-1234"
-                                                    :managed-by "waiter"}}}
+                                                    :waiter-cluster "waiter"}}}
                     :status {:replicas 2
                              :readyReplicas 2
                              :availableReplicas 2}}
                    {:metadata {:name "test-app-6789"
                                :namespace "myself"
                                :labels {:app "test-app-6789"
-                                        :managed-by "waiter"}
+                                        :waiter-cluster "waiter"}
                                :annotations {:waiter/service-id "test-app-6789"}}
                     :spec {:replicas 3
                            :selector {:matchLabels {:app "test-app-6789"
-                                                    :managed-by "waiter"}}}
+                                                    :waiter-cluster "waiter"}}}
                     :status {:replicas 3
                              :readyReplicas 1
                              :availableReplicas 2
@@ -203,11 +203,11 @@
            :items [{:metadata {:name "test-app-abcd"
                                :namespace "myself"
                                :labels {:app "test-app-abcd"
-                                        :managed-by "waiter"}
+                                        :waiter-cluster "waiter"}
                                :annotations {:waiter/service-id "test-app-abcd"}}
                     :spec {:replicas 2
                            :selector {:matchLabels {:app "test-app-abcd"
-                                                    :managed-by "waiter"}}}
+                                                    :waiter-cluster "waiter"}}}
                     :status {:replicas 2
                              :readyReplicas 2
                              :availableReplicas 2}}
@@ -215,11 +215,11 @@
                    {:metadata {:name "test-app-wxyz"
                                :namespace "myself"
                                :labels {:app "test-app-wxyz"
-                                        :managed-by "waiter"}
+                                        :waiter-cluster "waiter"}
                                :annotations {:waiter/service-id "test-app-wxyz"}}
                     :spec {:replicas 3
                            :selector {:matchLabels {:app "test-app-wxyz"
-                                                    :managed-by "waiter"}}}
+                                                    :waiter-cluster "waiter"}}}
                     :status {:replicas 3
                              :readyReplicas 1
                              :availableReplicas 2
@@ -238,11 +238,11 @@
            :items [{:metadata {:name "test-app-4321"
                                :namespace "myself"
                                :labels {:app "test-app-4321"
-                                        :managed-by "waiter"}
+                                        :waiter-cluster "waiter"}
                                :annotations {:waiter/service-id "test-app-4321"}}
                     :spec {:replicas 3
                            :selector {:matchLabels {:app "test-app-4321"
-                                                    :managed-by "waiter"}}}
+                                                    :waiter-cluster "waiter"}}}
                     :status {:replicas 3
                              :readyReplicas 1
                              :availableReplicas 1
@@ -257,11 +257,11 @@
            :items [{:metadata {:name "test-app-9999"
                                :namespace "myself"
                                :labels {:app "test-app-9999"
-                                        :managed-by "waiter"}
+                                        :waiter-cluster "waiter"}
                                :annotations {:waiter/service-id "test-app-9999"}}
                     :spec {:replicas 0
                            :selector {:matchLabels {:app "test-app-9999"
-                                                    :managed-by "waiter"}}}
+                                                    :waiter-cluster "waiter"}}}
                     :status {:replicas 0
                              :readyReplicas 0
                              :availableReplicas 0}}]}
@@ -286,22 +286,22 @@
          :items [{:metadata {:name "test-app-1234"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :managed-by "waiter"}
+                                      :waiter-cluster "waiter"}
                              :annotations {:waiter/service-id "test-app-1234"}}
                   :spec {:replicas 2
                          :selector {:matchLabels {:app "test-app-1234"
-                                                  :managed-by "waiter"}}}
+                                                  :waiter-cluster "waiter"}}}
                   :status {:replicas 2
                            :readyReplicas 2
                            :availableReplicas 2}}
                  {:metadata {:name "test-app-6789"
                              :namespace "myself"
                              :labels {:app "test-app-6789"
-                                      :managed-by "waiter"}
+                                      :waiter-cluster "waiter"}
                              :annotations {:waiter/service-id "test-app-6789"}}
                   :spec {:replicas 3
                          :selector {:matchLabels {:app "test-app-6789"
-                                                  :managed-by "waiter"}}}
+                                                  :waiter-cluster "waiter"}}}
                   :status {:replicas 3
                            :readyReplicas 1
                            :availableReplicas 2
@@ -313,7 +313,7 @@
          :items [{:metadata {:name "test-app-1234-abcd1"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :managed-by "waiter"}
+                                      :waiter-cluster "waiter"}
                              :annotations {:waiter/port-count "1"
                                            :waiter/protocol "https"
                                            :waiter/service-id "test-app-1234"}}
@@ -326,7 +326,7 @@
                  {:metadata {:name "test-app-1234-abcd2"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :managed-by "waiter"}
+                                      :waiter-cluster "waiter"}
                              :annotations {:waiter/port-count "1"
                                            :waiter/protocol "https"
                                            :waiter/service-id "test-app-1234"}}
@@ -339,7 +339,7 @@
                  {:metadata {:name "test-app-6789-abcd1"
                              :namespace "myself"
                              :labels {:app "test-app-6789"
-                                      :managed-by "waiter"}
+                                      :waiter-cluster "waiter"}
                              :annotations {:waiter/port-count "1"
                                            :waiter/protocol "http"
                                            :waiter/service-id "test-app-6789"}}
@@ -352,7 +352,7 @@
                  {:metadata {:name "test-app-6789-abcd2"
                              :namespace "myself"
                              :labels {:app "test-app-6789"
-                                      :managed-by "waiter"}
+                                      :waiter-cluster "waiter"}
                              :annotations {:waiter/port-count "1"
                                            :waiter/protocol "http"
                                            :waiter/service-id "test-app-6789"}}
@@ -367,7 +367,7 @@
                  {:metadata {:name "test-app-6789-abcd3"
                              :namespace "myself"
                              :labels {:app "test-app-6789"
-                                      :managed-by "waiter"}
+                                      :waiter-cluster "waiter"}
                              :annotations {:waiter/port-count "1"
                                            :waiter/protocol "http"
                                            :waiter/service-id "test-app-6789"}}
@@ -472,7 +472,7 @@
                              :items [{:metadata {:name service-id
                                                  :namespace "myself"
                                                  :labels {:app service-id
-                                                          :managed-by "waiter"}
+                                                          :waiter-cluster "waiter"}
                                                  :annotations {:waiter/service-id service-id}}
                                       :spec {:replicas 1}
                                       :status {:replicas 1
@@ -530,11 +530,11 @@
          :items [{:metadata {:name service-id
                              :namespace "myself"
                              :labels {:app service-id
-                                      :managed-by "waiter"}
+                                      :waiter-cluster "waiter"}
                              :annotations {:waiter/service-id service-id}}
                   :spec {:replicas 2
                          :selector {:matchLabels {:app service-id
-                                                  :managed-by "waiter"}}}
+                                                  :waiter-cluster "waiter"}}}
                   :status {:replicas 2
                            :readyReplicas 2
                            :availableReplicas 2}}]}
@@ -718,6 +718,7 @@
         k8s-config {:authentication nil
                     :authorizer {:kind :default
                                  :default {:factory-fn 'waiter.authorization/noop-authorizer}}
+                    :cluster-name "waiter"
                     :fileserver {:port 9090
                                  :scheme "http"}
                     :watch-state (atom nil)
@@ -725,7 +726,6 @@
                                    :socket-timeout 10000}
                     :max-patch-retries 5
                     :max-name-length 63
-                    :orchestrator-name "waiter"
                     :pod-base-port 8080
                     :pod-suffix-length default-pod-suffix-length
                     :replicaset-api-version "extensions/v1beta1"
@@ -785,11 +785,11 @@
          :items [{:metadata {:name "test-app-1234"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :managed-by "waiter"}
+                                      :waiter-cluster "waiter"}
                              :annotations {:waiter/service-id "test-app-1234"}}
                   :spec {:replicas 2
                          :selector {:matchLabels {:app "test-app-1234"
-                                                  :managed-by "waiter"}}}
+                                                  :waiter-cluster "waiter"}}}
                   :status {:replicas 2
                            :readyReplicas 1
                            :availableReplicas 2}}]}
@@ -799,12 +799,12 @@
           :object {:metadata {:name "test-app-1234"
                               :namespace "myself"
                               :labels {:app "test-app-1234"
-                                       :managed-by "waiter"}
+                                       :waiter-cluster "waiter"}
                               :annotations {:waiter/service-id "test-app-1234"}
                               :resourceVersion "1001"}
                    :spec {:replicas 2
                           :selector {:matchLabels {:app "test-app-1234"
-                                                   :managed-by "waiter"}}}
+                                                   :waiter-cluster "waiter"}}}
                    :status {:replicas 2
                             :readyReplicas 2
                             :availableReplicas 2}}}
@@ -812,12 +812,12 @@
           :object {:metadata {:name "test-app-1234"
                               :namespace "myself"
                               :labels {:app "test-app-1234"
-                                       :managed-by "waiter"}
+                                       :waiter-cluster "waiter"}
                               :annotations {:waiter/service-id "test-app-1234"}
                               :resourceVersion "1002"}
                    :spec {:replicas 3
                           :selector {:matchLabels {:app "test-app-1234"
-                                                   :managed-by "waiter"}}}
+                                                   :waiter-cluster "waiter"}}}
                    :status {:replicas 3
                             :readyReplicas 2
                             :availableReplicas 3}}}
@@ -825,12 +825,12 @@
           :object {:metadata {:name "test-app-1234"
                               :namespace "myself"
                               :labels {:app "test-app-1234"
-                                       :managed-by "waiter"}
+                                       :waiter-cluster "waiter"}
                               :annotations {:waiter/service-id "test-app-1234"}
                               :resourceVersion "1003"}
                    :spec {:replicas 2
                           :selector {:matchLabels {:app "test-app-1234"
-                                                   :managed-by "waiter"}}}
+                                                   :waiter-cluster "waiter"}}}
                    :status {:replicas 2
                             :readyReplicas 1
                             :availableReplicas 2}}}]
@@ -842,7 +842,7 @@
          :items [{:metadata {:name "test-app-1234-abcd1"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :managed-by "waiter"}
+                                      :waiter-cluster "waiter"}
                              :annotations {:waiter/port-count "1"
                                            :waiter/protocol "https"
                                            :waiter/service-id "test-app-1234"}}
@@ -855,7 +855,7 @@
                  {:metadata {:name "test-app-1234-abcd2"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :managed-by "waiter"}
+                                      :waiter-cluster "waiter"}
                              :annotations {:waiter/port-count "1"
                                            :waiter/protocol "https"
                                            :waiter/service-id "test-app-1234"}}
@@ -870,7 +870,7 @@
           :object {:metadata {:name "test-app-1234-abcd2"
                               :namespace "myself"
                               :labels {:app "test-app-1234"
-                                       :managed-by "waiter"}
+                                       :waiter-cluster "waiter"}
                               :annotations {:waiter/port-count "1"
                                             :waiter/protocol "https"
                                             :waiter/service-id "test-app-1234"}
@@ -885,7 +885,7 @@
           :object {:metadata {:name "test-app-1234-abcd3"
                               :namespace "myself"
                               :labels {:app "test-app-1234"
-                                       :managed-by "waiter"}
+                                       :waiter-cluster "waiter"}
                               :annotations {:waiter/port-count "1"
                                             :waiter/protocol "https"
                                             :waiter/service-id "test-app-1234"}
@@ -1021,11 +1021,11 @@
          :items [{:metadata {:name "test-app-1234"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :managed-by "waiter"}
+                                      :waiter-cluster "waiter"}
                              :annotations {:waiter/service-id "test-app-1234"}}
                   :spec {:replicas 2
                          :selector {:matchLabels {:app "test-app-1234"
-                                                  :managed-by "waiter"}}}
+                                                  :waiter-cluster "waiter"}}}
                   :status {:replicas 2
                            :readyReplicas 1
                            :availableReplicas 2}}]}
@@ -1035,12 +1035,12 @@
           :object {:metadata {:name "test-app-1234"
                               :namespace "myself"
                               :labels {:app "test-app-1234"
-                                       :managed-by "waiter"}
+                                       :waiter-cluster "waiter"}
                               :annotations {:waiter/service-id "test-app-1234"}
                               :resourceVersion "1001"}
                    :spec {:replicas 2
                           :selector {:matchLabels {:app "test-app-1234"
-                                                   :managed-by "waiter"}}}
+                                                   :waiter-cluster "waiter"}}}
                    :status {:replicas 2
                             :readyReplicas 2
                             :availableReplicas 2}}}
@@ -1048,12 +1048,12 @@
           :object {:metadata {:name "test-app-1234"
                               :namespace "myself"
                               :labels {:app "test-app-1234"
-                                       :managed-by "waiter"}
+                                       :waiter-cluster "waiter"}
                               :annotations {:waiter/service-id "test-app-1234"}
                               :resourceVersion "1002"}
                    :spec {:replicas 3
                           :selector {:matchLabels {:app "test-app-1234"
-                                                   :managed-by "waiter"}}}
+                                                   :waiter-cluster "waiter"}}}
                    :status {:replicas 3
                             :readyReplicas 2
                             :availableReplicas 3}}}
@@ -1061,12 +1061,12 @@
           :object {:metadata {:name "test-app-1234"
                               :namespace "myself"
                               :labels {:app "test-app-1234"
-                                       :managed-by "waiter"}
+                                       :waiter-cluster "waiter"}
                               :annotations {:waiter/service-id "test-app-1234"}
                               :resourceVersion "1004"}
                    :spec {:replicas 2
                           :selector {:matchLabels {:app "test-app-1234"
-                                                   :managed-by "waiter"}}}
+                                                   :waiter-cluster "waiter"}}}
                    :status {:replicas 2
                             :readyReplicas 1
                             :availableReplicas 2}}}]
@@ -1078,7 +1078,7 @@
          :items [{:metadata {:name "test-app-1234-abcd1"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :managed-by "waiter"}
+                                      :waiter-cluster "waiter"}
                              :annotations {:waiter/port-count "1"
                                            :waiter/protocol "https"
                                            :waiter/service-id "test-app-1234"}}
@@ -1091,7 +1091,7 @@
                  {:metadata {:name "test-app-1234-abcd2"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :managed-by "waiter"}
+                                      :waiter-cluster "waiter"}
                              :annotations {:waiter/port-count "1"
                                            :waiter/protocol "https"
                                            :waiter/service-id "test-app-1234"}}
@@ -1108,7 +1108,7 @@
          :items [{:metadata {:name "test-app-1234-abcd1"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :managed-by "waiter"}
+                                      :waiter-cluster "waiter"}
                              :annotations {:waiter/port-count "1"
                                            :waiter/protocol "https"
                                            :waiter/service-id "test-app-1234"}}
@@ -1121,7 +1121,7 @@
                  {:metadata {:name "test-app-1234-abcd2"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :managed-by "waiter"}
+                                      :waiter-cluster "waiter"}
                              :annotations {:waiter/port-count "1"
                                            :waiter/protocol "https"
                                            :waiter/service-id "test-app-1234"}}
@@ -1134,7 +1134,7 @@
                  {:metadata {:name "test-app-1234-abcd3"
                               :namespace "myself"
                               :labels {:app "test-app-1234"
-                                       :managed-by "waiter"}
+                                       :waiter-cluster "waiter"}
                               :annotations {:waiter/port-count "1"
                                             :waiter/protocol "https"
                                             :waiter/service-id "test-app-1234"}
@@ -1150,7 +1150,7 @@
           :object {:metadata {:name "test-app-1234-abcd2"
                               :namespace "myself"
                               :labels {:app "test-app-1234"
-                                       :managed-by "waiter"}
+                                       :waiter-cluster "waiter"}
                               :annotations {:waiter/port-count "1"
                                             :waiter/protocol "https"
                                             :waiter/service-id "test-app-1234"}
@@ -1165,7 +1165,7 @@
           :object {:metadata {:name "test-app-1234-abcd3"
                               :namespace "myself"
                               :labels {:app "test-app-1234"
-                                       :managed-by "waiter"}
+                                       :waiter-cluster "waiter"}
                               :annotations {:waiter/port-count "1"
                                             :waiter/protocol "https"
                                             :waiter/service-id "test-app-1234"}


### PR DESCRIPTION
## Changes proposed in this PR

- Replace `managed-by` label on K8s objects with `waiter-cluster`.

## Why are we making these changes?

Labeling with `managed-by` is vague, and could potentially conflict with objects from other apps. Using `waiter-cluster` instead gives us a reasonable expectation that other apps aren't setting that label.
