### PR TITLE
defaults the kerberos throttler core pool size to the concurrency level

### DIFF
--- a/waiter/src/waiter/auth/kerberos.clj
+++ b/waiter/src/waiter/auth/kerberos.clj
@@ -118,7 +118,8 @@
          (pos? keep-alive-mins)
          (integer? max-queue-length)
          (pos? max-queue-length)]}
-  (let [executor (ThreadPoolExecutor. 1 concurrency-level keep-alive-mins TimeUnit/MINUTES (LinkedBlockingQueue.))]
+  (let [queue (LinkedBlockingQueue.)
+        executor (ThreadPoolExecutor. concurrency-level concurrency-level keep-alive-mins TimeUnit/MINUTES queue)]
     (metrics/waiter-gauge #(.getActiveCount executor)
                           "core" "kerberos" "throttle" "active-thread-count")
     (metrics/waiter-gauge #(- concurrency-level (.getActiveCount executor))


### PR DESCRIPTION
## Changes proposed in this PR

- defaults the kerberos throttler core pool size to the concurrency level

## Why are we making these changes?

ThreadPoolExecutor spawns additional threads only when the queue becomes full. Instead, we want to have threads available to be processing tasks from the queue as soon as there are pending tasks.

