### PR TITLE
Allow per-scheduler deployment-error-config overrides

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1023,14 +1023,17 @@
                                                                                 inter-router-metrics-idle-timeout-ms metrics-sync-interval-ms
                                                                                 websocket-client bytes-encryptor websocket-request-auth-cookie-attacher)}))
    :router-state-maintainer (pc/fnk [[:routines refresh-service-descriptions-fn service-id->service-description-fn]
+                                     [:scheduler scheduler]
                                      [:settings deployment-error-config]
                                      [:state router-id scheduler-state-chan]
                                      router-list-maintainer]
                               (let [exit-chan (async/chan)
                                     router-chan (async/tap (:router-mult-chan router-list-maintainer) (au/latest-chan))
+                                    service-id->deployment-error-config-fn #(scheduler/deployment-error-config scheduler %)
                                     maintainer (state/start-router-state-maintainer
                                                  scheduler-state-chan router-chan router-id exit-chan service-id->service-description-fn
-                                                 refresh-service-descriptions-fn deployment-error-config)]
+                                                 refresh-service-descriptions-fn service-id->deployment-error-config-fn
+                                                 deployment-error-config)]
                                 {:exit-chan exit-chan
                                  :maintainer maintainer}))
    :scheduler-broken-services-gc (pc/fnk [[:curator gc-state-reader-fn gc-state-writer-fn leader?-fn]

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -96,6 +96,11 @@
       :result :deleted|:error|:no-such-service-exists
       :success true|false}")
 
+  (deployment-error-config [this ^String service-id]
+    "Returns nil, or a map containing a subset of the global :deployment-error-config options.
+     These options should be merged (to override) the global :deployment-error-config options
+     in the waiter.state module when computing the deployment errors for the given service-id.")
+
   (scale-service [this ^String service-id target-instances force]
     "Instructs the scheduler to scale up/down instances of the specified service to the specified number
      of instances. The force flag can be used enforce the scaling by ignoring previous pending operations.")

--- a/waiter/src/waiter/scheduler/composite.clj
+++ b/waiter/src/waiter/scheduler/composite.clj
@@ -79,6 +79,11 @@
         service-id->scheduler
         (scheduler/delete-service service-id)))
 
+  (deployment-error-config [_ service-id]
+    (-> service-id
+        service-id->scheduler
+        (scheduler/deployment-error-config service-id)))
+
   (scale-service [_ service-id target-instances force]
     (-> service-id
         service-id->scheduler

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -437,6 +437,9 @@
        :result :no-such-service-exists
        :success false}))
 
+  (deployment-error-config [_ _]
+    (comment ":deployment-error-config overrides currently not supported."))
+
   (scale-service [this service-id scale-to-instances _]
     (if (scheduler/service-exists? this service-id)
       (let [result (try

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -300,7 +300,7 @@
    Grouped by liveness status, i.e.: {:active-instances [...] :failed-instances [...] :killed-instances [...]}"
   [{:keys [service-id->failed-instances-transient-store] :as scheduler} {service-id :id :as basic-service-info}]
   {:active-instances (get-service-instances! scheduler basic-service-info)
-   :failed-instances (-> @service-id->failed-instances-transient-store (get service-id []) vals vec)})
+   :failed-instances (-> @service-id->failed-instances-transient-store (get service-id) vals vec)})
 
 (defn- patch-object-json
   "Make a JSON-patch request on a given Kubernetes object."
@@ -547,6 +547,11 @@
                   {:service-id service-id})
         {:result :error
          :message "Internal error while deleting service"})))
+
+  (deployment-error-config [_ _]
+    ;; The min-hosts count currently MUST be 1 on Kubernetes since a failing service's
+    ;; container restarts repeadly within a single Pod, normally not switching hosts.
+    {:min-hosts 1})
 
   (scale-service [this service-id scale-to-instances _]
     (ss/try+

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -409,6 +409,9 @@
         (log/warn "[delete-service] Marathon unavailable (Error 503).")
         (log/debug (:throwable &throw-context) "[delete-service] Marathon unavailable"))))
 
+  (deployment-error-config [_ _]
+    (comment ":deployment-error-config overrides currently not supported."))
+
   (scale-service [_ service-id scale-to-instances force]
     (ss/try+
       (scheduler/suppress-transient-server-exceptions

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -653,6 +653,9 @@
        :result :no-such-service-exists
        :message (str service-id " does not exist!")}))
 
