### PR TITLE
Writes a base config that can be used by the CLI integration tests

### DIFF
--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -99,12 +99,7 @@ class temp_config_file:
     """
 
     def __init__(self, config):
-        session_module = os.getenv('COOK_SESSION_MODULE')
-        if session_module:
-            self.config = {'http': {'modules': {'session-module': session_module, 'adapters-module': session_module}}}
-            self.config.update(config)
-        else:
-            self.config = config
+        self.config = config
 
     def deep_merge(self, a, b):
         """Merges a and b, letting b win if there is a conflict"""
@@ -120,7 +115,7 @@ class temp_config_file:
 
     def write_temp_json(self):
         path = tempfile.NamedTemporaryFile(delete=False).name
-        config = self.config
+        config = self.deep_merge(base_config(), self.config)
         write_json(path, config)
         return path
 

--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -157,3 +157,20 @@ def show_token(waiter_url=None, token_name=None, flags=None):
 def output(cp):
     """Returns a string containing the stdout and stderr from the given CompletedProcess"""
     return f'\nstdout:\n{stdout(cp)}\n\nstderr:\n{decode(cp.stderr)}'
+
+
+def plugins_config():
+    """If the WAITER_TEST_PLUGIN_JSON environment variable is set, returns its value, otherwise empty dict"""
+    return json.loads(os.environ['WAITER_TEST_PLUGIN_JSON']) if 'WAITER_TEST_PLUGIN_JSON' in os.environ else {}
+
+
+def base_config():
+    """Returns a "base" config map that can be added to."""
+    return plugins_config()
+
+
+def write_base_config():
+    """Creates a config file that can be used as a starting point for integration tests"""
+    config = base_config()
+    if config:
+        write_json(os.path.abspath('.waiter.json'), config)

--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -162,7 +162,7 @@ def plugins_config():
     if 'WAITER_TEST_PLUGIN_JSON' in os.environ:
         path = os.environ['WAITER_TEST_PLUGIN_JSON']
         content = util.load_json_file(os.path.abspath(path))
-        return content
+        return content or {}
     else:
         return {}
 

--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -155,8 +155,16 @@ def output(cp):
 
 
 def plugins_config():
-    """If the WAITER_TEST_PLUGIN_JSON environment variable is set, returns its value, otherwise empty dict"""
-    return json.loads(os.environ['WAITER_TEST_PLUGIN_JSON']) if 'WAITER_TEST_PLUGIN_JSON' in os.environ else {}
+    """
+    If the WAITER_TEST_PLUGIN_JSON environment variable is set,
+    returns the parsed contents of the file, otherwise empty dict
+    """
+    if 'WAITER_TEST_PLUGIN_JSON' in os.environ:
+        path = os.environ['WAITER_TEST_PLUGIN_JSON']
+        content = util.load_json_file(os.path.abspath(path))
+        return content
+    else:
+        return {}
 
 
 def base_config():

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -16,6 +16,7 @@ class WaiterCliTest(util.WaiterTest):
     def setUpClass(cls):
         cls.waiter_url = util.retrieve_waiter_url()
         util.init_waiter_session(cls.waiter_url)
+        cli.write_base_config()
 
     def setUp(self):
         self.waiter_url = type(self).waiter_url

--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -155,8 +155,8 @@ def load_json_file(path):
             try:
                 logging.debug(f'attempting to load json configuration from {path}')
                 content = json.load(json_file)
-            except Exception:
-                pass
+            except Exception as e:
+                logging.error(e, f'error loading json configuration from {path}')
     else:
         logging.info(f'{path} is not a file')
 

--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -1,5 +1,6 @@
 import functools
 import importlib
+import json
 import logging
 import os
 import random
@@ -143,3 +144,20 @@ def wait_until(query, predicate, max_wait_ms=DEFAULT_TIMEOUT_MS, wait_interval_m
             details = str(final_response)
         logging.info(f"Timeout exceeded waiting for condition. Details: {details}")
         raise
+
+
+def load_json_file(path):
+    """Decode a JSON formatted file."""
+    content = None
+
+    if os.path.isfile(path):
+        with open(path) as json_file:
+            try:
+                logging.debug(f'attempting to load json configuration from {path}')
+                content = json.load(json_file)
+            except Exception:
+                pass
+    else:
+        logging.info(f'{path} is not a file')
+
+    return content


### PR DESCRIPTION
## Changes proposed in this PR

- adding support for optional `WAITER_TEST_PLUGIN_JSON` environment variable

## Why are we making these changes?

`WAITER_TEST_PLUGIN_JSON` can be used to specify environment-specific configuration that will be used for the integration tests, e.g.

```bash
WAITER_TEST_PLUGIN_JSON=plugins.json ./bin/only-run test_implicit_create_args
```