### PR TITLE
includes server header in output generated from waiter

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -510,10 +510,11 @@
                           (utils/create-component entitlement-config))
    :fallback-state-atom (pc/fnk [] (atom {:available-service-ids #{}
                                           :healthy-service-ids #{}}))
-   :http-client (pc/fnk [[:settings [:instance-request-properties connection-timeout-ms] git-version]]
+   :http-client (pc/fnk [[:settings [:instance-request-properties connection-timeout-ms]]
+                         server-name]
                   (http-utils/http-client-factory {:conn-timeout connection-timeout-ms
                                                    :follow-redirects? false
-                                                   :user-agent (str "waiter/" (str/join (take 7 git-version)))}))
+                                                   :user-agent server-name}))
    :instance-rpc-chan (pc/fnk [] (async/chan 1024)) ; TODO move to service-chan-maintainer
    :interstitial-state-atom (pc/fnk [] (atom {:initialized? false
                                               :service-id->interstitial-promise {}}))
@@ -538,6 +539,10 @@
                               :max-blacklist-time-ms max-blacklist-time-ms})
    :scheduler-interactions-thread-pool (pc/fnk [] (Executors/newFixedThreadPool 20))
    :scheduler-state-chan (pc/fnk [] (au/latest-chan))
+   :server-name (pc/fnk [[:settings git-version]]
+                  (let [server-name (str "waiter/" (str/join (take 7 git-version)))]
+                    (utils/reset-server-name-atom! server-name)
+                    server-name))
    :service-description-builder (pc/fnk [[:settings service-description-builder-config service-description-constraints]]
                                   (when-let [unknown-keys (-> service-description-constraints
                                                               keys

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -434,9 +434,7 @@
         (let [request {:request-method :delete, :uri (str "/apps/" service-id), :authorization/user user}
               {:keys [body headers status]} (async/<!! ((ring-handler-factory waiter-request?-fn handlers) request))]
           (is (= 200 status))
-          (is (= {"content-type" "application/json"
-                  "server" "waiter"}
-                 headers))
+          (is (= expected-json-response-headers headers))
           (is (= {"success" true, "service-id" service-id, "result" "deleted"} (json/read-str body))))))
 
     (testing "service-handler:delete-nil-response"
@@ -445,9 +443,7 @@
         (let [request {:request-method :delete, :uri (str "/apps/" service-id), :authorization/user user}
               {:keys [body headers status]} (async/<!! ((ring-handler-factory waiter-request?-fn handlers) request))]
           (is (= 400 status))
-          (is (= {"content-type" "application/json"
-                  "server" "waiter"}
-                 headers))
+          (is (= expected-json-response-headers headers))
           (is (= {"success" false, "service-id" service-id} (json/read-str body))))))
 
     (testing "service-handler:delete-unauthorized-user"
@@ -459,9 +455,7 @@
                        :uri (str "/apps/" service-id)}
               {:keys [body headers status]} ((ring-handler-factory waiter-request?-fn handlers) request)]
           (is (= 403 status))
-          (is (= {"content-type" "application/json"
-                  "server" "waiter"}
-                 headers))
+          (is (= expected-json-response-headers headers))
           (is (str/includes? body "User not allowed to delete service")))))
 
     (testing "service-handler:delete-404-response"
@@ -470,9 +464,7 @@
         (let [request {:request-method :delete, :uri (str "/apps/" service-id), :authorization/user user}
               {:keys [body headers status]} (async/<!! ((ring-handler-factory waiter-request?-fn handlers) request))]
           (is (= 404 status))
-          (is (= {"content-type" "application/json"
-                  "server" "waiter"}
-                 headers))
+          (is (= expected-json-response-headers headers))
           (is (= {"result" "no-such-service-exists", "service-id" service-id, "success" false} (json/read-str body))))))
 
     (testing "service-handler:delete-non-existent-service"
@@ -486,9 +478,7 @@
               {{message "message"
                 {:strs [service-id]} "details"} "waiter-error"} (json/read-str body)]
           (is (= 404 status))
-          (is (= {"content-type" "application/json"
-                  "server" "waiter"}
-                 headers))
+          (is (= expected-json-response-headers headers))
           (is (= "Service not found" message))
           (is (= "test-service-1" service-id)))))
 
@@ -501,9 +491,7 @@
                        :uri (str "/apps/" service-id)}
               {:keys [headers status]} (async/<!! ((ring-handler-factory waiter-request?-fn handlers) request))]
           (is (= 500 status))
-          (is (= {"content-type" "application/json"
-                  "server" "waiter"}
-                 headers)))))
+          (is (= expected-json-response-headers headers)))))
 
     (.shutdown scheduler-interactions-thread-pool)))
 
@@ -538,9 +526,7 @@
                        :uri (str "/apps/" service-id)}
               {:keys [body headers status]} (ring-handler request)]
           (is (= 404 status))
-          (is (= {"content-type" "application/json"
-                  "server" "waiter"}
-                 headers))
+          (is (= expected-json-response-headers headers))
           (let [{{message "message"
                   {:strs [service-id]} "details"} "waiter-error"} (json/read-str (str body))]
             (is (= "Service not found" message))
@@ -560,9 +546,7 @@
                        :uri (str "/apps/" service-id)}
               {:keys [body headers status]} (ring-handler request)]
           (is (= 200 status))
