### PR TITLE
reduces error logs for client error scenarios

### DIFF
--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -64,7 +64,7 @@
   (let [{:keys [host location port request-id router-id service-id]} route-params]
     (when-not (and host location port request-id router-id service-id)
       (throw (ex-info "Missing host, location, port, request-id, router-id or service-id in uri"
-                      {:route-params route-params, :uri uri, :status 400})))
+                      {:logging :info :route-params route-params :status 400 :uri uri})))
     (counters/inc! (metrics/service-counter service-id "request-counts" counter-name))
     (let [{:strs [backend-proto metric-group]} (service-id->service-description-fn service-id)
           instance (scheduler/make-ServiceInstance {:host host :port port :protocol backend-proto :service-id service-id})
@@ -77,9 +77,9 @@
   (try
     (let [{:keys [request-id service-id]} route-params]
       (when (str/blank? service-id)
-        (throw (ex-info "No service-id specified" {:src-router-id src-router-id, :status 400, :uri uri})))
+        (throw (ex-info "No service-id specified" {:logging :info :src-router-id src-router-id :status 400 :uri uri})))
       (when (str/blank? request-id)
-        (throw (ex-info "No request-id specified" {:src-router-id src-router-id, :status 400, :uri uri})))
+        (throw (ex-info "No request-id specified" {:logging :info :src-router-id src-router-id :status 400 :uri uri})))
       (let [succeeded (async-request-terminate-fn request-id)]
         (utils/clj->json-response {:request-id request-id, :success succeeded})))
     (catch Exception ex
@@ -148,6 +148,7 @@
                 (or (not (integer? period-in-ms)) (neg? period-in-ms)))
           (throw (ex-info "Must provide the service-id, the instance id, the reason, and a positive period"
                           {:input-data request-body-map
+                           :logging :info
                            :status 400}))
           (let [response-chan (async/promise-chan)
                 _ (service/blacklist-instance! instance-rpc-chan service-id instance-id period-in-ms response-chan)
@@ -185,7 +186,7 @@
   (async/go
     (try
       (when (str/blank? service-id)
-        (throw (ex-info "Missing service-id" {:status 400})))
+        (throw (ex-info "Missing service-id" {:logging :info :status 400})))
       (let [response-chan (async/promise-chan)
             _ (service/query-instance! instance-rpc-chan service-id response-chan)
             _ (log/info "Waiting for response from query-state channel...")
@@ -307,8 +308,9 @@
     (if-not (allowed-to-manage-service?-fn service-id auth-user)
       (throw
         (ex-info "User not allowed to delete service"
-                 {:existing-owner run-as-user
-                  :current-user auth-user
+                 {:current-user auth-user
+                  :existing-owner run-as-user
+                  :logging :info
                   :service-id service-id
                   :status 403}))
       (async/go
@@ -434,10 +436,10 @@
    scheduler-interactions-thread-pool request]
   (try
     (when (not service-id)
-      (throw (ex-info "Missing service-id" {:status 400})))
+      (throw (ex-info "Missing service-id" {:logging :info :status 400})))
     (let [core-service-description (sd/fetch-core kv-store service-id :refresh true)]
       (if (empty? core-service-description)
-        (throw (ex-info "Service not found" {:status 404 :service-id service-id}))
+        (throw (ex-info "Service not found" {:logging :info :service-id service-id :status 404}))
         (case (:request-method request)
           :delete (delete-service-handler service-id core-service-description scheduler allowed-to-manage-service?-fn
                                           scheduler-interactions-thread-pool request)
@@ -457,7 +459,7 @@
   [kv-store allowed-to-manage-service? make-inter-router-requests-fn service-id mode request]
   (try
     (when (str/blank? service-id)
-      (throw (ex-info "Missing service-id" {:status 400})))
+      (throw (ex-info "Missing service-id" {:logging :info :status 400})))
     ; throw exception if no service description for service-id exists
     (sd/fetch-core kv-store service-id :refresh true :nil-on-missing? false)
     (let [auth-user (get request :authorization/user)
@@ -477,6 +479,7 @@
                                        :success success})))
         (throw (ex-info (str auth-user " not allowed to modify " service-id)
                         {:auth-user auth-user
+                         :logging :info
                          :service-id service-id
                          :status 403}))))
     (catch Exception ex
@@ -486,7 +489,7 @@
   "Handles overrides for a service."
   [kv-store allowed-to-manage-service? make-inter-router-requests-fn service-id {:keys [request-method] :as request}]
   (when (str/blank? service-id)
-    (throw (ex-info "Missing service-id" {:status 400})))
+    (throw (ex-info "Missing service-id" {:logging :info :status 400})))
   ; throw exception if no service description for service-id exists
   (sd/fetch-core kv-store service-id :refresh true :nil-on-missing? false)
   (let [auth-user (get request :authorization/user)]
@@ -500,7 +503,7 @@
             (trigger-service-refresh make-inter-router-requests-fn service-id)
             (utils/clj->json-response {:service-id service-id, :success true}))
           (throw (ex-info (str auth-user " not allowed to override " service-id)
-                          {:auth-user auth-user, :service-id service-id, :status 403}))))
+                          {:auth-user auth-user :logging :info :service-id service-id, :status 403}))))
 
       :get
       (if (allowed-to-manage-service? service-id auth-user)
@@ -508,7 +511,7 @@
             (assoc :service-id service-id)
             utils/clj->json-response)
         (throw (ex-info (str auth-user " not allowed view override information of " service-id)
-                        {:auth-user auth-user, :service-id service-id, :status 403})))
+                        {:auth-user auth-user :logging :info :service-id service-id :status 403})))
 
       :post
       (do
@@ -520,9 +523,9 @@
             (trigger-service-refresh make-inter-router-requests-fn service-id)
             (utils/clj->json-response {:service-id service-id, :success true}))
           (throw (ex-info (str auth-user " not allowed to override " service-id)
-                          {:auth-user auth-user, :service-id service-id, :status 403}))))
+                          {:auth-user auth-user :logging :info :service-id service-id :status 403}))))
 
