### PR TITLE
fixes the token syncer tests to handle for the new cluster metadata parameter

### DIFF
--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -38,6 +38,10 @@
         (str/split #",")
         sort)))
 
+(defn- waiter-url->cluster
+  [waiter-url]
+  (str "cluster-" (hash waiter-url)))
+
 (defn- waiter-api []
   (main/init-waiter-api {:connection-timeout-ms 5000, :idle-timeout-ms 5000}))
 
@@ -56,7 +60,8 @@
 (defn- basic-token-metadata
   "Returns the common metadata used in the tests."
   [current-time-ms]
-  {"last-update-time" current-time-ms
+  {"cluster" "cl.1"
+   "last-update-time" current-time-ms
    "last-update-user" "auth-user"
    "owner" "test-user"
    "previous" {"last-update-time" (- current-time-ms 30000)
@@ -382,6 +387,7 @@
               (fn [index waiter-url]
                 (store-token waiter-url token-name nil
                              (assoc basic-description
+                               "cluster" (waiter-url->cluster waiter-url)
                                "cpus" (inc index)
                                "last-update-time" (- last-update-time-ms index)
                                "last-update-user" (str "auth-user-" index)
@@ -398,6 +404,7 @@
 
               ;; ASSERT
               (let [latest-description (assoc basic-description
+                                         "cluster" (waiter-url->cluster (first waiter-urls))
                                          "cpus" 1
                                          "last-update-time" last-update-time-ms
                                          "last-update-user" "auth-user-0"
@@ -448,6 +455,7 @@
               (fn [index waiter-url]
                 (store-token waiter-url token-name nil
                              (assoc basic-description
+                               "cluster" (waiter-url->cluster waiter-url)
                                "cpus" (inc index)
                                "last-update-time" (- last-update-time-ms index)
                                "last-update-user" "auth-user"
@@ -464,6 +472,7 @@
 
               ;; ASSERT
               (let [latest-description (assoc basic-description
+                                         "cluster" (waiter-url->cluster (first waiter-urls))
                                          "cpus" 1
                                          "last-update-time" last-update-time-ms
                                          "last-update-user" "auth-user"
@@ -477,6 +486,7 @@
                                          [waiter-url
                                           {:code :error/root-mismatch
                                            :details {:cluster (assoc basic-description
+                                                                "cluster" (waiter-url->cluster waiter-url)
                                                                 "cpus" (+ index 2)
                                                                 "last-update-time" (- last-update-time-ms index 1)
                                                                 "last-update-user" "auth-user"
@@ -505,6 +515,7 @@
                       (let [token-last-modified-time (- last-update-time-ms index)
                             token-etag (token->etag waiter-api waiter-url token-name)]
                         (is (= {:description (assoc basic-description
+                                               "cluster" (waiter-url->cluster waiter-url)
                                                "cpus" (inc index)
                                                "last-update-time" token-last-modified-time
                                                "last-update-user" "auth-user"

--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -31,7 +31,9 @@
                         "mem" 2048
                         "metric-group" "syncer-test"})
 
-(defn- waiter-urls []
+(defn- waiter-urls
+  "Retrieves urls to the waiter clusters provided in the WAITER_URIS environment variable."
+  []
   (let [waiter-uris (System/getenv "WAITER_URIS")]
     (is waiter-uris)
     (-> waiter-uris
@@ -39,10 +41,13 @@
         sort)))
 
 (defn- waiter-url->cluster
+  "Retrieves the cluster name corresponding to the provided cluster,"
   [waiter-url]
   (str "cluster-" (hash waiter-url)))
 
-(defn- waiter-api []
+(defn- waiter-api
+  "Initializes and returns the Waiter API functions."
+  []
   (main/init-waiter-api {:connection-timeout-ms 5000, :idle-timeout-ms 5000}))
 
 (deftest ^:integration test-environment
@@ -75,6 +80,7 @@
       (get :token-etag)))
 
 (defn- cleanup-token
+  "'Hard' deletes the token on all provided clusters."
   [{:keys [hard-delete-token] :as waiter-api} waiter-urls token-name]
   (log/info "Cleaning up token:" token-name)
   (doseq [waiter-url waiter-urls]


### PR DESCRIPTION

## Changes proposed in this PR

- fixes the token syncer tests to handle for the new cluster metadata parameter

## Why are we making these changes?

We wish to have green builds.
