### PR TITLE
adds tolerance for delay in status updates for service status

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -45,9 +45,7 @@
           (is (get-in service-settings [:instances :killed-instances])))
 
         (testing "status is reported"
-          (is (= "Running" (get service-settings :status)))))
-
-
+          (is (wait-for #(= "Running" (get service-settings :status)) :interval 2 :timeout 30))))
 
       (testing "explicitly specifying default parameter resolves to different service"
         (let [{:keys [service-description-defaults]} (waiter-settings waiter-url)
@@ -377,7 +375,7 @@
         (testing "without parameters"
           (let [service (service waiter-url service-id {})] ;; see my app as myself
             (is service)
-            (is (= "Running" (get service "status")))
+            (is (contains? #{"Running" "Starting"} (get service "status")))
             (is (-> (get service "last-request-time") du/str-to-date .getMillis pos?))
             (is (pos? (get-in service ["service-description" "cpus"])) service)))
 
@@ -385,21 +383,21 @@
           (let [run-as-user-param (->> current-user reverse (drop 2) (cons "*") reverse (str/join ""))
                 service (service waiter-url service-id {"run-as-user" run-as-user-param})] ;; see my app as myself
             (is service)
-            (is (= "Running" (get service "status")))
+            (is (contains? #{"Running" "Starting"} (get service "status")))
             (is (-> (get service "last-request-time") du/str-to-date .getMillis pos?))
             (is (pos? (get-in service ["service-description" "cpus"])) service)))
 
         (testing "waiter user disabled" ;; see my app as myself
           (let [service (service waiter-url service-id {"force" "false"})]
             (is service)
-            (is (= "Running" (get service "status")))
+            (is (contains? #{"Running" "Starting"} (get service "status")))
             (is (-> (get service "last-request-time") du/str-to-date .getMillis pos?))
             (is (pos? (get-in service ["service-description" "cpus"])) service)))
 
         (testing "waiter user disabled and same user" ;; see my app as myself
           (let [service (service waiter-url service-id {"force" "false", "run-as-user" current-user})]
             (is service)
-            (is (= "Running" (get service "status")))
+            (is (contains? #{"Running" "Starting"} (get service "status")))
             (is (-> (get service "last-request-time") du/str-to-date .getMillis pos?))
             (is (pos? (get-in service ["service-description" "cpus"])) service)))
 
@@ -430,7 +428,7 @@
         (testing "list-apps-with-waiter-user-disabled-and-see-another-app" ;; can see another user's app
           (let [service (service waiter-url service-id {"force" "false", "run-as-user" current-user})]
             (is service)
-            (is (= "Running" (get service "status")))
+            (is (contains? #{"Running" "Starting"} (get service "status")))
             (is (-> (get service "last-request-time") du/str-to-date .getMillis pos?))
             (is (pos? (get-in service ["service-description" "cpus"])) service)))
         (delete-service waiter-url service-id)))))


### PR DESCRIPTION
## Changes proposed in this PR

- adds tolerance for delay in status updates for service status

## Why are we making these changes?

Make our integration tests more robust by allowing for delays in status updates for services.

