### PR TITLE
Fix failing request-queue-timeout tests

### DIFF
--- a/waiter/config-k8s.edn
+++ b/waiter/config-k8s.edn
@@ -37,8 +37,9 @@
                     :kubernetes {:authorizer {:kind :sanity-check
                                               :sanity-check {:factory-fn waiter.authorization/sanity-check-authorizer}}
                                  :fileserver {:port 591}
-                                 :log-bucket-sync-secs 10
+                                 :log-bucket-sync-secs 5
                                  :log-bucket-url #config/env-default ["WAITER_S3_BUCKET" nil]
+                                 :pod-sigkill-delay-secs 1
                                  :url "http://localhost:8001"}}
 
  ; ---------- Error Handling ----------


### PR DESCRIPTION
## Changes proposed in this PR

- Fix bad assertion logic for the "Check that your app can start properly" message.
- Shorten pod grace periods in Travis to avoid pod "congestion" while running tests.

## Why are we making these changes?

Fixes #557.