### PR TITLE
Fixes env display in waiter show

### DIFF
--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -268,7 +268,7 @@ class WaiterCliTest(util.WaiterTest):
 
     def test_show_env(self):
         token_name = self.token_name()
-        util.post_token(self.waiter_url, token_name, {'cpus': 0.1})
+        util.post_token(self.waiter_url, token_name, {'env': {'FOO': '1', 'BAR': 'baz'}})
         try:
             cp = cli.show(self.waiter_url, token_name)
             self.assertEqual(0, cp.returncode, cp.stderr)

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -265,3 +265,14 @@ class WaiterCliTest(util.WaiterTest):
                 self.assertIn('Encountered connection error with bar', cli.decode(cp.stderr), cli.output(cp))
         finally:
             util.delete_token(self.waiter_url, token_name)
+
+    def test_show_env(self):
+        token_name = self.token_name()
+        util.post_token(self.waiter_url, token_name, {'cpus': 0.1})
+        try:
+            cp = cli.show(self.waiter_url, token_name)
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            self.assertIn('Environment:\n', cli.stdout(cp))
+            self.assertNotIn('Env ', cli.stdout(cp))
+        finally:
+            util.delete_token(self.waiter_url, token_name)

--- a/cli/waiter/subcommands/show.py
+++ b/cli/waiter/subcommands/show.py
@@ -19,9 +19,9 @@ def tabulate_token(cluster_name, token, token_name):
     if token.get('mem'):
         table.append(['Memory', format_mem_field(token)])
     if token.get('ports'):
-        table.append(['Ports Requested', token['ports']])
+        table.append(['Ports requested', token['ports']])
 
-    explicit_keys = ('cmd', 'cpus', 'last-update-time', 'last-update-user', 'mem', 'name', 'owner', 'ports')
+    explicit_keys = ('cmd', 'cpus', 'env', 'last-update-time', 'last-update-user', 'mem', 'name', 'owner', 'ports')
     ignored_keys = ('cluster', 'previous', 'root')
     for key, value in token.items():
         if key not in (explicit_keys + ignored_keys):


### PR DESCRIPTION
## Changes proposed in this PR

- avoiding duplication of the environment in `show`

## Why are we making these changes?

Instead of this:

```bash
$ waiter show foo

=== Token: foo ===

Last Updated: seconds ago (dpo)

Cluster  dev0
Owner    dpo
Env      {'FOO': '1', 'BAR': 'baz'}

<No command specified>

Environment:
FOO=1
BAR=baz
```

We want this:

```bash
$ waiter show foo

=== Token: foo ===

Last Updated: seconds ago (dpo)

Cluster  dev0
Owner    dpo

<No command specified>

Environment:
FOO=1
BAR=baz
```