-      (throw (ex-info "Unsupported request method" {:request-method request-method, :status 405})))))
+      (throw (ex-info "Unsupported request method" {:logging :info :request-method request-method :status 405})))))
 
 (defn service-view-logs-handler
   "Redirects user to the log directory on the slave"
@@ -530,9 +533,9 @@
   (try
     (let [{:strs [instance-id host directory]} (-> request ru/query-params-request :query-params)
           _ (when-not instance-id
-              (throw (ex-info "Missing instance-id parameter" {:status 400})))
+              (throw (ex-info "Missing instance-id parameter" {:logging :info :status 400})))
           _ (when-not host
-              (throw (ex-info "Missing host parameter" {:status 400})))
+              (throw (ex-info "Missing host parameter" {:logging :info :status 400})))
           directory-content (map (fn [{:keys [path type] :as entry}]
                                    (if (= type "file")
                                      entry
@@ -556,7 +559,7 @@
         (log/info "received work-stealing offer" (:id instance) "of" service-id "from" router-id)
         (if-not (and cid instance request-id router-id service-id)
           (throw (ex-info "Missing one of cid, instance, request-id, router-id or service-id"
-                          (assoc request-body-map :status 400)))
+                          (assoc request-body-map :logging :info :status 400)))
           (let [response-chan (async/promise-chan)
                 offer-params {:cid cid
                               :instance (scheduler/make-ServiceInstance instance)
@@ -678,7 +681,7 @@
   (async/go
     (try
       (if (str/blank? service-id)
-        (throw (ex-info "Missing service-id" {:status 400}))
+        (throw (ex-info "Missing service-id" {:logging :info :status 400}))
         (let [timeout-ms (-> 10 t/seconds t/in-millis)
               _ (log/info "waiting for response from query-state channel...")
               responder-state-chan
@@ -729,36 +732,30 @@
    consent-cookie-value add-encoded-cookie consent-expiry-days {:keys [request-method] :as request}]
   (try
     (when-not (= :post request-method)
-      (throw (ex-info "Only POST supported" {:request-method request-method, :status 405})))
+      (throw (ex-info "Only POST supported" {:logging :info :request-method request-method :status 405})))
     (let [{:keys [headers params] :as request} (multipart-params/multipart-params-request request)
           {:strs [host origin referer x-requested-with]} headers
           {:strs [mode service-id] :as params} params]
       (when-not (str/blank? origin)
         (when-not (utils/same-origin request)
           (throw (ex-info "Origin is not the same as the host"
-                          {:host host
-                           :origin origin
-                           :status 400}))))
+                          {:host host :logging :info :origin origin :status 400}))))
       (when (and (not (str/blank? origin)) (not (str/blank? referer)))
         (when-not (str/starts-with? referer origin)
           (throw (ex-info "Referer does not start with origin"
-                          {:origin origin
-                           :referer referer
-                           :status 400}))))
+                          {:origin origin :logging :info :referer referer :status 400}))))
       (when-not (= x-requested-with "XMLHttpRequest")
         (throw (ex-info "Header x-requested-with does not match expected value"
-                        {:actual x-requested-with
-                         :expected "XMLHttpRequest"
-                         :status 400})))
+                        {:actual x-requested-with :expected "XMLHttpRequest" :logging :info :status 400})))
       (when-not (and mode (contains? #{"service" "token"} mode))
-        (throw (ex-info "Missing or invalid mode" (assoc params :status 400))))
+        (throw (ex-info "Missing or invalid mode" (assoc params :logging :info :status 400))))
       (when (= "service" mode)
         (when-not service-id
-          (throw (ex-info "Missing service-id" (assoc params :status 400)))))
+          (throw (ex-info "Missing service-id" (assoc params :logging :info :status 400)))))
       (let [token (utils/authority->host host)
             service-description-template (token->service-description-template token)]
         (when-not (seq service-description-template)
-          (throw (ex-info "Unable to load description for token" {:token token :status 400})))
+          (throw (ex-info "Unable to load description for token" {:logging :info :status 400 :token token})))
         (when (= "service" mode)
           (let [auth-user (:authorization/user request)
                 computed-service-id (-> service-description-template
@@ -766,7 +763,7 @@
                                         service-description->service-id)]
             (when-not (= service-id computed-service-id)
               (log/error "computed" computed-service-id ", but user[" auth-user "] provided" service-id "for" token)
-              (throw (ex-info "Invalid service-id for specified token" (assoc params :status 400))))))
+              (throw (ex-info "Invalid service-id for specified token" (assoc params :logging :info :status 400))))))
         (let [token-metadata (token->token-metadata token)
               cookie-name "x-waiter-consent"
               cookie-value (consent-cookie-value mode service-id token token-metadata)]
@@ -795,13 +792,13 @@
    {:keys [headers query-string request-method request-time route-params] :as request}]
   (try
     (when-not (= :get request-method)
-      (throw (ex-info "Only GET supported" {:request-method request-method, :status 405})))
+      (throw (ex-info "Only GET supported" {:logging :info :request-method request-method :status 405})))
     (let [host-header (get headers "host")
           token (utils/authority->host host-header)
           {:keys [path]} route-params
           {:strs [interstitial-secs] :as service-description-template} (token->service-description-template token)]
       (when-not (seq service-description-template)
-        (throw (ex-info "Unable to load description for token" {:token token :status 404})))
+        (throw (ex-info "Unable to load description for token" {:logging :info :status 404 :token token})))
       (let [auth-user (:authorization/user request)
             service-id (-> service-description-template
                            (sd/assoc-run-as-requester-fields auth-user)
@@ -860,11 +857,11 @@
                       "text/html" (render-welcome-html welcome-info)
                       "text/plain" (render-welcome-text welcome-info))
               :headers {"content-type" content-type}}
-        (throw (ex-info "Only GET supported" {:status 405})))
+        (throw (ex-info "Only GET supported" {:logging :info :status 405})))
       (catch Exception ex
         (utils/exception->response ex request)))))
 
 (defn not-found-handler
   "Responds with a handler indicating a resource isn't found."
   [request]
-  (utils/exception->response (ex-info (utils/message :not-found) {:status 404}) request))
+  (utils/exception->response (ex-info (utils/message :not-found) {:logging :info :status 404}) request))

