### PR TITLE
Include waiter in the user-agent header

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -500,7 +500,8 @@
    :fallback-state-atom (pc/fnk [] (atom {:available-service-ids #{}
                                           :healthy-service-ids #{}}))
    :http-client (pc/fnk [[:settings [:instance-request-properties connection-timeout-ms]]]
-                  (http-utils/http-client-factory {:conn-timeout connection-timeout-ms}))
+                  (http-utils/http-client-factory {:conn-timeout connection-timeout-ms
+                                                   :user-agent-prefix "waiter"}))
    :instance-rpc-chan (pc/fnk [] (async/chan 1024)) ; TODO move to service-chan-maintainer
    :interstitial-state-atom (pc/fnk [] (atom {:initialized? false
                                               :service-id->interstitial-promise {}}))
@@ -649,7 +650,8 @@
                                        service-id->service-description-fn*]
                                 (let [http-client (http-utils/http-client-factory
                                                     {:conn-timeout health-check-timeout-ms
-                                                     :socket-timeout health-check-timeout-ms})
+                                                     :socket-timeout health-check-timeout-ms
+                                                     :user-agent-prefix "waiter-syncer"})
                                       available? (fn scheduler-available? [service-instance health-check-path]
                                                    (scheduler/available? http-client service-instance health-check-path))]
                                   (fn start-scheduler-syncer-fn

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -500,8 +500,7 @@
    :fallback-state-atom (pc/fnk [] (atom {:available-service-ids #{}
                                           :healthy-service-ids #{}}))
    :http-client (pc/fnk [[:settings [:instance-request-properties connection-timeout-ms]]]
-                  (http-utils/http-client-factory {:conn-timeout connection-timeout-ms
-                                                   :user-agent-prefix "waiter"}))
+                  (http-utils/http-client-factory {:conn-timeout connection-timeout-ms}))
    :instance-rpc-chan (pc/fnk [] (async/chan 1024)) ; TODO move to service-chan-maintainer
    :interstitial-state-atom (pc/fnk [] (atom {:initialized? false
                                               :service-id->interstitial-promise {}}))
@@ -651,7 +650,7 @@
                                 (let [http-client (http-utils/http-client-factory
                                                     {:conn-timeout health-check-timeout-ms
                                                      :socket-timeout health-check-timeout-ms
-                                                     :user-agent-prefix "waiter-syncer"})
+                                                     :user-agent "waiter-syncer/1.0"})
                                       available? (fn scheduler-available? [service-instance health-check-path]
                                                    (scheduler/available? http-client service-instance health-check-path))]
                                   (fn start-scheduler-syncer-fn

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -500,7 +500,9 @@
    :fallback-state-atom (pc/fnk [] (atom {:available-service-ids #{}
                                           :healthy-service-ids #{}}))
    :http-client (pc/fnk [[:settings [:instance-request-properties connection-timeout-ms]]]
-                  (http-utils/http-client-factory {:conn-timeout connection-timeout-ms}))
+                  (http-utils/http-client-factory {:conn-timeout connection-timeout-ms
+                                                   :follow-redirects? false
+                                                   :user-agent "waiter/1.0"}))
    :instance-rpc-chan (pc/fnk [] (async/chan 1024)) ; TODO move to service-chan-maintainer
    :interstitial-state-atom (pc/fnk [] (atom {:initialized? false
                                               :service-id->interstitial-promise {}}))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -499,10 +499,10 @@
                           (utils/create-component entitlement-config))
    :fallback-state-atom (pc/fnk [] (atom {:available-service-ids #{}
                                           :healthy-service-ids #{}}))
-   :http-client (pc/fnk [[:settings [:instance-request-properties connection-timeout-ms]]]
+   :http-client (pc/fnk [[:settings [:instance-request-properties connection-timeout-ms] git-version]]
                   (http-utils/http-client-factory {:conn-timeout connection-timeout-ms
                                                    :follow-redirects? false
-                                                   :user-agent "waiter/1.0"}))
+                                                   :user-agent (str "waiter/" (str/join (take 7 git-version)))}))
    :instance-rpc-chan (pc/fnk [] (async/chan 1024)) ; TODO move to service-chan-maintainer
    :interstitial-state-atom (pc/fnk [] (atom {:initialized? false
                                               :service-id->interstitial-promise {}}))
@@ -646,13 +646,13 @@
                                             (sd/service-id->service-description
                                               kv-store service-id service-description-defaults
                                               metric-group-mappings :effective? effective?)))
-   :start-scheduler-syncer-fn (pc/fnk [[:settings [:health-check-config health-check-timeout-ms failed-check-threshold]]
+   :start-scheduler-syncer-fn (pc/fnk [[:settings [:health-check-config health-check-timeout-ms failed-check-threshold] git-version]
                                        [:state clock]
                                        service-id->service-description-fn*]
                                 (let [http-client (http-utils/http-client-factory
                                                     {:conn-timeout health-check-timeout-ms
                                                      :socket-timeout health-check-timeout-ms
-                                                     :user-agent "waiter-syncer/1.0"})
+                                                     :user-agent (str "waiter-syncer/" (str/join (take 7 git-version)))})
                                       available? (fn scheduler-available? [service-instance health-check-path]
                                                    (scheduler/available? http-client service-instance health-check-path))]
                                   (fn start-scheduler-syncer-fn

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -89,7 +89,7 @@
 (let [http-client (http-utils/http-client-factory {:conn-timeout 10000
                                                    :socket-timeout 10000
                                                    :spnego-auth false
-                                                   :user-agent-prefix "waiter-cook-health-check"})
+                                                   :user-agent "waiter-cook-health-check/1.0"})
       ;; TODO make this cache configurable
       healthy-instance-cache (cu/cache-factory {:threshold 5000
                                                 :ttl (-> 10 t/seconds t/in-millis)})]
@@ -525,7 +525,7 @@
          (utils/pos-int? scheduler-syncer-interval-secs)
          (fn? start-scheduler-syncer-fn)]}
   (let [http-client (-> http-options
-                        (utils/assoc-if-absent :user-agent-prefix "waiter-cook")
+                        (utils/assoc-if-absent :user-agent "waiter-cook/1.0")
                         http-utils/http-client-factory)
         cook-api {:http-client http-client
                   :impersonate impersonate

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -88,7 +88,8 @@
 
 (let [http-client (http-utils/http-client-factory {:conn-timeout 10000
                                                    :socket-timeout 10000
-                                                   :spnego-auth false})
+                                                   :spnego-auth false
+                                                   :user-agent-prefix "waiter-cook-health-check"})
       ;; TODO make this cache configurable
       healthy-instance-cache (cu/cache-factory {:threshold 5000
                                                 :ttl (-> 10 t/seconds t/in-millis)})]
@@ -523,7 +524,9 @@
          (au/chan? scheduler-state-chan)
          (utils/pos-int? scheduler-syncer-interval-secs)
          (fn? start-scheduler-syncer-fn)]}
-  (let [http-client (http-utils/http-client-factory http-options)
+  (let [http-client (-> http-options
+                        (utils/assoc-if-absent :user-agent-prefix "waiter-cook")
+                        http-utils/http-client-factory)
         cook-api {:http-client http-client
                   :impersonate impersonate
                   :slave-port mesos-slave-port

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -89,7 +89,7 @@
 (let [http-client (http-utils/http-client-factory {:conn-timeout 10000
                                                    :socket-timeout 10000
                                                    :spnego-auth false
-                                                   :user-agent "waiter-cook-health-check/1.0"})
+                                                   :user-agent "waiter-cook-health-check"})
       ;; TODO make this cache configurable
       healthy-instance-cache (cu/cache-factory {:threshold 5000
                                                 :ttl (-> 10 t/seconds t/in-millis)})]
@@ -525,7 +525,7 @@
          (utils/pos-int? scheduler-syncer-interval-secs)
          (fn? start-scheduler-syncer-fn)]}
   (let [http-client (-> http-options
-                        (utils/assoc-if-absent :user-agent "waiter-cook/1.0")
+                        (utils/assoc-if-absent :user-agent "waiter-cook")
                         http-utils/http-client-factory)
         cook-api {:http-client http-client
                   :impersonate impersonate

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -877,7 +877,7 @@
          (or (nil? watch-retries) (integer? watch-retries))]}
   (let [authorizer (utils/create-component authorizer)
         http-client (-> http-options
-                        (utils/assoc-if-absent :user-agent "waiter-k8s/1.0")
+                        (utils/assoc-if-absent :user-agent "waiter-k8s")
                         http-utils/http-client-factory)
         service-id->failed-instances-transient-store (atom {})
         replicaset-spec-builder-fn (let [f (-> replicaset-spec-builder

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -877,7 +877,7 @@
          (or (nil? watch-retries) (integer? watch-retries))]}
   (let [authorizer (utils/create-component authorizer)
         http-client (-> http-options
-                        (utils/assoc-if-absent :user-agent-prefix "waiter-k8s")
+                        (utils/assoc-if-absent :user-agent "waiter-k8s/1.0")
                         http-utils/http-client-factory)
         service-id->failed-instances-transient-store (atom {})
         replicaset-spec-builder-fn (let [f (-> replicaset-spec-builder

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -876,7 +876,9 @@
          (fn? start-scheduler-syncer-fn)
          (or (nil? watch-retries) (integer? watch-retries))]}
   (let [authorizer (utils/create-component authorizer)
-        http-client (http-utils/http-client-factory http-options)
+        http-client (-> http-options
+                        (utils/assoc-if-absent :user-agent-prefix "waiter-k8s")
+                        http-utils/http-client-factory)
         service-id->failed-instances-transient-store (atom {})
         replicaset-spec-builder-fn (let [f (-> replicaset-spec-builder
                                                :factory-fn

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -593,7 +593,7 @@
     (log/info "scheduler mesos-slave-port or slave-directory is missing, log directory and url support will be disabled"))
   (let [authorizer (utils/create-component authorizer)
         http-client (-> http-options
-                        (utils/assoc-if-absent :user-agent "waiter-marathon/1.0")
+                        (utils/assoc-if-absent :user-agent "waiter-marathon")
                         http-utils/http-client-factory)
         marathon-api (marathon/api-factory http-client http-options url)
         mesos-api (mesos/api-factory http-client http-options mesos-slave-port slave-directory)

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -592,7 +592,9 @@
   (when (or (not slave-directory) (not mesos-slave-port))
     (log/info "scheduler mesos-slave-port or slave-directory is missing, log directory and url support will be disabled"))
   (let [authorizer (utils/create-component authorizer)
-        http-client (http-utils/http-client-factory http-options)
+        http-client (-> http-options
+                        (utils/assoc-if-absent :user-agent-prefix "waiter-marathon")
+                        http-utils/http-client-factory)
         marathon-api (marathon/api-factory http-client http-options url)
         mesos-api (mesos/api-factory http-client http-options mesos-slave-port slave-directory)
         service-id->failed-instances-transient-store (atom {})

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -593,7 +593,7 @@
     (log/info "scheduler mesos-slave-port or slave-directory is missing, log directory and url support will be disabled"))
   (let [authorizer (utils/create-component authorizer)
         http-client (-> http-options
-                        (utils/assoc-if-absent :user-agent-prefix "waiter-marathon")
+                        (utils/assoc-if-absent :user-agent "waiter-marathon/1.0")
                         http-utils/http-client-factory)
         marathon-api (marathon/api-factory http-client http-options url)
         mesos-api (mesos/api-factory http-client http-options mesos-slave-port slave-directory)

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -848,7 +848,7 @@
         http-client (http-utils/http-client-factory
                       {:conn-timeout health-check-timeout-ms
                        :socket-timeout health-check-timeout-ms
-                       :user-agent "waiter-shell/1.0"})]
+                       :user-agent "waiter-shell"})]
     (when backup-file-name
       (let [backup-file-path (str work-directory (File/separator) backup-file-name)]
         ;; restore the state of the shell scheduler

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -848,7 +848,7 @@
         http-client (http-utils/http-client-factory
                       {:conn-timeout health-check-timeout-ms
                        :socket-timeout health-check-timeout-ms
-                       :user-agent-prefix "waiter-shell"})]
+                       :user-agent "waiter-shell/1.0"})]
     (when backup-file-name
       (let [backup-file-path (str work-directory (File/separator) backup-file-name)]
         ;; restore the state of the shell scheduler

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -27,11 +27,11 @@
             [plumbing.core :as pc]
             [qbits.jet.client.http :as http]
             [schema.core :as s]
-            [waiter.authorization :as authz]
             [waiter.metrics :as metrics]
             [waiter.scheduler :as scheduler]
             [waiter.util.async-utils :as au]
             [waiter.util.date-utils :as du]
+            [waiter.util.http-utils :as http-utils]
             [waiter.util.utils :as utils])
   (:import java.io.File
            java.lang.UNIXProcess
@@ -845,8 +845,10 @@
         (create-shell-scheduler (assoc config
                                   :id->service-agent id->service-agent
                                   :retrieve-syncer-state-fn retrieve-syncer-state-fn))
-        http-client (http/client {:connect-timeout health-check-timeout-ms
-                                  :idle-timeout health-check-timeout-ms})]
+        http-client (http-utils/http-client-factory
+                      {:conn-timeout health-check-timeout-ms
+                       :socket-timeout health-check-timeout-ms
+                       :user-agent-prefix "waiter-shell"})]
     (when backup-file-name
       (let [backup-file-path (str work-directory (File/separator) backup-file-name)]
         ;; restore the state of the shell scheduler

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -49,7 +49,7 @@
                                                                     (s/required-key :ttl) schema/positive-int}
                                            s/Keyword schema/require-symbol-factory-fn}
                                           schema/contains-kind-sub-map?)
-   (s/optional-key :git-version) s/Any
+   (s/required-key :git-version) s/Any
    (s/required-key :health-check-config) {(s/required-key :health-check-timeout-ms) schema/positive-int
                                           (s/required-key :failed-check-threshold) schema/positive-int}
    (s/required-key :host) schema/non-empty-string

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -159,7 +159,8 @@
 (defn make-http-client
   "Instantiates and returns a new HttpClient without a cookie store"
   []
-  (http-utils/http-client-factory {:user-agent "waiter-test/1.0"}))
+  (http-utils/http-client-factory {:clear-content-decoders false
+                                   :user-agent "waiter-test/1.0"}))
 
 (defn current-test-name
   "Get the name of the currently-running test."

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -159,7 +159,7 @@
 (defn make-http-client
   "Instantiates and returns a new HttpClient without a cookie store"
   []
-  (http-utils/http-client-factory {:user-agent-prefix "waiter-test"}))
+  (http-utils/http-client-factory {:user-agent "waiter-test/1.0"}))
 
 (defn current-test-name
   "Get the name of the currently-running test."

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -159,7 +159,7 @@
 (defn make-http-client
   "Instantiates and returns a new HttpClient without a cookie store"
   []
-  (http-utils/http-client-factory {}))
+  (http-utils/http-client-factory {:user-agent-prefix "waiter-test"}))
 
 (defn current-test-name
   "Get the name of the currently-running test."

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -30,11 +30,10 @@
             [waiter.mesos.marathon :as marathon]
             [waiter.statsd :as statsd]
             [waiter.util.date-utils :as du]
-            [waiter.util.utils :as utils]
-            [clojure.set :as set])
+            [waiter.util.http-utils :as http-utils]
+            [waiter.util.utils :as utils])
   (:import (java.net HttpCookie URI)
            (java.util.concurrent Callable Future Executors)
-           (org.eclipse.jetty.util HttpCookieStore$Empty)
            (org.joda.time Period)
            (org.joda.time.format PeriodFormatterBuilder)))
 
@@ -160,10 +159,7 @@
 (defn make-http-client
   "Instantiates and returns a new HttpClient without a cookie store"
   []
-  (let [client (http/client)]
-    (.setCookieStore client (HttpCookieStore$Empty.))
-    (.setDefaultRequestContentType client nil)
-    client))
+  (http-utils/http-client-factory {}))
 
 (defn current-test-name
   "Get the name of the currently-running test."

--- a/waiter/src/waiter/util/http_utils.clj
+++ b/waiter/src/waiter/util/http_utils.clj
@@ -60,14 +60,15 @@
 
 (defn ^HttpClient http-client-factory
   "Creates a HttpClient."
-  [{:keys [conn-timeout follow-redirects? socket-timeout user-agent]
-    :or {follow-redirects? false}}]
+  [{:keys [clear-content-decoders conn-timeout follow-redirects? socket-timeout user-agent]
+    :or {clear-content-decoders true}}]
   (let [^HttpClient client
         (http/client (cond-> {}
                        (some? conn-timeout) (assoc :connect-timeout conn-timeout)
                        (some? follow-redirects?) (assoc :follow-redirects? follow-redirects?)
                        (some? socket-timeout) (assoc :idle-timeout socket-timeout)))]
-    (.clear (.getContentDecoderFactories client))
+    (when clear-content-decoders
+      (.clear (.getContentDecoderFactories client)))
     (.setCookieStore client (HttpCookieStore$Empty.))
     (.setDefaultRequestContentType client nil)
     (when user-agent

--- a/waiter/src/waiter/util/http_utils.clj
+++ b/waiter/src/waiter/util/http_utils.clj
@@ -60,8 +60,9 @@
 
 (defn ^HttpClient http-client-factory
   "Creates a HttpClient."
-  [{:keys [conn-timeout follow-redirects? socket-timeout]
-    :or {follow-redirects? false}}]
+  [{:keys [conn-timeout follow-redirects? socket-timeout user-agent-prefix]
+    :or {follow-redirects? false
+         user-agent-prefix "waiter"}}]
   (let [^HttpClient client
         (http/client (cond-> {}
                        (some? conn-timeout) (assoc :connect-timeout conn-timeout)
@@ -72,7 +73,7 @@
     (.setDefaultRequestContentType client nil)
     (when-let [user-agent-field (.getUserAgentField client)]
       (let [user-agent-http-header (.getHeader user-agent-field)
-            user-agent-value (str "waiter." (.getValue user-agent-field))
+            user-agent-value (str user-agent-prefix " " (.getValue user-agent-field))
             new-user-agent-field (HttpField. user-agent-http-header user-agent-value)]
         (.setUserAgentField client new-user-agent-field)))
     client))

--- a/waiter/src/waiter/util/http_utils.clj
+++ b/waiter/src/waiter/util/http_utils.clj
@@ -23,7 +23,7 @@
             [waiter.auth.spnego :as spnego])
   (:import (java.net URI)
            (org.eclipse.jetty.client HttpClient)
-           (org.eclipse.jetty.http HttpField)
+           (org.eclipse.jetty.http HttpField HttpHeader)
            (org.eclipse.jetty.util HttpCookieStore$Empty)))
 
 (defn http-request
@@ -60,9 +60,8 @@
 
 (defn ^HttpClient http-client-factory
   "Creates a HttpClient."
-  [{:keys [conn-timeout follow-redirects? socket-timeout user-agent-prefix]
-    :or {follow-redirects? false
-         user-agent-prefix "waiter"}}]
+  [{:keys [conn-timeout follow-redirects? socket-timeout user-agent]
+    :or {follow-redirects? false}}]
   (let [^HttpClient client
         (http/client (cond-> {}
                        (some? conn-timeout) (assoc :connect-timeout conn-timeout)
@@ -71,9 +70,7 @@
     (.clear (.getContentDecoderFactories client))
     (.setCookieStore client (HttpCookieStore$Empty.))
     (.setDefaultRequestContentType client nil)
-    (when-let [user-agent-field (.getUserAgentField client)]
-      (let [user-agent-http-header (.getHeader user-agent-field)
-            user-agent-value (str user-agent-prefix " " (.getValue user-agent-field))
-            new-user-agent-field (HttpField. user-agent-http-header user-agent-value)]
+    (when user-agent
+      (let [new-user-agent-field (HttpField. HttpHeader/USER_AGENT (str user-agent))]
         (.setUserAgentField client new-user-agent-field)))
     client))


### PR DESCRIPTION
## Changes proposed in this PR

- consolidates the http-client factory method
- adds support for custom user-agent field
- configures user-agent string per http client

## Why are we making these changes?

It is considered good practice to include a custom user-agent as it can help with debugging.

With the change:
```
$ curl -s -H 'User-Agent:' -H"x-waiter-token: kitchen.localtest.me" http://127.0.0.1:9091/request-info | jq .
{
  "headers": {
    "user-agent": "waiter/59a650a",
...
}

$ curl -s -H"x-waiter-token: kitchen.localtest.me" http://127.0.0.1:9091/request-info | jq .
{
  "headers": {
    "user-agent": "curl/7.49.1",
...
}
```