-          (is (= {"content-type" "application/json"
-                  "server" "waiter"}
-                 headers))
+          (is (= expected-json-response-headers headers))
           (let [body-json (json/read-str (str body))]
             (is (= {"active-instances" [{"id" (str service-id ".A")
                                          "service-id" service-id
@@ -588,9 +572,7 @@
         (let [request {:request-method :get, :uri (str "/apps/" service-id)}
               {:keys [body headers status]} (ring-handler request)]
           (is (= 200 status))
-          (is (= {"content-type" "application/json"
-                  "server" "waiter"}
-                 headers))
+          (is (= expected-json-response-headers headers))
           (let [body-json (json/read-str (str body))]
             (is (= {"active-instances" [{"id" (str service-id ".A")
                                          "service-id" service-id
@@ -814,9 +796,7 @@
                        :uri "/metrics"}
               {:keys [body headers status]} (ring-handler request)]
           (is (= 200 status))
-          (is (= {"content-type" "application/json"
-                  "server" "waiter"}
-                 headers))
+          (is (= expected-json-response-headers headers))
           (is (str/includes? (str body) "metrics-from-get-metrics")))))
 
     (testing "metrics-request-handler:all-metrics:error"
@@ -826,18 +806,14 @@
                        :uri "/metrics"}
               {:keys [headers status]} ((ring-handler-factory waiter-request?-fn handlers) request)]
           (is (= 500 status))
-          (is (= {"content-type" "application/json"
-                  "server" "waiter"}
-                 headers)))))
+          (is (= expected-json-response-headers headers)))))
 
     (testing "metrics-request-handler:waiter-metrics"
       (with-redefs [metrics/get-waiter-metrics (fn get-waiter-metrics-fn [] {:data (str "metrics-for-waiter")})]
         (let [request {:request-method :get, :uri "/metrics", :query-string "exclude-services=true"}
               {:keys [body headers status]} (ring-handler request)]
           (is (= 200 status))
-          (is (= {"content-type" "application/json"
-                  "server" "waiter"}
-                 headers))
+          (is (= expected-json-response-headers headers))
           (is (str/includes? (str body) "metrics-for-waiter")))))
 
     (testing "metrics-request-handler:service-metrics"
@@ -845,9 +821,7 @@
         (let [request {:request-method :get, :uri "/metrics", :query-string "service-id=abcd"}
               {:keys [body headers status]} (ring-handler request)]
           (is (= 200 status))
-          (is (= {"content-type" "application/json"
-                  "server" "waiter"}
-                 headers))
+          (is (= expected-json-response-headers headers))
           (is (str/includes? (str body) "metrics-for-abcd")))))
 
     (testing "metrics-request-handler:service-metrics:error"
@@ -858,9 +832,7 @@
                        :uri "/metrics"}
               {:keys [headers status]} ((ring-handler-factory waiter-request?-fn handlers) request)]
           (is (= 500 status))
-          (is (= {"content-type" "application/json"
-                  "server" "waiter"}
-                 headers)))))))
+          (is (= expected-json-response-headers headers)))))))
 
 (deftest test-async-result-handler-call
   (testing "test-async-result-handler-call"

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -434,7 +434,9 @@
         (let [request {:request-method :delete, :uri (str "/apps/" service-id), :authorization/user user}
               {:keys [body headers status]} (async/<!! ((ring-handler-factory waiter-request?-fn handlers) request))]
           (is (= 200 status))
-          (is (= {"content-type" "application/json"} headers))
+          (is (= {"content-type" "application/json"
+                  "server" "waiter"}
+                 headers))
           (is (= {"success" true, "service-id" service-id, "result" "deleted"} (json/read-str body))))))
 
     (testing "service-handler:delete-nil-response"
@@ -443,7 +445,9 @@
         (let [request {:request-method :delete, :uri (str "/apps/" service-id), :authorization/user user}
               {:keys [body headers status]} (async/<!! ((ring-handler-factory waiter-request?-fn handlers) request))]
           (is (= 400 status))
-          (is (= {"content-type" "application/json"} headers))
+          (is (= {"content-type" "application/json"
+                  "server" "waiter"}
+                 headers))
           (is (= {"success" false, "service-id" service-id} (json/read-str body))))))
 
     (testing "service-handler:delete-unauthorized-user"
@@ -455,7 +459,9 @@
                        :uri (str "/apps/" service-id)}
               {:keys [body headers status]} ((ring-handler-factory waiter-request?-fn handlers) request)]
           (is (= 403 status))
-          (is (= {"content-type" "application/json"} headers))
+          (is (= {"content-type" "application/json"
+                  "server" "waiter"}
+                 headers))
           (is (str/includes? body "User not allowed to delete service")))))
 
     (testing "service-handler:delete-404-response"
@@ -464,7 +470,9 @@
         (let [request {:request-method :delete, :uri (str "/apps/" service-id), :authorization/user user}
               {:keys [body headers status]} (async/<!! ((ring-handler-factory waiter-request?-fn handlers) request))]
           (is (= 404 status))
-          (is (= {"content-type" "application/json"} headers))
+          (is (= {"content-type" "application/json"
+                  "server" "waiter"}
+                 headers))
           (is (= {"result" "no-such-service-exists", "service-id" service-id, "success" false} (json/read-str body))))))
 
     (testing "service-handler:delete-non-existent-service"
@@ -478,7 +486,9 @@
               {{message "message"
                 {:strs [service-id]} "details"} "waiter-error"} (json/read-str body)]
           (is (= 404 status))
-          (is (= {"content-type" "application/json"} headers))
+          (is (= {"content-type" "application/json"
+                  "server" "waiter"}
+                 headers))
           (is (= "Service not found" message))
           (is (= "test-service-1" service-id)))))
 
@@ -491,7 +501,9 @@
                        :uri (str "/apps/" service-id)}
               {:keys [headers status]} (async/<!! ((ring-handler-factory waiter-request?-fn handlers) request))]
           (is (= 500 status))
-          (is (= {"content-type" "application/json"} headers)))))
+          (is (= {"content-type" "application/json"
+                  "server" "waiter"}
+                 headers)))))
 
     (.shutdown scheduler-interactions-thread-pool)))
 
@@ -526,7 +538,9 @@
                        :uri (str "/apps/" service-id)}
               {:keys [body headers status]} (ring-handler request)]
           (is (= 404 status))
-          (is (= {"content-type" "application/json"} headers))
+          (is (= {"content-type" "application/json"
+                  "server" "waiter"}
+                 headers))
           (let [{{message "message"
                   {:strs [service-id]} "details"} "waiter-error"} (json/read-str (str body))]
             (is (= "Service not found" message))
@@ -546,7 +560,9 @@
                        :uri (str "/apps/" service-id)}
               {:keys [body headers status]} (ring-handler request)]
           (is (= 200 status))
