### PR TITLE
fix flaky reporters_integration_test

### DIFF
--- a/waiter/integration/waiter/reporters_integration_test.clj
+++ b/waiter/integration/waiter/reporters_integration_test.clj
@@ -55,8 +55,8 @@
                                                                                  .getMillis)]
                                                  (if (not= next-last-event-time-ms last-event-time-ms)
                                                    next-last-event-time-ms nil)))
-                    ;; expected precision for system "sleep" calls. a sleep call will sleep the right duration within 100 ms.
-                    sleep_precision 100]
+                    ;; expected precision for system "sleep" calls. a sleep call will sleep the right duration within 500 ms.
+                    sleep_precision 500]
                 (is next-last-event-time-ms)
                 (when next-last-event-time-ms
                   (is (< (Math/abs (- next-last-event-time-ms last-event-time-ms period-ms))


### PR DESCRIPTION
## Changes proposed in this PR

Make expected precision for system "sleep" calls larger

## Why are we making these changes?

Test failed with difference between events of 136 ms, so it seems that 100 ms doesn't account for expected fluctuations
