### PR TITLE
adds friendly error message for invalid metric-group

### DIFF
--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -383,7 +383,13 @@
                                          (contains? parameter->issues "env")
                                          (assoc :env (generate-friendly-environment-variable-error-message parameter->issues))
                                          (contains? parameter->issues "metadata")
-                                         (assoc :metadata (generate-friendly-metadata-error-message parameter->issues)))
+                                         (assoc :metadata (generate-friendly-metadata-error-message parameter->issues))
+                                         (contains? parameter->issues "metric-group")
+                                         (assoc :metric-group
+                                                (str "The metric-group must be be between 2 and 32 characters; "
+                                                     "only contain lowercase letters, numbers, dashes, and underscores; "
+                                                     "start with a lowercase letter; and "
+                                                     "only use dash and/or underscore as separators between alphanumeric portions.")))
               unresolved-parameters (set/difference (-> parameter->issues keys set)
                                                     (->> parameter->error-message keys (map name) set))]
           (throw-error e (select-keys parameter->issues unresolved-parameters) parameter->error-message))))

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -2058,7 +2058,12 @@
     (run-validate-schema-test
       valid-description constraints-schema config
       "cmd" (str/join "" (repeat 150 "c"))
-      "cmd must be at most 100 characters")))
+      "cmd must be at most 100 characters")
+
+    (run-validate-schema-test
+      valid-description constraints-schema config
+      "metric-group" (str/join "" (repeat 100 "m"))
+      "The metric-group must be be between 2 and 32 characters")))
 
 (deftest test-service-description-schema
   (testing "Service description schema"


### PR DESCRIPTION
## Changes proposed in this PR

- adds friendly error message for invalid metric-group

## Why are we making these changes?

Reporting friendlier error messages leads to happier users :)

