### PR TITLE
reports backend and client protocols in the request log

### DIFF
--- a/waiter/integration/waiter/websocket_integration_test.clj
+++ b/waiter/integration/waiter/websocket_integration_test.clj
@@ -61,7 +61,7 @@
           [close-code error] (async/<!! ctrl-chan)]
       (is (= :qbits.jet.websocket/error close-code))
       (is (instance? UpgradeException error))
-      (is (= "403 Unauthorized" (.getMessage error)))
+      (is (str/includes? (.getMessage error) "403 Unauthorized"))
       (is (not (realized? connect-success-promise))))))
 
 (deftest ^:parallel ^:integration-fast test-request-auth-success

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -32,7 +32,7 @@
 
   :dependencies [[bidi "2.1.4"
                   :exclusions [prismatic/schema ring/ring-core]]
-                 [twosigma/jet "0.7.10-20180627_133335-g2a9429e"]
+                 [twosigma/jet "0.7.10-20190124_123705-g05ee789"]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]
                  [clj-time "0.15.1"

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -69,6 +69,7 @@
             [waiter.work-stealing :as work-stealing])
   (:import (java.net InetAddress URI)
            java.util.concurrent.Executors
+           (javax.servlet ServletRequest)
            org.apache.curator.framework.CuratorFrameworkFactory
            org.apache.curator.framework.api.CuratorEventType
            org.apache.curator.framework.api.CuratorListener
@@ -172,7 +173,7 @@
       (cid/with-correlation-id
         request-cid
         (log/info "request received:"
-                  (-> (dissoc request :body :ctrl :request-time :server-name :server-port :servlet-request
+                  (-> (dissoc request :body :ctrl :in :out :request-time :server-name :server-port :servlet-request
                               :ssl-client-cert :support-info)
                       (update :headers headers/truncate-header-values)))
         (let [response (handler request)
@@ -185,12 +186,25 @@
                   (cid/ensure-correlation-id nested-response get-request-cid)
                   nested-response)))))))))
 
