### PR TITLE
Fixup/k8s watch error msgs

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -825,7 +825,7 @@
                       (when-let [version' (latest-watch-state-version scheduler options)]
                         (recur version' (inc iter)))))
                   (catch Exception e
-                    (log/error e "error in" resource-name "state watch thread")
+                    (log/warn "error in" resource-name "state watch thread:" e)
                     (throw e))))))
           (catch Throwable t
             (when exit-on-error?

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -870,14 +870,15 @@
                           service-id (k8s-object->service-id pod)
                           version (k8s-object->resource-version pod)]
                       (scheduler/log "pod state update:" update-type version pod)
-                      (swap! watch-state
-                             #(as-> % state
-                                (case update-type
-                                  "ADDED" (assoc-in state [:service-id->pod-id->pod service-id pod-id] pod)
-                                  "MODIFIED" (assoc-in state [:service-id->pod-id->pod service-id pod-id] pod)
-                                  "DELETED" (utils/dissoc-in state [:service-id->pod-id->pod service-id pod-id]))
-                                (assoc-in state [:pods-metadata :timestamp :watch] now)
-                                (assoc-in state [:pods-metadata :version :watch] version)))))}
+                      (when (not= "ERROR" update-type)
+                        (swap! watch-state
+                               #(as-> % state
+                                  (case update-type
+                                    "ADDED" (assoc-in state [:service-id->pod-id->pod service-id pod-id] pod)
+                                    "MODIFIED" (assoc-in state [:service-id->pod-id->pod service-id pod-id] pod)
+                                    "DELETED" (utils/dissoc-in state [:service-id->pod-id->pod service-id pod-id]))
+                                  (assoc-in state [:pods-metadata :timestamp :watch] now)
+                                  (assoc-in state [:pods-metadata :version :watch] version))))))}
       (merge options))))
 
 (defn global-rs-state-query
@@ -910,14 +911,15 @@
                           version (k8s-object->resource-version rs)]
                       (when service
                         (scheduler/log "rs state update:" update-type version service)
-                        (swap! watch-state
-                               #(as-> % state
-                                  (case update-type
-                                    "ADDED" (assoc-in state [:service-id->service service-id] service)
-                                    "MODIFIED" (assoc-in state [:service-id->service service-id] service)
-                                    "DELETED" (utils/dissoc-in state [:service-id->service service-id]))
-                                  (assoc-in state [:rs-metadata :timestamp :watch] now)
-                                  (assoc-in state [:rs-metadata :version :watch] version))))))}
+                        (when (not= "ERROR" update-type)
+                          (swap! watch-state
+                                 #(as-> % state
+                                    (case update-type
+                                      "ADDED" (assoc-in state [:service-id->service service-id] service)
+                                      "MODIFIED" (assoc-in state [:service-id->service service-id] service)
+                                      "DELETED" (utils/dissoc-in state [:service-id->service service-id]))
+                                    (assoc-in state [:rs-metadata :timestamp :watch] now)
+                                    (assoc-in state [:rs-metadata :version :watch] version)))))))}
       (merge options))))
 
 (defn kubernetes-scheduler


### PR DESCRIPTION
## Changes proposed in this PR

- Handle error messages in the kubernetes watch streams
- Log errors on the watch connection with log-level "warn" instead of "error" for non-fatal errors.

## Why are we making these changes?

These two issues were cluttering up our logs with a bunch of uninteresting error stack traces.