### PR TITLE
loads only valid previous descriptors

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -374,10 +374,10 @@
                 services (json/read-str body)
                 service-tokens (mapcat (fn [entry]
                                          (some->> entry
-                                           walk/keywordize-keys
-                                           :source-tokens
-                                           flatten
-                                           (map :token)))
+                                                  walk/keywordize-keys
+                                                  :source-tokens
+                                                  flatten
+                                                  (map :token)))
                                        services)]
             (assert-response-status response 200)
             (is (= (count @service-ids-atom) (count service-tokens))
@@ -394,10 +394,10 @@
                 services (json/read-str body)
                 service-tokens (mapcat (fn [entry]
                                          (some->> entry
-                                           walk/keywordize-keys
-                                           :source-tokens
-                                           flatten
-                                           (map :token)))
+                                                  walk/keywordize-keys
+                                                  :source-tokens
+                                                  flatten
+                                                  (map :token)))
                                        services)]
             (assert-response-status response 200)
             (is (= 3 (count service-tokens))
@@ -415,10 +415,10 @@
                   services (json/read-str body)
                   service-token-versions (mapcat (fn [entry]
                                                    (some->> entry
-                                                     walk/keywordize-keys
-                                                     :source-tokens
-                                                     flatten
-                                                     (map :version)))
+                                                            walk/keywordize-keys
+                                                            :source-tokens
+                                                            flatten
+                                                            (map :version)))
                                                  services)]
               (assert-response-status response 200)
               (is (= 1 (count service-token-versions))
@@ -442,9 +442,9 @@
           (log/info "basic hostname as token test")
           (let [current-user (retrieve-username)
                 service-description (assoc (kitchen-request-headers)
-                                      :x-waiter-metric-group token-prefix
-                                      :x-waiter-permitted-user "*"
-                                      :x-waiter-run-as-user current-user)]
+                                           :x-waiter-metric-group token-prefix
+                                           :x-waiter-permitted-user "*"
+                                           :x-waiter-run-as-user current-user)]
             (testing "hostname-token-creation"
               (log/info "creating configuration using token" token)
               (let [{:keys [body status]}
@@ -803,7 +803,7 @@
 (deftest ^:parallel ^:integration-fast ^:explicit test-on-the-fly-to-token
   (testing-using-waiter-url
     (let [name-string (rand-name)
-          {:keys [cookies] :as canary-response}
+          {:keys[cookies] :as canary-response}
           (make-request-with-debug-info {:x-waiter-name name-string} #(make-kitchen-request waiter-url %))
           service-id-1 (:service-id canary-response)]
       (with-service-cleanup
@@ -1410,6 +1410,7 @@
                                          :name (str service-name "-v1")
                                          :permitted-user "*"
                                          :run-as-user (retrieve-username)
+                                         :run-as-user (retrieve-username)
                                          :token token
                                          :version "version-1"))
           token-description-2 (-> token-description-1
@@ -1419,23 +1420,16 @@
           token-description-3 (-> token-description-1
                                   (assoc :name (str service-name "-v3")
                                          :version "version-3"))]
-      (-> token-description-1
-          (as-> token-description (post-token waiter-url token-description))
-          (assert-response-status 200))
+      (assert-response-status (post-token waiter-url token-description-1) 200)
       (let [service-id-1 (retrieve-service-id waiter-url request-headers)]
         (with-service-cleanup
           service-id-1
           (let [response-1 (make-request-with-debug-info request-headers #(make-request waiter-url "/hello" :headers %))]
             (assert-response-status response-1 200)
             (is (= service-id-1 (:service-id response-1))))
-          (-> token-description-2
-              (as-> token-description (post-token waiter-url token-description))
-              (assert-response-status 200))
-          (-> (make-request waiter-url "/hello" :headers request-headers)
-              (assert-response-status 400))
-          (-> token-description-3
-              (as-> token-description (post-token waiter-url token-description))
-              (assert-response-status 200))
+          (assert-response-status (post-token waiter-url token-description-2) 200)
+          (assert-response-status (make-request waiter-url "/hello" :headers request-headers) 400)
+          (assert-response-status (post-token waiter-url token-description-3) 200)
           (let [service-id-2 (retrieve-service-id waiter-url (assoc request-headers :x-waiter-fallback-period-secs 0))]
             (is (not= service-id-1 service-id-2))
             (with-service-cleanup

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -180,20 +180,14 @@
                    attempted-service-ids #{}]
               (if (<= iteration search-history-length)
                 (if-let [previous-descriptor (descriptor->previous-descriptor loop-descriptor)]
-                  (let [{:keys [service-description-valid? service-id]} previous-descriptor]
-                    (if service-description-valid?
-                      (if (service-healthy? fallback-state service-id)
-                        (do
-                          (log/info (str "iteration-" iteration) current-service-id "falling back to" service-id)
-                          previous-descriptor)
-                        (recur (inc iteration)
-                               previous-descriptor
-                               (conj attempted-service-ids service-id)))
+                  (let [{:keys [service-id]} previous-descriptor]
+                    (if (service-healthy? fallback-state service-id)
                       (do
-                        (log/info (str "iteration-" iteration) "retrieved an invalid service descriptor")
-                        (recur (inc iteration)
-                               previous-descriptor
-                               attempted-service-ids))))
+                        (log/info (str "iteration-" iteration) current-service-id "falling back to" service-id)
+                        previous-descriptor)
+                      (recur (inc iteration)
+                             previous-descriptor
+                             (conj attempted-service-ids service-id))))
                   (log/info "no fallback service found for" current-service-id "after entire history lookup"
                             {:attempted-service-ids attempted-service-ids
                              :fallback-state (retrieve-fallback-state-for fallback-state attempted-service-ids)}))
@@ -234,36 +228,44 @@
    {:keys [waiter-headers passthrough-headers sources service-id service-description core-service-description suspended-state]}"
   [service-description-defaults token-defaults service-id-prefix kv-store waiter-hostnames request metric-group-mappings
    service-description-builder assoc-run-as-user-approved?]
-  (let [current-request-user (get request :authorization/user)]
-    (-> (headers/split-headers (:headers request))
-        (sd/merge-service-description-sources kv-store waiter-hostnames service-description-defaults token-defaults)
-        (sd/merge-service-description-and-id kv-store service-id-prefix current-request-user metric-group-mappings
-                                             service-description-builder assoc-run-as-user-approved? true)
-        (sd/merge-suspended kv-store))))
+  (let [current-request-user (get request :authorization/user)
+        descriptor
+        (-> (headers/split-headers (:headers request))
+            (sd/merge-service-description-sources kv-store waiter-hostnames service-description-defaults token-defaults)
+            (sd/merge-service-description-and-id kv-store service-id-prefix current-request-user metric-group-mappings
+                                                 service-description-builder assoc-run-as-user-approved?)
+            (sd/merge-suspended kv-store))]
+    (when-let [throwable (sd/validate-service-description kv-store service-description-builder descriptor)]
+      (throw throwable))
+    descriptor))
 
 (defn descriptor->previous-descriptor
-  "Creates the previous version of the descriptor from the provided descriptor.
+  "Creates a valid previous version of the descriptor from the provided descriptor.
    The result map contains the following elements:
-   {:keys [waiter-headers passthrough-headers sources service-id service-description service-description-valid?
-           core-service-description suspended-state]}"
-  [kv-store service-id-prefix token-defaults metric-group-mappings service-description-builder service-approved? username
-   {:keys [sources] :as descriptor}]
-  (when-let [token-sequence (-> sources :token-sequence seq)]
-    (let [{:keys [token->token-data]} sources
-          previous-token (->> token->token-data
-                              (pc/map-vals (fn [token-data] (get token-data "previous")))
-                              sd/retrieve-most-recently-modified-token)
-          previous-token-data (get-in token->token-data [previous-token "previous"])]
-      (when (seq previous-token-data)
-        (let [new-sources (->> (assoc token->token-data previous-token previous-token-data)
-                               (sd/compute-service-description-template-from-tokens token-defaults token-sequence)
-                               (merge sources))]
-          (-> (select-keys descriptor [:passthrough-headers :waiter-headers])
-              (assoc :sources new-sources)
-              (sd/merge-service-description-and-id
-                kv-store service-id-prefix username metric-group-mappings service-description-builder service-approved?
-                false)
-              (sd/merge-suspended kv-store)))))))
+   {:keys [core-service-description passthrough-headers service-id service-description
+           sources suspended-state waiter-headers]}"
+  [kv-store service-id-prefix token-defaults metric-group-mappings service-description-builder
+   service-approved? username descriptor]
+  (loop [{:keys [sources]} descriptor]
+    (when-let [token-sequence (-> sources :token-sequence seq)]
+      (let [{:keys [token->token-data]} sources
+            previous-token (->> token->token-data
+                                (pc/map-vals (fn [token-data] (get token-data "previous")))
+                                sd/retrieve-most-recently-modified-token)
+            previous-token-data (get-in token->token-data [previous-token "previous"])]
+        (when (seq previous-token-data)
+          (let [new-sources (->> (assoc token->token-data previous-token previous-token-data)
+                                 (sd/compute-service-description-template-from-tokens token-defaults token-sequence)
+                                 (merge sources))
+                previous-descriptor
+                (-> (select-keys descriptor [:passthrough-headers :waiter-headers])
+                    (assoc :sources new-sources)
+                    (sd/merge-service-description-and-id
+                      kv-store service-id-prefix username metric-group-mappings service-description-builder service-approved?)
+                    (sd/merge-suspended kv-store))]
+            (if (sd/validate-service-description kv-store service-description-builder previous-descriptor)
+              (recur previous-descriptor)
+              previous-descriptor)))))))
 
 (let [request->descriptor-timer (metrics/waiter-timer "core" "request->descriptor")]
   (defn request->descriptor

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -918,10 +918,10 @@
     [kv-store service-description-builder
      {:keys [core-service-description passthrough-headers service-description service-id waiter-headers]}]
     (sling/try+
-      (let [stored-service-description? (fetch-core kv-store service-id)]
+      (let [stored-service-description (fetch-core kv-store service-id)]
         ; Validating is expensive, so avoid validating if we've validated before, relying on the fact
         ; that we'll only store validated service descriptions
-        (when-not (seq stored-service-description?)
+        (when-not (seq stored-service-description)
           (validate service-description-builder core-service-description {:allow-missing-required-fields? false})
           (validate service-description-builder service-description {:allow-missing-required-fields? false}))
         nil)

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -854,7 +854,7 @@
      If after the merge a permitted-user is not available, then `username` becomes the permitted-user."
     [{:keys [defaults headers service-description-template source-tokens token-authentication-disabled token-preauthorized]}
      waiter-headers passthrough-headers kv-store service-id-prefix username metric-group-mappings
-     service-description-builder assoc-run-as-user-approved? throw-if-invalid?]
+     service-description-builder assoc-run-as-user-approved?]
     (let [headers-without-params (dissoc headers "param")
           header-params (get headers "param")
           ; any change with the on-the-fly must change the run-as-user if it doesn't already exist
@@ -894,51 +894,50 @@
       (when-not (seq user-service-description)
         (throw (ex-info (utils/message :cannot-identify-service)
                         (error-message-map-fn passthrough-headers waiter-headers))))
-      (sling/try+
-        (let [{:keys [core-service-description service-description service-id]}
-              (build service-description-builder user-service-description
-                     {:assoc-run-as-user-approved? assoc-run-as-user-approved?
-                      :defaults defaults
-                      :kv-store kv-store
-                      :metric-group-mappings metric-group-mappings
-                      :service-id-prefix service-id-prefix
-                      :username username})
-              service-preauthorized (and token-preauthorized (empty? service-description-based-on-headers))
-              service-authentication-disabled (and token-authentication-disabled (empty? service-description-based-on-headers))
-              stored-service-description? (fetch-core kv-store service-id)
-              ; Validating is expensive, so avoid validating if we've validated before, relying on the fact
-              ; that we'll only store validated service descriptions
-              service-description-valid? (or stored-service-description?
-                                             (try
-                                               (validate service-description-builder core-service-description {:allow-missing-required-fields? false})
-                                               (validate service-description-builder service-description {:allow-missing-required-fields? false})
-                                               true
-                                               (catch Throwable th
-                                                 (if throw-if-invalid?
-                                                   (throw th)
-                                                   (do
-                                                     (log/info "invalid service description" (.getMessage th))
-                                                     false)))))]
-          {:core-service-description core-service-description
-           :on-the-fly? contains-waiter-header?
-           :service-authentication-disabled service-authentication-disabled
-           :service-description service-description
-           :service-description-valid? service-description-valid?
-           :service-id service-id
-           :service-preauthorized service-preauthorized
-           :source-tokens source-tokens})
-        (catch [:type :service-description-error] ex-data
-          (throw (ex-info (:message ex-data)
-                          (merge (error-message-map-fn passthrough-headers waiter-headers) ex-data)
-                          (:throwable &throw-context))))))))
+      (let [{:keys [core-service-description service-description service-id]}
+            (build service-description-builder user-service-description
+                   {:assoc-run-as-user-approved? assoc-run-as-user-approved?
+                    :defaults defaults
+                    :kv-store kv-store
+                    :metric-group-mappings metric-group-mappings
+                    :service-id-prefix service-id-prefix
+                    :username username})
+            service-preauthorized (and token-preauthorized (empty? service-description-based-on-headers))
+            service-authentication-disabled (and token-authentication-disabled (empty? service-description-based-on-headers))]
+        {:core-service-description core-service-description
+         :on-the-fly? contains-waiter-header?
+         :service-authentication-disabled service-authentication-disabled
+         :service-description service-description
+         :service-id service-id
+         :service-preauthorized service-preauthorized
+         :source-tokens source-tokens})))
+
+  (defn validate-service-description
+    "Returns nil if the provided descriptor contains a valid service description.
+     Else it returns an instance of Throwable that reflects the validation error."
+    [kv-store service-description-builder
+     {:keys [core-service-description passthrough-headers service-description service-id waiter-headers]}]
+    (sling/try+
+      (let [stored-service-description? (fetch-core kv-store service-id)]
+        ; Validating is expensive, so avoid validating if we've validated before, relying on the fact
+        ; that we'll only store validated service descriptions
+        (when-not (seq stored-service-description?)
+          (validate service-description-builder core-service-description {:allow-missing-required-fields? false})
+          (validate service-description-builder service-description {:allow-missing-required-fields? false}))
+        nil)
+      (catch [:type :service-description-error] ex-data
+        (ex-info (:message ex-data)
+                 (merge (error-message-map-fn passthrough-headers waiter-headers) ex-data)
+                 (:throwable &throw-context)))
+      (catch Throwable th
+        th))))
 
 (defn merge-service-description-and-id
   "Populates the descriptor with the service-description and service-id."
   [{:keys [passthrough-headers sources waiter-headers] :as descriptor} kv-store service-id-prefix username
-   metric-group-mappings service-description-builder assoc-run-as-user-approved? throw-if-invalid?]
+   metric-group-mappings service-description-builder assoc-run-as-user-approved?]
   (->> (compute-service-description sources waiter-headers passthrough-headers kv-store service-id-prefix username
-                                    metric-group-mappings service-description-builder assoc-run-as-user-approved?
-                                    throw-if-invalid?)
+                                    metric-group-mappings service-description-builder assoc-run-as-user-approved?)
        (merge descriptor)))
 
 (defn retrieve-most-recently-modified-token

--- a/waiter/test/waiter/descriptor_test.clj
+++ b/waiter/test/waiter/descriptor_test.clj
@@ -530,6 +530,7 @@
                 :passthrough-headers passthrough-headers
                 :service-authentication-disabled false
                 :service-description (merge (:defaults sources) service-description-1)
+                :service-description-valid? true
                 :service-id (sd/service-description->service-id service-id-prefix service-description-1)
                 :service-preauthorized false
                 :source-tokens [(sd/source-tokens-entry test-token token-data-1)]
@@ -571,6 +572,7 @@
                   :passthrough-headers passthrough-headers
                   :service-authentication-disabled false
                   :service-description (merge (:defaults sources) expected-core-service-description)
+                  :service-description-valid? true
                   :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)
                   :service-preauthorized false
                   :source-tokens [(sd/source-tokens-entry test-token token-data-1)]
@@ -636,6 +638,7 @@
                   :passthrough-headers passthrough-headers
                   :service-authentication-disabled false
                   :service-description (merge (:defaults sources) expected-core-service-description)
+                  :service-description-valid? true
                   :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)
                   :service-preauthorized false
                   :source-tokens [(sd/source-tokens-entry test-token-1 token-data-1)
@@ -659,6 +662,7 @@
                     :passthrough-headers passthrough-headers
                     :service-authentication-disabled false
                     :service-description (merge (:defaults sources) expected-core-service-description)
+                    :service-description-valid? true
                     :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)
                     :service-preauthorized false
                     :source-tokens [(sd/source-tokens-entry test-token-1 token-data-1p)

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -788,7 +788,7 @@
            waiter-headers (or waiter-headers {})]
        (compute-service-description sources waiter-headers {} kv-store "test-service-" "current-request-user"
                                     [] (create-default-service-description-builder {})
-                                    assoc-run-as-user-approved?)))))
+                                    assoc-run-as-user-approved? true)))))
 
 (defn- service-description
   ([sources & {:keys [assoc-run-as-user-approved? kv-store waiter-headers]}]
@@ -1384,7 +1384,8 @@
                                                                               "run-as-user" test-user}}
                                               {} {} kv-store service-id-prefix test-user []
                                               (create-default-service-description-builder {})
