### PR TITLE
fixes stale gc logic by making it conservative

### DIFF
--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -974,12 +974,12 @@
   (let [{:strs [idle-timeout-mins]} (service-id->service-description-fn service-id)
         source-tokens-set (service-id->source-tokens-set-fn service-id)]
     (if (and (seq source-tokens-set)
-             (some (fn [source-tokens]
-                     (and (seq source-tokens)
-                          ;; safe assumption mark a service stale when every token used to access it is stale
-                          (every? (fn [{:strs [token version]}]
-                                    (not= (token->token-hash token) version))
-                                source-tokens)))
+             ;; safe assumption mark a service stale when every token used to access it is stale
+             (every? (fn [source-tokens]
+                       (and (seq source-tokens)
+                            (every? (fn [{:strs [token version]}]
+                                      (not= (token->token-hash token) version))
+                                    source-tokens)))
                    source-tokens-set))
       (do
         (log/info service-id "that uses tokens is stale")


### PR DESCRIPTION
## Changes proposed in this PR

- fixes stale gc logic by making it conservative

## Why are we making these changes?

Avoids the issue where we eagerly GC services for scenarios where they have been accessed by multiple tokens, one of which is stale.