-          (is (= {"content-type" "application/json"} headers))
+          (is (= {"content-type" "application/json"
+                  "server" "waiter"}
+                 headers))
           (let [body-json (json/read-str (str body))]
             (is (= {"active-instances" [{"id" (str service-id ".A")
                                          "service-id" service-id
@@ -572,7 +588,9 @@
         (let [request {:request-method :get, :uri (str "/apps/" service-id)}
               {:keys [body headers status]} (ring-handler request)]
           (is (= 200 status))
-          (is (= {"content-type" "application/json"} headers))
+          (is (= {"content-type" "application/json"
+                  "server" "waiter"}
+                 headers))
           (let [body-json (json/read-str (str body))]
             (is (= {"active-instances" [{"id" (str service-id ".A")
                                          "service-id" service-id
@@ -796,7 +814,9 @@
                        :uri "/metrics"}
               {:keys [body headers status]} (ring-handler request)]
           (is (= 200 status))
-          (is (= {"content-type" "application/json"} headers))
+          (is (= {"content-type" "application/json"
+                  "server" "waiter"}
+                 headers))
           (is (str/includes? (str body) "metrics-from-get-metrics")))))
 
     (testing "metrics-request-handler:all-metrics:error"
@@ -806,14 +826,18 @@
                        :uri "/metrics"}
               {:keys [headers status]} ((ring-handler-factory waiter-request?-fn handlers) request)]
           (is (= 500 status))
-          (is (= {"content-type" "application/json"} headers)))))
+          (is (= {"content-type" "application/json"
+                  "server" "waiter"}
+                 headers)))))
 
     (testing "metrics-request-handler:waiter-metrics"
       (with-redefs [metrics/get-waiter-metrics (fn get-waiter-metrics-fn [] {:data (str "metrics-for-waiter")})]
         (let [request {:request-method :get, :uri "/metrics", :query-string "exclude-services=true"}
               {:keys [body headers status]} (ring-handler request)]
           (is (= 200 status))
-          (is (= {"content-type" "application/json"} headers))
+          (is (= {"content-type" "application/json"
+                  "server" "waiter"}
+                 headers))
           (is (str/includes? (str body) "metrics-for-waiter")))))
 
     (testing "metrics-request-handler:service-metrics"
@@ -821,7 +845,9 @@
         (let [request {:request-method :get, :uri "/metrics", :query-string "service-id=abcd"}
               {:keys [body headers status]} (ring-handler request)]
           (is (= 200 status))
-          (is (= {"content-type" "application/json"} headers))
+          (is (= {"content-type" "application/json"
+                  "server" "waiter"}
+                 headers))
           (is (str/includes? (str body) "metrics-for-abcd")))))
 
     (testing "metrics-request-handler:service-metrics:error"
@@ -832,7 +858,9 @@
                        :uri "/metrics"}
               {:keys [headers status]} ((ring-handler-factory waiter-request?-fn handlers) request)]
           (is (= 500 status))
-          (is (= {"content-type" "application/json"} headers)))))))
+          (is (= {"content-type" "application/json"
+                  "server" "waiter"}
+                 headers)))))))
 
 (deftest test-async-result-handler-call
   (testing "test-async-result-handler-call"

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -50,9 +50,7 @@
           async-request-terminate-fn (fn [_] (throw (Exception. "unexpected call!")))
           {:keys [body headers status]} (complete-async-handler async-request-terminate-fn request)]
       (is (= 400 status))
-      (is (= {"content-type" "application/json"
-              "server" "waiter"}
-             headers))
+      (is (= expected-json-response-headers headers))
       (is (str/includes? body "No request-id specified"))))
 
   (testing "missing-service-id"
@@ -65,9 +63,7 @@
           async-request-terminate-fn (fn [_] (throw (Exception. "unexpected call!")))
           {:keys [body headers status]} (complete-async-handler async-request-terminate-fn request)]
       (is (= 400 status))
-      (is (= {"content-type" "application/json"
-              "server" "waiter"}
-             headers))
+      (is (= expected-json-response-headers headers))
       (is (str/includes? body "No service-id specified"))))
 
   (testing "valid-request-id"
@@ -80,9 +76,7 @@
           async-request-terminate-fn (fn [in-request-id] (= request-id in-request-id))
           {:keys [body headers status]} (complete-async-handler async-request-terminate-fn request)]
       (is (= 200 status))
-      (is (= {"content-type" "application/json"
-              "server" "waiter"}
-             headers))
+      (is (= expected-json-response-headers headers))
       (is (= {:request-id request-id, :success true} (pc/keywordize-map (json/read-str body))))))
 
   (testing "unable-to-terminate-request"
@@ -95,9 +89,7 @@
           async-request-terminate-fn (fn [_] false)
           {:keys [body headers status]} (complete-async-handler async-request-terminate-fn request)]
       (is (= 200 status))
-      (is (= {"content-type" "application/json"
-              "server" "waiter"}
-             headers))
+      (is (= expected-json-response-headers headers))
       (is (= {:request-id request-id, :success false} (pc/keywordize-map (json/read-str body)))))))
 
 (deftest test-async-result-handler-errors
@@ -120,9 +112,7 @@
             (async/<!!
               (async-result-handler nil nil service-id->service-description-fn request))]
         (is (= 400 status))
-        (is (= {"content-type" "application/json"
-                "server" "waiter"}
-               headers))
+        (is (= expected-json-response-headers headers))
         (is (str/includes? body "Missing host, location, port, request-id, router-id or service-id in uri"))))
 
     (testing "missing-request-id"
@@ -132,9 +122,7 @@
             (async/<!!
               (async-result-handler nil nil service-id->service-description-fn request))]
         (is (= 400 status))
-        (is (= {"content-type" "application/json"
-                "server" "waiter"}
-               headers))
+        (is (= expected-json-response-headers headers))
         (is (str/includes? body "Missing host, location, port, request-id, router-id or service-id in uri"))))
 
     (testing "missing-router-id"
@@ -144,9 +132,7 @@
             (async/<!!
               (async-result-handler nil nil service-id->service-description-fn request))]
         (is (= 400 status))
-        (is (= {"content-type" "application/json"
-                "server" "waiter"}
-               headers))
+        (is (= expected-json-response-headers headers))
         (is (str/includes? body "Missing host, location, port, request-id, router-id or service-id in uri"))))
 
     (testing "error-in-checking-backend-status"
@@ -170,9 +156,7 @@
             (async/<!!
               (async-result-handler async-trigger-terminate-fn make-http-request-fn service-id->service-description-fn request))]
         (is (= 502 status))
