### PR TITLE
Avoids exit due to single cluster out of multiple

### DIFF
--- a/cli/waiter/http_util.py
+++ b/cli/waiter/http_util.py
@@ -116,7 +116,7 @@ def make_data_request(cluster, make_request_fn):
         logging.warning(f'Unexpected response code {resp.status_code} for data request. Response body: {resp.text}')
     except requests.exceptions.ConnectionError as ce:
         logging.exception(ce)
-        raise Exception(f'Encountered connection error with {cluster["name"]} ({cluster["url"]}).')
+        print_error(f'Encountered connection error with {cluster["name"]} ({cluster["url"]}).')
     except requests.exceptions.ReadTimeout as rt:
         logging.exception(rt)
         print_error(f'Encountered read timeout with {cluster["name"]} ({cluster["url"]}).')

--- a/cli/waiter/subcommands/show.py
+++ b/cli/waiter/subcommands/show.py
@@ -1,9 +1,10 @@
 import json
+import logging
 
 from tabulate import tabulate
 
 from waiter.format import format_mem_field, format_timestamp_string, format_field_name
-from waiter.querying import query_across_clusters, get_token
+from waiter.querying import query_across_clusters, get_token, print_no_data
 from waiter.util import guard_no_cluster
 
 
@@ -67,7 +68,8 @@ def get_token_on_cluster(cluster, token_name):
     if token_data:
         return {'count': 1, 'token': token_data}
     else:
-        raise Exception(f'Unable to retrieve token information on {cluster["name"]} ({cluster["url"]}).')
+        logging.info(f'Unable to retrieve token information on {cluster["name"]} ({cluster["url"]}).')
+        return {'count': 0}
 
 
 def query(clusters, token):
@@ -97,6 +99,8 @@ def show(clusters, args, _):
     if query_result['count'] > 0:
         return 0
     else:
+        if not as_json:
+            print_no_data(clusters)
         return 1
 
 


### PR DESCRIPTION
## Changes proposed in this PR

- improving error message when a token can't be found to:
```bash
$ waiter show dfsfsad
No matching data found in dev0.
Do you need to add another cluster to your configuration?
```
- avoiding exit when the CLI cannot connect to a cluster

## Why are we making these changes?

In some environments, it's common to have multiple clusters configured, and we don't want an error from one cluster to cause results from other clusters to not show up.