### PR TITLE
removes unused service-state-idle as we cannot have min-instances of zero

### DIFF
--- a/waiter/src/waiter/service.clj
+++ b/waiter/src/waiter/service.clj
@@ -304,6 +304,5 @@
   [deployment-error {:keys [healthy requested scheduled] :or {healthy 0 requested 0 scheduled 0}}]
   (cond
     deployment-error :service-state-failing
-    (and (zero? requested) (zero? scheduled) (zero? healthy)) :service-state-idle
     (zero? healthy) :service-state-starting
     :else :service-state-running))

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -267,7 +267,6 @@
               :not-found "Not found"
               :prestashed-tickets-not-available "Prestashed tickets not available"
               :service-state-failing "Failing"
-              :service-state-idle "Idle"
               :service-state-running "Running"
               :service-state-starting "Starting"}
    :metric-group-mappings []

--- a/waiter/test/waiter/service_test.clj
+++ b/waiter/test/waiter/service_test.clj
@@ -236,8 +236,8 @@
 
 (deftest test-resolve-service-status
   (is (= :service-state-failing (resolve-service-status :error {})))
-  (is (= :service-state-idle (resolve-service-status nil {})))
-  (is (= :service-state-idle (resolve-service-status nil {:healthy 0 :requested 0 :scheduled 0})))
+  (is (= :service-state-starting (resolve-service-status nil {})))
+  (is (= :service-state-starting (resolve-service-status nil {:healthy 0 :requested 0 :scheduled 0})))
   (is (= :service-state-running (resolve-service-status nil {:healthy 1 :requested 0 :scheduled 0})))
   (is (= :service-state-starting (resolve-service-status nil {:healthy 0 :requested 1 :scheduled 0})))
   (is (= :service-state-running (resolve-service-status nil {:healthy 1 :requested 1 :scheduled 0})))


### PR DESCRIPTION
## Changes proposed in this PR

- removes unused service-state-idle as we cannot have min-instances of zero

## Why are we making these changes?

Removes the `Idle` state since it is no longer possible to have zero instances for a running service.

