### PR TITLE
uses max known last-request-time in service gc metrics

### DIFF
--- a/waiter/src/waiter/util/date_utils.clj
+++ b/waiter/src/waiter/util/date_utils.clj
@@ -75,6 +75,9 @@
 (defn max-time
   "Returns the max time of the two input time instances."
   [t1 t2]
-  (if (t/after? t1 t2)
-    t1
-    t2))
+  (cond
+    (nil? t1) t2
+    (nil? t2) t1
+    :else (if (t/after? t1 t2)
+            t1
+            t2)))


### PR DESCRIPTION
## Changes proposed in this PR

- uses max known last-request-time in service GC metrics

## Why are we making these changes?

We would like for GC state to persist across router restarts. Using the monotonically increasing last known request time allows us to persist safely state for idle services that is unaffected by routers dropping off from the cluster.

