### PR TITLE
Allow user's apps to gracefully exit on SIGTERM on K8s

### DIFF
--- a/kitchen/bin/ci/run.sh
+++ b/kitchen/bin/ci/run.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-set -x
+set -ex
+
+#
+# Run Kitchen integration tests
+#
 
 source ./bin/ci/ssl-env.sh
 
@@ -8,3 +12,9 @@ python --version
 pytest --version
 
 pytest
+
+#
+# Run waiter-init script tests
+#
+
+./bin/test-waiter-init

--- a/kitchen/bin/test-waiter-init
+++ b/kitchen/bin/test-waiter-init
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+: ${TARGET:=./bin/waiter-init}
+failures=0
+
+start_test() {
+    test_desc="$1"
+    cmd="$(cat)"
+    printf '\nTest %s' "$test_desc"
+    "$TARGET" "$cmd" &>/dev/null &
+    test_pid=$!
+}
+
+wait_for_script_exit() {
+    wait $test_pid
+    exit_code=$?
+}
+
+send_sigterm() {
+    sleep 0.1
+    kill $test_pid
+}
+
+start_timing() {
+    started_at=$(date +%s)
+}
+
+end_timing() {
+    ended_at=$(date +%s)
+    elapsed_seconds=$(( $ended_at - $started_at ))
+}
+
+test_still_running() {
+    if kill -0 $test_pid &>/dev/null; then
+        still_running=true
+    else
+        still_running=false
+    fi
+}
+
+assert() {
+    if ! test "$@"; then
+        printf "\nFailed condition: %s\n" "$*"
+        exit 1
+    fi
+    echo -n .
+}
+
+#
+# Ensure the script exits cleanly on normal exit.
+# The script should not block awaiting a sigterm
+# if the user's process exited normally.
+# The script should also propagate the user process's
+# exit code as the script exit code in this case.
+#
+start_test 'normal exit' <<EOF
+sh -c 'echo OK && exit 123'
+EOF
+wait_for_script_exit
+assert $exit_code -eq 123
+assert "$(cat stdout)" == OK
+
+#
+# Ensure sigterm is propagated to child process.
+# The script should return 128+15=143,
+# which indicates the script exited due to a sigterm.
+#
+start_test 'immediate graceful termination' <<EOF
+sh -c 'trap "echo Terminated; exit 1" TERM; sleep 10'
+EOF
+send_sigterm
+send_sigterm
+wait_for_script_exit
+assert $exit_code -eq 143
+assert "$(cat stdout)" == Terminated
+
+#
+# Ensure script waits for the user's process
+# to terminate gracefully before exiting.
+#
+start_test 'slow graceful termination' <<EOF
+sh -c 'trap "echo -n Delay; sleep 2; echo X; exit 1" TERM; sleep 10'
+EOF
+start_timing
+send_sigterm
+send_sigterm
+test_still_running
+assert $still_running == true
+assert "$(cat stdout)" == Delay
+wait_for_script_exit
+end_timing
+assert $exit_code -eq 143
+assert "$(cat stdout)" == DelayX
+assert $elapsed_seconds -ge 2
+assert $elapsed_seconds -le 3
+
+#
+# Ensure script waits for both sigterm signals.
+# If the user's process terminates gracefully
+# before the second sigterm arrives,
+# the script needs to continue waiting,
+# but the script should then immediately terminate
+# after receiving the second sigterm.
+#
+start_test 'waits for second sigterm' <<EOF
+sh -c 'trap "echo Terminated; exit 1" TERM; sleep 10'
+EOF
+send_sigterm
+sleep 1
+assert "$(cat stdout)" == Terminated
+test_still_running
+assert $still_running == true
+start_timing
+send_sigterm
+wait_for_script_exit
+end_timing
+assert $exit_code -eq 143
+assert $elapsed_seconds -le 1
+
+printf '\n\nAll tests passed\n'

--- a/kitchen/bin/test-waiter-init
+++ b/kitchen/bin/test-waiter-init
@@ -11,11 +11,6 @@ start_test() {
     test_pid=$!
 }
 
