### PR TITLE
removes perm size JVM option as it is not supported since jdk8

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -112,8 +112,7 @@
              "-Dclojure.core.async.pool-size=64"
              ~(str "-Dwaiter.logFilePrefix=" (System/getenv "WAITER_LOG_FILE_PREFIX"))
              "-XX:+UseG1GC"
-             "-XX:MaxGCPauseMillis=50"
-             "-XX:PermSize=1g"]
+             "-XX:MaxGCPauseMillis=50"]
   :filespecs [{:type :fn
                :fn (fn [p]
                      {:type :bytes :path "git-log"


### PR DESCRIPTION
## Changes proposed in this PR

- removes perm size JVM option as it is not supported since jdk8

## Why are we making these changes?

The flag is no longer supported since JDK 8:
`Java HotSpot(TM) 64-Bit Server VM warning: Ignoring option PermSize; support was removed in 8.0`

