### PR TITLE
Graphite expects timestamp in seconds

### DIFF
--- a/waiter/src/waiter/metrics.clj
+++ b/waiter/src/waiter/metrics.clj
@@ -138,7 +138,7 @@
   (defn metric-registry->metric-filter->metric-map
     "Unpack codahale metrics into a map of values"
     ([] (metric-registry->metric-filter->metric-map mc/default-registry MetricFilter/ALL))
-    ([^MetricRegistry registry ^MetricFilter metric-filter]
+    ([^MetricRegistry registry ^MetricFilter metric-filter & {:keys [map-keys-fn] :or {map-keys-fn str}}]
      (merge
        (pc/map-vals (fn [c] (counters/value c))
                     (.getCounters registry metric-filter))
@@ -146,7 +146,7 @@
                     (.getGauges registry metric-filter))
        (pc/map-vals (fn [^Histogram h] {"count" (.getCount h)
                                         "value" (->> (histograms/percentiles h percentiles)
-                                                     (pc/map-keys str))})
+                                                     (pc/map-keys map-keys-fn))})
                     (.getHistograms registry metric-filter))
        (pc/map-vals (fn [^Meter m] {"count" (.getCount m)
                                     "value" (meters/rate-one m)})
@@ -156,7 +156,7 @@
                        ; nanos -> seconds
                        "value" (->> (timers/percentiles t percentiles)
                                     (pc/map-vals #(/ % 1e9))
-                                    (pc/map-keys str))})
+                                    (pc/map-keys map-keys-fn))})
                     (.getTimers registry metric-filter))))))
 
 (defn get-metrics

--- a/waiter/src/waiter/reporter.clj
+++ b/waiter/src/waiter/reporter.clj
@@ -119,9 +119,9 @@
 (defn- report-to-graphite
   "Report values from a codahale MetricRegistry"
   [^MetricRegistry registry prefix ^MetricFilter filter ^GraphiteSender graphite]
-  ;; Graphite expects timestamp in seconds
-  (let [timestamp (/ (.getTime (Clock/defaultClock)) 1000)
-        map (metrics/metric-registry->metric-filter->metric-map registry filter)]
+  (let [timestamp (/ (.getTime (Clock/defaultClock)) 1000) ;; Graphite expects timestamp in seconds
+        map (metrics/metric-registry->metric-filter->metric-map
+              registry filter :map-keys-fn #(clojure.string/replace (str %) "." "_"))]
     (try
       (when-not (.isConnected graphite)
         (log/info "Connecting to graphite server")

--- a/waiter/src/waiter/reporter.clj
+++ b/waiter/src/waiter/reporter.clj
@@ -119,7 +119,8 @@
 (defn- report-to-graphite
   "Report values from a codahale MetricRegistry"
   [^MetricRegistry registry prefix ^MetricFilter filter ^GraphiteSender graphite]
-  (let [timestamp (.getTime (Clock/defaultClock))
+  ;; Graphite expects timestamp in seconds
+  (let [timestamp (/ (.getTime (Clock/defaultClock)) 1000)
         map (metrics/metric-registry->metric-filter->metric-map registry filter)]
     (try
       (when-not (.isConnected graphite)

--- a/waiter/test/waiter/reporters_test.clj
+++ b/waiter/test/waiter/reporters_test.clj
@@ -113,6 +113,7 @@ services.service-id.counters.fee.fie
     (metrics/service-counter "service-id" "foo")
     (metrics/service-counter "service-id" "foo" "bar")
     (metrics/service-counter "service-id" "fee" "fie")
+    (metrics/service-histogram "service-id" "fum")
     (counters/inc! (metrics/service-counter "service-id" "foo" "bar") 100)
     (let [actual-values (atom {})
           time (t/now)
@@ -120,7 +121,7 @@ services.service-id.counters.fee.fie
                      (flush [_])
                      (getFailures [_] 0)
                      (isConnected [_] true)
-                     (send [_ name value timestamp]  (swap! actual-values assoc name value "timestamp" timestamp)))
+                     (send [_ name value timestamp] (swap! actual-values assoc name value "timestamp" timestamp)))
           codahale-reporter (make-graphite-reporter 0 #".*" "prefix" graphite)]
       (is (satisfies? CodahaleReporter codahale-reporter))
       (with-redefs [t/now (constantly time)]
@@ -128,11 +129,29 @@ services.service-id.counters.fee.fie
       (is (= #{"prefix.services.service-id.counters.fee.fie"
                "prefix.services.service-id.counters.foo"
                "prefix.services.service-id.counters.foo.bar"
+               "prefix.services.service-id.histograms.fum.count"
+               "prefix.services.service-id.histograms.fum.value.0_0"
+               "prefix.services.service-id.histograms.fum.value.0_25"
+               "prefix.services.service-id.histograms.fum.value.0_5"
+               "prefix.services.service-id.histograms.fum.value.0_75"
+               "prefix.services.service-id.histograms.fum.value.0_95"
+               "prefix.services.service-id.histograms.fum.value.0_99"
+               "prefix.services.service-id.histograms.fum.value.0_999"
+               "prefix.services.service-id.histograms.fum.value.1_0"
                "timestamp"}
              (set (keys @actual-values))))
       (is (= (get @actual-values "prefix.services.service-id.counters.fee.fie") "0"))
       (is (= (get @actual-values "prefix.services.service-id.counters.foo") "0"))
       (is (= (get @actual-values "prefix.services.service-id.counters.foo.bar") "100"))
+      (is (= (get @actual-values "prefix.services.service-id.histograms.fum.count") "0"))
+      (is (= (get @actual-values "prefix.services.service-id.histograms.fum.value.0_0") "0"))
+      (is (= (get @actual-values "prefix.services.service-id.histograms.fum.value.0_25") "0"))
+      (is (= (get @actual-values "prefix.services.service-id.histograms.fum.value.0_5") "0"))
+      (is (= (get @actual-values "prefix.services.service-id.histograms.fum.value.0_75") "0"))
+      (is (= (get @actual-values "prefix.services.service-id.histograms.fum.value.0_95") "0"))
+      (is (= (get @actual-values "prefix.services.service-id.histograms.fum.value.0_99") "0"))
+      (is (= (get @actual-values "prefix.services.service-id.histograms.fum.value.0_999") "0"))
+      (is (= (get @actual-values "prefix.services.service-id.histograms.fum.value.1_0") "0"))
       (is (< (Math/abs (- (* 1000 (get @actual-values "timestamp")) (System/currentTimeMillis))) max-test-duration-ms))
       (is (= {:run-state :created
               :last-reporting-time time
@@ -144,6 +163,7 @@ services.service-id.counters.fee.fie
     (metrics/service-counter "service-id" "foo")
     (metrics/service-counter "service-id" "foo" "bar")
     (metrics/service-counter "service-id" "fee" "fie")
+    (metrics/service-histogram "service-id" "fum")
     (counters/inc! (metrics/service-counter "service-id" "foo" "bar") 100)
     (let [actual-values (atom {})
           time (t/now)
@@ -151,7 +171,7 @@ services.service-id.counters.fee.fie
                      (flush [_])
                      (getFailures [_] 0)
                      (isConnected [_] true)
-                     (send [_ name value timestamp]  (swap! actual-values assoc name value "timestamp" timestamp)))
+                     (send [_ name value timestamp] (swap! actual-values assoc name value "timestamp" timestamp)))
           codahale-reporter (make-graphite-reporter 0 #"^.*fee.*" "prefix" graphite)]
       (is (satisfies? CodahaleReporter codahale-reporter))
       (with-redefs [t/now (constantly time)]

--- a/waiter/test/waiter/reporters_test.clj
+++ b/waiter/test/waiter/reporters_test.clj
@@ -105,27 +105,35 @@ services.service-id.counters.fee.fie
                   (clojure.string/join "\n"))))
       (is (= {:run-state :created} @state)))))
 
+;; maximum expected test duration. used for fuzzy timestamp comparison
+(def max-test-duration-ms 5000)
+
 (deftest graphite-reporter-wildcard-filter
   (with-isolated-registry
     (metrics/service-counter "service-id" "foo")
     (metrics/service-counter "service-id" "foo" "bar")
     (metrics/service-counter "service-id" "fee" "fie")
     (counters/inc! (metrics/service-counter "service-id" "foo" "bar") 100)
-    (let [actual-values (atom #{})
+    (let [actual-values (atom {})
           time (t/now)
           graphite (reify GraphiteSender
                      (flush [_])
                      (getFailures [_] 0)
                      (isConnected [_] true)
-                     (send [_ name value _] (swap! actual-values #(conj % (str name value)))))
+                     (send [_ name value timestamp]  (swap! actual-values assoc name value "timestamp" timestamp)))
           codahale-reporter (make-graphite-reporter 0 #".*" "prefix" graphite)]
       (is (satisfies? CodahaleReporter codahale-reporter))
-      (with-redefs [t/now (fn [] time)]
+      (with-redefs [t/now (constantly time)]
         (report codahale-reporter))
-      (is (= #{"prefix.services.service-id.counters.fee.fie0"
-               "prefix.services.service-id.counters.foo0"
-               "prefix.services.service-id.counters.foo.bar100"}
-             @actual-values))
+      (is (= #{"prefix.services.service-id.counters.fee.fie"
+               "prefix.services.service-id.counters.foo"
+               "prefix.services.service-id.counters.foo.bar"
+               "timestamp"}
+             (set (keys @actual-values))))
+      (is (= (get @actual-values "prefix.services.service-id.counters.fee.fie") "0"))
+      (is (= (get @actual-values "prefix.services.service-id.counters.foo") "0"))
+      (is (= (get @actual-values "prefix.services.service-id.counters.foo.bar") "100"))
+      (is (< (Math/abs (- (* 1000 (get @actual-values "timestamp")) (System/currentTimeMillis))) max-test-duration-ms))
       (is (= {:run-state :created
               :last-reporting-time time
               :failed-writes-to-server 0
@@ -137,19 +145,24 @@ services.service-id.counters.fee.fie
     (metrics/service-counter "service-id" "foo" "bar")
     (metrics/service-counter "service-id" "fee" "fie")
     (counters/inc! (metrics/service-counter "service-id" "foo" "bar") 100)
-    (let [actual-values (atom #{})
+    (let [actual-values (atom {})
           time (t/now)
           graphite (reify GraphiteSender
                      (flush [_])
                      (getFailures [_] 0)
                      (isConnected [_] true)
-                     (send [_ name value _] (swap! actual-values #(conj % (str name value)))))
+                     (send [_ name value timestamp]  (swap! actual-values assoc name value "timestamp" timestamp)))
           codahale-reporter (make-graphite-reporter 0 #"^.*fee.*" "prefix" graphite)]
       (is (satisfies? CodahaleReporter codahale-reporter))
-      (with-redefs [t/now (fn [] time)]
+      (with-redefs [t/now (constantly time)]
         (report codahale-reporter))
-      (is (= #{"prefix.services.service-id.counters.fee.fie0"}
-             @actual-values))
+      (is (= #{"prefix.services.service-id.counters.fee.fie"
+               "timestamp"}
+             (set (keys @actual-values))))
+      (is (= (get @actual-values "prefix.services.service-id.counters.fee.fie") "0"))
+      (println (get @actual-values "timestamp"))
+      (println (System/currentTimeMillis))
+      (is (< (Math/abs (- (* 1000 (get @actual-values "timestamp")) (System/currentTimeMillis))) max-test-duration-ms))
       (is (= {:run-state :created
               :last-reporting-time time
               :failed-writes-to-server 0
@@ -170,7 +183,7 @@ services.service-id.counters.fee.fie
                      (send [_ _ _ _] (throw (ex-info "test" {}))))
           codahale-reporter (make-graphite-reporter 0 #".*" "prefix" graphite)]
       (is (satisfies? CodahaleReporter codahale-reporter))
-      (with-redefs [t/now (fn [] time)]
+      (with-redefs [t/now (constantly time)]
         (is (thrown-with-msg? ExceptionInfo #"^test$"
                               (report codahale-reporter))))
       (is (= #{} @actual-values))


### PR DESCRIPTION
## Changes proposed in this PR

change timestamp sent to graphite from milliseconds to seconds

## Why are we making these changes?

Graphite expects timestamp in seconds
