### PR TITLE
Adds pytest setup.cfg for CLI tests

### DIFF
--- a/cli/integration/setup.cfg
+++ b/cli/integration/setup.cfg
@@ -1,0 +1,3 @@
+[tool:pytest]
+addopts = -n10 -v --maxfail=5
+timeout = 1200

--- a/cli/integration/setup.cfg
+++ b/cli/integration/setup.cfg
@@ -1,3 +1,3 @@
 [tool:pytest]
-addopts = -n10 -v --maxfail=5
+addopts = -n10 -v --maxfail=5 --log-level=DEBUG
 timeout = 1200


### PR DESCRIPTION
## Changes proposed in this PR

- adding `setup.cfg` for `pytest`

## Why are we making these changes?

To give reasonable defaults for number of threads, verbosity, max failed tests before stopping, and test timeout.