### PR TITLE
Adds 'CLI' to default test command env variable

### DIFF
--- a/cli/bin/ci/run-integration-tests.sh
+++ b/cli/bin/ci/run-integration-tests.sh
@@ -47,6 +47,6 @@ curl -s ${WAITER_URI}/settings | jq .port
 
 # Run the integration tests
 export WAITER_URI=127.0.0.1:${WAITER_PORT}
-export WAITER_TEST_DEFAULT_CMD="${ROOT_DIR}/kitchen/bin/kitchen --port \${PORT0}"
+export WAITER_CLI_TEST_DEFAULT_CMD="${ROOT_DIR}/kitchen/bin/kitchen --port \${PORT0}"
 cd ${CLI_DIR}/integration
 pytest

--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -105,7 +105,7 @@ def minimal_service_cmd(response_text=None):
 
 def minimal_service_description(**kwargs):
     service = {
-        'cmd': os.getenv('WAITER_TEST_DEFAULT_CMD', minimal_service_cmd()),
+        'cmd': os.getenv('WAITER_CLI_TEST_DEFAULT_CMD', minimal_service_cmd()),
         'cpus': float(os.getenv('WAITER_TEST_DEFAULT_CPUS', 1.0)),
         'mem': int(os.getenv('WAITER_TEST_DEFAULT_MEM_MB', 256)),
         'version': 'version-does-not-matter',


### PR DESCRIPTION
## Changes proposed in this PR

- `WAITER_TEST_DEFAULT_CMD` -> `WAITER_CLI_TEST_DEFAULT_CMD`

## Why are we making these changes?

To disambiguate this from `WAITER_TEST_KITCHEN_CMD` (the one used by the non-CLI tests).