### PR TITLE
Create a fresh working dir for each k8s waiter-app container run

### DIFF
--- a/kitchen/bin/test-waiter-init
+++ b/kitchen/bin/test-waiter-init
@@ -9,6 +9,8 @@ start_test() {
     printf '\nTest %s' "$test_desc"
     "$TARGET" "$cmd" &>/dev/null &
     test_pid=$!
+    sleep 0.1
+    working_dir=r$(( $(cat .waiter-container-runs) - 1 ))
 }
 
 send_sigterm() {
@@ -25,8 +27,12 @@ end_timing() {
     elapsed_seconds=$(( $ended_at - $started_at ))
 }
 
+dump_stdout() {
+    cat ./$working_dir/stdout
+}
+
 failure() {
-    printf "\nFailed condition: %s\n" "$1"
+    printf "\nFailed assertion: %s\n" "$1"
     exit 1
 }
 
@@ -45,6 +51,9 @@ await_exit_and_assert_code() {
     assert "EXIT=$?" == "EXIT=$1"
 }
 
+# Clean up any old copy of the restart state file
+rm -f .waiter-container-runs
+
 #
 # Ensure the script exits cleanly on normal exit.
 # The script should not block awaiting a sigterm
@@ -56,7 +65,7 @@ start_test 'normal exit' <<EOF
 sh -c 'echo OK && exit 123'
 EOF
 await_exit_and_assert_code 123
-assert "$(cat stdout)" == OK
+assert "$(dump_stdout)" == OK
 
 #
 # Ensure sigterm is propagated to child process.
@@ -69,7 +78,7 @@ EOF
 send_sigterm
 send_sigterm
 await_exit_and_assert_code 143
-assert "$(cat stdout)" == Terminated
+assert "$(dump_stdout)" == Terminated
 
 #
 # Ensure script waits for the user's process
@@ -82,10 +91,10 @@ start_timing
 send_sigterm
 send_sigterm
 assert_still_running
-assert "$(cat stdout)" == Delay
+assert "$(dump_stdout)" == Delay
 await_exit_and_assert_code 143
 end_timing
-assert "$(cat stdout)" == DelayX
+assert "$(dump_stdout)" == DelayX
 assert $elapsed_seconds -ge 2
 assert $elapsed_seconds -le 3
 
@@ -102,12 +111,26 @@ sh -c 'trap "echo Terminated; exit 1" TERM; sleep 10'
 EOF
 send_sigterm
 sleep 1
-assert "$(cat stdout)" == Terminated
+assert "$(dump_stdout)" == Terminated
 assert_still_running
 start_timing
 send_sigterm
 await_exit_and_assert_code 143
 end_timing
 assert $elapsed_seconds -le 1
+
+#
+# Ensure that a fresh working directory is created for each run,
+# and that it is exported as $HOME to the user's process.
+#
+old_working_dir=$working_dir
+fresh_file_name=$(date +%N).txt
+start_test 'fresh $HOME for each container restart' <<EOF
+echo hello > \$HOME/$fresh_file_name
+EOF
+await_exit_and_assert_code 0
+assert $working_dir != $old_working_dir
+assert -f $working_dir/$fresh_file_name
+assert $(cat $working_dir/$fresh_file_name) == hello
 
 printf '\n\nAll tests passed\n'

--- a/kitchen/bin/test-waiter-init
+++ b/kitchen/bin/test-waiter-init
@@ -54,6 +54,9 @@ await_exit_and_assert_code() {
 # Clean up any old copy of the restart state file
 rm -f .waiter-container-runs
 
+# Set up the expected container $HOME value
+export HOME=$PWD/latest
+
 #
 # Ensure the script exits cleanly on normal exit.
 # The script should not block awaiting a sigterm

--- a/kitchen/bin/waiter-init
+++ b/kitchen/bin/waiter-init
@@ -47,6 +47,15 @@ handle_k8s_terminate() {
 }
 trap handle_k8s_terminate SIGTERM
 
+# Track container restart count
+waiter_restart_count=$(( $([ -f .waiter-container-runs ] && cat .waiter-container-runs) ))
+echo $(( $waiter_restart_count + 1 )) > .waiter-container-runs
+
+# Ensure that HOME is set to the fresh working directory for this container instance.
+export HOME="$PWD/r${waiter_restart_count}"
+mkdir -p "$HOME"
+cd "$HOME"
+
 # Copy stdout and stderr to respectively named files to mimic Mesos containers.
 # We tee the output so that stdout and stderr are still accessible
 # via the Kubernetes `kubectl logs <pod-name>` command.

--- a/kitchen/bin/waiter-init
+++ b/kitchen/bin/waiter-init
@@ -52,8 +52,10 @@ waiter_restart_count=$(( $([ -f .waiter-container-runs ] && cat .waiter-containe
 echo $(( $waiter_restart_count + 1 )) > .waiter-container-runs
 
 # Ensure that HOME is set to the fresh working directory for this container instance.
-export HOME="$PWD/r${waiter_restart_count}"
-mkdir -p "$HOME"
+# HOME should be a symlink ./latest, which points to the new working directory.
+waiter_sandbox_dir="./r${waiter_restart_count}"
+mkdir -p "$waiter_sandbox_dir"
+ln -Tsf $waiter_sandbox_dir latest
 cd "$HOME"
 
 # Copy stdout and stderr to respectively named files to mimic Mesos containers.

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -599,7 +599,8 @@
            health-check-max-consecutive-failures mem min-instances ports
            run-as-user] :as service-description}
    {:keys [default-container-image] :as context}]
-  (let [home-path (str "/home/" run-as-user)
+  (let [work-path (str "/home/" run-as-user)
+        home-path (str work-path "/latest")
         base-env (scheduler/environment service-id service-description
                                         service-id->password-fn home-path)
         ;; Make $PORT0 value pseudo-random to ensure clients can't hardcode it.
@@ -658,9 +659,9 @@
                                                                    :memory memory}
                                                           :requests {:cpu cpus
                                                                      :memory memory}}
-                                              :volumeMounts [{:mountPath home-path
+                                              :volumeMounts [{:mountPath work-path
                                                               :name "user-home"}]
-                                              :workingDir home-path}]
+                                              :workingDir work-path}]
                                 :volumes [{:name "user-home"
                                            :emptyDir {}}]
                                 :terminationGracePeriodSeconds pod-sigkill-delay-secs}}}}
