### PR TITLE
limits min-instances value to be either 1 or 2

### DIFF
--- a/waiter/integration/waiter/killed_instance_test.clj
+++ b/waiter/integration/waiter/killed_instance_test.clj
@@ -28,7 +28,7 @@
     (let [requests-per-thread 5
           router-count (count (routers waiter-url))
           parallelism router-count
-          extra-headers {:x-waiter-min-instances 0
+          extra-headers {:x-waiter-min-instances 1
                          :x-waiter-distribution-scheme "simple"
                          :x-waiter-scale-down-factor 0.99
                          :x-waiter-scale-up-factor 0.99

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -88,7 +88,7 @@
    (s/optional-key "instance-expiry-mins") (s/constrained s/Int #(<= 0 %))
    (s/optional-key "jitter-threshold") schema/greater-than-or-equal-to-0-less-than-1
    (s/optional-key "max-instances") (s/both s/Int (s/pred #(<= 1 % 1000) 'between-one-and-1000))
-   (s/optional-key "min-instances") (s/both s/Int (s/pred #(<= 0 % 2) 'between-zero-and-two))
+   (s/optional-key "min-instances") (s/both s/Int (s/pred #(<= 1 % 2) 'either-one-or-two))
    (s/optional-key "scale-factor") schema/positive-fraction-less-than-or-equal-to-1
    (s/optional-key "scale-down-factor") schema/positive-fraction-less-than-1
    (s/optional-key "scale-up-factor") schema/positive-fraction-less-than-1


### PR DESCRIPTION
## Changes proposed in this PR

- limits min-instances value to be either 1 or 2

## Why are we making these changes?

Prevents a scenario where there can be a delay in scaling to `1` instance when there is an outstanding request. Users can use `min-instances` of 1 and a lower `idle-timeout` to mimic the previous `0` scenario.

