### PR TITLE
includes request info in the status output

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1378,8 +1378,7 @@
                               (wrap-secure-request-fn
                                 (fn state-statsd-handler-fn [request]
                                   (handler/get-statsd-state router-id request))))
-   :status-handler-fn (pc/fnk []
-                        (fn status-handler-fn [_] {:body "ok" :headers {} :status 200}))
+   :status-handler-fn (pc/fnk [] handler/status-handler)
    :token-handler-fn (pc/fnk [[:curator kv-store]
                               [:routines make-inter-router-requests-sync-fn synchronize-fn validate-service-description-fn]
                               [:settings [:token-config history-length limit-per-owner]]

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -738,8 +738,8 @@
                     :waiter-request?-fn (constantly true)}
           {:keys [body headers status]} ((ring-handler-factory waiter-request?-fn handlers) request)]
       (is (= 200 status))
-      (is (= {} headers))
-      (is (= "ok" (str body))))))
+      (is (= expected-json-response-headers headers))
+      (is (= {"status" "ok"} (json/read-str body))))))
 
 (deftest test-leader-fn-factory
   (with-redefs [discovery/cluster-size int]


### PR DESCRIPTION
## Changes proposed in this PR

- includes request info in the status output

## Why are we making these changes?

We would like to be able to introspect the properties of the request received by Waiter.

Current status endpoint:
<img width="850" alt="screen shot 2019-01-30 at 3 05 48 pm" src="https://user-images.githubusercontent.com/6611249/52012590-9da95b80-24a0-11e9-8326-3ed7d3cb2f72.png">

New status endpoint:

<img width="377" alt="screen shot 2019-01-30 at 3 10 12 pm" src="https://user-images.githubusercontent.com/6611249/52012815-2cb67380-24a1-11e9-9a74-fd0498bc43d3.png">

<img width="653" alt="screen shot 2019-01-30 at 3 11 52 pm" src="https://user-images.githubusercontent.com/6611249/52012908-6d15f180-24a1-11e9-9254-61d75547881a.png">


<img width="874" alt="screen shot 2019-01-30 at 8 30 09 am" src="https://user-images.githubusercontent.com/6611249/51988022-4936b980-2469-11e9-8223-29e539c9f07d.png">

