### PR TITLE
disallows creating tokens with empty user-editable parameters

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -143,6 +143,12 @@
           current-user (System/getProperty "user.name")
           token-root (retrieve-token-root waiter-url)]
 
+      (log/info "creating token without parameters should fail")
+      (let [token (str service-id-prefix ".empty")
+            {:keys [body] :as response} (post-token waiter-url {:token token})]
+        (assert-response-status response 400)
+        (is (str/includes? (str body) (str "No parameters provided for " token)) (str body)))
+
       (log/info "creating the tokens")
       (doseq [token tokens-to-create]
         (let [response (post-token waiter-url {:health-check-url "/check"

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -362,6 +362,8 @@
       (throw (ex-info "Must provide the token" {:status 400})))
     (when (some #(= token %) waiter-hostnames)
       (throw (ex-info "Token name is reserved" {:status 403 :token token})))
+    (when (empty? (select-keys new-token-data sd/token-user-editable-keys))
+      (throw (ex-info (str "No parameters provided for " token) {:status 400})))
     (sd/validate-token token)
     (validate-service-description-fn new-service-parameter-template)
     (when-let [user-metadata-check (s/check sd/user-metadata-schema new-user-metadata)]

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -996,6 +996,18 @@
           (is (= 403 status))
           (is (str/includes? body "Token name is reserved"))))
 
+      (testing "post:new-service-description:no-parameters"
+        (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+              service-description (walk/stringify-keys {:token "abcdefgh"})
+              {:keys [body status]}
+              (run-handle-token-request
+                kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true)
+                {:authorization/user auth-user
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
+                 :request-method :post})]
+          (is (= 400 status))
+          (is (str/includes? body (str "No parameters provided for abcdefgh")))))
+
       (testing "post:new-service-description:schema-fail"
         (let [kv-store (kv/->LocalKeyValueStore (atom {}))
               service-description (walk/stringify-keys


### PR DESCRIPTION
## Changes proposed in this PR

- disallows creating tokens with empty user-editable parameters

## Why are we making these changes?

Marker tokens are not handled well in the current codebase, best to disallow their creation at all.