+(defn determine-request-protocol
+  "Determines the protocol and version used by the request."
+  [{:keys [headers scheme ^ServletRequest servlet-request]}]
+  (if servlet-request
+    (.getProtocol servlet-request)
+    (when scheme
+      (str/upper-case
+        ;; currently, only websockets need this branch to determine version
+        (if-let [version (get headers "sec-websocket-version")]
+          (str (name scheme) "/" version)
+          (name scheme))))))
+
 (defn wrap-request-info
   "Attaches request info to the request."
   [handler router-id support-info]
   (fn wrap-request-info-fn [request]
     (-> request
-        (assoc :request-id (str (utils/unique-identifier) "-" (-> request utils/request->scheme name))
+        (assoc :protocol (determine-request-protocol request)
+               :request-id (str (utils/unique-identifier) "-" (-> request utils/request->scheme name))
                :request-time (t/now)
                :router-id router-id
                :support-info support-info)
@@ -1121,9 +1135,9 @@
                                    (fn default-websocket-handler-fn [request]
                                      (let [password (first passwords)
                                            make-request-fn (fn make-ws-request
-                                                             [instance request request-properties passthrough-headers end-route metric-group]
+                                                             [instance request request-properties passthrough-headers end-route metric-group proto-version]
                                                              (ws/make-request websocket-client service-id->password-fn instance request request-properties
-                                                                              passthrough-headers end-route metric-group))
+                                                                              passthrough-headers end-route metric-group proto-version))
                                            process-request-fn (fn process-request-fn [request]
                                                                 (pr/process make-request-fn instance-rpc-chan start-new-service-fn
                                                                             instance-request-properties determine-priority-fn ws/process-response!
@@ -1162,9 +1176,10 @@
                                 [:state http-client instance-rpc-chan local-usage-agent interstitial-state-atom]
                                 wrap-auth-bypass-fn wrap-descriptor-fn wrap-https-redirect-fn wrap-secure-request-fn
                                 wrap-service-discovery-fn]
-                         (let [make-request-fn (fn [instance request request-properties passthrough-headers end-route metric-group]
+                         (let [make-request-fn (fn [instance request request-properties passthrough-headers end-route metric-group proto-version]
                                                  (pr/make-request http-client make-basic-auth-fn service-id->password-fn
-                                                                  instance request request-properties passthrough-headers end-route metric-group))
+                                                                  instance request request-properties passthrough-headers
+                                                                  end-route metric-group proto-version))
                                process-response-fn (partial pr/process-http-response post-process-async-request-response-fn)
                                inner-process-request-fn (fn inner-process-request [request]
                                                           (pr/process make-request-fn instance-rpc-chan start-new-service-fn

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -186,8 +186,10 @@
                   (cid/ensure-correlation-id nested-response get-request-cid)
                   nested-response)))))))))
 
-(defn determine-request-protocol
-  "Determines the protocol and version used by the request."
+(defn request->protocol
+  "Determines the protocol and version used by the request.
+   For HTTP requests, it returns values like HTTP/1.0, HTTP/1.1, HTTP/2.
+   For WebSocket requests, it returns values like WS/8, WS/13."
   [{:keys [headers scheme ^ServletRequest servlet-request]}]
   (if servlet-request
     (.getProtocol servlet-request)
@@ -203,7 +205,7 @@
   [handler router-id support-info]
   (fn wrap-request-info-fn [request]
     (-> request
-        (assoc :protocol (determine-request-protocol request)
+        (assoc :protocol (request->protocol request)
                :request-id (str (utils/unique-identifier) "-" (-> request utils/request->scheme name))
                :request-time (t/now)
                :router-id router-id

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -39,6 +39,7 @@
             [waiter.statsd :as statsd]
             [waiter.util.async-utils :as au]
             [waiter.util.date-utils :as du]
+            [waiter.util.http-utils :as hu]
             [waiter.util.ring-utils :as ru]
             [waiter.util.utils :as utils])
   (:import (java.io InputStream)))
@@ -52,11 +53,12 @@
 (defn async-make-request-helper
   "Helper function that returns a function that can invoke make-request-fn."
   [http-client instance-request-properties make-basic-auth-fn service-id->password-fn prepare-request-properties-fn make-request-fn]
-  (fn async-make-request-fn [instance {:keys [headers] :as request} end-route metric-group]
+  (fn async-make-request-fn [instance {:keys [headers protocol] :as request} end-route metric-group]
     (let [{:keys [passthrough-headers waiter-headers]} (headers/split-headers headers)
-          instance-request-properties (prepare-request-properties-fn instance-request-properties waiter-headers)]
+          instance-request-properties (prepare-request-properties-fn instance-request-properties waiter-headers)
+          proto-version (hu/determine-backend-protocol-version protocol)]
       (make-request-fn http-client make-basic-auth-fn service-id->password-fn instance request
-                       instance-request-properties passthrough-headers end-route metric-group))))
+                       instance-request-properties passthrough-headers end-route metric-group proto-version))))
 
 (defn- async-make-http-request
   "Helper function for async status/result handlers."

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -37,11 +37,13 @@
             [waiter.statsd :as statsd]
             [waiter.util.async-utils :as au]
             [waiter.util.date-utils :as du]
+            [waiter.util.http-utils :as hu]
             [waiter.util.ring-utils :as ru]
             [waiter.util.utils :as utils])
   (:import (java.io InputStream IOException)
            (java.util.concurrent TimeoutException)
            (org.eclipse.jetty.client HttpClient)
+           (org.eclipse.jetty.http HttpVersion)
            (org.eclipse.jetty.io EofException)
            (org.eclipse.jetty.server HttpChannel HttpOutput)))
 
@@ -179,10 +181,19 @@
     (deliver reservation-status-promise promise-value)
     (utils/exception->response (ex-info message (assoc metrics-map :status status) error) request)))
 