-wait_for_script_exit() {
-    wait $test_pid
-    exit_code=$?
-}
-
 send_sigterm() {
     sleep 0.1
     kill $test_pid
@@ -30,20 +25,24 @@ end_timing() {
     elapsed_seconds=$(( $ended_at - $started_at ))
 }
 
-test_still_running() {
-    if kill -0 $test_pid &>/dev/null; then
-        still_running=true
-    else
-        still_running=false
-    fi
+failure() {
+    printf "\nFailed condition: %s\n" "$1"
+    exit 1
 }
 
 assert() {
-    if ! test "$@"; then
-        printf "\nFailed condition: %s\n" "$*"
-        exit 1
-    fi
+    test "$@" || failure "$*"
     echo -n .
+}
+
+assert_still_running() {
+    kill -0 $test_pid &>/dev/null
+    assert "RUNNING=$?" == "RUNNING=0"
+}
+
+await_exit_and_assert_code() {
+    wait $test_pid
+    assert "EXIT=$?" == "EXIT=$1"
 }
 
 #
@@ -56,8 +55,7 @@ assert() {
 start_test 'normal exit' <<EOF
 sh -c 'echo OK && exit 123'
 EOF
-wait_for_script_exit
-assert $exit_code -eq 123
+await_exit_and_assert_code 123
 assert "$(cat stdout)" == OK
 
 #
@@ -70,8 +68,7 @@ sh -c 'trap "echo Terminated; exit 1" TERM; sleep 10'
 EOF
 send_sigterm
 send_sigterm
-wait_for_script_exit
-assert $exit_code -eq 143
+await_exit_and_assert_code 143
 assert "$(cat stdout)" == Terminated
 
 #
@@ -84,12 +81,10 @@ EOF
 start_timing
 send_sigterm
 send_sigterm
-test_still_running
-assert $still_running == true
+assert_still_running
 assert "$(cat stdout)" == Delay
-wait_for_script_exit
+await_exit_and_assert_code 143
 end_timing
-assert $exit_code -eq 143
 assert "$(cat stdout)" == DelayX
 assert $elapsed_seconds -ge 2
 assert $elapsed_seconds -le 3
@@ -108,13 +103,11 @@ EOF
 send_sigterm
 sleep 1
 assert "$(cat stdout)" == Terminated
-test_still_running
-assert $still_running == true
+assert_still_running
 start_timing
 send_sigterm
-wait_for_script_exit
+await_exit_and_assert_code 143
 end_timing
-assert $exit_code -eq 143
 assert $elapsed_seconds -le 1
 
 printf '\n\nAll tests passed\n'

--- a/kitchen/bin/waiter-init
+++ b/kitchen/bin/waiter-init
@@ -2,9 +2,11 @@
 #
 # A wrapper script for the Waiter-specific setup for a user command in a Waiter-K8s pod.
 # The script is usually invoked by prepending it to the user's Waiter command.
+# If this script is invoked by dumb-init (github.com/Yelp/dumb-init) or a similar utility,
+# please ensure that it is run in single-child mode.
 #
-# A single argument is expected, the user's command string,
-# which is executed as its own bash shell process.
+# A single argument is expected: the user's command string,
+# which is executed in its own bash shell process.
 
 # This variable will be used to store the user's app's process ID.
 # We set it to null here just in case it was set in the external environment.

--- a/kitchen/bin/waiter-init
+++ b/kitchen/bin/waiter-init
@@ -6,24 +6,56 @@
 # A single argument is expected, the user's command string,
 # which is executed as its own bash shell process.
 
-# Ignore SIGTERM sent by Kubernetes on pod deletion,
-# waiting for SIGKILL (force delete) before exiting.
-trap : SIGTERM
+# This variable will be used to store the user's app's process ID.
+# We set it to null here just in case it was set in the external environment.
+waiter_child_pid=
 
-# Run the user's Waiter app command,
-# copying stdout and stderr to respectively named files.
+# Catch the first SIGTERM sent by Kubernetes on pod deletion,
+# waiting for a second signal (SIGTERM or SIGKILL) before exiting.
+# This double-termination is an important part of our Waiter scale-down logic,
+# and the mechanics are described in more detail below.
+handle_k8s_terminate() {
+    trap : SIGTERM  # reset SIGTERM handler to no-op
+
+    # Propagate the SIGTERM to the user's app's process group,
+    # giving it the opportunity to shut down gracefully.
+    if [ "$waiter_child_pid" ]; then
+        kill -- -$waiter_child_pid
+    else
+        echo 'waiter error: user process not initialized' >&2
+    fi
+
+    # Wait for a long time (15 minutes), awaiting another signal from Kubernetes.
+    # This delay gives Waiter time to safely update the desired replica count
+    # before the pod actually terminates, avoiding a race to replace this pod.
+    # If we receive a second SIGTERM from Kubernetes, then the sleep period is canceled,
+    # and we simply wait for the user's process to complete (or get SIGKILLed).
+    # The main point here is to NOT exit before the second SIGTERM is received.
+    # If for some reason the second SIGTERM never arrives, the sleep will eventually expire,
+    # or the pod's grace period will expire (resulting in a SIGKILL from Kubernetes).
+    # Likewise, if the user's process takes too long to terminate gracefully,
+    # the pod's grace period will expire (resulting in a SIGKILL from Kubernetes).
+    sleep 900 &
+    wait     # wait for sleep to complete, or a second SIGTERM
+    kill %2  # cancel sleep
+    wait     # wait for graceful termination of user's process
+
+    # Exit container with code 128+15=143, indicating termination via SIGTERM.
+    exit 143
+}
+trap handle_k8s_terminate SIGTERM
+
+# Copy stdout and stderr to respectively named files to mimic Mesos containers.
 # We tee the output so that stdout and stderr are still accessible
 # via the Kubernetes `kubectl logs <pod-name>` command.
-/bin/bash -c "$1" 1> >(tee stdout) 2> >(tee stderr 1>&2)
-exit_code=$?
+exec 2> >(tee stderr 1>&2)
+exec 1> >(tee stdout)
 
-# If the sub-command exited 143 (usually indicated it was killed via SIGTERM),
-# then sleep for a long time (15 minutes) awaiting a SIGKILL from Kubernetes.
-# This delay gives Waiter time to safely update the desired replica count
-# before the pod actually terminates, avoiding a race to replace this pod.
-if [ $exit_code -eq 143 ]; then
-    sleep 900
-fi
+# Run the user's Waiter app command in its own process group.
+/usr/bin/setsid /bin/bash -c "$1" &
+waiter_child_pid=$!
 
-# Propagate the user's command's exit code
-exit $exit_code
+# Wait for the user's process to exit, propagating the exit code.
+# If this wait call is interrupted by a SIGTERM,
+# then the control flow switches to the handle_k8s_terminate routine.
+wait %1


### PR DESCRIPTION
## Changes proposed in this PR

* Modify `waiter-init` script, allowing user's apps to gracefully exit when K8s deletes a pod.
* Add some tests for the `waiter-init` script (written in bash).
* Change default behavior of second "hard" delete to give a 20 second grace period.

## Why are we making these changes?

Trying to be nicer and give the users some time to shut down their apps gracefully, instead of instantly `SIGKILL`-ing the whole pod once the ReplicaSet patch is complete.