### PR TITLE
deflake test-reserve-ports!

### DIFF
--- a/waiter/test/waiter/reporters_test.clj
+++ b/waiter/test/waiter/reporters_test.clj
@@ -180,8 +180,6 @@ services.service-id.counters.fee.fie
                "timestamp"}
              (set (keys @actual-values))))
       (is (= (get @actual-values "prefix.services.service-id.counters.fee.fie") "0"))
-      (println (get @actual-values "timestamp"))
-      (println (System/currentTimeMillis))
       (is (< (Math/abs (- (* 1000 (get @actual-values "timestamp")) (System/currentTimeMillis))) max-test-duration-ms))
       (is (= {:run-state :created
               :last-reporting-time time

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -529,16 +529,15 @@
     (is (false? (port-reserved? port->reservation-atom port)))))
 
 (deftest test-reserve-ports!
-
   (testing "successfully reserve all ports"
     (let [port->reservation-atom (atom {})
-          port-range [10000 11000]
+          port-range [50000 51000]
           reserved-ports (reserve-ports! 20 port->reservation-atom port-range)]
-      (is (= (range 10000 10020) reserved-ports))))
+      (is (= (range 50000 50020) reserved-ports))))
 
   (testing "unable to reserve all ports"
     (let [port->reservation-atom (atom {})
-          port-range [10000 10010]]
+          port-range [50000 50010]]
       (try
         (reserve-ports! 20 port->reservation-atom port-range)
         (is false "reserve-ports! did not throw an exception!")


### PR DESCRIPTION
## Changes proposed in this PR

- deflake test-reserve-ports!

Changing the ports we try to reserve has made the test less flaky. I have run it in a loop with 200 iterations on travis twice (total of 400) without failures. Other branches that run this test seem to report error about 1 in 3 runs.