### PR TITLE
Enable Kerberos when accessing S3 buckets

### DIFF
--- a/kitchen/bin/waiter-init
+++ b/kitchen/bin/waiter-init
@@ -75,7 +75,9 @@ handle_k8s_terminate() {
                 logfile="r$i/$f"
                 # Using the -T option with curl PUTs the target file to the given URL,
                 # and avoids loading the full file into memory when sending the payload.
-                curl -s -T "$logfile" "$base_url/$logfile"
+                # Enabling Kerberos/SPNEGO when the bucket is not kerberized does not
+                # cause an error, and the extra flags are ignored on non-kerberized systems.
+                curl -s --negotiate -u: -T "$logfile" "$base_url/$logfile"
             done
         done
     fi

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -596,7 +596,10 @@
                   result (http-utils/http-request
                            http-client
                            log-bucket-url
-                           :query-string query-string)
+                           :query-string query-string
+                           ;; Enabling Kerberos/SPNEGO when the bucket is not kerberized does not
+                           ;; cause an error, and the extra flag is ignored on non-kerberized systems.
+                           :spnego-auth true)
                   xml-listing (-> result .getBytes io/input-stream xml/parse zip/xml-zip)]
               (vec
                 (concat


### PR DESCRIPTION
## Changes proposed in this PR

Enable Kerberos when accessing S3 buckets.

## Why are we making these changes?

These requests fail (HTTP 401) if the buckets are kerberized. Enabling Kerberos/SPNEGO when they're not kerberized doesn't hurt anything.