+(defn determine-http-version
+  "Determines the http protocol version to use for the request to the backend."
+  [^String protocol]
+  (try
+    (when (and protocol (str/starts-with? protocol "HTTP"))
+      (HttpVersion/fromString protocol))
+    (catch Exception e
+      (log/error e "unable to determine http version from" protocol))))
+
 (defn- make-http-request
   "Makes an asynchronous request to the endpoint using Basic authentication."
   [^HttpClient http-client make-basic-auth-fn request-method endpoint query-string headers body service-password
-   {:keys [username principal]} idle-timeout output-buffer-size]
+   {:keys [username principal]} idle-timeout output-buffer-size proto-version]
   (let [auth (make-basic-auth-fn endpoint "waiter" service-password)
         headers (headers/assoc-auth-headers headers username principal)]
     (http/request
@@ -197,12 +208,13 @@
        :idle-timeout idle-timeout
        :method request-method
        :query-string query-string
+       :version (determine-http-version proto-version)
        :url endpoint})))
 
 (defn make-request
   "Makes an asynchronous http request to the instance endpoint and returns a channel."
   [http-client make-basic-auth-fn service-id->password-fn instance {:keys [body query-string request-method] :as request}
-   {:keys [initial-socket-timeout-ms output-buffer-size]} passthrough-headers end-route metric-group]
+   {:keys [initial-socket-timeout-ms output-buffer-size]} passthrough-headers end-route metric-group proto-version]
   (let [instance-endpoint (scheduler/end-point-url instance end-route)
         service-id (scheduler/instance->service-id instance)
         service-password (service-id->password-fn service-id)
@@ -225,7 +237,7 @@
       (log/info "connecting to" instance-endpoint))
     (make-http-request
       http-client make-basic-auth-fn request-method instance-endpoint query-string headers body service-password
-      (handler/make-auth-user-map request) initial-socket-timeout-ms output-buffer-size)))
+      (handler/make-auth-user-map request) initial-socket-timeout-ms output-buffer-size proto-version)))
 
 (defn extract-async-request-response-data
   "Helper function that inspects the response and returns the location and query-string if the response
@@ -409,7 +421,7 @@
     [make-request-fn instance-rpc-chan start-new-service-fn
      instance-request-properties determine-priority-fn process-backend-response-fn
      request-abort-callback-factory local-usage-agent
-     {:keys [ctrl descriptor request-id request-time] :as request}]
+     {:keys [ctrl descriptor protocol request-id request-time] :as request}]
     (let [reservation-status-promise (promise)
           control-mult (async/mult ctrl)
           {:keys [uri] :as request} (-> request (dissoc :ctrl) (assoc :ctrl-mult control-mult))
@@ -449,7 +461,7 @@
                                             :time request-time
                                             :cid (cid/get-correlation-id)
                                             :request-id request-id}
-                                           priority (assoc :priority priority))
+                                     priority (assoc :priority priority))
                         ; pass false to keep request-state-chan open after control-mult is closed
                         ; request-state-chan should be explicitly closed after the request finishes processing
                         request-state-chan (async/tap control-mult (au/latest-chan) false)
@@ -460,7 +472,8 @@
                                                                   start-new-service-fn request-state-chan queue-timeout-ms
                                                                   reservation-status-promise metric-group)))
                         instance (:out timed-instance)
-                        instance-elapsed (:elapsed timed-instance)]
+                        instance-elapsed (:elapsed timed-instance)
+                        proto-version (hu/determine-backend-protocol-version protocol)]
                     (statsd/histo! metric-group "get_instance" instance-elapsed)
                     (-> (try
                           (log/info "suggested instance:" (:id instance) (:host instance) (:port instance))
@@ -469,7 +482,7 @@
                                                  (metrics/service-timer service-id "backend-response")
                                                  (async/<!
                                                    (make-request-fn instance request instance-request-properties
-                                                                    passthrough-headers uri metric-group)))
+                                                                    passthrough-headers uri metric-group proto-version)))
                                 response-elapsed (:elapsed timed-response)
                                 {:keys [error] :as response} (:out timed-response)]
                             (statsd/histo! metric-group "backend_response" response-elapsed)
@@ -494,7 +507,8 @@
                             (async/close! request-state-chan)
                             (handle-process-exception e request)))
                         (assoc :get-instance-latency-ns instance-elapsed
-                               :instance instance)
+                               :instance instance
+                               :protocol proto-version)
                         (assoc-debug-header "x-waiter-get-available-instance-ns" (str instance-elapsed))))))
               (catch Exception e ; Handle case where we couldn't get an instance
                 (counters/dec! (metrics/service-counter service-id "request-counts" "outstanding"))
@@ -508,8 +522,8 @@
     (if (get suspended-state :suspended false)
       (let [{:keys [last-updated-by time]} suspended-state
             response-map (cond-> {:service-id service-id}
-                                 time (assoc :suspended-at (du/date-to-str time))
-                                 (not (str/blank? last-updated-by)) (assoc :last-updated-by last-updated-by))]
+                           time (assoc :suspended-at (du/date-to-str time))
+                           (not (str/blank? last-updated-by)) (assoc :last-updated-by last-updated-by))]
         (log/info "Service has been suspended" response-map)
         (meters/mark! (metrics/service-meter service-id "response-rate" "error" "suspended"))
         (-> {:details response-map, :message "Service has been suspended", :status 503}

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -181,7 +181,7 @@
     (deliver reservation-status-promise promise-value)
     (utils/exception->response (ex-info message (assoc metrics-map :status status) error) request)))
 
