### PR TITLE
add image field validation per scheduler

### DIFF
--- a/waiter/bin/ci/run-integration-tests-k8s-scheduler.sh
+++ b/waiter/bin/ci/run-integration-tests-k8s-scheduler.sh
@@ -40,6 +40,7 @@ bash +x ${DIR}/monitor-pods.sh &
 
 # Run the integration tests
 export INTEGRATION_TEST_CUSTOM_IMAGE="twosigma/integration"
+export INTEGRATION_TEST_KITCHEN_IMAGE="twosigma/kitchen"
 export LEIN_TEST_THREADS=4
 export WAITER_TEST_KITCHEN_CMD=/opt/kitchen/kitchen
 export WAITER_AUTH_RUN_AS_USER=${USER}

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -939,9 +939,7 @@
             (let [kitchen-image (System/getenv "INTEGRATION_TEST_KITCHEN_IMAGE")
                   _ (is (not (str/blank? kitchen-image)) "You must provide a kitchen image in the INTEGRATION_TEST_KITCHEN_IMAGE environment variable")]
               (make-kitchen-request-fn kitchen-image 200))
-            (using-cook? waiter-url)
-            (make-kitchen-request-fn "dummy/image" 500)
-            (using-marathon? waiter-url)
-            (make-kitchen-request-fn "dummy/image" 500)
-            (using-shell? waiter-url)
+            (or (using-cook? waiter-url)
+                (using-marathon? waiter-url)
+                (using-shell? waiter-url))
             (make-kitchen-request-fn "dummy/image" 500)))))

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -926,3 +926,22 @@
             (is (service waiter-url service-id {}) (str service-id "not found in /apps endpoint")))
           (doseq [service-id service-ids]
             (delete-service waiter-url service-id)))))))
+
+(deftest ^:parallel ^:integration-slow test-image-field-validation
+  (testing-using-waiter-url
+    (let [make-kitchen-request-fn #(let [response (make-kitchen-request
+                                                    waiter-url
+                                                    {:x-waiter-name (rand-name)
+                                                     :x-waiter-image %1}
+                                                    :path "/hello")
+                                         _ (assert-response-status response %2)])]
+      (cond (using-k8s? waiter-url)
+            (let [kitchen-image (System/getenv "INTEGRATION_TEST_KITCHEN_IMAGE")
+                  _ (is (not (str/blank? kitchen-image)) "You must provide a kitchen image in the INTEGRATION_TEST_KITCHEN_IMAGE environment variable")]
+              (make-kitchen-request-fn kitchen-image 200))
+            (using-cook? waiter-url)
+            (make-kitchen-request-fn "dummy/image" 500)
+            (using-marathon? waiter-url)
+            (make-kitchen-request-fn "dummy/image" 500)
+            (using-shell? waiter-url)
+            (make-kitchen-request-fn "dummy/image" 500)))))

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -490,7 +490,7 @@
   (validate-service [_ service-id]
     (let [{:strs [run-as-user image]} (service-id->service-description-fn service-id)]
       (authz/check-user authorizer run-as-user service-id)
-      (when image (throw (ex-info "Image field is set. Images are not supported with Marathon scheduler" {:image image}))))))
+      (when image (throw (ex-info "Image field is set. Images are not supported with Cook scheduler" {:image image}))))))
 
 (s/defn ^:always-validate create-cook-scheduler
   "Returns a new CookScheduler with the provided configuration."

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -488,8 +488,9 @@
      :syncer (retrieve-syncer-state-fn)})
 
   (validate-service [_ service-id]
-    (let [{:strs [run-as-user]} (service-id->service-description-fn service-id)]
-      (authz/check-user authorizer run-as-user service-id))))
+    (let [{:strs [run-as-user image]} (service-id->service-description-fn service-id)]
+      (authz/check-user authorizer run-as-user service-id)
+      (when image (throw (ex-info "Image field is set. Images are not supported with Marathon scheduler" {:image image}))))))
 
 (s/defn ^:always-validate create-cook-scheduler
   "Returns a new CookScheduler with the provided configuration."

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -460,8 +460,9 @@
      :syncer (retrieve-syncer-state-fn)})
 
   (validate-service [_ service-id]
-    (let [{:strs [run-as-user]} (service-id->service-description-fn service-id)]
-      (authz/check-user authorizer run-as-user service-id))))
+    (let [{:strs [run-as-user image]} (service-id->service-description-fn service-id)]
+      (authz/check-user authorizer run-as-user service-id)
+      (when image (throw (ex-info "Image field is set. Images are not supported with Marathon scheduler" {:image image}))))))
 
 (defn- get-apps-with-deployments
   "Retrieves the apps with the deployment info embedded."

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -685,7 +685,9 @@
      :port->reservation @port->reservation-atom
      :syncer (retrieve-syncer-state-fn)})
 
