### PR TITLE
adds error messages for commonly used parameters

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -328,7 +328,7 @@
                      :x-waiter-env-foo "bar"
                      :x-waiter-env-fee_fie "fum"}
             {:keys [body status]} (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))
-            env-error-message (get-in (json/read-str body) ["waiter-error" "message" "env"])]
+            env-error-message (get-in (json/read-str body) ["waiter-error" "message"])]
         (is (= 400 status))
         (is (every? #(str/includes? env-error-message %)
                     ["The following environment variable keys are invalid:" "1_INVALID" "123456" "BEGIN-DATE" "END-DATE"]))

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -263,7 +263,9 @@
   [^Exception ex request]
   (let [wrapped-ex (wrap-unhandled-exception ex)
         {:keys [friendly-error-message headers message status suppress-logging] :as data} (ex-data wrapped-ex)
-        response-msg (or friendly-error-message message (.getMessage wrapped-ex))
+        response-msg (if (or message friendly-error-message)
+                       (str/trim (str message \newline friendly-error-message))
+                       (.getMessage wrapped-ex))
         processed-headers (into {} (for [[k v] headers] [(name k) (str v)]))]
     (when-not suppress-logging
       (log/error wrapped-ex))

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -1245,7 +1245,7 @@
                  :request-method :post})
               {{:strs [message]} "waiter-error"} (json/read-str body)]
           (is (= 400 status))
-          (is (str/includes? message "invalid-authentication") body)))
+          (is (str/includes? message "authentication must be one of disabled or standard") body)))
 
       (testing "post:new-service-description:missing-permitted-user-with-authentication-disabled"
         (let [kv-store (kv/->LocalKeyValueStore (atom {}))


### PR DESCRIPTION
## Changes proposed in this PR

- ensures scheduler/delete-service call from delete-service-handler executes in scheduler thread pool
- adds error messages for commonly used parameters

## Why are we making these changes?

Improved error messaging.
