### PR TITLE
updates jet version to 0.7.10-20190301_162650-g2b50425

### DIFF
--- a/token-syncer/project.clj
+++ b/token-syncer/project.clj
@@ -14,7 +14,7 @@
 ;; limitations under the License.
 ;;
 (defproject token-syncer "0.1.0-SNAPSHOT"
-  :dependencies [[twosigma/jet "0.7.10-20190124_123705-g05ee789"]
+  :dependencies [[twosigma/jet "0.7.10-20190301_162650-g2b50425"]
                  [clj-time "0.15.1"]
                  [commons-codec/commons-codec "1.11"]
                  [org.clojure/clojure "1.10.0"]

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -32,7 +32,7 @@
 
   :dependencies [[bidi "2.1.5"
                   :exclusions [prismatic/schema ring/ring-core]]
-                 [twosigma/jet "0.7.10-20190124_123705-g05ee789"]
+                 [twosigma/jet "0.7.10-20190301_162650-g2b50425"]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]
                  [clj-time "0.15.1"

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -43,7 +43,6 @@
   (:import (java.io InputStream IOException)
            (java.util.concurrent TimeoutException)
            (org.eclipse.jetty.client HttpClient)
-           (org.eclipse.jetty.http HttpVersion)
            (org.eclipse.jetty.io EofException)
            (org.eclipse.jetty.server HttpChannel HttpOutput)))
 
@@ -181,15 +180,6 @@
     (deliver reservation-status-promise promise-value)
     (utils/exception->response (ex-info message (assoc metrics-map :status status) error) request)))
 
-(defn protocol->http-version
-  "Determines the http protocol version to use for the request to the backend."
-  [^String protocol]
-  (try
-    (when (and protocol (str/starts-with? protocol "HTTP"))
-      (HttpVersion/fromString protocol))
-    (catch Exception e
-      (log/error e "unable to determine http version from" protocol))))
-
 (defn- make-http-request
   "Makes an asynchronous request to the endpoint using Basic authentication."
   [^HttpClient http-client make-basic-auth-fn request-method endpoint query-string headers body service-password
@@ -208,7 +198,7 @@
        :idle-timeout idle-timeout
        :method request-method
        :query-string query-string
-       :version (protocol->http-version proto-version)
+       :version proto-version
        :url endpoint})))
 
 (defn make-request

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -28,8 +28,7 @@
             [waiter.process-request :refer :all]
             [waiter.statsd :as statsd])
   (:import (java.io ByteArrayOutputStream)
-           (org.eclipse.jetty.client HttpClient)
-           (org.eclipse.jetty.http HttpVersion)))
+           (org.eclipse.jetty.client HttpClient)))
 
 (deftest test-prepare-request-properties
   (let [test-cases (list
@@ -264,18 +263,6 @@
             {:status 202 :headers {"location" "http://www.example.com:5678/retrieve/result/location"}}
             "http://www.example.com:1234/query/for/status")))))
 
-(deftest test-protocol->http-version
-  (is (nil? (protocol->http-version nil)))
-  (is (nil? (protocol->http-version "")))
-  (is (nil? (protocol->http-version "Http/0.9")))
-  (is (= HttpVersion/HTTP_0_9 (protocol->http-version "HTTP/0.9")))
-  (is (nil? (protocol->http-version "http/1.0")))
-  (is (= HttpVersion/HTTP_1_0 (protocol->http-version "HTTP/1.0")))
-  (is (= HttpVersion/HTTP_1_1 (protocol->http-version "HTTP/1.1")))
-  (is (= HttpVersion/HTTP_2 (protocol->http-version "HTTP/2.0")))
-  (is (nil? (protocol->http-version "HTTP/2.1")))
-  (is (nil? (protocol->http-version "HTTP/3.0"))))
-
 (deftest test-make-request
   (let [instance {:service-id "test-service-id", :host "example.com", :port 8080, :protocol "proto"}
         request {:authorization/principal "test-user@test.com"
@@ -341,7 +328,7 @@
                                                    (merge {"x-waiter-auth-principal"          "test-user"
                                                            "x-waiter-authenticated-principal" "test-user@test.com"}))
                                                (:headers request-config)))))
-          proto-version HttpVersion/HTTP_1_1]
+          proto-version "HTTP/1.1"]
       (testing "make-request:headers"
         (let [request-method-fn-call-counter (atom 0)]
           (with-redefs [http/request (http-request-mock-factory passthrough-headers request-method-fn-call-counter)]

--- a/waiter/test/waiter/request_log_test.clj
+++ b/waiter/test/waiter/request_log_test.clj
@@ -16,15 +16,14 @@
 (ns waiter.request-log-test
   (:require [clj-time.core :as t]
             [clojure.test :refer :all]
-            [waiter.request-log :refer :all])
-  (:import [org.eclipse.jetty.http HttpVersion]))
+            [waiter.request-log :refer :all]))
 
 (deftest test-request->context
   (let [request {:headers {"host" "host"
                            "origin" "www.origin.org"
                            "user-agent" "test-user-agent"
                            "x-cid" "123"}
-                 :protocol (str HttpVersion/HTTP_1_1)
+                 :protocol "HTTP/1.1"
                  :query-string "a=1"
                  :remote-addr "127.0.0.1"
                  :request-id "abc"
@@ -61,7 +60,7 @@
                              :port 123
                              :protocol "instance-proto"}
                   :latest-service-id "latest-service-id"
-                  :protocol (str HttpVersion/HTTP_2)
+                  :protocol "HTTP/2.0"
                   :status 200}]
     (is (= {:backend-response-latency-ns 1000
             :backend-protocol "HTTP/2.0"

--- a/waiter/test/waiter/websocket_test.clj
+++ b/waiter/test/waiter/websocket_test.clj
@@ -24,7 +24,6 @@
             [waiter.websocket :refer :all])
   (:import (java.net HttpCookie SocketTimeoutException URLDecoder)
            (java.util ArrayList Collection)
-           (org.eclipse.jetty.http HttpVersion)
            (org.eclipse.jetty.websocket.api MessageTooLargeException UpgradeRequest)
            (org.eclipse.jetty.websocket.client ClientUpgradeRequest)
            (org.eclipse.jetty.websocket.servlet ServletUpgradeResponse)))
@@ -270,7 +269,7 @@
         assert-request-headers (fn assert-request-headers [upgrade-request]
                                  (doseq [[header-name header-value] assertion-headers]
                                    (is (= header-value (.getHeader upgrade-request header-name)) header-name)))
-        proto-version HttpVersion/HTTP_1_1]
+        proto-version "HTTP/1.1"]
 
     (testing "successful-connect-ws"
       (with-redefs [ws-client/connect! (fn [_ instance-endpoint request-callback {:keys [middleware] :as request-properties}]


### PR DESCRIPTION
## Changes proposed in this PR

- updates jet version to 0.7.10-20190301_162650-g2b50425

## Why are we making these changes?

We want to tackle NoClassDefErrors we are seeing in our builds. This new jet jar avoids one of the problematic class creations.

