### PR TITLE
Fix failure detection on replicaset->Service payload

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -91,7 +91,7 @@
 (defn replicaset->Service
   "Convert a Kubernetes ReplicaSet JSON response into a Waiter Service record."
   [replicaset-json]
-  (if (contains? replicaset-json :error)
+  (if (= "Failure" (:status replicaset-json))
     (do
       (log/info "encountered error response in ReplicaSet query:" replicaset-json)
       nil)


### PR DESCRIPTION
## Changes proposed in this PR

Look for `"Failure"` status rather than `:error` key in the ReplicaSet JSON payload.

## Why are we making these changes?

Looking for the `:error` key was a bug. That key doesn't actually exist in this object.