@@ -682,7 +683,7 @@
                        :requests {:cpu cpu :memory memory}}
            :volumeMounts [{:mountPath "/srv/www"
                            :name "user-home"}]
-           :workingDir home-path})))))
+           :workingDir work-path})))))
 
 (defn start-auth-renewer
   "Initialize the k8s-api-auth-str atom,

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -388,7 +388,7 @@
                        {:healthy? true
                         :host "10.141.141.11"
                         :id "test-app-1234.test-app-1234-abcd1-0"
-                        :log-directory "/home/myself"
+                        :log-directory "/home/myself/r0"
                         :port 8080
                         :protocol "https"
                         :service-id "test-app-1234"
@@ -397,7 +397,7 @@
                        {:healthy? true
                         :host "10.141.141.12"
                         :id "test-app-1234.test-app-1234-abcd2-0"
-                        :log-directory "/home/myself"
+                        :log-directory "/home/myself/r0"
                         :port 8080
                         :protocol "https"
                         :service-id "test-app-1234"
@@ -411,7 +411,7 @@
                        {:healthy? true
                         :host "10.141.141.13"
                         :id "test-app-6789.test-app-6789-abcd1-0"
-                        :log-directory "/home/myself"
+                        :log-directory "/home/myself/r0"
                         :port 8080
                         :protocol "http"
                         :service-id "test-app-6789"
@@ -420,7 +420,7 @@
                        {:healthy? false
                         :host "10.141.141.14"
                         :id "test-app-6789.test-app-6789-abcd2-1"
-                        :log-directory "/home/myself"
+                        :log-directory "/home/myself/r1"
                         :port 8080
                         :protocol "http"
                         :service-id "test-app-6789"
@@ -429,7 +429,7 @@
                        {:healthy? false
                         :host "10.141.141.15"
                         :id "test-app-6789.test-app-6789-abcd3-0"
-                        :log-directory "/home/myself"
+                        :log-directory "/home/myself/r0"
                         :port 8080
                         :protocol "http"
                         :service-id "test-app-6789"
@@ -440,7 +440,7 @@
                         :healthy? false
                         :host "10.141.141.14"
                         :id "test-app-6789.test-app-6789-abcd2-0"
-                        :log-directory "/home/myself"
+                        :log-directory "/home/myself/r0"
                         :port 8080
                         :protocol "http"
                         :service-id "test-app-6789"
@@ -461,7 +461,7 @@
                     :healthy? true
                     :host "10.141.141.10"
                     :id instance-id
-                    :log-directory "/home/myself"
+                    :log-directory "/home/myself/r0"
                     :k8s/namespace "myself"
                     :port 8080
                     :protocol "https"
@@ -665,13 +665,14 @@
 
 (deftest test-retrieve-directory-content
   (let [service-id "test-service-id"
-        instance-id "test-service-instance-id"
+        instance-id "test-service-instance-id-0"
+        instance-base-dir "/r0"
         host "host.local"
         path "/some/path/"
         dummy-scheduler (make-dummy-scheduler [service-id])
         port (get-in dummy-scheduler [:fileserver :port])
         make-file (fn [file-name size]
-                    {:url (str "http://" host ":" port path file-name)
+                    {:url (str "http://" host ":" port instance-base-dir path file-name)
                      :name file-name
                      :size 1
                      :type "file"})


### PR DESCRIPTION
## Changes proposed in this PR

- Create a fresh working directory for each run of a K8s pod's `waiter-app` container.
- Update the `log-directory` / `log-url` logic accordingly.

## Why are we making these changes?

This allows us to keep track of our Waiter service instance logs across container restarts within a given Waiter-manged K8s pod.