### PR TITLE
Make K8s pod termination grace period configurable

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -375,6 +375,11 @@
                                  ;; e.g., if pod-base-port is 31000, and the random offset was 390, then $PORT0==31390 and $PORT9==31399:
                                  :pod-base-port 31000
 
+                                 ;; The number of seconds between the SIGTERM and SIGKILL signals sent to a pod on shutdown.
+                                 ;; This value should be placed in the terminationGracePeriodSeconds field in the pod template.
+                                 ;; Should be set between 0 and 300 seconds, inclusive.
+                                 :pod-sigkill-delay-secs 3
+
                                  ;; The number of characters (not including the preceding dash) in the unique suffix appended to each generated Pod name in a ReplicaSet.
                                  ;; Unless you've custom-patched your Kubernetes code, then this is probably hard-coded to 5 in the controller code.
                                  ;; https://github.com/kubernetes/kubernetes/blob/207e9d1/staging/src/k8s.io/apiserver/pkg/storage/names/generate.go#L45

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -309,6 +309,9 @@
                                    :max-patch-retries 5
                                    :max-name-length 63
                                    :pod-base-port 31000
+                                   ; Marathon also defaults this value to 3 seconds:
+                                   ; https://mesosphere.github.io/marathon/docs/health-checks.html#taskkillgraceperiodseconds
+                                   :pod-sigkill-delay-secs 3
                                    :pod-suffix-length 5
                                    :replicaset-api-version "extensions/v1beta1"
                                    :replicaset-spec-builder {:factory-fn 'waiter.scheduler.kubernetes/default-replicaset-builder

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -54,6 +54,7 @@
       :max-patch-retries 5
       :max-name-length 63
       :pod-base-port 8080
+      :pod-sigkill-delay-secs 3
       :pod-suffix-length default-pod-suffix-length
       :replicaset-api-version "extensions/v1beta1"
       :replicaset-spec-builder-fn #(waiter.scheduler.kubernetes/default-replicaset-builder
@@ -727,6 +728,7 @@
                     :max-patch-retries 5
                     :max-name-length 63
                     :pod-base-port 8080
+                    :pod-sigkill-delay-secs 3
                     :pod-suffix-length default-pod-suffix-length
                     :replicaset-api-version "extensions/v1beta1"
                     :replicaset-spec-builder {:factory-fn 'waiter.scheduler.kubernetes/default-replicaset-builder
@@ -757,7 +759,13 @@
           (testing "bad base port number"
             (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-base-port -1))))
             (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-base-port "8080"))))
-            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-base-port 1234567890))))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-base-port 1234567890)))))
+
+          (testing "bad pod termination grace period"
+            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-sigkill-delay-secs -1))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-sigkill-delay-secs "10"))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-sigkill-delay-secs 1200))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-sigkill-delay-secs 1234567890))))))
 
         (testing "should work with valid configuration"
           (is (instance? KubernetesScheduler (kubernetes-scheduler base-config))))


### PR DESCRIPTION
## Changes proposed in this PR

- Switch the `terminationGracePeriodSeconds` setting in our K8s pod templates from hard-coded to configurable.
- Switch the default from 20 seconds to 3 seconds.

## Why are we making these changes?

Configurable is better for us than hard-coded if we need to adjust this. We shortened the delay to match [Marathon's 3-second default ](https://mesosphere.github.io/marathon/docs/health-checks.html#taskkillgraceperiodseconds). I've also been seeing some integration tests flake, and I'm guessing it's because the 20 second grace period was causing problems.