### PR TITLE
updates jet version for ALPN support

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -32,7 +32,8 @@
 
   :dependencies [[bidi "2.1.5"
                   :exclusions [prismatic/schema ring/ring-core]]
-                 [twosigma/jet "0.7.10-20190315_050957-g3e53036"]
+                 [twosigma/jet "0.7.10-20190319_181636-g5104f1f"
+                  :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]
                  [clj-time "0.15.1"
@@ -84,9 +85,9 @@
                  [org.clojure/tools.logging "0.4.1"]
                  [org.clojure/tools.namespace "0.2.11"]
                  [org.clojure/tools.reader "1.3.2"]
-                 [org.eclipse.jetty/jetty-alpn-openjdk8-client "9.4.15.v20190215"]
                  ;; use maven to download this jar so we can set up the boot classpath
-                 [org.mortbay.jetty.alpn/alpn-boot "8.1.13.v20181017"]
+                 [org.mortbay.jetty.alpn/alpn-boot "8.1.13.v20181017"
+                  :scope "provided"]
                  [org.slf4j/slf4j-log4j12 "1.7.25"
                   :exclusions [log4j]]
                  [potemkin "0.4.5"]


### PR DESCRIPTION
## Changes proposed in this PR

- updates [jet version for ALPN support](https://github.com/twosigma/jet/pull/16)

## Why are we making these changes?

We would like Waiter to respond to h2 requests using ALPN support.

```
$ curl -s -k --http2 "https://localhost:9099/status?include=request-info" | jq .
{                                                                                        
  "request-time": "2019-03-19T18:23:45.958Z",                                  
  "request-id": "784262c84d23-7e044d29c53e29e9-https",                       
  "protocol": "HTTP/2.0",                                                                      
  "headers": {                                   
    "host": "localhost:9099",                         
    "user-agent": "curl/7.54.0",
    "accept": "*/*",
    "x-cid": "784262c8d05d-7e9a5e5feba5a75"
  },
  "content-length": null,
  "status": "ok",
  "content-type": null,
  "character-encoding": null,
  "uri": "/status",
  "query-string": "include=request-info",
  "router-id": "r9091-783c83761eb3-e8f0bb72370a4a5",
  "scheme": "https",
  "request-method": "get"
}
```

