### PR TITLE
makes the server options configurable

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -121,6 +121,49 @@
  :hostname ["waiter.example.com"
             "waiter-alternate.example.com"]
 
+ ;; The configuration for the Waiter server that will be launched.
+ ;; Unless specified otherwise, all the entries below are optional:
+ :server-options {;; Whether or not to  enable secure HTTP2 transport, default false
+                  :http2? false
+
+                  ;; Whether or not to  enable HTTP2 cleartext transport, default true
+                  :http2c? true
+
+                  ;; When SSL is enabled, the keystore to use for SSL connections
+                  :keystore "/path/to/keystore.p12"
+                  ;; When SSL is enabled, the format of keystore
+                  :keystore-type "pkcs12"
+                  ;; When SSL is enabled, the password to the keystore
+                  :key-password "keystore-password"
+
+                  ;; The maximum number of threads to use (default 250)
+                  :max-threads 250
+
+                  ;; The maximum size in bytes of the request header.
+                  ;; Larger headers will allow for more and/or larger cookies plus larger form content encoded in a URL.
+                  ;; However, larger headers consume more memory and can make a server more vulnerable to denial of service attacks.
+                  :request-header-size 32768
+
+                  ;; The maximum size in bytes of the response header.
+                  ;; Larger headers will allow for more and/or larger cookies and longer HTTP headers (eg for redirection).
+                  ;; However, larger headers will also consume more memory.
+                  :response-header-size 8192
+
+                  ;; Whether to send the Date header in responses
+                  :send-date-header? false
+
+                  ;; The SSL port to listen on.
+                  ;; To disable SSL support, do not include this entry in the config.
+                  ;; Specifying a value for this port (which must be different from port above) enables SSL support.
+                  :ssl-port 9443
+
+                  ;; When SSL is enabled, the truststore to use for SSL connections
+                  :truststore "/path/to/truststore.p12"
+                  ;; When SSL is enabled, the format of trust store
+                  :truststore-type "pkcs12"
+                  ;; When SSL is enabled, the password to the truststore
+                  :trust-password "truststore-password"}
+
  ; ---------- Token Storage ----------
 
  :kv-config {

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -52,7 +52,9 @@
    (s/required-key :git-version) s/Any
    (s/required-key :health-check-config) {(s/required-key :health-check-timeout-ms) schema/positive-int
                                           (s/required-key :failed-check-threshold) schema/positive-int}
+   ;; TODO host belongs in server-options?
    (s/required-key :host) schema/non-empty-string
+   ;; TODO hostname belongs in server-options?
    (s/required-key :hostname) (s/if string? schema/non-empty-string (s/constrained [schema/non-empty-string]
                                                                                    not-empty))
    (s/required-key :instance-request-properties) {(s/required-key :async-check-interval-ms) schema/positive-int
@@ -83,6 +85,7 @@
                                              {:kind s/Keyword
                                               s/Keyword schema/require-symbol-factory-fn}
                                              schema/contains-kind-sub-map?)
+   ;; TODO port belongs in server-options?
    (s/required-key :port) schema/positive-int
    (s/required-key :router-id-prefix) s/Str
    (s/required-key :router-syncer) {(s/required-key :delay-ms) schema/positive-int
@@ -100,6 +103,19 @@
                                           (s/required-key :scheduler-gc-broken-service-interval-ms) schema/positive-int
                                           (s/required-key :scheduler-gc-interval-ms) schema/positive-int}
    (s/required-key :scheduler-syncer-interval-secs) schema/positive-int
+   (s/required-key :server-options) {(s/optional-key :http2?) s/Bool
+                                     (s/optional-key :http2c?) s/Bool
+                                     (s/optional-key :keystore) schema/non-empty-string
+                                     (s/optional-key :keystore-type) schema/non-empty-string
+                                     (s/optional-key :key-password) schema/non-empty-string
+                                     (s/optional-key :max-threads) schema/positive-int
+                                     (s/optional-key :request-header-size) schema/positive-int
+                                     (s/optional-key :response-header-size) schema/positive-int
+                                     (s/optional-key :send-date-header?) s/Bool
+                                     (s/optional-key :ssl-port) schema/positive-int
+                                     (s/optional-key :truststore) schema/non-empty-string
+                                     (s/optional-key :truststore-type) schema/non-empty-string
+                                     (s/optional-key :trust-password) schema/non-empty-string}
    (s/required-key :service-description-builder-config) (s/constrained
                                                           {:kind s/Keyword
                                                            s/Keyword schema/require-symbol-factory-fn}
@@ -358,6 +374,12 @@
                          :scheduler-gc-broken-service-interval-ms 60000
                          :scheduler-gc-interval-ms 60000}
    :scheduler-syncer-interval-secs 5
+   :server-options {:http2? false
+                    :http2c? true
+                    :max-threads 250
+                    :request-header-size 32768
+                    :response-header-size 8192
+                    :send-date-header? false}
    :service-description-builder-config {:kind :default
                                         :default {:factory-fn 'waiter.service-description/create-default-service-description-builder}}
    :service-description-constraints {"cmd" {:max 1200}


### PR DESCRIPTION
## Changes proposed in this PR

- makes the server options configurable

## Why are we making these changes?

Makes it easy to plugin HTTP/2 and SSL support along with the other options.

