### PR TITLE
Add PORT environment variable in K8s pods

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -687,6 +687,7 @@
                         :value (str log-bucket-url "/" run-as-user "/" service-id)}])
                     (for [[k v] base-env]
                       {:name k :value v})
+                    [{:name "PORT" :value (str port0)}]
                     (for [i (range ports)]
                       {:name (str "PORT" i) :value (str (+ port0 i))})))
         k8s-name (service-id->k8s-app-name scheduler service-id)


### PR DESCRIPTION
## Changes proposed in this PR

Add the `PORT` environment variable to our K8s pods.

## Why are we making these changes?

Improves compatibility with some legacy Waiter-Marathon apps which use `$PORT` in place of `$PORT0`.