### PR TITLE
Adds support for last-request-time in /apps/<service-id> endpoint

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -357,6 +357,10 @@
         (make-kitchen-request waiter-url request-headers :method :get)
         (let [service-last-request-time (service-id->last-request-time waiter-url service-id)]
           (is (pos? (.getMillis service-last-request-time)))
+          (is (t/before? canary-request-time-from-header service-last-request-time)))
+        (let [service-settings (service-settings waiter-url service-id)
+              service-last-request-time (-> service-settings :last-request-time du/str-to-date)]
+          (is (pos? (.getMillis service-last-request-time)))
           (is (t/before? canary-request-time-from-header service-last-request-time)))))))
 
 (deftest ^:parallel ^:integration-fast test-list-apps

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1142,17 +1142,18 @@
    :service-handler-fn (pc/fnk [[:curator kv-store]
                                 [:daemons router-state-maintainer]
                                 [:routines allowed-to-manage-service?-fn generate-log-url-fn make-inter-router-requests-sync-fn
-                                 service-id->service-description-fn service-id->source-tokens-entries-fn]
+                                 router-metrics-helpers service-id->service-description-fn service-id->source-tokens-entries-fn]
                                 [:scheduler scheduler]
                                 [:state router-id]
                                 wrap-secure-request-fn]
-                         (let [{{:keys [query-state-fn]} :maintainer} router-state-maintainer]
+                         (let [{{:keys [query-state-fn]} :maintainer} router-state-maintainer
+                               {:keys [service-id->metrics-fn]} router-metrics-helpers]
                            (wrap-secure-request-fn
                              (fn service-handler-fn [{:as request {:keys [service-id]} :route-params}]
                                (handler/service-handler router-id service-id scheduler kv-store allowed-to-manage-service?-fn
                                                         generate-log-url-fn make-inter-router-requests-sync-fn
                                                         service-id->service-description-fn service-id->source-tokens-entries-fn
-                                                        query-state-fn request)))))
+                                                        query-state-fn service-id->metrics-fn request)))))
    :service-id-handler-fn (pc/fnk [[:curator kv-store]
                                    [:routines store-service-description-fn]
                                    wrap-descriptor-fn wrap-secure-request-fn]


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for last-request-time in /apps/<service-id> endpoint

## Why are we making these changes?

Avoids having to go to the `/apps` endpoint for this information.

<img width="812" alt="last-request-time" src="https://user-images.githubusercontent.com/6611249/48574134-ffabe900-e8d3-11e8-9d35-fbc1c7ab098c.png">
