### PR TITLE
Persist custom K8s scheduler options

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -471,6 +471,7 @@
 (defrecord KubernetesScheduler [api-server-url
                                 authorizer
                                 cluster-name
+                                custom-options
                                 daemon-state
                                 fileserver
                                 http-client
@@ -943,13 +944,14 @@
 (defn kubernetes-scheduler
   "Returns a new KubernetesScheduler with the provided configuration. Validates the
    configuration against kubernetes-scheduler-schema and throws if it's not valid."
-  [{:keys [authentication authorizer cluster-name http-options log-bucket-sync-secs log-bucket-url
-           max-patch-retries max-name-length pod-base-port pod-sigkill-delay-secs pod-suffix-length
-           replicaset-api-version replicaset-spec-builder scheduler-name scheduler-state-chan
-           scheduler-syncer-interval-secs service-id->service-description-fn service-id->password-fn
-           url start-scheduler-syncer-fn watch-retries]
-    {fileserver-port :port fileserver-scheme :scheme :as fileserver} :fileserver}]
+  [{:keys [authentication authorizer cluster-name custom-options http-options log-bucket-sync-secs
+           log-bucket-url max-patch-retries max-name-length pod-base-port pod-sigkill-delay-secs
+           pod-suffix-length replicaset-api-version replicaset-spec-builder scheduler-name
+           scheduler-state-chan scheduler-syncer-interval-secs service-id->service-description-fn
+           service-id->password-fn start-scheduler-syncer-fn url watch-retries]
+    {fileserver-port :port fileserver-scheme :scheme :as fileserver} :fileserver :as context}]
   {:pre [(schema/contains-kind-sub-map? authorizer)
+         (or (nil? custom-options) (map? custom-options))
          (or (nil? fileserver-port)
              (and (integer? fileserver-port)
                   (< 0 fileserver-port 65535)))
@@ -1013,6 +1015,7 @@
           scheduler (->KubernetesScheduler url
                                            authorizer
                                            cluster-name
+                                           custom-options
                                            daemon-state
                                            fileserver
                                            http-client

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -757,10 +757,12 @@
                  :service-id->password-fn (constantly nil)
                  :service-id->service-description-fn (constantly nil)
                  :start-scheduler-syncer-fn (constantly nil)}
+        custom-options {:a 1 :b "two"}
         k8s-config {:authentication nil
                     :authorizer {:kind :default
                                  :default {:factory-fn 'waiter.authorization/noop-authorizer}}
                     :cluster-name "waiter"
+                    :custom-options custom-options
                     :fileserver {:port 9090
                                  :scheme "http"}
                     :watch-state (atom nil)
@@ -812,6 +814,9 @@
 
         (testing "should work with valid configuration"
           (is (instance? KubernetesScheduler (kubernetes-scheduler base-config))))
+
+        (testing "should retain custom plugin options"
+          (is (= custom-options (-> base-config kubernetes-scheduler :custom-options))))
 
         (testing "periodic auth-refresh task"
           (let [kill-task-fn (atom (constantly nil))


### PR DESCRIPTION
## Changes proposed in this PR

Persist custom (namespaced) options to the Kubernetes scheduler.

## Why are we making these changes?

This provides a way for custom "plugin" logic (e.g., a custom ReplicaSet Builder function) to read options from the Waiter configuration file.