### PR TITLE
Adds support for a 'central' .waiter.json

### DIFF
--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -177,3 +177,25 @@ def write_base_config():
     config = base_config()
     if config:
         write_json(os.path.abspath('.waiter.json'), config)
+
+
+class temp_base_config_file:
+    """
+    A context manager used to generate and subsequently delete a temporary
+    base config file for the CLI. Takes as input the config dictionary to use.
+    """
+
+    def __init__(self, config):
+        # Get the location of the waiter executable so we can add a default `.waiter.json` file
+        cp = subprocess.run(args=['which', command()], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        base_exec = cp.stdout.decode("utf-8").rstrip('\n')
+        base_dir = os.path.dirname(os.path.abspath(base_exec))
+        self.path = os.path.join(base_dir, '.waiter.json')
+        self.config = config
+
+    def __enter__(self):
+        write_json(self.path, self.config)
+        return self.path
+
+    def __exit__(self, _, __, ___):
+        os.remove(self.path)

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1,6 +1,8 @@
 import getpass
 import logging
+import os
 import threading
+import unittest
 import uuid
 
 import pytest
@@ -230,3 +232,24 @@ class WaiterCliTest(util.WaiterTest):
             thread.join()
             self.logger.info('Thread finished')
             util.delete_token(self.waiter_url, token_name)
+
+    @unittest.skipIf('WAITER_TEST_CLI_COMMAND' in os.environ, 'waiter executable may be unknown.')
+    def test_base_config_file(self):
+        token_name = self.token_name()
+        cluster_name_1 = str(uuid.uuid4())
+        config = {'clusters': [{"name": cluster_name_1, "url": self.waiter_url}]}
+        with cli.temp_base_config_file(config):
+            # Use entry in base config file
+            cp = cli.create_minimal(token_name=token_name)
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            self.assertIn(f'on {cluster_name_1} cluster', cli.decode(cp.stdout))
+
+            # Overwrite "base" with specified config file
+            cluster_name_2 = str(uuid.uuid4())
+            config = {'clusters': [{"name": cluster_name_2, "url": self.waiter_url}]}
+            with cli.temp_config_file(config) as path:
+                # Verify "base" config is overwritten
+                flags = '--config %s' % path
+                cp = cli.create_minimal(token_name=token_name, flags=flags)
+                self.assertEqual(0, cp.returncode, cp.stderr)
+                self.assertIn(f'on {cluster_name_2} cluster', cli.decode(cp.stdout))

--- a/cli/waiter/configuration.py
+++ b/cli/waiter/configuration.py
@@ -1,12 +1,19 @@
 import json
 import logging
 import os
+import sys
 
-# Default locations to check for configuration files if one isn't given on the command line
 from waiter.util import deep_merge
 
-DEFAULT_CONFIG_PATHS = ['.waiter.json',
-                        os.path.expanduser('~/.waiter.json')]
+# Base locations to check for configuration files, relative to the executable.
+# Always tries to load these in.
+BASE_CONFIG_PATHS = ['.waiter.json',
+                     '../.waiter.json',
+                     '../config/.waiter.json']
+
+# Additional locations to check for configuration files if one isn't given on the command line
+ADDITIONAL_CONFIG_PATHS = ['.waiter.json',
+                           os.path.expanduser('~/.waiter.json')]
 
 DEFAULT_CONFIG = {'http': {'retries': 2,
                            'connect-timeout': 3.05,
@@ -43,10 +50,18 @@ def __load_first_json_file(paths):
     return next(((p, c) for p, c in contents if c), (None, None))
 
 
-def load_config(config_path):
+def __load_base_config():
+    """Loads the base configuration map."""
+    base_dir = os.path.dirname(os.path.abspath(sys.argv[0]))
+    paths = [os.path.join(base_dir, path) for path in BASE_CONFIG_PATHS]
+    _, config = __load_first_json_file(paths)
+    return config
+
+
+def __load_local_config(config_path):
     """
     Loads the configuration map, using the provided config_path if not None,
-    otherwise, searching the default config paths for a valid JSON config file
+    otherwise, searching the additional config paths for a valid JSON config file
     """
     if config_path:
         if os.path.isfile(config_path):
@@ -55,15 +70,18 @@ def load_config(config_path):
         else:
             raise Exception(f'The configuration path specified ({config_path}) is not valid.')
     else:
-        config_path, config = __load_first_json_file(DEFAULT_CONFIG_PATHS)
+        config_path, config = __load_first_json_file(ADDITIONAL_CONFIG_PATHS)
 
     return config_path, config
 
 
 def load_config_with_defaults(config_path=None):
     """Loads the configuration map to use, merging in the defaults"""
-    _, config = load_config(config_path)
+    base_config = __load_base_config()
+    base_config = base_config or {}
+    base_config = deep_merge(DEFAULT_CONFIG, base_config)
+    config_path, config = __load_local_config(config_path)
     config = config or {}
-    config = deep_merge(DEFAULT_CONFIG, config)
+    config = deep_merge(base_config, config)
     logging.debug(f'using configuration: {config}')
     return config


### PR DESCRIPTION
## Changes proposed in this PR

- allowing the CLI to use a config file that's co-located with the executing program

## Why are we making these changes?

This allows deployers to maintain a "central" config with reasonable defaults (e.g. the list of clusters of interest) instead of requiring that these defaults be specified on each end-user's host.
