### PR TITLE
Adds support for authentication scheme on /status

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -907,5 +907,6 @@
 
 (deftest ^:parallel ^:integration-fast test-status-include-auth-info
   (testing-using-waiter-url
-    (let [{:keys [authentication-scheme]} (waiter-status waiter-url {"include" "auth-info"})]
-      (is (some #{authentication-scheme} ["one-user" "kerberos"])))))
+    (let [{:keys [authentication-scheme]} (waiter-status waiter-url {"include" "auth-info"})
+          {:keys [authenticator-config]} (waiter-settings waiter-url)]
+      (is (= (:kind authenticator-config) authentication-scheme)))))

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -904,3 +904,8 @@
             (is (service waiter-url service-id {}) (str service-id "not found in /apps endpoint")))
           (doseq [service-id service-ids]
             (delete-service waiter-url service-id)))))))
+
+(deftest ^:parallel ^:integration-fast test-status-include-auth-info
+  (testing-using-waiter-url
+    (let [{:keys [authentication-scheme]} (waiter-status waiter-url {"include" "auth-info"})]
+      (is (some #{authentication-scheme} ["one-user" "kerberos"])))))

--- a/waiter/src/waiter/auth/authentication.clj
+++ b/waiter/src/waiter/auth/authentication.clj
@@ -27,7 +27,10 @@
     "Attaches middleware that enables the application to perform authentication.
      The middleware should
      - either issue a 401 challenge asking the client to authenticate itself,
-     - or upon successful authentication populate the request with :authorization/user and :authorization/principal"))
+     - or upon successful authentication populate the request with :authorization/user and :authorization/principal")
+
+  (scheme [this]
+    "Returns a string representing the authentication scheme (e.g. kerberos)"))
 
 (defn- add-cached-auth
   [response password principal]
@@ -100,7 +103,10 @@
   Authenticator
   (wrap-auth-handler [_ request-handler]
     (fn anonymous-handler [request] 
-      (handle-request-auth request-handler request run-as-user run-as-user password))))
+      (handle-request-auth request-handler request run-as-user run-as-user password)))
+
+  (scheme [_]
+    "one-user"))
 
 (defn one-user-authenticator
   "Factory function for creating single-user authenticator"

--- a/waiter/src/waiter/auth/kerberos.clj
+++ b/waiter/src/waiter/auth/kerberos.clj
@@ -106,7 +106,10 @@
 (defrecord KerberosAuthenticator [^ThreadPoolExecutor executor max-queue-length password]
   auth/Authenticator
   (wrap-auth-handler [_ request-handler]
-    (spnego/require-gss request-handler executor max-queue-length password)))
+    (spnego/require-gss request-handler executor max-queue-length password))
+
+  (scheme [_]
+    "kerberos"))
 
 (defn kerberos-authenticator
   "Factory function for creating Kerberos authenticator middleware"

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1395,7 +1395,9 @@
                               (wrap-secure-request-fn
                                 (fn state-statsd-handler-fn [request]
                                   (handler/get-statsd-state router-id request))))
-   :status-handler-fn (pc/fnk [] handler/status-handler)
+   :status-handler-fn (pc/fnk [[:state authenticator]]
+                        (fn status-handler-fn [request]
+                          (handler/status-handler authenticator request)))
    :token-handler-fn (pc/fnk [[:curator kv-store]
                               [:routines make-inter-router-requests-sync-fn synchronize-fn validate-service-description-fn]
                               [:settings [:token-config history-length limit-per-owner]]

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -889,7 +889,7 @@
                     (update :headers headers/truncate-header-values))))
 
             include-auth-info
-            (merge {:authentication-scheme (auth/scheme authenticator)})      )
+            (merge {:authentication-scheme (auth/scheme authenticator)}))
           utils/clj->json-response))
     (catch Throwable th
       (utils/exception->response th request))))

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -889,7 +889,7 @@
                     (update :headers headers/truncate-header-values))))
 
             include-auth-info
-            (merge {:authentication-scheme (auth/scheme authenticator)}))
+            (assoc :authentication-scheme (auth/scheme authenticator)))
           utils/clj->json-response))
     (catch Throwable th
       (utils/exception->response th request))))

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -952,3 +952,8 @@
          cookies# ~cookies]
      (doseq [[_# router-url#] (routers ~waiter-url)]
        (is (wait-for #(seq (active-instances router-url# service-id# :cookies cookies#)))))))
+
+(defn waiter-status [waiter-url query-params]
+  (let [status-result (make-request waiter-url "/status" :verbose true :query-params query-params)
+        status-json (try-parse-json (:body status-result))]
+    (walk/keywordize-keys status-json)))

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -954,6 +954,6 @@
        (is (wait-for #(seq (active-instances router-url# service-id# :cookies cookies#)))))))
 
 (defn waiter-status [waiter-url query-params]
-  (let [status-result (make-request waiter-url "/status" :verbose true :query-params query-params)
+  (let [status-result (make-request waiter-url "/status" :query-params query-params :verbose true)
         status-json (try-parse-json (:body status-result))]
     (walk/keywordize-keys status-json)))

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -735,7 +735,7 @@
   (testing "health-check-handler:status-ok"
     (let [request {:request-method :get, :uri "/status"}
           waiter-request?-fn (fn [_] true)
-          handlers {:status-handler-fn ((:status-handler-fn request-handlers) {})
+          handlers {:status-handler-fn ((:status-handler-fn request-handlers) {:state {:authenticator {}}})
                     :waiter-request?-fn (constantly true)}
           {:keys [body headers status]} ((ring-handler-factory waiter-request?-fn handlers) request)]
       (is (= 200 status))


### PR DESCRIPTION
## Changes proposed in this PR

- adding `scheme` to the `Authenticator` protocol and implementations
- adding `include=auth-info` on `/status`, which populates `authentication-scheme`

## Why are we making these changes?

When running integration tests, it's nice for them to be able to ask Waiter what authentication scheme it's using. In particular, this will be used in the Waiter CLI integration tests.

## Examples

```bash
$ curl -s localhost:9091/status?include=auth-info | jq
{
  "status": "ok",
  "authentication-scheme": "one-user"
}
```

```bash
$ curl -s localhost:9091/status?include=auth-info | jq
{
  "status": "ok",
  "authentication-scheme": "kerberos"
}
```