### PR TITLE
converts the x-forwarded-proto to a keyword in request->scheme

### DIFF
--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -442,10 +442,11 @@
     (if port-index (subs authority (inc port-index)) (str default))))
 
 (defn request->scheme
-  "Extracts the scheme from the request."
+  "Extracts the scheme from the request, and returns it as a keyword."
   [{:keys [headers scheme]}]
   (let [{:strs [x-forwarded-proto]} headers]
-    (or x-forwarded-proto scheme)))
+    (or (some-> x-forwarded-proto str/lower-case keyword)
+        scheme)))
 
 (defn same-origin
   "Returns true if the host and origin are non-nil and are equivalent."

--- a/waiter/test/waiter/util/utils_test.clj
+++ b/waiter/test/waiter/util/utils_test.clj
@@ -502,6 +502,19 @@
   (is (= "1234" (authority->port "www.example.com:1234")))
   (is (= "80" (authority->port "www.example2.com:80"))))
 
+(deftest test-request->scheme
+  (is (= :http (request->scheme {:headers {"x-forwarded-proto" "http"}})))
+  (is (= :http (request->scheme {:headers {"x-forwarded-proto" "HTTP"}})))
+  (is (= :http (request->scheme {:headers {"x-forwarded-proto" "http"} :scheme :http})))
+  (is (= :http (request->scheme {:headers {"x-forwarded-proto" "http"} :scheme :https})))
+  (is (= :http (request->scheme {:scheme :http})))
+
+  (is (= :https (request->scheme {:headers {"x-forwarded-proto" "https"}})))
+  (is (= :https (request->scheme {:headers {"x-forwarded-proto" "HTTPS"}})))
+  (is (= :https (request->scheme {:headers {"x-forwarded-proto" "https"} :scheme :http})))
+  (is (= :https (request->scheme {:headers {"x-forwarded-proto" "https"} :scheme :https})))
+  (is (= :https (request->scheme {:scheme :https}))))
+
 (deftest test-same-origin
   (is (not (same-origin nil)))
   (is (not (same-origin {})))


### PR DESCRIPTION
## Changes proposed in this PR

- converts the x-forwarded-proto to a keyword in request->scheme

## Why are we making these changes?

Correct the mechanism for determining the request scheme.