--- a/waiter/src/waiter/scheduler/composite.clj
+++ b/waiter/src/waiter/scheduler/composite.clj
@@ -113,7 +113,7 @@
       scheduler
       (throw (ex-info "No matching scheduler found!"
                       {:available-schedulers (-> scheduler-id->scheduler keys sort)
-                       :logging :info
+                       :log-level :info
                        :service-id service-id
                        :specified-scheduler scheduler-id})))))
 

--- a/waiter/src/waiter/scheduler/composite.clj
+++ b/waiter/src/waiter/scheduler/composite.clj
@@ -113,6 +113,7 @@
       scheduler
       (throw (ex-info "No matching scheduler found!"
                       {:available-schedulers (-> scheduler-id->scheduler keys sort)
+                       :logging :info
                        :service-id service-id
                        :specified-scheduler scheduler-id})))))
 

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -400,7 +400,7 @@
                               {:strs [min-instances run-as-user]} service-description]
                           (when-not (contains? allowed-users run-as-user)
                             (throw (ex-info "User not allowed to launch service via cook scheduler"
-                                            {:service-id service-id :user run-as-user})))
+                                            {:logging :info :service-id service-id :user run-as-user})))
                           (launch-jobs cook-api service-id service-description service-id->password-fn
                                        home-path-prefix min-instances allowed-priorities #{} backend-port)
                           true)
