### PR TITLE
adds support for http2 requests to the Waiter API server

### DIFF
--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -93,6 +93,7 @@
                                                                core/correlation-id-middleware
                                                                (core/wrap-request-info router-id support-info))
                                         :host host
+                                        :http2c? true
                                         :join? false
                                         :max-threads 250
                                         :port port


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for Waiter to act as a http2 server

## Why are we making these changes?

We would like to start supporting http/2 requests initially only for the API, and eventually to the backends. This is a stepping stone to supporting HTTP/2 on the API server.

Examples:
```
$ curl --http1.0 http://localhost:9091/status
> GET /status HTTP/1.0
< HTTP/1.1 200 OK
{"status":"ok"}

$ curl --http1.0 http://localhost:9091/status
> GET /status HTTP/1.1
< HTTP/1.1 200 OK
{"status":"ok"}

$ curl --http2 http://localhost:9091/status
> GET /status HTTP/1.1
> Connection: Upgrade, HTTP2-Settings
> Upgrade: h2c
> HTTP2-Settings: AA...
< HTTP/1.1 101 Switching Protocols
* Using HTTP2, server supports multi-use
< HTTP/2 200 
{"status":"ok"}

$ curl --http2-prior-knowledge http://localhost:9091/status
* Using HTTP2, server supports multi-use
> GET /status HTTP/2
< HTTP/2 200 
{"status":"ok"}
```