### PR TITLE
avoids displaying key and trust store passwords

### DIFF
--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -225,11 +225,13 @@
                              (map? nested-data)
                              (contains? nested-data :factory-fn))))
              (select-keys data))))
-    (cond-> (utils/dissoc-in settings [:zookeeper :connect-string])
+    (cond-> settings
       (get-in settings [:server-options :key-password])
-      (assoc-in [:server-options :key-password] "_hidden_")
+      (assoc-in [:server-options :key-password] "<hidden>")
       (get-in settings [:server-options :trust-password])
-      (assoc-in [:server-options :trust-password] "_hidden_"))))
+      (assoc-in [:server-options :trust-password] "<hidden>")
+      (get-in settings [:zookeeper :connect-string])
+      (assoc-in [:zookeeper :connect-string] "<hidden>"))))
 
 (defn display-settings
   "Endpoint to display the current settings in use."

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -214,22 +214,29 @@
 (defn sanitize-settings
   "Sanitizes settings for eventual conversion to JSON"
   [settings]
-  (->> (utils/dissoc-in settings [:zookeeper :connect-string])
-       (walk/postwalk (fn [data]
-                        (if-not (and (map? data) (contains? data :kind))
-                          data
-                          (->> (keys data)
-                               (remove #(let [nested-data (get data %)]
-                                          (and (not= % :kind)
-                                               (not= % (:kind data))
-                                               (map? nested-data)
-                                               (contains? nested-data :factory-fn))))
-                               (select-keys data)))))))
+  (walk/postwalk
+    (fn [data]
+      (if-not (and (map? data) (contains? data :kind))
+        data
+        (->> (keys data)
+             (remove #(let [nested-data (get data %)]
+                        (and (not= % :kind)
+                             (not= % (:kind data))
+                             (map? nested-data)
+                             (contains? nested-data :factory-fn))))
+             (select-keys data))))
+    (cond-> (utils/dissoc-in settings [:zookeeper :connect-string])
+      (get-in settings [:server-options :key-password])
+      (assoc-in [:server-options :key-password] "_hidden_")
+      (get-in settings [:server-options :trust-password])
+      (assoc-in [:server-options :trust-password] "_hidden_"))))
 
 (defn display-settings
   "Endpoint to display the current settings in use."
   [settings]
-  (utils/clj->json-response (into (sorted-map) (sanitize-settings settings))))
+  (-> settings
+      sanitize-settings
+      utils/clj->json-response))
 
 (def settings-defaults
   {:authenticator-config {:kind :one-user

--- a/waiter/test/waiter/settings_test.clj
+++ b/waiter/test/waiter/settings_test.clj
@@ -313,9 +313,13 @@
           :scheduler-config {:cache {:ttl 100}
                              :kind :marathon
                              :marathon {:factory-fn "create-marathon-scheduler" :url "http://marathon.example.com:8080"}}
+          :server-options {:truststore "/path/to/truststore.p12"
+                           :truststore-type "pkcs12"
+                           :trust-password "<hidden>"}
           :work-stealing {:offer-help-interval-ms 100
                           :reserve-timeout-ms 1000}
-          :zookeeper {:gc-relative-path "gc-state"
+          :zookeeper {:connect-string "<hidden>"
+                      :gc-relative-path "gc-state"
                       :leader-latch-relative-path "leader-latch"}}
          (sanitize-settings {:example {:foo {:kind :test
                                              :test {:factory-fn "create-test" :param "value-test"}
@@ -331,6 +335,9 @@
                                                 :kind :marathon
                                                 :marathon {:factory-fn "create-marathon-scheduler" :url "http://marathon.example.com:8080"}
                                                 :shell {:factory-fn "create-shell-scheduler" :working-directory "/path/to/some/directory"}}
+                             :server-options {:truststore "/path/to/truststore.p12"
+                                              :truststore-type "pkcs12"
+                                              :trust-password "truststore-password"}
                              :work-stealing {:offer-help-interval-ms 100
                                              :reserve-timeout-ms 1000}
                              :zookeeper {:connect-string "test-connect-string"


### PR DESCRIPTION
## Changes proposed in this PR

- avoids displaying key and trust store passwords

## Why are we making these changes?

We wish to avoid displaying passwords in our apis.

<img width="320" alt="Screen Shot 2019-03-22 at 4 15 47 PM" src="https://user-images.githubusercontent.com/6611249/54853597-4ebcbd00-4cbe-11e9-9517-ada5923d0c95.png">