-  (validate-service [_ _] nil))
+  (validate-service [_ service-id]
+    (let [{:strs [image]} (service-id->service-description-fn service-id)]
+      (when image (throw (ex-info "Image field is set. Images are not supported with Marathon scheduler" {:image image}))))))
 
 (s/defn ^:always-validate create-shell-scheduler
   "Returns a new ShellScheduler with the provided configuration. Validates the

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -880,6 +880,11 @@
   [waiter-url]
   (= "marathon" (retrieve-default-scheduler-name waiter-url)))
 
+(defn using-shell?
+  "Returns true if Waiter is configured to use Shell Scheduler for scheduling"
+  [waiter-url]
+  (= "shell" (retrieve-default-scheduler-name waiter-url)))
+
 (defn can-query-for-grace-period?
   "Returns true if Waiter supports querying for grace period"
   [waiter-url]

--- a/waiter/test/waiter/scheduler/cook_test.clj
+++ b/waiter/test/waiter/scheduler/cook_test.clj
@@ -893,4 +893,13 @@
         (is (thrown? Throwable (create-cook-scheduler-helper (assoc valid-config :search-interval-days 0)))))
 
       (testing "should work with valid configuration"
-        (is (instance? CookScheduler (create-cook-scheduler-helper valid-config)))))))
+        (is (instance? CookScheduler (create-cook-scheduler-helper valid-config))))
+
+      (testing "validate service - normal"
+        (scheduler/validate-service
+          (create-cook-scheduler-helper (assoc valid-config :service-id->service-description-fn (constantly {}))) nil))
+      (testing "validate service - test that image can't be set"
+        (is (thrown? Throwable (scheduler/validate-service
+                                 (create-cook-scheduler-helper (assoc valid-config
+                                                                 :service-id->service-description-fn
+                                                                 (constantly {"image" "twosigma/kitchen"}))) nil)))))))

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -851,7 +851,16 @@
                                                                                                              :refresh-value secret-value})))))
               (is (ct/wait-for #(= secret-value @k8s-api-auth-str) :interval 1 :timeout 10))
               (finally
-                (@kill-task-fn)))))))))
+                (@kill-task-fn)))))
+
+        (testing "validate service - normal"
+          (scheduler/validate-service
+            (kubernetes-scheduler (assoc base-config :service-id->service-description-fn (constantly {}))) nil))
+        (testing "validate service - test that image can be set"
+          (scheduler/validate-service
+            (kubernetes-scheduler (assoc base-config
+                                    :service-id->service-description-fn
+                                    (constantly {"image" "twosigma/kitchen"}))) nil))))))
 
 (deftest test-start-k8s-watch!
   (let [service-id "test-app-1234"

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -794,7 +794,16 @@
 
       (testing "should work with valid configuration"
         (is (instance? MarathonScheduler (create-marathon-scheduler valid-config)))
-        (is (instance? MarathonScheduler (create-marathon-scheduler (dissoc valid-config :force-kill-after-ms))))))))
+        (is (instance? MarathonScheduler (create-marathon-scheduler (dissoc valid-config :force-kill-after-ms)))))
+
+      (testing "validate service - normal"
+        (scheduler/validate-service
+          (create-marathon-scheduler (assoc valid-config :service-id->service-description-fn (constantly {}))) nil))
+      (testing "validate service - test that image can't be set"
+        (is (thrown? Throwable (scheduler/validate-service
+                                 (create-marathon-scheduler (assoc valid-config
+                                                              :service-id->service-description-fn
+                                                              (constantly {"image" "twosigma/kitchen"}))) nil)))))))
 
 (deftest test-process-kill-instance-request
   (let [marathon-api (Object.)

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -224,7 +224,16 @@
         (is (thrown? Throwable (create-shell-scheduler (assoc valid-config :port-grace-period-ms 0))))
         (is (thrown? Throwable (create-shell-scheduler (assoc valid-config :failed-instance-retry-interval-ms 0))))
         (is (thrown? Throwable (create-shell-scheduler (assoc valid-config :health-check-interval-ms 0))))
-        (is (thrown? Throwable (create-shell-scheduler (assoc valid-config :work-directory ""))))))))
+        (is (thrown? Throwable (create-shell-scheduler (assoc valid-config :work-directory "")))))
+
+      (testing "validate service - normal"
+        (scheduler/validate-service
+          (create-shell-scheduler (assoc valid-config :service-id->service-description-fn (constantly {}))) nil))
+      (testing "validate service - test that image can't be set"
+        (is (thrown? Throwable (scheduler/validate-service
+                                 (create-shell-scheduler (assoc valid-config
+                                                           :service-id->service-description-fn
+                                                           (constantly {"image" "twosigma/kitchen"}))) nil)))))))
 
 (deftest test-reserve-port!
   (testing "Reserving a port"


### PR DESCRIPTION
## Changes proposed in this PR

- add image field validation per scheduler

## Why are we making these changes?

The new service image field is not supported by all schedulers

