### PR TITLE
Make scaling operation async friendly

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -537,7 +537,7 @@
    :start-service-cache (pc/fnk []
                           (cu/cache-factory {:threshold 100
                                              :ttl (-> 1 t/minutes t/in-millis)}))
-   :task-thread-pool (pc/fnk [] (Executors/newFixedThreadPool 20))
+   :start-service-thread-pool (pc/fnk [] (Executors/newFixedThreadPool 20))
    :token-root (pc/fnk [[:settings [:cluster-config name]]] name)
    :waiter-hostnames (pc/fnk [[:settings hostname]]
                        (set (if (sequential? hostname)
@@ -813,13 +813,13 @@
    :service-id->source-tokens-entries-fn (pc/fnk [[:curator kv-store]]
                                            (partial sd/service-id->source-tokens-entries kv-store))
    :start-new-service-fn (pc/fnk [[:scheduler scheduler]
-                                  [:state start-service-cache task-thread-pool]
+                                  [:state start-service-cache start-service-thread-pool]
                                   store-service-description-fn]
                            (fn start-new-service [{:keys [service-id] :as descriptor}]
                              (store-service-description-fn descriptor)
                              (scheduler/validate-service scheduler service-id)
                              (service/start-new-service
-                               scheduler descriptor start-service-cache task-thread-pool)))
+                               scheduler descriptor start-service-cache start-service-thread-pool)))
    :start-work-stealing-balancer-fn (pc/fnk [[:settings [:work-stealing offer-help-interval-ms reserve-timeout-ms]]
                                              [:state instance-rpc-chan router-id]
                                              make-inter-router-requests-async-fn router-metrics-helpers]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -515,6 +515,7 @@
                 (cond->> (utils/unique-identifier)
                   (not (str/blank? router-id-prefix))
                   (str (str/replace router-id-prefix #"[@.]" "-") "-")))
+   :scale-service-thread-pool (pc/fnk [] (Executors/newFixedThreadPool 20))
    :scaling-timeout-config (pc/fnk [[:settings
                                      [:blacklist-config blacklist-backoff-base-time-ms max-blacklist-time-ms]
                                      [:scaling inter-kill-request-wait-time-ms]]]
@@ -888,7 +889,7 @@
                                       service-id->service-description-fn]
                                      [:scheduler scheduler]
                                      [:settings [:scaling quanta-constraints]]
-                                     [:state instance-rpc-chan scaling-timeout-config]
+                                     [:state instance-rpc-chan scale-service-thread-pool scaling-timeout-config]
                                      router-state-maintainer]
                               (let [{{:keys [notify-instance-killed-fn]} :maintainer} router-state-maintainer]
                                 (scaling/service-scaling-multiplexer
@@ -897,7 +898,7 @@
                                       notify-instance-killed-fn peers-acknowledged-blacklist-requests-fn
                                       delegate-instance-kill-request-fn service-id->service-description-fn
                                       scheduler instance-rpc-chan quanta-constraints scaling-timeout-config
-                                      service-id))
+                                      scale-service-thread-pool service-id))
                                   {})))
    :fallback-maintainer (pc/fnk [[:state fallback-state-atom]
                                  router-state-maintainer]

--- a/waiter/src/waiter/scaling.clj
+++ b/waiter/src/waiter/scaling.clj
@@ -272,7 +272,7 @@
                           (counters/inc! (metrics/service-counter service-id "scaling" "scale-down" "total"))
                           (if (or (nil? last-scale-down-time)
                                   (t/after? (t/now) (t/plus last-scale-down-time inter-kill-request-wait-time-in-millis)))
-                            (if (or (-> (fn []
+                            (if (or (-> (fn execute-scale-down-request-task []
                                           (-> (execute-scale-down-request
                                                 notify-instance-killed-fn peers-acknowledged-blacklist-requests-fn
                                                 scheduler instance-rpc-chan timeout-config

--- a/waiter/src/waiter/scaling.clj
+++ b/waiter/src/waiter/scaling.clj
@@ -272,13 +272,14 @@
                           (counters/inc! (metrics/service-counter service-id "scaling" "scale-down" "total"))
                           (if (or (nil? last-scale-down-time)
                                   (t/after? (t/now) (t/plus last-scale-down-time inter-kill-request-wait-time-in-millis)))
-                            (if (or (-> (fn execute-scale-down-request-task []
-                                          (-> (execute-scale-down-request
-                                                notify-instance-killed-fn peers-acknowledged-blacklist-requests-fn
-                                                scheduler instance-rpc-chan timeout-config
-                                                service-id iter-correlation-id num-instances-to-kill response-chan)
-                                              async/<!!))
-                                        (au/execute scale-service-thread-pool)
+                            (if (or (-> (au/execute
+                                          (fn execute-scale-down-request-task []
+                                            (-> (execute-scale-down-request
+                                                  notify-instance-killed-fn peers-acknowledged-blacklist-requests-fn
+                                                  scheduler instance-rpc-chan timeout-config
+                                                  service-id iter-correlation-id num-instances-to-kill response-chan)
+                                                async/<!!))
+                                          scale-service-thread-pool)
                                         async/<!
                                         :result)
                                     (delegate-instance-kill-request-fn service-id))

--- a/waiter/src/waiter/scaling.clj
+++ b/waiter/src/waiter/scaling.clj
@@ -92,7 +92,7 @@
 
 (defn- execute-scale-service-request
   "Helper function to scale instances of a service.
-   The force? flag can be used to detmerine whether we will make a best effort or a forced scale operation."
+   The force? flag can be used to determine whether we will make a best effort or a forced scale operation."
   [scheduler service-id scale-to-instances force?]
   (let [mode (if force? "scale-force" "scale-up")]
     (try

--- a/waiter/src/waiter/scaling.clj
+++ b/waiter/src/waiter/scaling.clj
@@ -277,9 +277,10 @@
                                                 notify-instance-killed-fn peers-acknowledged-blacklist-requests-fn
                                                 scheduler instance-rpc-chan timeout-config
                                                 service-id iter-correlation-id num-instances-to-kill response-chan)
-                                              (async/<!!)))
+                                              async/<!!))
                                         (au/execute scale-service-thread-pool)
-                                        async/<!)
+                                        async/<!
+                                        :result)
                                     (delegate-instance-kill-request-fn service-id))
                               (assoc executor-state :last-scale-down-time (t/now))
                               executor-state)

--- a/waiter/src/waiter/util/async_utils.clj
+++ b/waiter/src/waiter/util/async_utils.clj
@@ -20,7 +20,8 @@
             [metrics.core]
             [metrics.histograms :as histograms]
             [slingshot.slingshot :refer [throw+ try+]])
-  (:import clojure.core.async.impl.channels.ManyToManyChannel))
+  (:import clojure.core.async.impl.channels.ManyToManyChannel
+           java.util.concurrent.ExecutorService))
 
 (defn sliding-buffer-chan [n]
   (async/chan (async/sliding-buffer n)))
@@ -187,3 +188,20 @@
   "Determines if v is a channel."
   [v]
   (instance? ManyToManyChannel v))
+
+(defn execute
+  "Helper function, like core.async/thread, which asynchronously executes task on a thread in the provided thread pool.
+   Returns a channel which will receive the result of the task when completed, then close."
+  [task ^ExecutorService task-thread-pool]
+  (let [task-complete-chan (async/promise-chan)]
+    (.submit task-thread-pool
+             ^Runnable
+             (fn execute-task []
+               (try
+                 (when-let [result (task)]
+                   (async/>!! task-complete-chan result))
+                 (catch Throwable th
+                   (async/>!! task-complete-chan th))
+                 (finally
+                   (async/close! task-complete-chan)))))
+    task-complete-chan))

--- a/waiter/src/waiter/util/async_utils.clj
+++ b/waiter/src/waiter/util/async_utils.clj
@@ -198,10 +198,10 @@
              ^Runnable
              (fn execute-task []
                (try
-                 (when-let [result (task)]
-                   (async/>!! task-complete-chan result))
+                 (async/>!! task-complete-chan {:result (task)})
                  (catch Throwable th
-                   (async/>!! task-complete-chan th))
+                   (log/error th "error while executing task")
+                   (async/>!! task-complete-chan {:error th}))
                  (finally
                    (async/close! task-complete-chan)))))
     task-complete-chan))

--- a/waiter/test/waiter/util/async_utils_test.clj
+++ b/waiter/test/waiter/util/async_utils_test.clj
@@ -314,14 +314,17 @@
 
 (deftest test-execute
   (let [task-thread-pool (Executors/newFixedThreadPool 5)]
-    (is (= 5 (-> (constantly 5)
-                 (execute task-thread-pool)
-                 (async/<!!))))
-    (is (nil? (-> (constantly nil)
-                  (execute task-thread-pool)
-                  (async/<!!))))
+    (is (= {:result 5}
+           (-> (constantly 5)
+               (execute task-thread-pool)
+               (async/<!!))))
+    (is (= {:result nil}
+           (-> (constantly nil)
+               (execute task-thread-pool)
+               (async/<!!))))
     (let [ex (Exception. "for test")]
-      (is (= ex (-> #(throw ex)
-                    (execute task-thread-pool)
-                    (async/<!!)))))
+      (is (= {:error ex}
+             (-> #(throw ex)
+                 (execute task-thread-pool)
+                 (async/<!!)))))
     (.shutdown task-thread-pool)))


### PR DESCRIPTION
## Changes proposed in this PR

- renames task-thread-pool to start-service-thread-pool
- executes execute-scale-service-request on its own thread to avoid blocking async threads
- executes execute-scale-down-request during scaling on its own thread to avoid blocking async threads

## Why are we making these changes?

We would like to avoid blocking async threads that can lead to a deadlock with our implementation of synchronous requests using the jet library.

### Outstanding question

Should all the scaling scheduler interactions (create, scale, kill and delete) move to a common thread pool? If yes, they can be part of a follow-up PR.


### Why didn;t we try making the http calls to the scheduler full async?

An example call stack:
```
scaling/service-scaling-executor [go-block]
-> scaling/execute-scale-service-request
  -> scheduler/scale-service 
   -> extract-service-deployment-info
    -> marathon/get-deployments
   -> marathon/delete-deployment
   -> marathon/get-app
   -> marathon/update-app
```
Introducing async means each of these call paths need to be converted to async and need to handle throwing/returning exceptions.
