### PR TITLE
adds support for dynamically calculating token clusters

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -801,7 +801,7 @@
                                              ;; A regex to determine the root from the incoming request host header.
                                              ;; The first group from the match is used to determine the root.
                                              ;; If no match is found, it defaults to the :cluster-config :name.
-                                             :root-regex #config/regex "(.*)(:.*)?"}}
+                                             :root-regex #config/regex "^waiter-([a-zA-Z][0-9a-zA-Z\\-]*)"}}
 
                 ;; Configures the amount of history we store for a token.
                 ;; It must be a positive integer.

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -790,6 +790,19 @@
                        :failed-check-threshold 5}
 
  :token-config {
+                ;; Define the calculator that compute the root assigned to a token when they are created.
+                :cluster-calculator {;; :kind :configured create a calculator that always assigns root as :cluster-config :name
+                                     :kind :configured
+                                     :configured {:factory-fn 'waiter.token/new-configured-cluster-calculator}
+
+                                     ;; :kind :configured create a calculator that always assigns root as :cluster-config :name
+                                     ;; :kind :regex
+                                     :regex {:factory-fn 'waiter.token/new-regex-cluster-calculator
+                                             ;; A regex to determine the root from the incoming request host header.
+                                             ;; The first group from the match is used to determine the root.
+                                             ;; If no match is found, it defaults to the :cluster-config :name.
+                                             :root-regex #config/regex "(.*)(:.*)?"}}
+
                 ;; Configures the amount of history we store for a token.
                 ;; It must be a positive integer.
                 :history-length 5

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -578,6 +578,9 @@
    :start-service-cache (pc/fnk []
                           (cu/cache-factory {:threshold 100
                                              :ttl (-> 1 t/minutes t/in-millis)}))
+   :token-cluster-calculator (pc/fnk [[:settings [:cluster-config name] [:token-config cluster-calculator]]]
+                               (utils/create-component
+                                 cluster-calculator :context {:default-cluster name}))
    :token-root (pc/fnk [[:settings [:cluster-config name]]] name)
    :waiter-hostnames (pc/fnk [[:settings hostname]]
                        (set (if (sequential? hostname)
@@ -1399,13 +1402,13 @@
    :token-handler-fn (pc/fnk [[:curator kv-store]
                               [:routines make-inter-router-requests-sync-fn synchronize-fn validate-service-description-fn]
                               [:settings [:token-config history-length limit-per-owner]]
-                              [:state clock entitlement-manager token-root waiter-hostnames]
+                              [:state clock entitlement-manager token-cluster-calculator token-root waiter-hostnames]
                               wrap-secure-request-fn]
                        (wrap-secure-request-fn
                          (fn token-handler-fn [request]
                            (token/handle-token-request
-                             clock synchronize-fn kv-store token-root history-length limit-per-owner waiter-hostnames
-                             entitlement-manager make-inter-router-requests-sync-fn validate-service-description-fn
+                             clock synchronize-fn kv-store token-cluster-calculator token-root history-length limit-per-owner
+                             waiter-hostnames entitlement-manager make-inter-router-requests-sync-fn validate-service-description-fn
                              request))))
    :token-list-handler-fn (pc/fnk [[:curator kv-store]
                                    [:state entitlement-manager]

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -135,7 +135,7 @@
 (def ^:const on-the-fly-service-description-keys (set/union service-parameter-keys #{"token"}))
 
 ; keys allowed in system metadata for tokens, these need to be distinct from service description keys
-(def ^:const system-metadata-keys #{"deleted" "last-update-time" "last-update-user" "previous" "root"})
+(def ^:const system-metadata-keys #{"cluster" "deleted" "last-update-time" "last-update-user" "previous" "root"})
 
 ; keys allowed in user metadata for tokens, these need to be distinct from service description keys
 (def ^:const user-metadata-keys #{"fallback-period-secs" "https-redirect" "owner" "stale-timeout-mins"})

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -395,7 +395,7 @@
    :token-config {:cluster-calculator {:kind :configured
                                        :configured {:factory-fn 'waiter.token/new-configured-cluster-calculator}
                                        :regex {:factory-fn 'waiter.token/new-regex-cluster-calculator
-                                               :root-regex #"(.*)(:.*)?"}}
+                                               :root-regex #"^waiter-([a-zA-Z][0-9a-zA-Z\\-]*)"}}
                   :history-length 5
                   :limit-per-owner 1000
                   :token-defaults {"fallback-period-secs" (-> 5 t/minutes t/in-seconds)

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -76,7 +76,7 @@
                                      (s/required-key :metrics-gc-interval-ms) schema/positive-int
                                      (s/required-key :metrics-sync-interval-ms) schema/positive-int
                                      (s/required-key :codahale-reporters) {s/Keyword {(s/required-key :factory-fn) s/Symbol
-                                                                             s/Any s/Any}}
+                                                                                      s/Any s/Any}}
                                      (s/required-key :router-update-interval-ms) schema/positive-int
                                      (s/required-key :transient-metrics-timeout-ms) schema/positive-int}
    (s/required-key :password-store-config) (s/constrained
@@ -144,7 +144,11 @@
    (s/required-key :support-info) [{(s/required-key :label) schema/non-empty-string
                                     (s/required-key :link) {(s/required-key :type) s/Keyword
                                                             (s/required-key :value) schema/non-empty-string}}]
-   (s/required-key :token-config) {(s/required-key :history-length) schema/positive-int
+   (s/required-key :token-config) {(s/required-key :cluster-calculator) (s/constrained
+                                                                          {:kind s/Keyword
+                                                                           s/Keyword schema/require-symbol-factory-fn}
+                                                                          schema/contains-kind-sub-map?)
+                                   (s/required-key :history-length) schema/positive-int
                                    (s/required-key :limit-per-owner) schema/positive-int
                                    (s/required-key :token-defaults) {(s/required-key "fallback-period-secs") schema/non-negative-int
                                                                      (s/required-key "https-redirect") s/Bool
@@ -388,7 +392,11 @@
    :support-info [{:label "Waiter on GitHub"
                    :link {:type :url
                           :value "http://github.com/twosigma/waiter"}}]
-   :token-config {:history-length 5
+   :token-config {:cluster-calculator {:kind :configured
+                                       :configured {:factory-fn 'waiter.token/new-configured-cluster-calculator}
+                                       :regex {:factory-fn 'waiter.token/new-regex-cluster-calculator
+                                               :root-regex #"(.*)(:.*)?"}}
+                  :history-length 5
                   :limit-per-owner 1000
                   :token-defaults {"fallback-period-secs" (-> 5 t/minutes t/in-seconds)
                                    "https-redirect" false


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for dynamically calculating token clusters

## Why are we making these changes?

We would like to know the target cluster for a token. The `root` metadata does not suffice since while running in failure mode the request maybe capture by a different Waiter cluster than the one determined from the `host` header.

