### PR TITLE
Enforces limit on length of the command string

### DIFF
--- a/waiter/src/waiter/headers.clj
+++ b/waiter/src/waiter/headers.clj
@@ -23,10 +23,11 @@
 (def ^:const waiter-header-prefix "x-waiter-")
 
 ;; authentication is intentionally missing from this list as we do not support it as an on-the-fly header
-(def ^:const waiter-headers-with-str-value
-  (set (map #(str waiter-header-prefix %)
-            #{"allowed-params" "backend-proto" "cmd" "cmd-type" "distribution-scheme" "endpoint-path" "health-check-url"
-              "metric-group" "name" "permitted-user" "run-as-user" "token" "version"})))
+(def ^:const params-with-str-value
+  #{"allowed-params" "backend-proto" "cmd" "cmd-type" "distribution-scheme" "endpoint-path" "health-check-url"
+    "metric-group" "name" "permitted-user" "run-as-user" "token" "version"})
+
+(def ^:const waiter-headers-with-str-value (set (map #(str waiter-header-prefix %) params-with-str-value)))
 
 (defn get-waiter-header
   "Retrieves the waiter header value."

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -52,7 +52,7 @@
 
 (def service-description-schema
   {;; Required
-   (s/required-key "cmd") (s/both s/Str (s/pred #(<= 1 (count %) 1024)'at-most-1K-chars))
+   (s/required-key "cmd") (s/both s/Str (s/pred #(<= 1 (count %) 1024) 'at-most-1K-chars))
    (s/required-key "cpus") schema/positive-num
    (s/required-key "mem") schema/positive-num
    (s/required-key "run-as-user") schema/non-empty-string

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -52,7 +52,7 @@
 
 (def service-description-schema
   {;; Required
-   (s/required-key "cmd") schema/non-empty-string
+   (s/required-key "cmd") (s/both s/Str (s/pred #(<= (count %) 1024)'at-most-1K-chars))
    (s/required-key "cpus") schema/positive-num
    (s/required-key "mem") schema/positive-num
    (s/required-key "run-as-user") schema/non-empty-string

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -52,7 +52,7 @@
 
 (def service-description-schema
   {;; Required
-   (s/required-key "cmd") (s/both s/Str (s/pred #(<= 1 (count %) 1024) 'at-most-1K-chars))
+   (s/required-key "cmd") (s/both s/Str (s/pred #(<= 1 (count %) 1200) 'at-most-1200-chars))
    (s/required-key "cpus") schema/positive-num
    (s/required-key "mem") schema/positive-num
    (s/required-key "run-as-user") schema/non-empty-string
@@ -379,7 +379,7 @@
                                          (contains? parameter->issues "allowed-params")
                                          (assoc :allowed-params (generate-friendly-allowed-params-error-message parameter->issues))
                                          (contains? parameter->issues "cmd")
-                                         (assoc :cmd "The command must be a non-empty string and must be at most 1024 characters.")
+                                         (assoc :cmd "The command must be a non-empty string and must be at most 1200 characters.")
                                          (contains? parameter->issues "env")
                                          (assoc :env (generate-friendly-environment-variable-error-message parameter->issues))
                                          (contains? parameter->issues "metadata")

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -336,7 +336,8 @@
    :scheduler-syncer-interval-secs 5
    :service-description-builder-config {:kind :default
                                         :default {:factory-fn 'waiter.service-description/create-default-service-description-builder}}
-   :service-description-constraints {"cpus" {:max 32}
+   :service-description-constraints {"cmd" {:max 1200}
+                                     "cpus" {:max 32}
                                      "mem" {:max (* 128 1024)}}
    :service-description-defaults {"allowed-params" #{}
                                   "authentication" "standard"

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -60,6 +60,11 @@
                                                  "ports" 5})))
   (is (not (nil? (s/check service-description-schema {"cpus" 1
                                                       "mem" 1
+                                                      "cmd" (str "test command " (str/join "" (repeat 1024 "x")))
+                                                      "version" "v123"
+                                                      "run-as-user" "test-user"}))))
+  (is (not (nil? (s/check service-description-schema {"cpus" 1
+                                                      "mem" 1
                                                       "cmd" "test command"
                                                       "version" "v123"
                                                       "run-as-user" "test-user"

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -60,7 +60,7 @@
                                                  "ports" 5})))
   (is (not (nil? (s/check service-description-schema {"cpus" 1
                                                       "mem" 1
-                                                      "cmd" (str "test command " (str/join "" (repeat 1024 "x")))
+                                                      "cmd" (apply str "test command " (repeat 1200 "x"))
                                                       "version" "v123"
                                                       "run-as-user" "test-user"}))))
   (is (not (nil? (s/check service-description-schema {"cpus" 1

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -60,7 +60,7 @@
                                                  "ports" 5})))
   (is (not (nil? (s/check service-description-schema {"cpus" 1
                                                       "mem" 1
-                                                      "cmd" (apply str "test command " (repeat 1200 "x"))
+                                                      "cmd" ""
                                                       "version" "v123"
                                                       "run-as-user" "test-user"}))))
   (is (not (nil? (s/check service-description-schema {"cpus" 1
@@ -2020,6 +2020,45 @@
         (is (str/includes? error-msg "PORT0") error-msg)
         (is (str/includes? error-msg "reserved") error-msg)
         (is (not (str/includes? error-msg "upper case")) error-msg)))))
+
+(defmacro run-validate-schema-test
+  [valid-description constraints-schema config param-name param-value error-message]
+  `(let [param-name# ~param-name
+         param-value# ~param-value
+         error-message# ~error-message]
+     (testing (str "testing invalid " param-name#)
+       (try
+         (-> ~valid-description
+             (assoc param-name# param-value#)
+             (validate-schema ~constraints-schema ~config))
+         (is false "Fail as exception was not thrown!")
+         (catch ExceptionInfo ex#
+           (let [exception-data# (ex-data ex#)
+                 actual-error-message# (-> (or (get-in exception-data# [:friendly-error-message (keyword param-name#)])
+                                               (get exception-data# :friendly-error-message))
+                                           str)]
+             (is (str/includes? actual-error-message# error-message#))))))))
+
+(deftest test-validate-schema
+  (let [valid-description {"cpus" 1
+                           "mem" 1
+                           "cmd" "default-cmd"
+                           "version" "default-version"
+                           "run-as-user" "default-run-as-user"}
+        constraints-schema {(s/optional-key "cmd") (s/pred #(<= (count %) 100) (symbol "limit-100"))
+                            s/Str s/Any}
+        config {:allow-missing-required-fields? false}]
+    (is (nil? (validate-schema valid-description constraints-schema config)))
+
+    (run-validate-schema-test
+      valid-description constraints-schema config
+      "cmd" ""
+      "cmd must be a non-empty string")
+
+    (run-validate-schema-test
+      valid-description constraints-schema config
+      "cmd" (str/join "" (repeat 150 "c"))
+      "cmd must be at most 100 characters")))
 
 (deftest test-service-description-schema
   (testing "Service description schema"

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -1182,7 +1182,7 @@
       (testing "post:new-service-description:bad-token-command"
         (let [kv-store (kv/->LocalKeyValueStore (atom {}))
               service-description (walk/stringify-keys
-                                    {:cmd (str "tc " (str/join "" (repeat 1024 "x")))
+                                    {:cmd (apply str "tc " (repeat 1024 "x"))
                                      :cpus 1 :mem 200 :version "a1b2c3" :run-as-user "tu1"
                                      :token "abcdefgh"})
               {:keys [body status]}

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -1195,7 +1195,7 @@
               {{:strs [message]} "waiter-error"} (json/read-str body)]
           (is (= 400 status))
           (is (not (str/includes? body "clojure")))
-          (is (str/includes? message "at-most-1K-chars") body)))
+          (is (str/includes? message "The command must be a non-empty string and must be at most 1024 characters") body)))
 
       (testing "post:new-service-description:bad-token-metadata"
         (let [kv-store (kv/->LocalKeyValueStore (atom {}))

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -1182,8 +1182,7 @@
       (testing "post:new-service-description:bad-token-command"
         (let [kv-store (kv/->LocalKeyValueStore (atom {}))
               service-description (walk/stringify-keys
-                                    {:cmd (apply str "tc " (repeat 1200 "x"))
-                                     :cpus 1 :mem 200 :version "a1b2c3" :run-as-user "tu1"
+                                    {:cmd "" :cpus 1 :mem 200 :version "a1b2c3" :run-as-user "tu1"
                                      :token "abcdefgh"})
               {:keys [body status]}
               (run-handle-token-request
@@ -1195,7 +1194,7 @@
               {{:strs [message]} "waiter-error"} (json/read-str body)]
           (is (= 400 status))
           (is (not (str/includes? body "clojure")))
-          (is (str/includes? message "The command must be a non-empty string and must be at most 1200 characters") body)))
+          (is (str/includes? message "cmd must be a non-empty string") body)))
 
       (testing "post:new-service-description:bad-token-metadata"
         (let [kv-store (kv/->LocalKeyValueStore (atom {}))

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -1182,7 +1182,7 @@
       (testing "post:new-service-description:bad-token-command"
         (let [kv-store (kv/->LocalKeyValueStore (atom {}))
               service-description (walk/stringify-keys
-                                    {:cmd (apply str "tc " (repeat 1024 "x"))
+                                    {:cmd (apply str "tc " (repeat 1200 "x"))
                                      :cpus 1 :mem 200 :version "a1b2c3" :run-as-user "tu1"
                                      :token "abcdefgh"})
               {:keys [body status]}
@@ -1195,7 +1195,7 @@
               {{:strs [message]} "waiter-error"} (json/read-str body)]
           (is (= 400 status))
           (is (not (str/includes? body "clojure")))
-          (is (str/includes? message "The command must be a non-empty string and must be at most 1024 characters") body)))
+          (is (str/includes? message "The command must be a non-empty string and must be at most 1200 characters") body)))
 
       (testing "post:new-service-description:bad-token-metadata"
         (let [kv-store (kv/->LocalKeyValueStore (atom {}))


### PR DESCRIPTION
## Changes proposed in this PR

- enforces validation limit on cmd - must be no larger than 1K characters
- issues friendly error message when command string validation fails

## Why are we making these changes?

We would like to prevent users from sending huge command strings as inputs with a goal of avoiding stress on our backing store.

