### PR TITLE
marks test-request-parallel-streaming as flaky

### DIFF
--- a/waiter/integration/waiter/websocket_integration_test.clj
+++ b/waiter/integration/waiter/websocket_integration_test.clj
@@ -439,7 +439,17 @@
       (log/error e "error in executing websocket request for test")
       (is false (str "websocket streaming iteration threw an error:" (.getMessage e))))))
 
-(deftest ^:parallel ^:integration-slow test-request-parallel-streaming
+;FAIL in (test-request-parallel-streaming) (websocket_integration_test.clj:476)
+;test-request-parallel-streaming
+;{:1006 11}
+;expected: 12
+;actual: 11
+;lein parallel-test :only waiter.websocket-integration-test/test-request-parallel-streaming
+;FAIL in (test-request-parallel-streaming) (websocket_integration_test.clj:477)
+;test-request-parallel-streaming
+;Only in a: {:waiting-to-stream 0}
+;Only in b: {:waiting-to-stream 1}
+(deftest ^:parallel ^:integration-slow ^:explicit test-request-parallel-streaming
   ;; streams requests in parallel and verifies all bytes were transferred correctly and
   ;; they were closed with status codes 1000 and 1006 (due to an issue with jet closing requests).
   (testing-using-waiter-url


### PR DESCRIPTION
## Changes proposed in this PR

- marks test-request-parallel-streaming as flaky

## Why are we making these changes?

Suppress flaky tests and get them fixed while not interfering with PRs in progress.
