### PR TITLE
Fix misbehaving integration tests

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1284,7 +1284,7 @@
         (finally
           (delete-token-and-assert waiter-url token))))))
 
-(deftest ^:parallel ^:integration-slow test-service-fallback-support
+(deftest ^:parallel ^:integration-slow ^:resource-heavy test-service-fallback-support
   (testing-using-waiter-url
     (let [service-name (rand-name)
           token (create-token-name waiter-url service-name)

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -404,6 +404,9 @@
       (log/info "service id: " service-id))
     service-id))
 
+(defn retrieve-kitchen-service-id [waiter-url waiter-headers & options]
+  (pc/mapply retrieve-service-id waiter-url (merge (kitchen-request-headers) waiter-headers) options))
+
 (defn waiter-settings [waiter-url & {:keys [cookies] :or {cookies []}}]
   (let [settings-result (make-request waiter-url "/settings" :verbose true :cookies cookies)
         settings-json (try-parse-json (:body settings-result))]


### PR DESCRIPTION
## Changes proposed in this PR

- Recategorize service-fallback-support test as resource-heavy (it creates at least 3 pods)
- Clean up service after backend-request-errors test (the deletion logic was wrong)

## Why are we making these changes?

This should make the Kubernetes scheduler integration tests run more smoothly.