### PR TITLE
fix reporters_integration_test flake

### DIFF
--- a/waiter/config-composite.edn
+++ b/waiter/config-composite.edn
@@ -13,7 +13,7 @@
                                                   :factory-fn waiter.reporter/graphite-reporter
                                                   :filter-regex #config/regex "^jvm.*|^waiter.*"
                                                   :host "localhost"
-                                                  :period-ms 3000
+                                                  :period-ms 6000
                                                   :pickled? true
                                                   :prefix "waiter-internal"
                                                   :port #config/env-int "GRAPHITE_SERVER_PORT"}}}

--- a/waiter/config-k8s.edn
+++ b/waiter/config-k8s.edn
@@ -12,7 +12,7 @@
                                                   :factory-fn waiter.reporter/graphite-reporter
                                                   :filter-regex #config/regex "^jvm.*|^waiter.*"
                                                   :host "localhost"
-                                                  :period-ms 3000
+                                                  :period-ms 6000
                                                   :pickled? true
                                                   :prefix "waiter-internal"
                                                   :port #config/env-int "GRAPHITE_SERVER_PORT"}}}

--- a/waiter/config-minimesos.edn
+++ b/waiter/config-minimesos.edn
@@ -11,7 +11,7 @@
                                                   :factory-fn waiter.reporter/graphite-reporter
                                                   :filter-regex #config/regex "^jvm.*|^waiter.*"
                                                   :host "localhost"
-                                                  :period-ms 3000
+                                                  :period-ms 6000
                                                   :pickled? true
                                                   :prefix "waiter-internal"
                                                   :port #config/env-int "GRAPHITE_SERVER_PORT"}}}

--- a/waiter/config-shell.edn
+++ b/waiter/config-shell.edn
@@ -13,7 +13,7 @@
                                                   :factory-fn waiter.reporter/graphite-reporter
                                                   :filter-regex #config/regex "^jvm.*|^waiter.*"
                                                   :host "localhost"
-                                                  :period-ms 3000
+                                                  :period-ms 6000
                                                   :pickled? true
                                                   :prefix "waiter-internal"
                                                   :port #config/env-int "GRAPHITE_SERVER_PORT"}}}

--- a/waiter/integration/waiter/reporters_integration_test.clj
+++ b/waiter/integration/waiter/reporters_integration_test.clj
@@ -56,7 +56,7 @@
                                                  (if (not= next-last-event-time-ms last-event-time-ms)
                                                    next-last-event-time-ms nil)))
                     ;; expected precision for system "sleep" calls. a sleep call will sleep the right duration within 500 ms.
-                    sleep_precision 500]
+                    sleep_precision 2000]
                 (is next-last-event-time-ms)
                 (when next-last-event-time-ms
                   (is (< (Math/abs (- next-last-event-time-ms last-event-time-ms period-ms))


### PR DESCRIPTION
## Changes proposed in this PR

- Make expected precision for system "sleep" calls larger

## Why are we making these changes?

Test failed with difference between events of 728 ms, seems like that timer threadpool was busy
