### PR TITLE
Compile all sources with uberjar

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -136,5 +136,6 @@
                           "-XX:+PrintAdaptiveSizePolicy"
                           "-Xmx512m"
                           "-Xloggc:log/gc.log"]}
-             :override-maven {:local-repo ~(System/getenv "WAITER_MAVEN_LOCAL_REPO")}}
+             :override-maven {:local-repo ~(System/getenv "WAITER_MAVEN_LOCAL_REPO")}
+             :uberjar {:aot :all}}
   :uberjar-name ~(System/getenv "UBERJAR_NAME"))

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -436,17 +436,15 @@
     (when (and host origin scheme)
       (= origin (str (name scheme) "://" host)))))
 
-(let [ns-loader-lock (Object.)]
-  (defn resolve-symbol
-    "Resolve the given symbol to the corresponding Var."
-    [sym]
-    {:pre [(symbol? sym)]}
-    (if-let [target-ns (some-> sym namespace symbol)]
-      (locking ns-loader-lock
-        (require target-ns))
-      (log/warn "Unable to load namespace for symbol" sym))
-    (log/info "Dynamically loading Clojure var:" sym)
-    (resolve sym)))
+(defn resolve-symbol
+  "Resolve the given symbol to the corresponding Var."
+  [sym]
+  {:pre [(symbol? sym)]}
+  (if-let [target-ns (some-> sym namespace symbol)]
+    (require target-ns)
+    (log/warn "Unable to load namespace for symbol" sym))
+  (log/info "Dynamically loading Clojure var:" sym)
+  (resolve sym))
 
 (defn create-component
   "Creates a component based on the specified :kind"


### PR DESCRIPTION
## Changes proposed in this PR

- Ahead-of-time compile *all* sources when building the uberjar.
- Remove lock around dynamic `require` in `resolve-symbol` helper.

## Why are we making these changes?

The lock doesn't seem to actually do anything since `resolve-symbol` is always invoked on the main thread (confirmed via logging). Instead, we expect that run-time compiling was triggering the inconsistencies around class loaders, and AOT compiling *all* source code should solve that issue.