@@ -466,13 +466,13 @@
        :success false}))
 
   (retrieve-directory-content [_ service-id instance-id host directory]
-    (when (str/blank? service-id) (throw (ex-info (str "Service id is missing!") {})))
-    (when (str/blank? instance-id) (throw (ex-info (str "Instance id is missing!") {})))
-    (when (str/blank? host) (throw (ex-info (str "Host is missing!") {})))
+    (when (str/blank? service-id) (throw (ex-info (str "Service id is missing!") {:logging :info})))
+    (when (str/blank? instance-id) (throw (ex-info (str "Instance id is missing!") {:logging :info})))
+    (when (str/blank? host) (throw (ex-info (str "Host is missing!") {:logging :info})))
     (let [task-id-start-index (str/last-index-of instance-id "_")
           task-id (->> task-id-start-index inc (subs instance-id))
           log-directory (or directory (mesos/retrieve-log-url cook-api task-id host "cook"))]
-      (when (str/blank? log-directory) (throw (ex-info "No directory found for instance!" {})))
+      (when (str/blank? log-directory) (throw (ex-info "No directory found for instance!" {:logging :info})))
       (mesos/retrieve-directory-content-from-host cook-api host log-directory)))
 
   (service-id->state [_ service-id]

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -400,7 +400,7 @@
                               {:strs [min-instances run-as-user]} service-description]
                           (when-not (contains? allowed-users run-as-user)
                             (throw (ex-info "User not allowed to launch service via cook scheduler"
-                                            {:logging :info :service-id service-id :user run-as-user})))
+                                            {:log-level :info :service-id service-id :user run-as-user})))
                           (launch-jobs cook-api service-id service-description service-id->password-fn
                                        home-path-prefix min-instances allowed-priorities #{} backend-port)
                           true)
