### PR TITLE
updates ubuntu image to 16.04 for mesos master and agents

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-dist: trusty
+dist: xenial
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 
 addons:
   artifacts: true
@@ -26,6 +26,8 @@ install:
 matrix:
   include:
     - name: 'Kitchen tests'
+      language: python
+      python: "3.6"
       before_script: cd kitchen && ./bin/ci/setup.sh
       script: ./bin/ci/run.sh
 

--- a/cli/bin/ci/setup.sh
+++ b/cli/bin/ci/setup.sh
@@ -5,7 +5,10 @@ set -ev
 ################################
 # Python environment setup
 
-pyenv global 3.6
+apt-get update && apt-get install -y python3
+
+pyenv install 3.6.3
+pyenv global 3.6.3
 
 python3 --version
 

--- a/kitchen/Dockerfile
+++ b/kitchen/Dockerfile
@@ -1,4 +1,6 @@
-FROM containersol/mesos-agent:1.0.0-0.1.0
+FROM twosigma/mesos-agent:1.0.0-1.0.1604
+
+RUN apt-get update && apt-get install -y python3
 
 RUN mkdir -p /opt/kitchen
 COPY bin/kitchen /opt/kitchen

--- a/waiter/bin/ci/upload-logs.sh
+++ b/waiter/bin/ci/upload-logs.sh
@@ -40,7 +40,7 @@ if [ -d ./waiter/scheduler ]; then
 fi
 
 # Tarball-up all of our Waiter/Mesos/etc logs
-tar -cJf $tarball --transform="s|\\./[^/]*/\\.*|${dump_name}/|" --warning=no-file-changed $log_dirs || exitcode=$?
+tar --ignore-failed-read -cJf $tarball --transform="s|\\./[^/]*/\\.*|${dump_name}/|" --warning=no-file-changed $log_dirs || exitcode=$?
 
 # GNU tar always exits with 0, 1 or 2 (https://www.gnu.org/software/tar/manual/html_section/tar_19.html)
 # 0 = Successful termination

--- a/waiter/minimesosFile
+++ b/waiter/minimesosFile
@@ -125,8 +125,8 @@ minimesos {
     master {
         aclJson = null
         authenticate = false
-        imageName = "containersol/mesos-master"
-        imageTag = "1.0.0-0.1.0"
+        imageName = "twosigma/mesos-master"
+        imageTag = "1.0.0-1.0.1604"
         loggingLevel = "# INHERIT FROM CLUSTER"
     }
 


### PR DESCRIPTION
## Changes proposed in this PR

- updates ubuntu image to 16.04 for Mesos master and agents

## Why are we making these changes?

We would like to control the images used in the scheduler builds instead of relying on the one from Containersol. In addition, upgrading to xenial means we can use newer versions of the additional applications like nginx.

Minimesos docker container changes are [committed in this repository](https://github.com/shamsimam/minimesos-docker/tree/xenial-16.06).