### PR TITLE
removes hop-by-hop headers in responses

### DIFF
--- a/test-apps/nginx/data/nginx-template.conf
+++ b/test-apps/nginx/data/nginx-template.conf
@@ -22,13 +22,13 @@ http {
     ssl_certificate_key nginx-server.key;
 
     location ~ \.* {
-      return 200 'From nginx';
       add_header X-Nginx-Client-Proto $server_protocol;
       add_header X-Nginx-Client-Scheme $scheme;
       add_header X-Nginx-Request-Method $request_method;
       add_header X-Nginx-Server-Name $server_name;
       add_header X-Nginx-Server-Port $server_port;
       add_header X-Nginx-Uri $uri;
+      proxy_pass http://127.0.0.1:${PORT2};
     }
   }
 }

--- a/waiter/src/waiter/headers.clj
+++ b/waiter/src/waiter/headers.clj
@@ -88,11 +88,12 @@
       truncated-headers)))
 
 (defn dissoc-hop-by-hop-headers
-  "Remove the hop-by-hop headers as specified in
-   https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.5.1"
-  [headers]
-  (dissoc headers "connection" "keep-alive" "proxy-authenticate" "proxy-authorization" "te" "trailers"
-          "transfer-encoding" "upgrade"))
+  "Proxies must remove hop-by-hop headers before forwarding messages — both requests and responses.
+   Remove the hop-by-hop headers as specified in https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.5.1"
+  [{:strs [connection] :as headers}]
+  (let [connection-headers (map str/trim (str/split (str connection) #","))]
+    (apply dissoc headers "connection" "keep-alive" "proxy-authenticate" "proxy-authorization"
+           "te" "trailers" "transfer-encoding" "upgrade" connection-headers)))
 
 (defn assoc-auth-headers
   "`assoc`s the x-waiter-auth-principal and x-waiter-authenticated-principal headers if the

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -499,6 +499,7 @@
                           (catch Exception e
                             (async/close! request-state-chan)
                             (handle-process-exception e request)))
+                        (update :headers headers/dissoc-hop-by-hop-headers)
                         (assoc :get-instance-latency-ns instance-elapsed
                                :instance instance
                                :protocol proto-version)

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -357,7 +357,7 @@
                                    :pod-suffix-length 5
                                    :replicaset-api-version "extensions/v1beta1"
                                    :replicaset-spec-builder {:factory-fn 'waiter.scheduler.kubernetes/default-replicaset-builder
-                                                             :default-container-image "twosigma/kitchen:20190315"}}
+                                                             :default-container-image "twosigma/kitchen:latest"}}
                       :marathon {:factory-fn 'waiter.scheduler.marathon/marathon-scheduler
                                  :authorizer {:kind :default
                                               :default {:factory-fn 'waiter.authorization/noop-authorizer}}

--- a/waiter/test/waiter/headers_test.clj
+++ b/waiter/test/waiter/headers_test.clj
@@ -152,3 +152,23 @@
       (let [token (str/join (repeat 30 "foo"))]
         (is (= 90 (count token)))
         (is (= {"x-waiter-token" token} (truncate-header-values {"x-waiter-token" token})))))))
+
+(deftest test-dissoc-hop-by-hop-headers
+  (let [headers {"connection" "keep-alive, foo, lorem, ipsum"
+                 "content" "text/html"
+                 "content-encoding" "gzip"
+                 "bar" "bar-value"
+                 "foo" "foo-value"
+                 "lorem" "lorem-value"
+                 "keep-alive" "timeout=5, max=1000"
+                 "proxy-connection" "keep-alive"
+                 "referer" "http://www.test-referer.com"
+                 "te" "trailers, deflate"
+                 "transfer-encoding" "trailers, deflate"
+                 "upgrade" "http/2.0, https/1.3, irc/6.9, rta/x11, websocket"}]
+    (is (= {"bar" "bar-value"
+            "content" "text/html"
+            "content-encoding" "gzip"
+            "proxy-connection" "keep-alive"
+            "referer" "http://www.test-referer.com"}
+           (dissoc-hop-by-hop-headers headers)))))

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -293,6 +293,7 @@
                              "pragma" "no-cache"
                              "proxy-authenticate" "proxy-authenticate value"
                              "proxy-authorization" "proxy-authorization value"
+                             "proxy-connection" "keep-alive"
                              "referer" "http://www.test-referer.com"
                              "te" "trailers, deflate"
                              "trailers" "trailer-name-1, trailer-name-2"
@@ -326,7 +327,7 @@
                                         (is (= (-> (dissoc passthrough-headers "expect" "authorization"
                                                            "connection" "keep-alive" "proxy-authenticate" "proxy-authorization"
                                                            "te" "trailers" "transfer-encoding" "upgrade")
-                                                   (merge {"x-waiter-auth-principal"          "test-user"
+                                                   (merge {"x-waiter-auth-principal" "test-user"
                                                            "x-waiter-authenticated-principal" "test-user@test.com"}))
                                                (:headers request-config)))
                                         (is (= proto-version (:version request-config)))))]


### PR DESCRIPTION
## Changes proposed in this PR

- removes connection-specific header fields when transmitting HTTP/1.x message via HTTP/2

## Why are we making these changes?

> HTTP/2 does not use the Connection header field to indicate connection-specific header fields; in this protocol, connection-specific metadata is conveyed by other means. An endpoint MUST NOT generate an HTTP/2 message containing connection-specific header fields; any message containing connection-specific header fields MUST be treated as malformed (Section 8.1.2.6).
> 
> The only exception to this is the TE header field, which MAY be present in an HTTP/2 request; when it is, it MUST NOT contain any value other than "trailers".
> 
> This means that an intermediary transforming an HTTP/1.x message to HTTP/2 will need to remove any header fields nominated by the Connection header field, along with the Connection header field itself. Such intermediaries SHOULD also remove other connection-specific header fields, such as Keep-Alive, Proxy-Connection, Transfer-Encoding, and Upgrade, even if they are not nominated by the Connection header field.

https://http2.github.io/http2-spec/
