### PR TITLE
includes timestamps in kitchen logging

### DIFF
--- a/kitchen/bin/kitchen
+++ b/kitchen/bin/kitchen
@@ -929,7 +929,7 @@ if __name__ == '__main__':
     else:
         logging_config = {'stream': getattr(sys, args.log_output)}
 
-    logging.basicConfig(level=logging.DEBUG, **logging_config)
+    logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s', level=logging.DEBUG, **logging_config)
     kitchen_logger = logging.getLogger('kitchen')
     kitchen_logger.setLevel(logging.DEBUG)
 


### PR DESCRIPTION
## Changes proposed in this PR

- includes timestamps in kitchen logging

## Why are we making these changes?

We would like to include timestamps to understand time delays between log events.

Example logs:
```
2019-01-06 21:49:01,819 INFO Basic Authentication Enabled
2019-01-06 21:49:01,825 INFO Starting HTTP server on *:10501...
```