-        (is (= {"content-type" "application/json"
-                "server" "waiter"}
-               headers))
+        (is (= expected-json-response-headers headers))
         (is (every? #(str/includes? body %) ["backend-status-error"]))))))
 
 (deftest test-async-result-handler-with-return-codes
@@ -275,9 +259,7 @@
                      :query-string ""}
             {:keys [body headers status]} (async/<!! (async-status-handler nil nil service-id->service-description-fn request))]
         (is (= 400 status))
-        (is (= {"content-type" "application/json"
-                "server" "waiter"}
-               headers))
+        (is (= expected-json-response-headers headers))
         (is (str/includes? body "Missing host, location, port, request-id, router-id or service-id in uri"))))
 
     (testing "missing-location"
@@ -285,9 +267,7 @@
                      :route-params (make-route-params "missing-location")}
             {:keys [body headers status]} (async/<!! (async-status-handler nil nil service-id->service-description-fn request))]
         (is (= 400 status))
-        (is (= {"content-type" "application/json"
-                "server" "waiter"}
-               headers))
+        (is (= expected-json-response-headers headers))
         (is (str/includes? body "Missing host, location, port, request-id, router-id or service-id in uri"))))
 
     (testing "missing-request-id"
@@ -295,9 +275,7 @@
                      :route-params (make-route-params "missing-request-id")}
             {:keys [body headers status]} (async/<!! (async-status-handler nil nil service-id->service-description-fn request))]
         (is (= 400 status))
-        (is (= {"content-type" "application/json"
-                "server" "waiter"}
-               headers))
+        (is (= expected-json-response-headers headers))
         (is (str/includes? body "Missing host, location, port, request-id, router-id or service-id in uri"))))
 
     (testing "missing-router-id"
@@ -305,9 +283,7 @@
                      :route-params (make-route-params "missing-router-id")}
             {:keys [body headers status]} (async/<!! (async-status-handler nil nil service-id->service-description-fn request))]
         (is (= 400 status))
-        (is (= {"content-type" "application/json"
-                "server" "waiter"}
-               headers))
+        (is (= expected-json-response-headers headers))
         (is (str/includes? body "Missing host, location, port, request-id, router-id or service-id in uri"))))
 
     (testing "error-in-checking-backend-status"
@@ -326,9 +302,7 @@
             async-trigger-terminate-fn nil
             {:keys [body headers status]} (async/<!! (async-status-handler async-trigger-terminate-fn make-http-request-fn service-id->service-description-fn request))]
         (is (= 400 status))
-        (is (= {"content-type" "application/json"
-                "server" "waiter"}
-               headers))
+        (is (= expected-json-response-headers headers))
         (is (every? #(str/includes? body %) ["backend-status-error"]))))))
 
 (deftest test-async-status-handler-with-return-codes
@@ -1039,9 +1013,7 @@
       (let [request {:request-method :get}
             {:keys [body headers status]} (acknowledge-consent-handler-fn request)]
         (is (= 405 status))
-        (is (= {"content-type" "text/plain"
-                "server" "waiter"}
-               headers))
+        (is (= expected-text-response-headers headers))
         (is (str/includes? body "Only POST supported"))))
 
     (testing "host and origin mismatch"
@@ -1049,9 +1021,7 @@
                                "origin" (str "http://" test-token)}}
             {:keys [body cookie headers status]} (acknowledge-consent-handler-fn request)]
         (is (= 400 status))
-        (is (= {"content-type" "text/plain"
-                "server" "waiter"}
-               headers))
+        (is (= expected-text-response-headers headers))
         (is (nil? cookie))
         (is (str/includes? body "Origin is not the same as the host"))))
 
@@ -1061,9 +1031,7 @@
                                "referer" "http://www.example2.com/consent"}}
             {:keys [body cookie headers status]} (acknowledge-consent-handler-fn request)]
         (is (= 400 status))
-        (is (= {"content-type" "text/plain"
-                "server" "waiter"}
-               headers))
+        (is (= expected-text-response-headers headers))
         (is (nil? cookie))
         (is (str/includes? body "Referer does not start with origin"))))
 
@@ -1074,9 +1042,7 @@
                                "x-requested-with" "AJAX"}}
             {:keys [body cookie headers status]} (acknowledge-consent-handler-fn request)]
         (is (= 400 status))
-        (is (= {"content-type" "text/plain"
-                "server" "waiter"}
-               headers))
+        (is (= expected-text-response-headers headers))
         (is (nil? cookie))
         (is (str/includes? body "Header x-requested-with does not match expected value"))))
 
@@ -1088,9 +1054,7 @@
                      :params {"service-id" "service-id-1"}}
             {:keys [body cookie headers status]} (acknowledge-consent-handler-fn request)]
         (is (= 400 status))
-        (is (= {"content-type" "text/plain"
-                "server" "waiter"}
-               headers))
+        (is (= expected-text-response-headers headers))
         (is (nil? cookie))
         (is (str/includes? body "Missing or invalid mode"))))
 
@@ -1103,9 +1067,7 @@
                      :params {"mode" "unsupported", "service-id" "service-id-1"}}
             {:keys [body cookie headers status]} (acknowledge-consent-handler-fn request)]
         (is (= 400 status))
-        (is (= {"content-type" "text/plain"
-                "server" "waiter"}
-               headers))
+        (is (= expected-text-response-headers headers))
         (is (nil? cookie))
         (is (str/includes? body "Missing or invalid mode"))))
 
@@ -1118,9 +1080,7 @@
                      :params {"mode" "service"}}
             {:keys [body cookie headers status]} (acknowledge-consent-handler-fn request)]
         (is (= 400 status))
-        (is (= {"content-type" "text/plain"
-                "server" "waiter"}
-               headers))
+        (is (= expected-text-response-headers headers))
         (is (nil? cookie))
         (is (str/includes? body "Missing service-id"))))
 
@@ -1134,9 +1094,7 @@
                      :params {"mode" "service", "service-id" "service-id-1"}}
             {:keys [body cookie headers status]} (acknowledge-consent-handler-fn request)]
         (is (= 400 status))
-        (is (= {"content-type" "text/plain"
-                "server" "waiter"}
-               headers))
+        (is (= expected-text-response-headers headers))
         (is (nil? cookie))
         (is (str/includes? body "Unable to load description for token"))))
 