-                                              (constantly false))))
+                                              (constantly false)
+                                              true)))
     (is (thrown? Exception
                  (compute-service-description {:defaults {"health-check-url" 1}
                                                :headers {}
@@ -1395,14 +1396,16 @@
                                                                               "run-as-user" test-user}}
                                               {} {} kv-store service-id-prefix test-user []
                                               (create-default-service-description-builder {})
-                                              (constantly false))))
+                                              (constantly false)
+                                              true)))
     (is (thrown? Exception
                  (compute-service-description {:defaults {"health-check-url" 1}
                                                :headers {}
                                                :service-description-template {}}
                                               {} {} kv-store service-id-prefix test-user []
                                               (create-default-service-description-builder {})
-                                              (constantly false))))
+                                              (constantly false)
+                                              true)))
     (is (thrown? Exception
                  (compute-service-description {:defaults {"health-check-url" "/health"}
                                                :service-description-template {"cmd" "cmd for missing run-as-user"
@@ -1411,7 +1414,8 @@
                                                                               "version" "a1b2c3"}}
                                               {} {} kv-store service-id-prefix test-user []
                                               (create-default-service-description-builder {})
-                                              (constantly false))))
+                                              (constantly false)
+                                              true)))
 
     (testing "invalid allowed params - reserved"
       (is (thrown? Exception
@@ -1426,7 +1430,8 @@
                                                                                 "version" "a1b2c3"}}
                                                 {} {} kv-store service-id-prefix test-user []
                                                 (create-default-service-description-builder {})
-                                                (constantly false)))))
+                                                (constantly false)
+                                                true))))
 
     (testing "invalid allowed params - bad naming"
       (is (thrown? Exception
@@ -1441,7 +1446,8 @@
                                                                                 "version" "a1b2c3"}}
                                                 {} {} kv-store service-id-prefix test-user []
                                                 (create-default-service-description-builder {})
-                                                (constantly false)))))
+                                                (constantly false)
+                                                true))))
 
     (testing "invalid allowed params - reserved and bad naming"
       (is (thrown? Exception
@@ -1456,7 +1462,8 @@
                                                                                 "version" "a1b2c3"}}
                                                 {} {} kv-store service-id-prefix test-user []
                                                 (create-default-service-description-builder {})
-                                                (constantly false)))))
+                                                (constantly false)
+                                                true))))
 
     (testing "token + disallowed param header - on-the-fly"
       (is (thrown? Exception
@@ -1471,7 +1478,8 @@
                                                                                 "run-as-user" "test-user"}}
                                                 {} {} kv-store service-id-prefix test-user []
                                                 (create-default-service-description-builder {})
-                                                (constantly false)))))
+                                                (constantly false)
+                                                true))))
 
     (testing "token + no allowed params - on-the-fly"
       (is (thrown? Exception
@@ -1486,7 +1494,8 @@
                                                                                 "run-as-user" "test-user"}}
                                                 {} {} kv-store service-id-prefix test-user []
                                                 (create-default-service-description-builder {})
-                                                (constantly false)))))
+                                                (constantly false)
+                                                true))))
 
     (testing "instance-expiry-mins"
       (let [core-service-description {"cmd" "cmd for missing run-as-user"
@@ -1499,7 +1508,8 @@
                                                                             :service-description-template service-description}
                                                                            {} {} kv-store service-id-prefix test-user []
                                                                            (create-default-service-description-builder {})
-                                                                           (constantly false)))]
+                                                                           (constantly false)
+                                                                           true))]
         (is (thrown? Exception (run-compute-service-description (assoc core-service-description "instance-expiry-mins" -1))))
         (is (run-compute-service-description (assoc core-service-description "instance-expiry-mins" 0)))
         (is (run-compute-service-description (assoc core-service-description "instance-expiry-mins" 1)))))))

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -787,8 +787,7 @@
            kv-store (or kv-store (kv/->LocalKeyValueStore (atom {})))
            waiter-headers (or waiter-headers {})]
        (compute-service-description sources waiter-headers {} kv-store "test-service-" "current-request-user"
-                                    [] (create-default-service-description-builder {})
-                                    assoc-run-as-user-approved? true)))))
+                                    [] (create-default-service-description-builder {}) assoc-run-as-user-approved?)))))
 
 (defn- service-description
   ([sources & {:keys [assoc-run-as-user-approved? kv-store waiter-headers]}]
@@ -1373,129 +1372,108 @@
 (deftest test-compute-service-description-error-scenarios
   (let [kv-store (kv/->LocalKeyValueStore (atom {}))
         service-id-prefix "test-service-"
-        test-user "test-header-user"]
+        test-user "test-header-user"
+        waiter-headers {}
+        passthrough-headers {}
+        metric-group-mappings []
+        assoc-run-as-user-approved? (constantly false)
+        service-description-builder (create-default-service-description-builder {})
+        run-compute-service-description
+        (fn run-compute-service-description [descriptor]
+          (let [result-descriptor
+                (compute-service-description
+                  descriptor waiter-headers passthrough-headers kv-store service-id-prefix test-user
+                  metric-group-mappings service-description-builder assoc-run-as-user-approved?)
+                result-errors (validate-service-description kv-store service-description-builder result-descriptor)]
+            (when result-errors
+              (throw result-errors))
+            result-descriptor))]
     (is (thrown? Exception
-                 (compute-service-description {:defaults {"health-check-url" "/ping"}
-                                               :headers {}
-                                               :service-description-template {"cmd" "test command"
-                                                                              "cpus" "one"
-                                                                              "mem" 200
-                                                                              "version" "a1b2c3"
-                                                                              "run-as-user" test-user}}
-                                              {} {} kv-store service-id-prefix test-user []
-                                              (create-default-service-description-builder {})
-                                              (constantly false)
-                                              true)))
+                 (run-compute-service-description {:defaults {"health-check-url" "/ping"}
+                                                   :headers {}
+                                                   :service-description-template {"cmd" "test command"
+                                                                                  "cpus" "one"
+                                                                                  "mem" 200
+                                                                                  "version" "a1b2c3"
+                                                                                  "run-as-user" test-user}})))
     (is (thrown? Exception
-                 (compute-service-description {:defaults {"health-check-url" 1}
-                                               :headers {}
-                                               :service-description-template {"cmd" "test command"
-                                                                              "cpus" 1
-                                                                              "mem" 200
-                                                                              "version" "a1b2c3"
-                                                                              "run-as-user" test-user}}
-                                              {} {} kv-store service-id-prefix test-user []
-                                              (create-default-service-description-builder {})
-                                              (constantly false)
-                                              true)))
+                 (run-compute-service-description {:defaults {"health-check-url" 1}
+                                                   :headers {}
+                                                   :service-description-template {"cmd" "test command"
+                                                                                  "cpus" 1
+                                                                                  "mem" 200
+                                                                                  "version" "a1b2c3"
+                                                                                  "run-as-user" test-user}})))
     (is (thrown? Exception
-                 (compute-service-description {:defaults {"health-check-url" 1}
-                                               :headers {}
-                                               :service-description-template {}}
-                                              {} {} kv-store service-id-prefix test-user []
-                                              (create-default-service-description-builder {})
-                                              (constantly false)
-                                              true)))
+                 (run-compute-service-description {:defaults {"health-check-url" 1}
+                                                   :headers {}
+                                                   :service-description-template {}})))
     (is (thrown? Exception
-                 (compute-service-description {:defaults {"health-check-url" "/health"}
-                                               :service-description-template {"cmd" "cmd for missing run-as-user"
-                                                                              "cpus" 1
-                                                                              "mem" 200
-                                                                              "version" "a1b2c3"}}
-                                              {} {} kv-store service-id-prefix test-user []
-                                              (create-default-service-description-builder {})
-                                              (constantly false)
-                                              true)))
+                 (run-compute-service-description {:defaults {"health-check-url" "/health"}
+                                                   :service-description-template {"cmd" "cmd for missing run-as-user"
+                                                                                  "cpus" 1
+                                                                                  "mem" 200
+                                                                                  "version" "a1b2c3"}})))
 
     (testing "invalid allowed params - reserved"
       (is (thrown? Exception
-                   (compute-service-description {:defaults {"health-check-url" "/ping"
-                                                            "permitted-user" "bob"}
-                                                 :headers {}
-                                                 :service-description-template {"allowed-params" #{"HOME" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
-                                                                                "cmd" "token-cmd"
-                                                                                "cpus" 1
-                                                                                "mem" 200
-                                                                                "run-as-user" "test-user"
-                                                                                "version" "a1b2c3"}}
-                                                {} {} kv-store service-id-prefix test-user []
-                                                (create-default-service-description-builder {})
-                                                (constantly false)
-                                                true))))
+                   (run-compute-service-description {:defaults {"health-check-url" "/ping"
+                                                                "permitted-user" "bob"}
+                                                     :headers {}
+                                                     :service-description-template {"allowed-params" #{"HOME" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
+                                                                                    "cmd" "token-cmd"
+                                                                                    "cpus" 1
+                                                                                    "mem" 200
+                                                                                    "run-as-user" "test-user"
+                                                                                    "version" "a1b2c3"}}))))
 
     (testing "invalid allowed params - bad naming"
       (is (thrown? Exception
-                   (compute-service-description {:defaults {"health-check-url" "/ping"
-                                                            "permitted-user" "bob"}
-                                                 :headers {}
-                                                 :service-description-template {"allowed-params" #{"VAR.1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
-                                                                                "cmd" "token-cmd"
-                                                                                "cpus" 1
-                                                                                "mem" 200
-                                                                                "run-as-user" "test-user"
-                                                                                "version" "a1b2c3"}}
-                                                {} {} kv-store service-id-prefix test-user []
-                                                (create-default-service-description-builder {})
-                                                (constantly false)
-                                                true))))
+                   (run-compute-service-description {:defaults {"health-check-url" "/ping"
+                                                                "permitted-user" "bob"}
+                                                     :headers {}
+                                                     :service-description-template {"allowed-params" #{"VAR.1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
+                                                                                    "cmd" "token-cmd"
+                                                                                    "cpus" 1
+                                                                                    "mem" 200
+                                                                                    "run-as-user" "test-user"
+                                                                                    "version" "a1b2c3"}}))))
 
     (testing "invalid allowed params - reserved and bad naming"
       (is (thrown? Exception
-                   (compute-service-description {:defaults {"health-check-url" "/ping"
-                                                            "permitted-user" "bob"}
-                                                 :headers {}
-                                                 :service-description-template {"allowed-params" #{"USER" "VAR.1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
-                                                                                "cmd" "token-cmd"
-                                                                                "cpus" 1
-                                                                                "mem" 200
-                                                                                "run-as-user" "test-user"
-                                                                                "version" "a1b2c3"}}
-                                                {} {} kv-store service-id-prefix test-user []
-                                                (create-default-service-description-builder {})
-                                                (constantly false)
-                                                true))))
+                   (run-compute-service-description {:defaults {"health-check-url" "/ping"
+                                                                "permitted-user" "bob"}
+                                                     :headers {}
+                                                     :service-description-template {"allowed-params" #{"USER" "VAR.1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
+                                                                                    "cmd" "token-cmd"
+                                                                                    "cpus" 1
+                                                                                    "mem" 200
+                                                                                    "run-as-user" "test-user"
+                                                                                    "version" "a1b2c3"}}))))
 
     (testing "token + disallowed param header - on-the-fly"
       (is (thrown? Exception
-                   (compute-service-description {:defaults {"health-check-url" "/ping"
-                                                            "permitted-user" "bob"}
-                                                 :headers {"param" {"VAR_1" "VALUE-1"
-                                                                    "ANOTHER_VAR_2" "VALUE-2"}
-                                                           "version" "on-the-fly-version"}
-                                                 :service-description-template {"allowed-params" #{"VAR_1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
-                                                                                "cmd" "token-cmd"
-                                                                                "concurrency-level" 5
-                                                                                "run-as-user" "test-user"}}
-                                                {} {} kv-store service-id-prefix test-user []
-                                                (create-default-service-description-builder {})
-                                                (constantly false)
-                                                true))))
+                   (run-compute-service-description {:defaults {"health-check-url" "/ping"
+                                                                "permitted-user" "bob"}
+                                                     :headers {"param" {"VAR_1" "VALUE-1"
+                                                                        "ANOTHER_VAR_2" "VALUE-2"}
+                                                               "version" "on-the-fly-version"}
+                                                     :service-description-template {"allowed-params" #{"VAR_1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
+                                                                                    "cmd" "token-cmd"
+                                                                                    "concurrency-level" 5
+                                                                                    "run-as-user" "test-user"}}))))
 
     (testing "token + no allowed params - on-the-fly"
       (is (thrown? Exception
-                   (compute-service-description {:defaults {"health-check-url" "/ping"
-                                                            "permitted-user" "bob"}
-                                                 :headers {"param" {"VAR_1" "VALUE-1"
-                                                                    "VAR_2" "VALUE-2"}
-                                                           "version" "on-the-fly-version"}
-                                                 :service-description-template {"allowed-params" #{}
-                                                                                "cmd" "token-cmd"
-                                                                                "concurrency-level" 5
-                                                                                "run-as-user" "test-user"}}
-                                                {} {} kv-store service-id-prefix test-user []
-                                                (create-default-service-description-builder {})
-                                                (constantly false)
-                                                true))))
+                   (run-compute-service-description {:defaults {"health-check-url" "/ping"
+                                                                "permitted-user" "bob"}
+                                                     :headers {"param" {"VAR_1" "VALUE-1"
+                                                                        "VAR_2" "VALUE-2"}
+                                                               "version" "on-the-fly-version"}
+                                                     :service-description-template {"allowed-params" #{}
+                                                                                    "cmd" "token-cmd"
+                                                                                    "concurrency-level" 5
+                                                                                    "run-as-user" "test-user"}}))))
 
     (testing "instance-expiry-mins"
       (let [core-service-description {"cmd" "cmd for missing run-as-user"
@@ -1503,16 +1481,12 @@
                                       "mem" 200
                                       "run-as-user" test-user
                                       "version" "a1b2c3"}
-            run-compute-service-description (fn [service-description]
-                                              (compute-service-description {:defaults {"health-check-url" "/health"}
-                                                                            :service-description-template service-description}
-                                                                           {} {} kv-store service-id-prefix test-user []
-                                                                           (create-default-service-description-builder {})
-                                                                           (constantly false)
-                                                                           true))]
-        (is (thrown? Exception (run-compute-service-description (assoc core-service-description "instance-expiry-mins" -1))))
-        (is (run-compute-service-description (assoc core-service-description "instance-expiry-mins" 0)))
-        (is (run-compute-service-description (assoc core-service-description "instance-expiry-mins" 1)))))))
+            run-compute-service-description-helper (fn [service-description]
+                                                     (run-compute-service-description {:defaults {"health-check-url" "/health"}
+                                                                                       :service-description-template service-description}))]
+        (is (thrown? Exception (run-compute-service-description-helper (assoc core-service-description "instance-expiry-mins" -1))))
+        (is (run-compute-service-description-helper (assoc core-service-description "instance-expiry-mins" 0)))
+        (is (run-compute-service-description-helper (assoc core-service-description "instance-expiry-mins" 1)))))))
 
 (deftest test-compute-service-description-service-preauthorized-and-authentication-disabled
   (letfn [(execute-test [service-description-template header-parameters]


### PR DESCRIPTION
## Changes proposed in this PR

- loads only valid previous descriptors

## Why are we making these changes?

Fallback support should look back in history to a valid service description and the lookup should not be cut short by an intermediate invalid description.
