### PR TITLE
Add cpu bursting support to K8s pod specs

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -733,8 +733,7 @@
                                                                :failureThreshold 1
                                                                :periodSeconds health-check-interval-secs
                                                                :timeoutSeconds 1}
-                                              :resources {:limits {:cpu cpus
-                                                                   :memory memory}
+                                              :resources {:limits {:memory memory}
                                                           :requests {:cpu cpus
                                                                      :memory memory}}
                                               :volumeMounts [{:mountPath work-path
@@ -756,7 +755,7 @@
            :imagePullPolicy "IfNotPresent"
            :name "waiter-fileserver"
            :ports [{:containerPort port}]
-           :resources {:limits {:cpu cpu :memory memory}
+           :resources {:limits {:memory memory}
                        :requests {:cpu cpu :memory memory}}
            :volumeMounts [{:mountPath "/srv/www"
                            :name "user-home"}]


### PR DESCRIPTION
## Changes proposed in this PR

Allow K8s pods to burst above requested cpu (but memory limits remain strict).

## Why are we making these changes?

This matches our current Waiter on Marathon behavior.