@@ -1149,9 +1107,7 @@
                      :params {"mode" "service", "service-id" "service-id-1"}}
             {:keys [body cookie headers status]} (acknowledge-consent-handler-fn request)]
         (is (= 400 status))
-        (is (= {"content-type" "text/plain"
-                "server" "waiter"}
-               headers))
+        (is (= expected-text-response-headers headers))
         (is (nil? cookie))
         (is (str/includes? body "Invalid service-id for specified token"))))
 
@@ -1270,9 +1226,7 @@
                      :scheme :http}
             {:keys [body headers status]} (request-consent-handler-fn request)]
         (is (= 405 status))
-        (is (= {"content-type" "text/plain"
-                "server" "waiter"}
-               headers))
+        (is (= expected-text-response-headers headers))
         (is (str/includes? body "Only GET supported"))))
 
     (testing "token without service description"
@@ -1284,9 +1238,7 @@
                      :scheme :http}
             {:keys [body headers status]} (request-consent-handler-fn request)]
         (is (= 404 status))
-        (is (= {"content-type" "text/plain"
-                "server" "waiter"}
-               headers))
+        (is (= expected-text-response-headers headers))
         (is (str/includes? body "Unable to load description for token"))))
 
     (with-redefs [io/resource io-resource-fn

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -50,7 +50,9 @@
           async-request-terminate-fn (fn [_] (throw (Exception. "unexpected call!")))
           {:keys [body headers status]} (complete-async-handler async-request-terminate-fn request)]
       (is (= 400 status))
-      (is (= {"content-type" "application/json"} headers))
+      (is (= {"content-type" "application/json"
+              "server" "waiter"}
+             headers))
       (is (str/includes? body "No request-id specified"))))
 
   (testing "missing-service-id"
@@ -63,7 +65,9 @@
           async-request-terminate-fn (fn [_] (throw (Exception. "unexpected call!")))
           {:keys [body headers status]} (complete-async-handler async-request-terminate-fn request)]
       (is (= 400 status))
-      (is (= {"content-type" "application/json"} headers))
+      (is (= {"content-type" "application/json"
+              "server" "waiter"}
+             headers))
       (is (str/includes? body "No service-id specified"))))
 
   (testing "valid-request-id"
@@ -76,7 +80,9 @@
           async-request-terminate-fn (fn [in-request-id] (= request-id in-request-id))
           {:keys [body headers status]} (complete-async-handler async-request-terminate-fn request)]
       (is (= 200 status))
-      (is (= {"content-type" "application/json"} headers))
+      (is (= {"content-type" "application/json"
+              "server" "waiter"}
+             headers))
       (is (= {:request-id request-id, :success true} (pc/keywordize-map (json/read-str body))))))
 
   (testing "unable-to-terminate-request"
@@ -89,7 +95,9 @@
           async-request-terminate-fn (fn [_] false)
           {:keys [body headers status]} (complete-async-handler async-request-terminate-fn request)]
       (is (= 200 status))
-      (is (= {"content-type" "application/json"} headers))
+      (is (= {"content-type" "application/json"
+              "server" "waiter"}
+             headers))
       (is (= {:request-id request-id, :success false} (pc/keywordize-map (json/read-str body)))))))
 
 (deftest test-async-result-handler-errors
@@ -112,7 +120,9 @@
             (async/<!!
               (async-result-handler nil nil service-id->service-description-fn request))]
         (is (= 400 status))
-        (is (= {"content-type" "application/json"} headers))
+        (is (= {"content-type" "application/json"
+                "server" "waiter"}
+               headers))
         (is (str/includes? body "Missing host, location, port, request-id, router-id or service-id in uri"))))
 
     (testing "missing-request-id"
@@ -122,7 +132,9 @@
             (async/<!!
               (async-result-handler nil nil service-id->service-description-fn request))]
         (is (= 400 status))
-        (is (= {"content-type" "application/json"} headers))
+        (is (= {"content-type" "application/json"
+                "server" "waiter"}
+               headers))
         (is (str/includes? body "Missing host, location, port, request-id, router-id or service-id in uri"))))
 
     (testing "missing-router-id"
@@ -132,7 +144,9 @@
             (async/<!!
               (async-result-handler nil nil service-id->service-description-fn request))]
         (is (= 400 status))
-        (is (= {"content-type" "application/json"} headers))
+        (is (= {"content-type" "application/json"
+                "server" "waiter"}
+               headers))
         (is (str/includes? body "Missing host, location, port, request-id, router-id or service-id in uri"))))
 
     (testing "error-in-checking-backend-status"
@@ -156,7 +170,9 @@
             (async/<!!
               (async-result-handler async-trigger-terminate-fn make-http-request-fn service-id->service-description-fn request))]
         (is (= 502 status))
-        (is (= {"content-type" "application/json"} headers))
+        (is (= {"content-type" "application/json"
+                "server" "waiter"}
+               headers))
         (is (every? #(str/includes? body %) ["backend-status-error"]))))))
 
 (deftest test-async-result-handler-with-return-codes
@@ -259,7 +275,9 @@
                      :query-string ""}
             {:keys [body headers status]} (async/<!! (async-status-handler nil nil service-id->service-description-fn request))]
         (is (= 400 status))
-        (is (= {"content-type" "application/json"} headers))
+        (is (= {"content-type" "application/json"
+                "server" "waiter"}
+               headers))
         (is (str/includes? body "Missing host, location, port, request-id, router-id or service-id in uri"))))
 
     (testing "missing-location"
@@ -267,7 +285,9 @@
                      :route-params (make-route-params "missing-location")}
             {:keys [body headers status]} (async/<!! (async-status-handler nil nil service-id->service-description-fn request))]
         (is (= 400 status))
-        (is (= {"content-type" "application/json"} headers))
+        (is (= {"content-type" "application/json"
+                "server" "waiter"}
+               headers))
         (is (str/includes? body "Missing host, location, port, request-id, router-id or service-id in uri"))))
 
     (testing "missing-request-id"
@@ -275,7 +295,9 @@
                      :route-params (make-route-params "missing-request-id")}
             {:keys [body headers status]} (async/<!! (async-status-handler nil nil service-id->service-description-fn request))]
         (is (= 400 status))
