### PR TITLE
throttles the number of simultaneous kerberos library invocations during authentication

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -167,7 +167,9 @@
 
                         ;; :kind :kerberos enables authentication using the Kerberos protocol
                         ;:kind :kerberos
-                        :kerberos {:factory-fn waiter.auth.kerberos/kerberos-authenticator}}
+                        :kerberos {:factory-fn waiter.auth.kerberos/kerberos-authenticator
+                                   ;; the number of concurrent Kerberos library (GSSLibStub) invocations allowed
+                                   :concurrency-level 20}}
 
  ;; Waiter supports the run-as-requester feature to launch a service as the requesting user.
  ;; Triggering this feature without passing explicit headers requires providing an explicit consent and storing this in a cookie.

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -168,8 +168,10 @@
                         ;; :kind :kerberos enables authentication using the Kerberos protocol
                         ;:kind :kerberos
                         :kerberos {:factory-fn waiter.auth.kerberos/kerberos-authenticator
-                                   ;; the number of concurrent Kerberos library (GSSLibStub) invocations allowed
-                                   :concurrency-level 20}}
+                                   ;; the maximum number of concurrent Kerberos library (GSSLibStub) invocations allowed
+                                   :concurrency-level 20
+                                   ;; the idle time before cached threads from the invocation throttler are terminated
+                                   :keep-alive-mins 5}}
 
  ;; Waiter supports the run-as-requester feature to launch a service as the requesting user.
  ;; Triggering this feature without passing explicit headers requires providing an explicit consent and storing this in a cookie.

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -171,7 +171,10 @@
                                    ;; the maximum number of concurrent Kerberos library (GSSLibStub) invocations allowed
                                    :concurrency-level 20
                                    ;; the idle time before cached threads from the invocation throttler are terminated
-                                   :keep-alive-mins 5}}
+                                   :keep-alive-mins 5
+                                   ;; the maximum number of request waiting for Kerberos auth before server responds
+                                   ;; with a 503 temporarily unavailable
+                                   :max-queue-length 1000}}
 
  ;; Waiter supports the run-as-requester feature to launch a service as the requesting user.
  ;; Triggering this feature without passing explicit headers requires providing an explicit consent and storing this in a cookie.

