### PR TITLE
* upgrade to jdk 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: trusty
 language: java
-jdk: oraclejdk8
+jdk: oraclejdk11
 
 addons:
   artifacts: true

--- a/waiter/integration/waiter/metrics_output_test.clj
+++ b/waiter/integration/waiter/metrics_output_test.clj
@@ -69,7 +69,6 @@
 
 (def jvm-metrics-schema
   {(s/required-key "attribute") s/Any
-   (s/required-key "file") s/Any
    (s/required-key "gc") s/Any
    (s/required-key "memory") s/Any
    (s/required-key "thread") {(s/required-key "blocked") counted-gauge-metric-schema

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -20,6 +20,7 @@
             [clojure.string :as str]
             [clojure.tools.cli :as cli]
             [clojure.tools.logging :as log]
+            [metrics.core :as mc]
             [metrics.jvm.core :as jvm-metrics]
             [plumbing.core :as pc]
             [plumbing.graph :as graph]
@@ -136,13 +137,25 @@
         validate-config (:schema-validate options)]
     {:validate-config validate-config}))
 
+(defn- instrument-jvm
+  "Glues together metrics-clojure and jvm instrumentation.
+   We explicitly avoid jvm-metrics/register-file-descriptor-ratio-gauge-set as it is not JDK 11 compatible
+   when we are stuck at using io.dropwizard.metrics/metrics-jvm/3.2.2"
+  []
+  (let [registry mc/default-registry]
+    (doseq [register-metric-set [jvm-metrics/register-jvm-attribute-gauge-set
+                                 jvm-metrics/register-memory-usage-gauge-set
+                                 jvm-metrics/register-garbage-collector-metric-set
+                                 jvm-metrics/register-thread-state-gauge-set]]
+      (register-metric-set registry))))
+
 (defn -main
   [config & args]
   (Thread/setDefaultUncaughtExceptionHandler
     (reify Thread$UncaughtExceptionHandler
       (uncaughtException [_ thread throwable]
         (log/error throwable (str (.getName thread) " threw exception: " (.getMessage throwable))))))
-  (jvm-metrics/instrument-jvm)
+  (instrument-jvm)
   (let [{:keys [validate-config]} (parse-options args)]
     (if validate-config
       (validate-config-schema config)

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -34,19 +34,13 @@
             [waiter.util.http-utils :as http-utils]
             [waiter.util.utils :as utils])
   (:import java.io.File
-           java.lang.UNIXProcess
            java.util.ArrayList))
 
 (defn pid
-  "Returns the pid of the provided process (if it is a UNIXProcess)"
+  "Returns the pid of the provided process"
   [^Process process]
   (try
-    (when (= UNIXProcess (type process))
-      (let [field (.getDeclaredField (.getClass process) "pid")
-            _ (.setAccessible field true)
-            pid (.getLong field process)]
-        (.setAccessible field false)
-        pid))
+    (.pid process)
     (catch Exception e
       (log/error e "error getting pid from" process))))
 

--- a/waiter/test/waiter/metrics_test.clj
+++ b/waiter/test/waiter/metrics_test.clj
@@ -30,6 +30,7 @@
             [waiter.util.async-utils :as au]
             [waiter.util.utils :as utils])
   (:import (com.codahale.metrics MetricFilter MetricRegistry)
+           (com.codahale.metrics.jvm FileDescriptorRatioGauge)
            (org.joda.time DateTime)))
 
 (deftest test-compress-strings
@@ -502,3 +503,11 @@
     (is (= {"bar" {"last-request-time" time-4}, "foo" {"last-request-time" time-2}}
            (cleanup-local-usage-metrics
              {"bar" {"last-request-time" time-4}, "foo" {"last-request-time" time-2}} "cid" "baz")))))
+
+(deftest test-metrics-clojure-jvm-file-descriptor-ratio-gauge
+  (try
+    (.getValue (FileDescriptorRatioGauge.))
+    (is false (str "No exception thrown while accessing FileDescriptorRatioGauge, "
+                   "if you upgraded io.dropwizard.metrics/metrics-jvm fix waiter.main/instrument-jvm and this test"))
+    (catch Exception ex
+      (is true (str "Expected Exception thrown:" (.getMessage ex))))))

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -159,14 +159,9 @@
     (is (= "Hello, World!\n" (slurp (:url (first (filter #(= "stdout" (:name %)) content))))))))
 
 (deftest test-pid
-  (testing "Getting the pid of a Process"
-
-    (testing "should return nil if it is not a UNIXProcess"
-      (is (nil? (pid (proxy [Process] [])))))
-
-    (testing "should return nil if it catches an Exception"
-      (with-redefs [type (fn [_] (throw (ex-info "ERROR!" {})))]
-        (is (nil? (pid (:process (launch-process "foo" (work-dir) "ls" {})))))))))
+  (testing "Getting the pid of a Process should return nil if it catches an Exception"
+    (with-redefs [type (fn [_] (throw (ex-info "ERROR!" {})))]
+      (is (nil? (pid (Object.)))))))
 
 (defn common-scheduler-config
   []


### PR DESCRIPTION
This is delayed since we have [HTTP/2 working on JDK8](https://github.com/twosigma/waiter/pull/599).
 
## Changes proposed in this PR

- upgrade to jdk 11

## Why are we making these changes?

We would like to be running on the latest JDK version to benefit from library updates.