-        (is (= {"content-type" "application/json"} headers))
+        (is (= {"content-type" "application/json"
+                "server" "waiter"}
+               headers))
         (is (str/includes? body "Missing host, location, port, request-id, router-id or service-id in uri"))))
 
     (testing "missing-router-id"
@@ -283,7 +305,9 @@
                      :route-params (make-route-params "missing-router-id")}
             {:keys [body headers status]} (async/<!! (async-status-handler nil nil service-id->service-description-fn request))]
         (is (= 400 status))
-        (is (= {"content-type" "application/json"} headers))
+        (is (= {"content-type" "application/json"
+                "server" "waiter"}
+               headers))
         (is (str/includes? body "Missing host, location, port, request-id, router-id or service-id in uri"))))
 
     (testing "error-in-checking-backend-status"
@@ -302,7 +326,9 @@
             async-trigger-terminate-fn nil
             {:keys [body headers status]} (async/<!! (async-status-handler async-trigger-terminate-fn make-http-request-fn service-id->service-description-fn request))]
         (is (= 400 status))
-        (is (= {"content-type" "application/json"} headers))
+        (is (= {"content-type" "application/json"
+                "server" "waiter"}
+               headers))
         (is (every? #(str/includes? body %) ["backend-status-error"]))))))
 
 (deftest test-async-status-handler-with-return-codes
@@ -1013,7 +1039,9 @@
       (let [request {:request-method :get}
             {:keys [body headers status]} (acknowledge-consent-handler-fn request)]
         (is (= 405 status))
-        (is (= {"content-type" "text/plain"} headers))
+        (is (= {"content-type" "text/plain"
+                "server" "waiter"}
+               headers))
         (is (str/includes? body "Only POST supported"))))
 
     (testing "host and origin mismatch"
@@ -1021,7 +1049,9 @@
                                "origin" (str "http://" test-token)}}
             {:keys [body cookie headers status]} (acknowledge-consent-handler-fn request)]
         (is (= 400 status))
-        (is (= {"content-type" "text/plain"} headers))
+        (is (= {"content-type" "text/plain"
+                "server" "waiter"}
+               headers))
         (is (nil? cookie))
         (is (str/includes? body "Origin is not the same as the host"))))
 
@@ -1031,7 +1061,9 @@
                                "referer" "http://www.example2.com/consent"}}
             {:keys [body cookie headers status]} (acknowledge-consent-handler-fn request)]
         (is (= 400 status))
-        (is (= {"content-type" "text/plain"} headers))
+        (is (= {"content-type" "text/plain"
+                "server" "waiter"}
+               headers))
         (is (nil? cookie))
         (is (str/includes? body "Referer does not start with origin"))))
 
@@ -1042,7 +1074,9 @@
                                "x-requested-with" "AJAX"}}
             {:keys [body cookie headers status]} (acknowledge-consent-handler-fn request)]
         (is (= 400 status))
-        (is (= {"content-type" "text/plain"} headers))
+        (is (= {"content-type" "text/plain"
+                "server" "waiter"}
+               headers))
         (is (nil? cookie))
         (is (str/includes? body "Header x-requested-with does not match expected value"))))
 
@@ -1054,7 +1088,9 @@
                      :params {"service-id" "service-id-1"}}
             {:keys [body cookie headers status]} (acknowledge-consent-handler-fn request)]
         (is (= 400 status))
-        (is (= {"content-type" "text/plain"} headers))
+        (is (= {"content-type" "text/plain"
+                "server" "waiter"}
+               headers))
         (is (nil? cookie))
         (is (str/includes? body "Missing or invalid mode"))))
 
@@ -1067,7 +1103,9 @@
                      :params {"mode" "unsupported", "service-id" "service-id-1"}}
             {:keys [body cookie headers status]} (acknowledge-consent-handler-fn request)]
         (is (= 400 status))
-        (is (= {"content-type" "text/plain"} headers))
+        (is (= {"content-type" "text/plain"
+                "server" "waiter"}
+               headers))
         (is (nil? cookie))
         (is (str/includes? body "Missing or invalid mode"))))
 
@@ -1080,7 +1118,9 @@
                      :params {"mode" "service"}}
             {:keys [body cookie headers status]} (acknowledge-consent-handler-fn request)]
         (is (= 400 status))
-        (is (= {"content-type" "text/plain"} headers))
+        (is (= {"content-type" "text/plain"
+                "server" "waiter"}
+               headers))
         (is (nil? cookie))
         (is (str/includes? body "Missing service-id"))))
 
@@ -1094,7 +1134,9 @@
                      :params {"mode" "service", "service-id" "service-id-1"}}
             {:keys [body cookie headers status]} (acknowledge-consent-handler-fn request)]
         (is (= 400 status))
-        (is (= {"content-type" "text/plain"} headers))
+        (is (= {"content-type" "text/plain"
+                "server" "waiter"}
+               headers))
         (is (nil? cookie))
         (is (str/includes? body "Unable to load description for token"))))
 
@@ -1107,7 +1149,9 @@
                      :params {"mode" "service", "service-id" "service-id-1"}}
             {:keys [body cookie headers status]} (acknowledge-consent-handler-fn request)]
         (is (= 400 status))
-        (is (= {"content-type" "text/plain"} headers))
+        (is (= {"content-type" "text/plain"
+                "server" "waiter"}
+               headers))
         (is (nil? cookie))
         (is (str/includes? body "Invalid service-id for specified token"))))
 
@@ -1226,7 +1270,9 @@
                      :scheme :http}
             {:keys [body headers status]} (request-consent-handler-fn request)]
         (is (= 405 status))
-        (is (= {"content-type" "text/plain"} headers))
+        (is (= {"content-type" "text/plain"
+                "server" "waiter"}
+               headers))
         (is (str/includes? body "Only GET supported"))))
 
     (testing "token without service description"
@@ -1238,7 +1284,9 @@
                      :scheme :http}
             {:keys [body headers status]} (request-consent-handler-fn request)]
         (is (= 404 status))