--- a/waiter/src/waiter/auth/kerberos.clj
+++ b/waiter/src/waiter/auth/kerberos.clj
@@ -117,10 +117,16 @@
          (integer? keep-alive-mins)
          (pos? keep-alive-mins)]}
   (let [thread-pool (ThreadPoolExecutor. 1 concurrency-level keep-alive-mins TimeUnit/MINUTES (LinkedBlockingQueue.))]
-    (metrics/waiter-gauge #(.getActiveCount thread-pool) "core" "kerberos" "throttle" "active-thread-count")
-    (metrics/waiter-gauge #(.getMaximumPoolSize thread-pool) "core" "kerberos" "throttle" "max-thread-count")
-    (metrics/waiter-gauge #(-> thread-pool .getQueue .size) "core" "kerberos" "throttle" "pending-task-count")
-    (metrics/waiter-gauge #(.getTaskCount thread-pool) "core" "kerberos" "throttle" "scheduled-task-count")
+    (metrics/waiter-gauge #(.getActiveCount thread-pool)
+                          "core" "kerberos" "throttle" "active-thread-count")
+    (metrics/waiter-gauge #(- concurrency-level (.getActiveCount thread-pool))
+                          "core" "kerberos" "throttle" "available-thread-count")
+    (metrics/waiter-gauge #(.getMaximumPoolSize thread-pool)
+                          "core" "kerberos" "throttle" "max-thread-count")
+    (metrics/waiter-gauge #(-> thread-pool .getQueue .size)
+                          "core" "kerberos" "throttle" "pending-task-count")
+    (metrics/waiter-gauge #(.getTaskCount thread-pool)
+                          "core" "kerberos" "throttle" "scheduled-task-count")
     (->KerberosAuthenticator thread-pool password)))
 
 (defrecord KerberosAuthorizer

--- a/waiter/src/waiter/auth/spnego.clj
+++ b/waiter/src/waiter/auth/spnego.clj
@@ -100,7 +100,7 @@
         (get-in request [:headers "authorization"])
         (let [current-correlation-id (cid/get-correlation-id)
               response-chan (async/promise-chan)
-              timer-context (timers/start (metrics/waiter-timer "core" "spnego" "throttle-delay"))]
+              timer-context (timers/start (metrics/waiter-timer "core" "kerberos" "throttle" "delay"))]
           ;; launch task that will populate the response in response-chan
           (.execute
             thread-pool

--- a/waiter/src/waiter/metrics.clj
+++ b/waiter/src/waiter/metrics.clj
@@ -21,6 +21,7 @@
             [clojure.string :as str]
             [metrics.core :as mc]
             [metrics.counters :as counters]
+            [metrics.gauges :as gauges]
             [metrics.histograms :as histograms]
             [metrics.meters :as meters]
             [metrics.timers :as timers]
@@ -92,6 +93,11 @@
   "Creates a counter with waiter-specific naming scheme"
   [classifier & nested-path]
   `(counters/counter ~(metric-name (concat ["waiter" classifier "counters"] nested-path))))
+
+(defmacro waiter-gauge
+  "Creates a gauge with waiter-specific naming scheme"
+  [f classifier & nested-path]
+  `(gauges/gauge-fn ~(metric-name (concat ["waiter" classifier "counters"] nested-path)) ~f))
 
 (defmacro waiter-meter
   "Creates a waiter-meter with waiter-specific naming scheme"

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -207,7 +207,8 @@
 (def settings-defaults
   {:authenticator-config {:kind :one-user
                           :kerberos {:factory-fn 'waiter.auth.kerberos/kerberos-authenticator
-                                     :concurrency-level 20}
+                                     :concurrency-level 20
+                                     :keep-alive-mins 5}
                           :one-user {:factory-fn 'waiter.auth.authentication/one-user-authenticator}}
    :cors-config {:kind :patterns
                  :patterns {:factory-fn 'waiter.cors/pattern-based-validator

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -206,6 +206,8 @@
 
 (def settings-defaults
   {:authenticator-config {:kind :one-user
+                          :kerberos {:factory-fn 'waiter.auth.kerberos/kerberos-authenticator
+                                     :concurrency-level 20}
                           :one-user {:factory-fn 'waiter.auth.authentication/one-user-authenticator}}
    :cors-config {:kind :patterns
                  :patterns {:factory-fn 'waiter.cors/pattern-based-validator

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -208,7 +208,8 @@
   {:authenticator-config {:kind :one-user
                           :kerberos {:factory-fn 'waiter.auth.kerberos/kerberos-authenticator
                                      :concurrency-level 20
-                                     :keep-alive-mins 5}
+                                     :keep-alive-mins 5
+                                     :max-queue-length 1000}
                           :one-user {:factory-fn 'waiter.auth.authentication/one-user-authenticator}}
    :cors-config {:kind :patterns
                  :patterns {:factory-fn 'waiter.cors/pattern-based-validator

--- a/waiter/test/waiter/auth/kerberos_test.clj
+++ b/waiter/test/waiter/auth/kerberos_test.clj
@@ -110,7 +110,8 @@
 
 (deftest test-kerberos-authenticator
   (with-redefs [start-prestash-cache-maintainer (constantly nil)]
-    (let [config {:password "test-password"
+    (let [config {:concurrency-level 20
+                  :password "test-password"
                   :prestash-cache-refresh-ms 100
                   :prestash-cache-min-refresh-ms 10
                   :prestash-query-host "example.com"}

--- a/waiter/test/waiter/auth/kerberos_test.clj
+++ b/waiter/test/waiter/auth/kerberos_test.clj
@@ -111,6 +111,7 @@
 (deftest test-kerberos-authenticator
   (with-redefs [start-prestash-cache-maintainer (constantly nil)]
     (let [config {:concurrency-level 20
+                  :keep-alive-mins 5
                   :password "test-password"
                   :prestash-cache-refresh-ms 100
                   :prestash-cache-min-refresh-ms 10

--- a/waiter/test/waiter/auth/kerberos_test.clj
+++ b/waiter/test/waiter/auth/kerberos_test.clj
@@ -112,6 +112,7 @@
   (with-redefs [start-prestash-cache-maintainer (constantly nil)]
     (let [config {:concurrency-level 20
                   :keep-alive-mins 5
+                  :max-queue-length 100
                   :password "test-password"
                   :prestash-cache-refresh-ms 100
                   :prestash-cache-min-refresh-ms 10

--- a/waiter/test/waiter/auth/spnego_test.clj
+++ b/waiter/test/waiter/auth/spnego_test.clj
@@ -40,7 +40,7 @@
         standard-request {}
         handler (require-gss request-handler thread-pool max-queue-length password)
         standard-401-response {:body "Unauthorized"
-                               :headers {"Content-Type" "text/html"
+                               :headers {"Content-Type" "text/plain"
                                          "Server" "waiter"
                                          "WWW-Authenticate" "Negotiate"}
                                :status 401}]
@@ -58,8 +58,8 @@
                     auth/decoded-auth-valid? (constantly false)
                     too-many-pending-auth-requests? (constantly true)]
         (let [handler (require-gss request-handler thread-pool max-queue-length password)]
-          (is (= {:body "Service Temporarily Unavailable - Too Many Kerberos authentication requests"
-                  :headers {"Content-Type" "text/html"
+          (is (= {:body "Too many Kerberos authentication requests"
+                  :headers {"Content-Type" "text/plain"
                             "Server" "waiter"}
                   :status 503}
                  (handler standard-request))))))

--- a/waiter/test/waiter/auth/spnego_test.clj
+++ b/waiter/test/waiter/auth/spnego_test.clj
@@ -14,8 +14,12 @@
 ;; limitations under the License.
 ;;
 (ns waiter.auth.spnego-test
-  (:require [clojure.test :refer :all]
-            [waiter.auth.spnego :refer :all]))
+  (:require [clojure.core.async :as async]
+            [clojure.string :as str]
+            [clojure.test :refer :all]
+            [waiter.auth.authentication :as auth]
+            [waiter.auth.spnego :refer :all]
+            [waiter.util.utils :as utils]))
 
 (deftest test-decode-input-token
   (is (decode-input-token {:headers {"authorization" "Negotiate Kerberos-Auth"}}))
@@ -25,3 +29,99 @@
   (let [encoded-token (encode-output-token (.getBytes "Kerberos-Auth"))]
     (is (= "Kerberos-Auth"
            (String. (decode-input-token {:headers {"authorization" encoded-token}}))))))
+
+(deftest test-require-gss
+  (let [ideal-response {:body "OK" :status 200}
+        request-handler (constantly ideal-response)
+        thread-pool (Object.)
+        max-queue-length 10
+        password [:cached "test-password"]
+        auth-principal "user@test.com"
+        standard-request {}
+        handler (require-gss request-handler thread-pool max-queue-length password)
+        standard-401-response {:body "Unauthorized"
+                               :headers {"Content-Type" "text/html"
+                                         "Server" "waiter"
+                                         "WWW-Authenticate" "Negotiate"}
+                               :status 401}]
+
+    (testing "valid auth cookie"
+      (with-redefs [auth/decode-auth-cookie (constantly [auth-principal nil])
+                    auth/decoded-auth-valid? (constantly true)]
+        (is (= (assoc ideal-response
+                 :authorization/principal auth-principal
+                 :authorization/user (first (str/split auth-principal #"@" 2)))
+               (handler standard-request)))))
+
+    (testing "too many pending kerberos requests"
+      (with-redefs [auth/decode-auth-cookie (constantly [auth-principal nil])
+                    auth/decoded-auth-valid? (constantly false)
+                    too-many-pending-auth-requests? (constantly true)]
+        (let [handler (require-gss request-handler thread-pool max-queue-length password)]
+          (is (= {:body "Service Temporarily Unavailable - Too Many Kerberos authentication requests"
+                  :headers {"Content-Type" "text/html"
+                            "Server" "waiter"}
+                  :status 503}
+                 (handler standard-request))))))
+
+    (testing "standard 401 response on missing authorization header"
+      (with-redefs [auth/decode-auth-cookie (constantly [auth-principal nil])
+                    auth/decoded-auth-valid? (constantly false)
+                    too-many-pending-auth-requests? (constantly false)]
+        (let [handler (require-gss request-handler thread-pool max-queue-length password)]
+          (is (= standard-401-response (handler standard-request))))))
+
+    (testing "kerberos authentication path"
+      (with-redefs [auth/decode-auth-cookie (constantly [auth-principal nil])
+                    auth/decoded-auth-valid? (constantly false)
+                    too-many-pending-auth-requests? (constantly false)]
+        (let [auth-request (update standard-request :headers assoc "authorization" "foo-bar")
+              error-object (Object.)]
+
+          (testing "401 response on failed authentication"
+            (with-redefs [populate-gss-credentials (fn [_ _ response-chan]
+                                                     (async/>!! response-chan {:foo :bar}))]
+              (let [handler (require-gss request-handler thread-pool max-queue-length password)
+                    response (handler auth-request)
+                    response (if (map? response)
+                               response
+                               (async/<!! response))]
+                (is (= standard-401-response response)))))
+
+          (testing "error object on exception"
+            (with-redefs [populate-gss-credentials (fn [_ _ response-chan]
+                                                     (async/>!! response-chan {:error error-object}))]
+              (let [handler (require-gss request-handler thread-pool max-queue-length password)
+                    response (handler auth-request)
+                    response (if (map? response)
+                               response
+                               (async/<!! response))]
+                (is (= error-object response)))))
+
+          (testing "successful authentication - principal and token"
+            (with-redefs [populate-gss-credentials (fn [_ _ response-chan]
+                                                     (async/>!! response-chan {:principal auth-principal
+                                                                               :token "test-token"}))]
+              (let [handler (require-gss request-handler thread-pool max-queue-length password)
+                    response (handler auth-request)
+                    response (if (map? response)
+                               response
+                               (async/<!! response))]
+                (is (= (assoc ideal-response
+                         :authorization/principal "user@test.com"
+                         :authorization/user "user"
+                         :headers {"WWW-Authenticate" "test-token"})
+                       (utils/dissoc-in response [:headers "set-cookie"]))))))
+
+          (testing "successful authentication - principal only"
+            (with-redefs [populate-gss-credentials (fn [_ _ response-chan]
+                                                     (async/>!! response-chan {:principal auth-principal}))]
+              (let [handler (require-gss request-handler thread-pool max-queue-length password)
+                    response (handler auth-request)
+                    response (if (map? response)
+                               response
+                               (async/<!! response))]
+                (is (= (assoc ideal-response
+                         :authorization/principal "user@test.com"
+                         :authorization/user "user")
+                       (utils/dissoc-in response [:headers "set-cookie"])))))))))))


### PR DESCRIPTION
## Changes proposed in this PR

- throttles the number of simultaneous kerberos library invocations during authentication
- reports a 503 temporarily unavailable when there are too many pending kerberos authentications

## Why are we making these changes?

This prevents a router from crashing due to too many concurrent calls to the GSS library. The concurrency level controls the number of threads present in the Thread pool and hence throttles the number of concurrent calls to the GSS library. Using the custom thread pool also offloads the relatively expensive native GSS calls to not block the `core.async` threads. In addition, the PR also responds with `503`s to requests that cause the pending kerberos authentication requests to grow beyond a pre-configured limit.

The [Semaphore](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Semaphore.html) based [solution](https://github.com/twosigma/waiter/tree/e3b803368623e85532c85dd96e08c6b6dc0ff892) looks much simpler but can potentially block async threads waiting on the `acquire` call. As this scenario can lead to poor performance in processing requests through Waiter, the [Semaphore](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Semaphore.html) based approach was avoided.

Screenshot of Kerberos metrics:
![image](https://user-images.githubusercontent.com/6611249/50528240-b04fff80-0ab2-11e9-8f82-71eabdbd9dd5.png)

