### PR TITLE
Adds update alias to CLI

### DIFF
--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -59,29 +59,53 @@ def cli(args, waiter_url=None, flags=None, stdin=None, env=None, wait_for_exit=T
     return cp
 
 
-def create(waiter_url=None, token_name=None, flags=None, create_flags=None):
-    """Creates a token via the CLI"""
-    args = f"create {token_name} {create_flags or ''}"
+def create_or_update(subcommand, waiter_url=None, token_name=None, flags=None, create_flags=None):
+    """Creates or updates a token via the CLI"""
+    args = f"{subcommand} {token_name} {create_flags or ''}"
     cp = cli(args, waiter_url, flags)
     return cp
 
 
-def create_from_service_description(waiter_url, token_name, service, flags=None):
-    """Creates a token via the CLI, using the provided service fields"""
+def create(waiter_url=None, token_name=None, flags=None, create_flags=None):
+    """Creates a token via the CLI"""
+    cp = create_or_update('create', waiter_url, token_name, flags, create_flags)
+    return cp
+
+
+def create_or_update_from_service_description(subcommand, waiter_url, token_name, service, flags=None):
+    """Creates or updates a token via the CLI, using the provided service fields"""
     create_flags = \
         f"--cmd '{service['cmd']}' " \
         f"--cpus {service['cpus']} " \
         f"--mem {service['mem']} " \
         f"--cmd-type {service['cmd-type']} " \
         f"--version {service['version']}"
-    cp = create(waiter_url, token_name, flags=flags, create_flags=create_flags)
+    cp = create_or_update(subcommand, waiter_url, token_name, flags=flags, create_flags=create_flags)
+    return cp
+
+
+def create_from_service_description(waiter_url, token_name, service, flags=None):
+    """Creates a token via the CLI, using the provided service fields"""
+    cp = create_or_update_from_service_description('create', waiter_url, token_name, service, flags)
+    return cp
+
+
+def create_or_update_minimal(subcommand, waiter_url=None, token_name=None, flags=None, **kwargs):
+    """Creates or updates a token via the CLI, using the "minimal" service description"""
+    service = util.minimal_service_description(**kwargs)
+    cp = create_or_update_from_service_description(subcommand, waiter_url, token_name, service, flags=flags)
     return cp
 
 
 def create_minimal(waiter_url=None, token_name=None, flags=None, **kwargs):
     """Creates a token via the CLI, using the "minimal" service description"""
-    service = util.minimal_service_description(**kwargs)
-    cp = create_from_service_description(waiter_url, token_name, service, flags=flags)
+    cp = create_or_update_minimal('create', waiter_url, token_name, flags, **kwargs)
+    return cp
+
+
+def update_minimal(waiter_url=None, token_name=None, flags=None, **kwargs):
+    """Updates a token via the CLI, using the "minimal" service description"""
+    cp = create_or_update_minimal('update', waiter_url, token_name, flags, **kwargs)
     return cp
 
 

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -30,7 +30,26 @@ class WaiterCliTest(util.WaiterTest):
         self.assertEqual(0, cp.returncode, cp.stderr)
         try:
             token_data = util.load_token(self.waiter_url, token_name)
-            print(token_data)
+            self.assertIsNotNone(token_data)
+            self.assertEqual('shell', token_data['cmd-type'])
+            self.assertEqual(cmd, token_data['cmd'])
+            self.assertEqual(0.1, token_data['cpus'])
+            self.assertEqual(128, token_data['mem'])
+            self.assertEqual(getpass.getuser(), token_data['owner'])
+            self.assertEqual(getpass.getuser(), token_data['last-update-user'])
+            self.assertEqual({}, token_data['previous'])
+            self.assertEqual(version, token_data['version'])
+        finally:
+            util.delete_token(self.waiter_url, token_name)
+
+    def test_basic_update(self):
+        token_name = self.token_name()
+        version = str(uuid.uuid4())
+        cmd = util.minimal_service_cmd()
+        cp = cli.update_minimal(self.waiter_url, token_name, flags=None, cmd=cmd, cpus=0.1, mem=128, version=version)
+        self.assertEqual(0, cp.returncode, cp.stderr)
+        try:
+            token_data = util.load_token(self.waiter_url, token_name)
             self.assertIsNotNone(token_data)
             self.assertEqual('shell', token_data['cmd-type'])
             self.assertEqual(cmd, token_data['cmd'])

--- a/cli/waiter/cli.py
+++ b/cli/waiter/cli.py
@@ -16,8 +16,10 @@ parser.add_argument('--version', help='output version information and exit',
 
 subparsers = parser.add_subparsers(dest='action')
 
+create_or_update = create.register(subparsers.add_parser)
 actions = {
-    'create': create.register(subparsers.add_parser),
+    'create': create_or_update,
+    'update': create_or_update,
     'show': show.register(subparsers.add_parser)
 }
 

--- a/cli/waiter/subcommands/create.py
+++ b/cli/waiter/subcommands/create.py
@@ -84,14 +84,17 @@ def create(clusters, args, _):
 def register(add_parser):
     """Adds this sub-command's parser and returns the action function"""
     global create_parser
-    create_parser = add_parser('create', help='create token', description='Create or update a Waiter token. '
-                                                                          'In addition to the optional arguments '
-                                                                          'explicitly listed below, '
-                                                                          'you can optionally provide any Waiter '
-                                                                          'token parameter as a flag. For example, '
-                                                                          'to specify 10 seconds for the '
-                                                                          'grace-period-secs parameter, '
-                                                                          'you can pass --grace-period-secs 10.')
+    create_parser = add_parser('create',
+                               help='create or update token',
+                               description='Create or update a Waiter token. '
+                                           'In addition to the optional arguments '
+                                           'explicitly listed below, '
+                                           'you can optionally provide any Waiter '
+                                           'token parameter as a flag. For example, '
+                                           'to specify 10 seconds for the '
+                                           'grace-period-secs parameter, '
+                                           'you can pass --grace-period-secs 10.',
+                               aliases=['update'])
     create_parser.add_argument('--name', '-n', help='name of service')
     create_parser.add_argument('--version', '-v', help='version of service')
     create_parser.add_argument('--cmd', '-C', help='command to start service')


### PR DESCRIPTION
## Changes proposed in this PR

- adding the `update` alias for `create`

## Why are we making these changes?

When users are updating an existing token, `waiter update` is more natural than `waiter create`.

## Demo

[![asciicast](https://asciinema.org/a/fdtUD6TubyrbluiLSBGG7B8GN.svg)](https://asciinema.org/a/fdtUD6TubyrbluiLSBGG7B8GN?autoplay=1)