### PR TITLE
adds support for synchronous state query to service-gc-go-routine

### DIFF
--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -587,8 +587,10 @@
           scheme (some-> request utils/request->scheme name)
           make-url (fn make-url [path]
                      (str (when scheme (str scheme "://")) host "/state/" path))]
-      (-> {:details (->> ["autoscaler" "autoscaling-multiplexer" "fallback" "interstitial" "kv-store"
-                          "launch-metrics" "leader" "local-usage" "maintainer" "router-metrics" "scheduler" "statsd"]
+      (-> {:details (->> ["autoscaler" "autoscaling-multiplexer" "fallback"
+                          "gc-broken-services" "gc-services" "gc-transient-metrics"
+                          "interstitial" "kv-store" "launch-metrics" "leader" "local-usage" "maintainer"
+                          "router-metrics" "scheduler" "statsd"]
                          (pc/map-from-keys make-url))
            :router-id router-id
            :routers routers}
@@ -634,8 +636,8 @@
     (catch Exception ex
       (utils/exception->response ex request))))
 
-(defn get-autoscaler-state
-  "Outputs the autoscaler state."
+(defn get-query-fn-state
+  "Outputs the state retrieved by invoking the query-state-fn."
   [router-id query-state-fn request]
   (get-function-state query-state-fn router-id request))
 

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -796,9 +796,9 @@
               (str "Body did not include necessary JSON keys:\n" body))
           (is (= 200 status)))))))
 
-(deftest test-get-autoscaler-state
+(deftest test-get-query-fn-state
   (let [router-id "test-router-id"
-        test-fn (wrap-handler-json-response get-autoscaler-state)]
+        test-fn (wrap-handler-json-response get-query-fn-state)]
     (testing "successful response"
       (let [state {"autoscaler" "state"}
             query-state-fn (constantly state)


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for synchronous state query to `service-gc-go-routine`

## Why are we making these changes?

This is part of our general refactor to move away from asynchronous queries on channels to report internal state.