+  (deployment-error-config [_ _]
+    (comment ":deployment-error-config overrides currently not supported."))
+
   (scale-service [this service-id scale-to-instances _]
     (if (scheduler/service-exists? this service-id)
       (let [completion-promise (promise)]

--- a/waiter/src/waiter/state.clj
+++ b/waiter/src/waiter/state.clj
@@ -1184,7 +1184,7 @@
    Acts as the central access point for modifying this data for the router.
    Exposes the state of the router via a `query-state-fn` no-args function that is returned."
   [scheduler-state-chan router-chan router-id exit-chan service-id->service-description-fn
-   refresh-service-descriptions-fn deployment-error-config]
+   refresh-service-descriptions-fn service-id->deployment-error-config-fn default-deployment-error-config]
   (cid/with-correlation-id
     "router-state-maintainer"
     (let [killed-instances-to-keep 10
@@ -1278,6 +1278,8 @@
                                           service-id->starting-instances' (assoc service-id->starting-instances service-id starting-instances)
                                           service-id->failed-instances' (assoc service-id->failed-instances service-id failed-instances)
                                           service-id->instance-counts' (assoc service-id->instance-counts service-id instance-counts)
+                                          deployment-error-config (merge default-deployment-error-config
+                                                                         (service-id->deployment-error-config-fn service-id))
                                           deployment-error (get-deployment-error healthy-instances unhealthy-instances failed-instances deployment-error-config)
                                           service-id->deployment-error' (if deployment-error
                                                                           (assoc service-id->deployment-error service-id deployment-error)

--- a/waiter/test/waiter/scheduler/composite_test.clj
+++ b/waiter/test/waiter/scheduler/composite_test.clj
@@ -68,6 +68,9 @@
   (delete-service [_ service-id]
     {:identifier service-id :operation :delete :scheduler-name scheduler-name})
 
+  (deployment-error-config [_ service-id]
+    {:scheduler-name scheduler-name})
+
   (scale-service [_ service-id target-instances force]
     {:identifier (str service-id ":" target-instances ":" force) :operation :scale :scheduler-name scheduler-name})
 
@@ -327,6 +330,11 @@
                     :operation :delete
                     :scheduler-name (service-id->scheduler-id service-id)}
                    (scheduler/delete-service composite-scheduler service-id)))))
+
+        (testing "deployment-error-config"
+          (doseq [service-id all-service-ids]
+            (is (= {:scheduler-name (service-id->scheduler-id service-id)}
+                   (scheduler/deployment-error-config composite-scheduler service-id)))))
 
         (testing "scale-service"
           (doseq [service-id all-service-ids]

--- a/waiter/test/waiter/state_test.clj
+++ b/waiter/test/waiter/state_test.clj
@@ -997,6 +997,8 @@
       (testing (str "Test " name)
         (is (= expected (get-instability-issue failed-instances)))))))
 
+(defn- dummy-deployment-error-config-fn [_] nil)
+
 (deftest test-router-state-maintainer-removes-expired-instances
   (let [scheduler-state-chan (async/chan 1)
         router-chan (async/chan 1)
@@ -1015,7 +1017,7 @@
     (let [{:keys [router-state-push-mult]}
           (start-router-state-maintainer
             scheduler-state-chan router-chan router-id exit-chan service-id->service-description-fn
-            refresh-service-descriptions-fn deployment-error-config)]
+            refresh-service-descriptions-fn dummy-deployment-error-config-fn deployment-error-config)]
       (async/tap router-state-push-mult router-state-push-chan))
     (async/>!! router-chan {router-id (str "http://www." router-id ".com")})
     (async/>!! scheduler-state-chan [[:update-available-services {:available-service-ids #{service-id}
@@ -1063,7 +1065,7 @@
     (let [{:keys [notify-instance-killed-fn query-chan router-state-push-mult]}
           (start-router-state-maintainer
             scheduler-state-chan router-chan router-id exit-chan service-id->service-description-fn
-            refresh-service-descriptions-fn deployment-error-config)]
+            refresh-service-descriptions-fn dummy-deployment-error-config-fn deployment-error-config)]
       (async/tap router-state-push-mult router-state-push-chan)
       (async/>!! router-chan {router-id (str "http://www." router-id ".com")})
       (async/>!! scheduler-state-chan [[:update-available-services {:available-service-ids #{service-id}
@@ -1160,7 +1162,7 @@
 
       (let [{:keys [router-state-push-mult]}
             (start-router-state-maintainer scheduler-state-chan router-chan router-id exit-chan service-id->service-description-fn
-                                           refresh-service-descriptions-fn deployment-error-config)]
+                                           refresh-service-descriptions-fn dummy-deployment-error-config-fn deployment-error-config)]
         (async/tap router-state-push-mult router-state-push-chan))
 
 
@@ -1277,7 +1279,7 @@
 
       (let [{:keys [router-state-push-mult]}
             (start-router-state-maintainer scheduler-state-chan router-chan router-id exit-chan service-id->service-description-fn
-                                           refresh-service-descriptions-fn deployment-error-config)]
+                                           refresh-service-descriptions-fn dummy-deployment-error-config-fn deployment-error-config)]
         (async/tap router-state-push-mult router-state-push-chan))
 
       (async/>!! router-chan routers)


### PR DESCRIPTION
## Changes proposed in this PR

- Allow overriding the `:deployment-error-config` options within each scheduler.
- Override `:deployment-error-config {:min-hosts 1}` for the Kubernetes scheduler.

## Why are we making these changes?

Currently, `{:min-hosts 1}` is the only value that makes sense for deployment errors on Kubernetes. This is because a failing instance restarts a container within a single pod scheduled on a single host, which means the host is very unlikely to change.