### PR TITLE
Deflakes test-basic-logs, test-multiple-ports and test-on-the-fly-to-token

### DIFF
--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -548,7 +548,9 @@
   item found in the instance's working directory + relative-dir"
   [{:keys [id->instance]} instance-id relative-dir]
   (let [{:keys [:shell-scheduler/working-directory]} (get id->instance instance-id)
-        directory (io/file working-directory relative-dir)
+        directory (if (str/blank? relative-dir)
+                    (io/file working-directory)
+                    (io/file working-directory relative-dir))
         directory-content (vec (.listFiles directory))]
     (map (fn [^File file]
            (cond-> {:name (.getName file)


### PR DESCRIPTION
## Changes proposed in this PR

- Deflakes test-basic-logs, test-multiple-ports and test-on-the-fly-to-token by ensuring service is known on every router before queries are made for the service

## Why are we making these changes?

We prefer no flakes in our tests.