@@ -466,13 +466,13 @@
        :success false}))
 
   (retrieve-directory-content [_ service-id instance-id host directory]
-    (when (str/blank? service-id) (throw (ex-info (str "Service id is missing!") {:logging :info})))
-    (when (str/blank? instance-id) (throw (ex-info (str "Instance id is missing!") {:logging :info})))
-    (when (str/blank? host) (throw (ex-info (str "Host is missing!") {:logging :info})))
+    (when (str/blank? service-id) (throw (ex-info (str "Service id is missing!") {:log-level :info})))
+    (when (str/blank? instance-id) (throw (ex-info (str "Instance id is missing!") {:log-level :info})))
+    (when (str/blank? host) (throw (ex-info (str "Host is missing!") {:log-level :info})))
     (let [task-id-start-index (str/last-index-of instance-id "_")
           task-id (->> task-id-start-index inc (subs instance-id))
           log-directory (or directory (mesos/retrieve-log-url cook-api task-id host "cook"))]
-      (when (str/blank? log-directory) (throw (ex-info "No directory found for instance!" {:logging :info})))
+      (when (str/blank? log-directory) (throw (ex-info "No directory found for instance!" {:log-level :info})))
       (mesos/retrieve-directory-content-from-host cook-api host log-directory)))
 
   (service-id->state [_ service-id]

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -422,11 +422,11 @@
         (log/debug (:throwable &throw-context) "[autoscaler] Marathon unavailable"))))
 
   (retrieve-directory-content [_ service-id instance-id host directory]
-    (when (str/blank? service-id) (throw (ex-info (str "Service id is missing!") {:logging :info})))
-    (when (str/blank? instance-id) (throw (ex-info (str "Instance id is missing!") {:logging :info})))
-    (when (str/blank? host) (throw (ex-info (str "Host is missing!") {:logging :info})))
+    (when (str/blank? service-id) (throw (ex-info (str "Service id is missing!") {:log-level :info})))
+    (when (str/blank? instance-id) (throw (ex-info (str "Instance id is missing!") {:log-level :info})))
+    (when (str/blank? host) (throw (ex-info (str "Host is missing!") {:log-level :info})))
     (let [log-directory (or directory (mesos/retrieve-log-url mesos-api instance-id host "marathon"))]
-      (when (str/blank? log-directory) (throw (ex-info "No directory found for instance!" {:logging :info})))
+      (when (str/blank? log-directory) (throw (ex-info "No directory found for instance!" {:log-level :info})))
       (mesos/retrieve-directory-content-from-host mesos-api host log-directory)))
 
   (service-id->state [_ service-id]

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -422,11 +422,11 @@
         (log/debug (:throwable &throw-context) "[autoscaler] Marathon unavailable"))))
 
   (retrieve-directory-content [_ service-id instance-id host directory]
-    (when (str/blank? service-id) (throw (ex-info (str "Service id is missing!") {})))
-    (when (str/blank? instance-id) (throw (ex-info (str "Instance id is missing!") {})))
-    (when (str/blank? host) (throw (ex-info (str "Host is missing!") {})))
+    (when (str/blank? service-id) (throw (ex-info (str "Service id is missing!") {:logging :info})))
+    (when (str/blank? instance-id) (throw (ex-info (str "Instance id is missing!") {:logging :info})))
+    (when (str/blank? host) (throw (ex-info (str "Host is missing!") {:logging :info})))
     (let [log-directory (or directory (mesos/retrieve-log-url mesos-api instance-id host "marathon"))]
-      (when (str/blank? log-directory) (throw (ex-info "No directory found for instance!" {})))
+      (when (str/blank? log-directory) (throw (ex-info "No directory found for instance!" {:logging :info})))
       (mesos/retrieve-directory-content-from-host mesos-api host log-directory)))
 
   (service-id->state [_ service-id]

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -479,7 +479,7 @@
       :get (handle-get-token-request kv-store token-root waiter-hostnames request)
       :post (handle-post-token-request clock synchronize-fn kv-store token-root history-length waiter-hostnames entitlement-manager
                                        make-peer-requests-fn validate-service-description-fn request)
-      (throw (ex-info "Invalid request method" {:request-method request-method, :status 405})))
+      (throw (ex-info "Invalid request method" {:logging :info :request-method request-method :status 405})))
     (catch Exception ex
       (utils/exception->response ex request))))
 
@@ -512,7 +512,8 @@
                                    (assoc :owner owner :token token)))))))
                   flatten
                   utils/clj->streaming-json-response))