-        (is (= {"content-type" "text/plain"} headers))
+        (is (= {"content-type" "text/plain"
+                "server" "waiter"}
+               headers))
         (is (str/includes? body "Unable to load description for token"))))
 
     (with-redefs [io/resource io-resource-fn

--- a/waiter/test/waiter/scaling_test.clj
+++ b/waiter/test/waiter/scaling_test.clj
@@ -23,7 +23,8 @@
             [waiter.correlation-id :as cid]
             [waiter.mocks :refer :all]
             [waiter.scaling :refer :all]
-            [waiter.scheduler :as scheduler])
+            [waiter.scheduler :as scheduler]
+            [waiter.test-helpers :refer :all])
   (:import (java.util.concurrent CountDownLatch Executors)))
 
 (defn- retrieve-state-fn
@@ -166,10 +167,7 @@
                         {:basic-authentication {:src-router-id src-router-id} :route-params {:service-id test-service-id}}))
                     {:keys [body headers status]} (async/<!! response-chan)]
                 (is (= 200 status))
-                (is (= {"content-type" "application/json"
-                        "server" "waiter"
-                        "x-cid" correlation-id}
-                       headers))
+                (is (= (assoc expected-json-response-headers "x-cid" correlation-id) headers))
                 (is (= {:kill-response {:instance-id "instance-1", :killed? true, :message "Killed", :service-id test-service-id, :status 200},
                         :service-id test-service-id, :source-router-id src-router-id, :success true}
                        (walk/keywordize-keys (json/read-str body))))
@@ -197,10 +195,7 @@
                       {:basic-authentication {:src-router-id src-router-id} :route-params {:service-id test-service-id}}))
                   {:keys [body headers status]} (async/<!! response-chan)]
               (is (= 404 status))
-              (is (= {"content-type" "application/json"
-                      "server" "waiter"
-                      "x-cid" correlation-id}
-                     headers))
+              (is (= (assoc expected-json-response-headers "x-cid" correlation-id) headers))
               (is (= {:kill-response {:message "no-instance-killed", :status 404}, :service-id test-service-id,
                       :source-router-id src-router-id, :success false}
                      (walk/keywordize-keys (json/read-str body))))
@@ -232,10 +227,7 @@
                       {:basic-authentication {:src-router-id src-router-id} :route-params {:service-id test-service-id}}))
                   {:keys [body headers status]} (async/<!! response-chan)]
               (is (= 404 status))
-              (is (= {"content-type" "application/json"
-                      "server" "waiter"
-                      "x-cid" correlation-id}
-                     headers))
+              (is (= (assoc expected-json-response-headers "x-cid" correlation-id) headers))
               (is (= {:kill-response {:instance-id "instance-1", :killed? false, :message "Failure message",
                                       :service-id test-service-id, :status 404},
                       :service-id test-service-id, :source-router-id src-router-id, :success false}

--- a/waiter/test/waiter/scaling_test.clj
+++ b/waiter/test/waiter/scaling_test.clj
@@ -166,7 +166,10 @@
                         {:basic-authentication {:src-router-id src-router-id} :route-params {:service-id test-service-id}}))
                     {:keys [body headers status]} (async/<!! response-chan)]
                 (is (= 200 status))
-                (is (= {"content-type" "application/json", "x-cid" correlation-id} headers))
+                (is (= {"content-type" "application/json"
+                        "server" "waiter"
+                        "x-cid" correlation-id}
+                       headers))
                 (is (= {:kill-response {:instance-id "instance-1", :killed? true, :message "Killed", :service-id test-service-id, :status 200},
                         :service-id test-service-id, :source-router-id src-router-id, :success true}
                        (walk/keywordize-keys (json/read-str body))))
@@ -194,7 +197,10 @@
                       {:basic-authentication {:src-router-id src-router-id} :route-params {:service-id test-service-id}}))
                   {:keys [body headers status]} (async/<!! response-chan)]
               (is (= 404 status))
-              (is (= {"content-type" "application/json", "x-cid" correlation-id} headers))
+              (is (= {"content-type" "application/json"
+                      "server" "waiter"
+                      "x-cid" correlation-id}
+                     headers))
               (is (= {:kill-response {:message "no-instance-killed", :status 404}, :service-id test-service-id,
                       :source-router-id src-router-id, :success false}
                      (walk/keywordize-keys (json/read-str body))))
@@ -226,7 +232,10 @@
                       {:basic-authentication {:src-router-id src-router-id} :route-params {:service-id test-service-id}}))
                   {:keys [body headers status]} (async/<!! response-chan)]
               (is (= 404 status))
-              (is (= {"content-type" "application/json", "x-cid" correlation-id} headers))
+              (is (= {"content-type" "application/json"
+                      "server" "waiter"
+                      "x-cid" correlation-id}
+                     headers))
               (is (= {:kill-response {:instance-id "instance-1", :killed? false, :message "Failure message",
                                       :service-id test-service-id, :status 404},
                       :service-id test-service-id, :source-router-id src-router-id, :success false}

--- a/waiter/test/waiter/test_helpers.clj
+++ b/waiter/test/waiter/test_helpers.clj
@@ -27,6 +27,15 @@
            (javax.servlet ServletOutputStream
                           ServletResponse)))
 
+(def expected-html-response-headers {"content-type" "text/html"
+                                     "server" "waiter"})
+
+(def expected-json-response-headers {"content-type" "application/json"
+                                     "server" "waiter"})
+
+(def expected-text-response-headers {"content-type" "text/plain"
+                                     "server" "waiter"})
+
 (def ^:const ANSI-RESET "\033[0m")
 (def ^:const ANSI-BLUE "\033[34m")
 (def ^:const ANSI-CYAN "\033[36m")

