### PR TITLE
uses x-forwarded-proto-version for protocol version when available

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -192,7 +192,10 @@
    For WebSocket requests, it returns values like WS/8, WS/13."
   [{:keys [headers scheme ^ServletRequest servlet-request]}]
   (if servlet-request
-    (.getProtocol servlet-request)
+    (or (some-> headers
+                (get "x-forwarded-proto-version")
+                str/upper-case)
+        (.getProtocol servlet-request))
     (when scheme
       (str/upper-case
         ;; currently, only websockets need this branch to determine version

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -1429,7 +1429,10 @@
 
 (deftest test-request->protocol
   (is (nil? (request->protocol {})))
+  (is (nil? (request->protocol {:headers {"x-forwarded-proto-version" "Foo/Bar"}})))
   (is (= "HTTP" (request->protocol {:scheme :http})))
+  (is (= "FOO/BAR" (request->protocol {:headers {"x-forwarded-proto-version" "Foo/Bar"}
+                                       :servlet-request (Object.)})))
   (is (= "HTTP/1.1" (request->protocol {:scheme :http
                                                  :servlet-request (reify ServletRequest
                                                                     (getProtocol [_] "HTTP/1.1"))})))


### PR DESCRIPTION
## Changes proposed in this PR

- uses x-forwarded-proto-version for protocol version when available

## Why are we making these changes?

Allows the client/proxy to specify the protocol version of the originating request. Chose to use `x-forwarded-proto-version` based on a response from to a [stackoverflow question](https://stackoverflow.com/questions/34839292/how-to-forward-http-2-protocol-version-via-proxy).
