### PR TITLE
adds support for star in the run-as-user filter on /apps endpoint

### DIFF
--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -253,7 +253,7 @@
                                                         flatten)]
                                   (and (if (str/blank? run-as-user)
                                          (authz/manage-service? entitlement-manager auth-user service-id service-description)
-                                         (= run-as-user (get service-description "run-as-user")))
+                                         ((str->filter-fn run-as-user) (get service-description "run-as-user")))
                                        (or (str/blank? token)
                                            (let [filter-fn (str->filter-fn token)]
                                              (->> source-tokens


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for `*` in the `run-as-user` filter on the `/apps` endpoint

## Why are we making these changes?

We would like to be able to explicitly search and see all services running on Waiter.

