### PR TITLE
Defaults to the checked-in minimesos

### DIFF
--- a/waiter/bin/run-using-minimesos.sh
+++ b/waiter/bin/run-using-minimesos.sh
@@ -11,7 +11,7 @@ export WAITER_PORT=${1:-9091}
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-$(${MINIMESOS_CMD:-minimesos} info | grep MINIMESOS)
+$(${MINIMESOS_CMD:-${DIR}/ci/minimesos} info | grep MINIMESOS)
 EXIT_CODE=$?
 if [ ${EXIT_CODE} -eq 0 ]
 then


### PR DESCRIPTION
## Changes proposed in this PR

- changing the default minimesos command to be the one at `waiter/bin/ci/minimesos`

## Why are we making these changes?

It's a better default than assuming there is a `minimesos` on the `PATH`.
