### PR TITLE
Deflake k8s s3 logs test

### DIFF
--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -106,7 +106,7 @@
                 instance-request-fn (fn []
                                       (let [instance-id (request-fn)]
                                         (swap! instance-ids-atom conj instance-id)))
-                instance-ids (->> (parallelize-requests 4 10 instance-request-fn
+                instance-ids (->> (parallelize-requests 4 16 instance-request-fn
                                                         :canceled? (fn [] (> (count @instance-ids-atom) 2))
                                                         :verbose true
                                                         :service-id service-id)


### PR DESCRIPTION
## Changes proposed in this PR

Increase number of parallel requests in the s3 logs integration test (used to force a scale-up).

## Why are we making these changes?

When testing against a real k8s cluster (not just minikube), this test currently flakes due to slightly longer pod startup time. Bumping this count ensures sufficient instances are created.