### PR TITLE
returns empty lists instead of nil for instances

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -38,6 +38,12 @@
             {:x-waiter-name (rand-name)}
             #(make-kitchen-request waiter-url % :path "/hello"))]
 
+      (testing "instances are non-null"
+        (let [service-settings (service-settings waiter-url service-id)]
+          (is (get-in service-settings [:instances :active-instances]))
+          (is (get-in service-settings [:instances :failed-instances]))
+          (is (get-in service-settings [:instances :killed-instances]))))
+
       (testing "explicitly specifying default parameter resolves to different service"
         (let [{:keys [service-description-defaults]} (waiter-settings waiter-url)
               request-headers (walk/stringify-keys request-headers)]

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -337,8 +337,7 @@
   (let [service-instance-maps (try
                                 (let [assoc-log-url-to-instances
                                       (fn assoc-log-url-to-instances [instances]
-                                        (when (not-empty instances)
-                                          (map #(assoc-log-url generate-log-url-fn %) instances)))]
+                                        (map #(assoc-log-url generate-log-url-fn %) instances))]
                                   (-> (get-service-instances query-state-fn service-id)
                                       (update :active-instances assoc-log-url-to-instances)
                                       (update :failed-instances assoc-log-url-to-instances)

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -530,8 +530,8 @@
                                          "log-url" "http://www.example.com/apps/test-service-1/logs?instance-id=test-service-1.A&host=10.141.141.11"
                                          "port" 31045,
                                          "started-at" (du/date-to-str started-time du/formatter-iso8601)}]
-                    "failed-instances" nil
-                    "killed-instances" nil}
+                    "failed-instances" []
+                    "killed-instances" []}
                    (get body-json "instances")))
             (is (= {"aggregate" {"routers-sent-requests-to" 0}} (get body-json "metrics")))
             (is (= 1 (get body-json "num-active-instances")))


### PR DESCRIPTION
## Changes proposed in this PR

- returns empty lists instead of nil for instances

## Why are we making these changes?

Avoids outputting `nil` in the instances results.