--- a/waiter/test/waiter/util/utils_test.clj
+++ b/waiter/test/waiter/util/utils_test.clj
@@ -118,7 +118,9 @@
     (testing "should convert empty map"
       (let [{:keys [body headers status]} (clj->json-response {})]
         (is (= 200 status))
-        (is (= {"content-type" "application/json"} headers))
+        (is (= {"content-type" "application/json"
+                "server" "waiter"}
+               headers))
         (is (not (nil? body)))))
 
     (testing "should convert regex patterns to strings"
@@ -132,7 +134,9 @@
   (testing "convert empty map"
     (let [{:keys [body headers status]} (clj->streaming-json-response {})]
       (is (= 200 status))
-      (is (= {"content-type" "application/json"} headers))
+      (is (= {"content-type" "application/json"
+              "server" "waiter"}
+             headers))
       (is (= {} (json/read-str (json-response->str body))))))
   (testing "consumes status argument"
     (let [{:keys [status]} (clj->streaming-json-response {} :status 404)]
@@ -164,7 +168,9 @@
               (ex-info "TestCase Exception" (map->TestResponse {:status 400}))
               (assoc-in request [:headers "accept"] "text/html"))]
         (is (= 400 status))
-        (is (= {"content-type" "text/html"} headers))
+        (is (= {"content-type" "text/html"
+                "server" "waiter"}
+               headers))
         (is (str/includes? body "TestCase Exception"))))
     (testing "html response with links"
       (let [{:keys [body headers status]}
@@ -173,7 +179,9 @@
                                                                 :friendly-error-message "See http://localhost/path"}))
               (assoc-in request [:headers "accept"] "text/html"))]
         (is (= 400 status))
-        (is (= {"content-type" "text/html"} headers))
+        (is (= {"content-type" "text/html"
+                "server" "waiter"}
+               headers))
         (is (str/includes? body "See <a href=\"http://localhost/path\">http://localhost/path</a>"))))
     (testing "plaintext response"
       (let [{:keys [body headers status]}
@@ -181,7 +189,9 @@
               (ex-info "TestCase Exception" (map->TestResponse {:status 400}))
               (assoc-in request [:headers "accept"] "text/plain"))]
         (is (= 400 status))
-        (is (= {"content-type" "text/plain"} headers))
+        (is (= {"content-type" "text/plain"
+                "server" "waiter"}
+               headers))
         (is (str/includes? body "TestCase Exception"))))
     (testing "json response"
       (let [{:keys [body headers status]}
@@ -189,7 +199,9 @@
               (ex-info "TestCase Exception" (map->TestResponse {:status 500}))
               (assoc-in request [:headers "accept"] "application/json"))]
         (is (= 500 status))
-        (is (= {"content-type" "application/json"} headers))
+        (is (= {"content-type" "application/json"
+                "server" "waiter"}
+               headers))
         (is (str/includes? body "TestCase Exception"))))))
 
 (deftest test-log-and-suppress-when-exception-thrown

--- a/waiter/test/waiter/util/utils_test.clj
+++ b/waiter/test/waiter/util/utils_test.clj
@@ -118,9 +118,7 @@
     (testing "should convert empty map"
       (let [{:keys [body headers status]} (clj->json-response {})]
         (is (= 200 status))
-        (is (= {"content-type" "application/json"
-                "server" "waiter"}
-               headers))
+        (is (= expected-json-response-headers headers))
         (is (not (nil? body)))))
 
     (testing "should convert regex patterns to strings"
@@ -134,9 +132,7 @@
   (testing "convert empty map"
     (let [{:keys [body headers status]} (clj->streaming-json-response {})]
       (is (= 200 status))
-      (is (= {"content-type" "application/json"
-              "server" "waiter"}
-             headers))
+      (is (= expected-json-response-headers headers))
       (is (= {} (json/read-str (json-response->str body))))))
   (testing "consumes status argument"
     (let [{:keys [status]} (clj->streaming-json-response {} :status 404)]
@@ -168,9 +164,7 @@
               (ex-info "TestCase Exception" (map->TestResponse {:status 400}))
               (assoc-in request [:headers "accept"] "text/html"))]
         (is (= 400 status))
-        (is (= {"content-type" "text/html"
-                "server" "waiter"}
-               headers))
+        (is (= expected-html-response-headers headers))
         (is (str/includes? body "TestCase Exception"))))
     (testing "html response with links"
       (let [{:keys [body headers status]}
@@ -179,9 +173,7 @@
                                                                 :friendly-error-message "See http://localhost/path"}))
               (assoc-in request [:headers "accept"] "text/html"))]
         (is (= 400 status))
-        (is (= {"content-type" "text/html"
-                "server" "waiter"}
-               headers))
+        (is (= expected-html-response-headers headers))
         (is (str/includes? body "See <a href=\"http://localhost/path\">http://localhost/path</a>"))))
     (testing "plaintext response"
       (let [{:keys [body headers status]}
@@ -189,9 +181,7 @@
               (ex-info "TestCase Exception" (map->TestResponse {:status 400}))
               (assoc-in request [:headers "accept"] "text/plain"))]
         (is (= 400 status))
-        (is (= {"content-type" "text/plain"
-                "server" "waiter"}
-               headers))
+        (is (= expected-text-response-headers headers))
         (is (str/includes? body "TestCase Exception"))))
     (testing "json response"
       (let [{:keys [body headers status]}
@@ -199,9 +189,7 @@
               (ex-info "TestCase Exception" (map->TestResponse {:status 500}))
               (assoc-in request [:headers "accept"] "application/json"))]
         (is (= 500 status))
-        (is (= {"content-type" "application/json"
-                "server" "waiter"}
-               headers))
+        (is (= expected-json-response-headers headers))
         (is (str/includes? body "TestCase Exception"))))))
 
 (deftest test-log-and-suppress-when-exception-thrown


### PR DESCRIPTION
## Changes proposed in this PR

- includes server name in output generated from waiter

## Why are we making these changes?

Adding the `Server` header allows clients to differentiate between responses originating in Waiter and the backend.

**Before**:
```
$ curl -I -s -H"x-waiter-cpus: 1" -H"x-waiter-mem: 1024" -H"x-waiter-cmd: foo-bar" -H"x-waiter-version: fv" -H"x-waiter-timeout: 10000" http://localhost:9091/foo-bar 
HTTP/1.1 503 Service Unavailable
Content-Type: text/plain
Transfer-Encoding: chunked
...
```

**After** (note the extra `server` header):
```
$ curl -I -s -H"x-waiter-cpus: 1" -H"x-waiter-mem: 1024" -H"x-waiter-cmd: foo-bar" -H"x-waiter-version: fv" -H"x-waiter-timeout: 10000" http://localhost:9091/foo-bar                                      
HTTP/1.1 503 Service Unavailable
Content-Type: text/plain
Server: waiter/099b03d
Transfer-Encoding: chunked
...
```