-(defn determine-http-version
+(defn protocol->http-version
   "Determines the http protocol version to use for the request to the backend."
   [^String protocol]
   (try
@@ -208,7 +208,7 @@
        :idle-timeout idle-timeout
        :method request-method
        :query-string query-string
-       :version (determine-http-version proto-version)
+       :version (protocol->http-version proto-version)
        :url endpoint})))
 
 (defn make-request

--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -29,7 +29,7 @@
 
 (defn request->context
   "Convert a request into a context suitable for logging."
-  [{:keys [headers query-string remote-addr request-id request-method request-time uri] :as request}]
+  [{:keys [headers protocol query-string remote-addr request-id request-method request-time uri] :as request}]
   (let [{:strs [host origin user-agent x-cid x-forwarded-for]} headers]
     (cond-> {:cid x-cid
              :host host
@@ -39,6 +39,7 @@
              :scheme (-> request utils/request->scheme name)}
       origin (assoc :origin origin)
       request-method (assoc :method (-> request-method name str/upper-case))
+      protocol (assoc :client-protocol protocol)
       query-string (assoc :query-string query-string)
       request-time (assoc :request-time (du/date-to-str request-time))
       user-agent (assoc :user-agent user-agent))))
@@ -46,7 +47,7 @@
 (defn response->context
   "Convert a response into a context suitable for logging."
   [{:keys [authorization/principal backend-response-latency-ns descriptor latest-service-id get-instance-latency-ns
-           handle-request-latency-ns headers instance status] :as response}]
+           handle-request-latency-ns headers instance protocol status] :as response}]
   (let [{:keys [service-id service-description]} descriptor
         server (get headers "server")]
     (cond-> {:status (or status 200)}
@@ -62,6 +63,7 @@
                       :get-instance-latency-ns get-instance-latency-ns)
       latest-service-id (assoc :latest-service-id latest-service-id)
       principal (assoc :principal principal)
+      protocol (assoc :backend-protocol protocol)
       server (assoc :server server)
       handle-request-latency-ns (assoc :handle-request-latency-ns handle-request-latency-ns))))
 

--- a/waiter/src/waiter/util/http_utils.clj
+++ b/waiter/src/waiter/util/http_utils.clj
@@ -77,6 +77,8 @@
     client))
 
 (defn determine-backend-protocol-version
-  "Determines the protocol version to use for the request to the backend."
+  "Determines the protocol version to use for the request to the backend.
+   TODO: Once we add support for http/2 we will need to determine which protocol to use while
+   talking with the backend, using additional info from the service description."
   [^String protocol]
   protocol)

--- a/waiter/src/waiter/util/http_utils.clj
+++ b/waiter/src/waiter/util/http_utils.clj
@@ -75,3 +75,8 @@
       (let [new-user-agent-field (HttpField. HttpHeader/USER_AGENT (str user-agent))]
         (.setUserAgentField client new-user-agent-field)))
     client))
+
+(defn determine-backend-protocol-version
+  "Determines the protocol version to use for the request to the backend."
+  [^String protocol]
+  protocol)

--- a/waiter/src/waiter/websocket.clj
+++ b/waiter/src/waiter/websocket.clj
@@ -139,7 +139,7 @@
 
 (defn make-request
   "Makes an asynchronous websocket request to the instance endpoint and returns a channel."
-  [websocket-client service-id->password-fn instance ws-request request-properties passthrough-headers end-route _]
+  [websocket-client service-id->password-fn instance ws-request request-properties passthrough-headers end-route _ _]
   (let [ws-middleware (fn ws-middleware [_ ^UpgradeRequest request]
                         (let [service-password (-> instance scheduler/instance->service-id service-id->password-fn)
                               headers

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -37,8 +37,9 @@
             [waiter.test-helpers :refer :all]
             [waiter.util.date-utils :as du]
             [waiter.util.utils :as utils])
-  (:import java.io.StringBufferInputStream
-           (java.util.concurrent Executors)))
+  (:import (java.io StringBufferInputStream)
+           (java.util.concurrent Executors)
+           (javax.servlet ServletRequest)))
 
 (defn request
   [resource request-method & params]
@@ -1425,3 +1426,13 @@
                             "server" "waiter"}
                   :status 301}
                  response)))))))
