### PR TITLE
adds support for custom websocket subprotocols

### DIFF
--- a/kitchen/bin/kitchen
+++ b/kitchen/bin/kitchen
@@ -250,6 +250,7 @@ class HTTPWebSocketsHandler(http.server.BaseHTTPRequestHandler, LoggerMixin):
     def _handshake(self):
         headers=self.headers
         assert headers.get("Upgrade", None) == "websocket"
+        self.logger().info('Upgrade request headers:' + str(headers))
         key = headers['Sec-WebSocket-Key']
         sha1_hash = hashlib.sha1(key.encode('ascii') + self._ws_GUID)
         digest = base64.b64encode(sha1_hash.digest()).decode('ascii')
@@ -257,6 +258,8 @@ class HTTPWebSocketsHandler(http.server.BaseHTTPRequestHandler, LoggerMixin):
         self.send_header('Upgrade', 'websocket')
         self.send_header('Connection', 'Upgrade')
         self.send_header('Sec-WebSocket-Accept', digest)
+        if headers['Sec-WebSocket-Protocol']:
+            self.send_header('Sec-WebSocket-Protocol', headers['Sec-WebSocket-Protocol'])
         self.end_headers()
         self.connected = True
         self.on_ws_connected()

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -74,7 +74,7 @@
    :scheduler core/scheduler
    :settings (pc/fnk dummy-symbol-for-fnk-schema-logic :- settings/settings-schema [] settings)
    :state core/state
-   :http-server (pc/fnk [[:routines generate-log-url-fn waiter-request?-fn websocket-request-authenticator]
+   :http-server (pc/fnk [[:routines generate-log-url-fn waiter-request?-fn websocket-request-acceptor]
                          [:settings cors-config host port support-info websocket-config]
                          [:state cors-validator router-id]
                          handlers] ; Insist that all systems are running before we start server
@@ -87,7 +87,7 @@
                                                           core/correlation-id-middleware
                                                           (core/wrap-request-info router-id support-info)
                                                           consume-request-stream)
-                                        :websocket-acceptor websocket-request-authenticator
+                                        :websocket-acceptor websocket-request-acceptor
                                         :websocket-handler (-> (core/websocket-handler-factory handlers)
                                                                rlog/wrap-log
                                                                core/correlation-id-middleware


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for custom websocket subprotocols
- updates integration tests for the subprotocol selection behavior
- uses a generic `ServletUpgradeResponse` in the unit tests

## Why are we making these changes?

We would like to support a custom subprotocol for websockets.

