### PR TITLE
Adds multi-cluster test support

### DIFF
--- a/cli/bin/ci/run-integration-tests.sh
+++ b/cli/bin/ci/run-integration-tests.sh
@@ -67,6 +67,6 @@ curl -s ${WAITER_URI_2}/settings | jq .port
 # Run the integration tests
 export WAITER_URI=127.0.0.1:${WAITER_PORT}
 export WAITER_CLI_TEST_DEFAULT_CMD="${ROOT_DIR}/kitchen/bin/kitchen --port \${PORT0}"
-export WAITER_TEST_MULTI_CLUSTER=
+export WAITER_TEST_MULTI_CLUSTER=true
 cd ${CLI_DIR}/integration
 pytest

--- a/cli/integration/tests/waiter/test_cli_multi_cluster.py
+++ b/cli/integration/tests/waiter/test_cli_multi_cluster.py
@@ -1,0 +1,53 @@
+import logging
+import unittest
+import uuid
+
+import pytest
+
+from tests.waiter import cli, util
+
+
+@pytest.mark.cli
+@unittest.skipUnless(util.multi_cluster_tests_enabled(), 'Requires setting WAITER_TEST_MULTI_CLUSTER')
+@pytest.mark.timeout(util.DEFAULT_TEST_TIMEOUT_SECS)
+class MultiWaiterCliTest(util.WaiterTest):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.waiter_url_1 = util.retrieve_waiter_url()
+        cls.waiter_url_2 = util.retrieve_waiter_url('WAITER_URL_2', 'http://localhost:9191')
+        util.init_waiter_session(cls.waiter_url_1, cls.waiter_url_2)
+        cli.write_base_config()
+
+    def setUp(self):
+        self.waiter_url_1 = type(self).waiter_url_1
+        self.waiter_url_2 = type(self).waiter_url_2
+        self.logger = logging.getLogger(__name__)
+
+    def __two_cluster_config(self):
+        return {'clusters': [{'name': 'waiter1', 'url': self.waiter_url_1},
+                             {'name': 'waiter2', 'url': self.waiter_url_2}]}
+
+    def test_federated_show(self):
+        # Create in cluster #1
+        token_name = self.token_name()
+        version_1 = str(uuid.uuid4())
+        util.post_token(self.waiter_url_1, token_name, {'version': version_1})
+        try:
+            # Create in cluster #2
+            version_2 = str(uuid.uuid4())
+            util.post_token(self.waiter_url_2, token_name, {'version': version_2})
+            try:
+                # Single query for both jobs, federated across clusters
+                config = self.__two_cluster_config()
+                with cli.temp_config_file(config) as path:
+                    cp, tokens = cli.show_token(token_name=token_name, flags='--config %s' % path)
+                    versions = [t['version'] for t in tokens]
+                    self.assertEqual(0, cp.returncode, cp.stderr)
+                    self.assertEqual(2, len(tokens), tokens)
+                    self.assertIn(version_1, versions)
+                    self.assertIn(version_2, versions)
+            finally:
+                util.delete_token(self.waiter_url_2, token_name)
+        finally:
+            util.delete_token(self.waiter_url_1, token_name)

--- a/cli/integration/tests/waiter/test_cli_multi_cluster.py
+++ b/cli/integration/tests/waiter/test_cli_multi_cluster.py
@@ -38,7 +38,7 @@ class MultiWaiterCliTest(util.WaiterTest):
             version_2 = str(uuid.uuid4())
             util.post_token(self.waiter_url_2, token_name, {'version': version_2})
             try:
-                # Single query for both jobs, federated across clusters
+                # Single query for the token name, federated across clusters
                 config = self.__two_cluster_config()
                 with cli.temp_config_file(config) as path:
                     cp, tokens = cli.show_token(token_name=token_name, flags='--config %s' % path)

--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -165,7 +165,7 @@ def load_json_file(path):
 
 def multi_cluster_tests_enabled():
     """
-    Returns true if the WAITER_TEST_MULTI_CLUSTER environment variable is set,
+    Returns true if the WAITER_TEST_MULTI_CLUSTER environment variable is set to "true",
     indicating that multiple Waiter instances are running.
     """
-    return os.getenv('WAITER_TEST_MULTI_CLUSTER') is not None
+    return os.getenv('WAITER_TEST_MULTI_CLUSTER', None) == 'true'

--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -161,3 +161,11 @@ def load_json_file(path):
         logging.info(f'{path} is not a file')
 
     return content
+
+
+def multi_cluster_tests_enabled():
+    """
+    Returns true if the WAITER_TEST_MULTI_CLUSTER environment variable is set,
+    indicating that multiple Waiter instances are running.
+    """
+    return os.getenv('WAITER_TEST_MULTI_CLUSTER') is not None


### PR DESCRIPTION
## Changes proposed in this PR

- making the travis test-running script start a second Waiter cluster
- adding a test for `waiter show` where the token exists on two clusters

## Why are we making these changes?

We want to write tests that verify that the multi-cluster features of the CLI are working as expected.