+
+(deftest test-determine-request-protocol
+  (is (nil? (determine-request-protocol {})))
+  (is (= "HTTP" (determine-request-protocol {:scheme :http})))
+  (is (= "HTTP/1.1" (determine-request-protocol {:scheme :http
+                                                 :servlet-request (reify ServletRequest
+                                                                    (getProtocol [_] "HTTP/1.1"))})))
+  (is (= "WS" (determine-request-protocol {:scheme :ws})))
+  (is (= "WS" (determine-request-protocol {:headers {} :scheme :ws})))
+  (is (= "WS/13" (determine-request-protocol {:headers {"sec-websocket-version" "13"} :scheme :ws}))))

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -1427,12 +1427,12 @@
                   :status 301}
                  response)))))))
 
-(deftest test-determine-request-protocol
-  (is (nil? (determine-request-protocol {})))
-  (is (= "HTTP" (determine-request-protocol {:scheme :http})))
-  (is (= "HTTP/1.1" (determine-request-protocol {:scheme :http
+(deftest test-request->protocol
+  (is (nil? (request->protocol {})))
+  (is (= "HTTP" (request->protocol {:scheme :http})))
+  (is (= "HTTP/1.1" (request->protocol {:scheme :http
                                                  :servlet-request (reify ServletRequest
                                                                     (getProtocol [_] "HTTP/1.1"))})))
-  (is (= "WS" (determine-request-protocol {:scheme :ws})))
-  (is (= "WS" (determine-request-protocol {:headers {} :scheme :ws})))
-  (is (= "WS/13" (determine-request-protocol {:headers {"sec-websocket-version" "13"} :scheme :ws}))))
+  (is (= "WS" (request->protocol {:scheme :ws})))
+  (is (= "WS" (request->protocol {:headers {} :scheme :ws})))
+  (is (= "WS/13" (request->protocol {:headers {"sec-websocket-version" "13"} :scheme :ws}))))

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -264,17 +264,17 @@
             {:status 202 :headers {"location" "http://www.example.com:5678/retrieve/result/location"}}
             "http://www.example.com:1234/query/for/status")))))
 
-(deftest test-determine-http-version
-  (is (nil? (determine-http-version nil)))
-  (is (nil? (determine-http-version "")))
-  (is (nil? (determine-http-version "Http/0.9")))
-  (is (= HttpVersion/HTTP_0_9 (determine-http-version "HTTP/0.9")))
-  (is (nil? (determine-http-version "http/1.0")))
-  (is (= HttpVersion/HTTP_1_0 (determine-http-version "HTTP/1.0")))
-  (is (= HttpVersion/HTTP_1_1 (determine-http-version "HTTP/1.1")))
-  (is (= HttpVersion/HTTP_2 (determine-http-version "HTTP/2.0")))
-  (is (nil? (determine-http-version "HTTP/2.1")))
-  (is (nil? (determine-http-version "HTTP/3.0"))))
+(deftest test-protocol->http-version
+  (is (nil? (protocol->http-version nil)))
+  (is (nil? (protocol->http-version "")))
+  (is (nil? (protocol->http-version "Http/0.9")))
+  (is (= HttpVersion/HTTP_0_9 (protocol->http-version "HTTP/0.9")))
+  (is (nil? (protocol->http-version "http/1.0")))
+  (is (= HttpVersion/HTTP_1_0 (protocol->http-version "HTTP/1.0")))
+  (is (= HttpVersion/HTTP_1_1 (protocol->http-version "HTTP/1.1")))
+  (is (= HttpVersion/HTTP_2 (protocol->http-version "HTTP/2.0")))
+  (is (nil? (protocol->http-version "HTTP/2.1")))
+  (is (nil? (protocol->http-version "HTTP/3.0"))))
 
 (deftest test-make-request
   (let [instance {:service-id "test-service-id", :host "example.com", :port 8080, :protocol "proto"}

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -28,7 +28,8 @@
             [waiter.process-request :refer :all]
             [waiter.statsd :as statsd])
   (:import (java.io ByteArrayOutputStream)
-           (org.eclipse.jetty.client HttpClient)))
+           (org.eclipse.jetty.client HttpClient)
+           (org.eclipse.jetty.http HttpVersion)))
 
 (deftest test-prepare-request-properties
   (let [test-cases (list
@@ -263,6 +264,18 @@
             {:status 202 :headers {"location" "http://www.example.com:5678/retrieve/result/location"}}
             "http://www.example.com:1234/query/for/status")))))
 