-      (throw (ex-info "Only GET supported" {:request-method request-method
+      (throw (ex-info "Only GET supported" {:logging :info
+                                            :request-method request-method
                                             :status 405})))
     (catch Exception ex
       (utils/exception->response ex req))))
@@ -528,7 +529,8 @@
     (case request-method
       :get (let [owner->owner-ref (token-owners-map kv-store)]
              (utils/clj->json-response owner->owner-ref))
-      (throw (ex-info "Only GET supported" {:request-method request-method
+      (throw (ex-info "Only GET supported" {:logging :info
+                                            :request-method request-method
                                             :status 405})))
     (catch Exception ex
       (utils/exception->response ex req))))
@@ -560,7 +562,8 @@
                                      :method :post
                                      :body (utils/clj->json {:index true}))
               (utils/clj->json-response {:message "Successfully re-indexed" :tokens (count tokens)}))
-      (throw (ex-info "Only POST supported" {:request-method request-method
+      (throw (ex-info "Only POST supported" {:logging :info
+                                             :request-method request-method
                                              :status 405})))
     (catch Exception ex
       (utils/exception->response ex req))))

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -479,7 +479,7 @@
       :get (handle-get-token-request kv-store token-root waiter-hostnames request)
       :post (handle-post-token-request clock synchronize-fn kv-store token-root history-length waiter-hostnames entitlement-manager
                                        make-peer-requests-fn validate-service-description-fn request)
-      (throw (ex-info "Invalid request method" {:logging :info :request-method request-method :status 405})))
+      (throw (ex-info "Invalid request method" {:log-level :info :request-method request-method :status 405})))
     (catch Exception ex
       (utils/exception->response ex request))))
 
@@ -512,7 +512,7 @@
                                    (assoc :owner owner :token token)))))))
                   flatten
                   utils/clj->streaming-json-response))
-      (throw (ex-info "Only GET supported" {:logging :info
+      (throw (ex-info "Only GET supported" {:log-level :info
                                             :request-method request-method
                                             :status 405})))
     (catch Exception ex
@@ -529,7 +529,7 @@
     (case request-method
       :get (let [owner->owner-ref (token-owners-map kv-store)]
              (utils/clj->json-response owner->owner-ref))
-      (throw (ex-info "Only GET supported" {:logging :info
+      (throw (ex-info "Only GET supported" {:log-level :info
                                             :request-method request-method
                                             :status 405})))
     (catch Exception ex
@@ -562,7 +562,7 @@
                                      :method :post
                                      :body (utils/clj->json {:index true}))
               (utils/clj->json-response {:message "Successfully re-indexed" :tokens (count tokens)}))
-      (throw (ex-info "Only POST supported" {:logging :info
+      (throw (ex-info "Only POST supported" {:log-level :info
                                              :request-method request-method
                                              :status 405})))
     (catch Exception ex

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -262,13 +262,14 @@
   "Converts an exception into a ring response."
   [^Exception ex request]
   (let [wrapped-ex (wrap-unhandled-exception ex)
-        {:keys [friendly-error-message headers logging message status] :as data} (ex-data wrapped-ex)
+        {:keys [friendly-error-message headers log-level message status] :as data} (ex-data wrapped-ex)
         response-msg (if (or message friendly-error-message)
                        (str/trim (str message \newline friendly-error-message))
                        (.getMessage wrapped-ex))
         processed-headers (into {} (for [[k v] headers] [(name k) (str v)]))]
-    (condp = logging
+    (condp = log-level
       :info (log/info (.getMessage wrapped-ex))
+      :warn (log/warn (.getMessage wrapped-ex))
       (log/error wrapped-ex))
     (-> {:details data, :headers processed-headers, :message response-msg, :status status}
         (data->error-response request))))


### PR DESCRIPTION
## Changes proposed in this PR

- reduces error logs for client error scenarios
- removes the `suppress-logging` flag

## Why are we making these changes?

Avoids corrupting the log files with exception stack traces.