+(deftest test-determine-http-version
+  (is (nil? (determine-http-version nil)))
+  (is (nil? (determine-http-version "")))
+  (is (nil? (determine-http-version "Http/0.9")))
+  (is (= HttpVersion/HTTP_0_9 (determine-http-version "HTTP/0.9")))
+  (is (nil? (determine-http-version "http/1.0")))
+  (is (= HttpVersion/HTTP_1_0 (determine-http-version "HTTP/1.0")))
+  (is (= HttpVersion/HTTP_1_1 (determine-http-version "HTTP/1.1")))
+  (is (= HttpVersion/HTTP_2 (determine-http-version "HTTP/2.0")))
+  (is (nil? (determine-http-version "HTTP/2.1")))
+  (is (nil? (determine-http-version "HTTP/3.0"))))
+
 (deftest test-make-request
   (let [instance {:service-id "test-service-id", :host "example.com", :port 8080, :protocol "proto"}
         request {:authorization/principal "test-user@test.com"
@@ -327,11 +340,13 @@
                                                            "te" "trailers" "transfer-encoding" "upgrade")
                                                    (merge {"x-waiter-auth-principal"          "test-user"
                                                            "x-waiter-authenticated-principal" "test-user@test.com"}))
-                                               (:headers request-config)))))]
+                                               (:headers request-config)))))
+          proto-version HttpVersion/HTTP_1_1]
       (testing "make-request:headers"
         (let [request-method-fn-call-counter (atom 0)]
           (with-redefs [http/request (http-request-mock-factory passthrough-headers request-method-fn-call-counter)]
-            (make-request http-client make-basic-auth-fn service-id->password-fn instance request request-properties passthrough-headers end-route nil)
+            (make-request http-client make-basic-auth-fn service-id->password-fn instance request request-properties
+                          passthrough-headers end-route nil proto-version)
             (is (= 1 @request-method-fn-call-counter)))))
 
       (testing "make-request:headers-long-content-length"
@@ -344,7 +359,8 @@
                           (is (nil? metric-group))
                           (is (= "request_bytes" metric))
                           (deliver statsd-inc-call-value value))]
-            (make-request http-client make-basic-auth-fn service-id->password-fn instance request request-properties passthrough-headers end-route nil)
+            (make-request http-client make-basic-auth-fn service-id->password-fn instance request request-properties
+                          passthrough-headers end-route nil proto-version)
             (is (= 1 @request-method-fn-call-counter))
             (is (= 1234123412341234 (deref statsd-inc-call-value 0 :statsd-inc-not-called)))))))))
 

--- a/waiter/test/waiter/request_log_test.clj
+++ b/waiter/test/waiter/request_log_test.clj
@@ -16,21 +16,24 @@
 (ns waiter.request-log-test
   (:require [clj-time.core :as t]
             [clojure.test :refer :all]
-            [waiter.request-log :refer :all]))
+            [waiter.request-log :refer :all])
+  (:import [org.eclipse.jetty.http HttpVersion]))
 
 (deftest test-request->context
   (let [request {:headers {"host" "host"
                            "origin" "www.origin.org"
                            "user-agent" "test-user-agent"
                            "x-cid" "123"}
-                 :request-method :post
+                 :protocol (str HttpVersion/HTTP_1_1)
                  :query-string "a=1"
                  :remote-addr "127.0.0.1"
                  :request-id "abc"
+                 :request-method :post
                  :request-time (t/date-time 2018 4 11)
                  :scheme "http"
                  :uri "/" }]
     (is (= {:cid "123"
+            :client-protocol "HTTP/1.1"
             :host "host"
             :method "POST"
             :origin "www.origin.org"
@@ -58,8 +61,10 @@
                              :port 123
                              :protocol "instance-proto"}
                   :latest-service-id "latest-service-id"
+                  :protocol (str HttpVersion/HTTP_2)
                   :status 200}]
     (is (= {:backend-response-latency-ns 1000
+            :backend-protocol "HTTP/2.0"
             :get-instance-latency-ns 500
             :handle-request-latency-ns 2000
             :instance-host "instance-host"


### PR DESCRIPTION

## Changes proposed in this PR

- reports backend and client protocols in the request log
- updates jet version
- adds protocol into the request map

## Why are we making these changes?

This is preliminary support to enable making requests to backend servers with a different protocol version than incoming client requests. We would like to know, in the request log, the two protocol versions used.

Example request log data:
```
{"backend-protocol":"HTTP/1.1","client-protocol":"HTTP/1.1","path":"/hello","server":"BaseHTTP/0.6 Python/3.5.3",...}
{"backend-protocol":"WS/13","client-protocol":"WS/13","path":"/websocket-auth",...}
```