### PR TITLE
Enables implicit update flags

### DIFF
--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -77,6 +77,12 @@ def create(waiter_url=None, token_name=None, flags=None, create_flags=None):
     return cp
 
 
+def update(waiter_url=None, token_name=None, flags=None, create_flags=None):
+    """Updates a token via the CLI"""
+    cp = create_or_update('update', waiter_url, token_name, flags, create_flags)
+    return cp
+
+
 def create_or_update_from_service_description(subcommand, waiter_url, token_name, service, flags=None):
     """Creates or updates a token via the CLI, using the provided service fields"""
     create_flags = \

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -179,6 +179,46 @@ class WaiterCliTest(util.WaiterTest):
         finally:
             util.delete_token(self.waiter_url, token_name)
 
+    def test_implicit_update_args(self):
+        cp = cli.create(create_flags='--help')
+        self.assertEqual(0, cp.returncode, cp.stderr)
+        self.assertIn('--cpus', cli.stdout(cp))
+        self.assertNotIn('--https-redirect', cli.stdout(cp))
+        self.assertNotIn('--fallback-period-secs', cli.stdout(cp))
+        self.assertNotIn('--idle-timeout-mins', cli.stdout(cp))
+        self.assertNotIn('--max-instances', cli.stdout(cp))
+        self.assertNotIn('--restart-backoff-factor', cli.stdout(cp))
+        token_name = self.token_name()
+        cp = cli.update(self.waiter_url, token_name, create_flags='--https-redirect true '
+                                                                  '--cpus 0.1 '
+                                                                  '--fallback-period-secs 10 '
+                                                                  '--idle-timeout-mins 1 '
+                                                                  '--max-instances 100 '
+                                                                  '--restart-backoff-factor 1.1')
+        self.assertEqual(0, cp.returncode, cp.stderr)
+        try:
+            token = util.load_token(self.waiter_url, token_name)
+            self.assertTrue(token['https-redirect'])
+            self.assertEqual(10, token['fallback-period-secs'])
+            self.assertEqual(1, token['idle-timeout-mins'])
+            self.assertEqual(100, token['max-instances'])
+            self.assertEqual(1.1, token['restart-backoff-factor'])
+            cp = cli.update(self.waiter_url, token_name, create_flags='--https-redirect false '
+                                                                      '--cpus 0.1 '
+                                                                      '--fallback-period-secs 20 '
+                                                                      '--idle-timeout-mins 2 '
+                                                                      '--max-instances 200 '
+                                                                      '--restart-backoff-factor 2.2')
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            token = util.load_token(self.waiter_url, token_name)
+            self.assertFalse(token['https-redirect'])
+            self.assertEqual(20, token['fallback-period-secs'])
+            self.assertEqual(2, token['idle-timeout-mins'])
+            self.assertEqual(200, token['max-instances'])
+            self.assertEqual(2.2, token['restart-backoff-factor'])
+        finally:
+            util.delete_token(self.waiter_url, token_name)
+
     def test_basic_show(self):
         token_name = self.token_name()
         cp = cli.show(self.waiter_url, token_name)

--- a/cli/waiter/cli.py
+++ b/cli/waiter/cli.py
@@ -56,7 +56,7 @@ def run(args):
     sub-commands (actions) if necessary.
     """
     args, unknown_args = parser.parse_known_args(args)
-    if args.action == 'create':
+    if args.action == 'create' or args.action == 'update':
         create.add_implicit_arguments(unknown_args)
     args = parser.parse_args()
     args = vars(args)


### PR DESCRIPTION
## Changes proposed in this PR

- allowing implicit args for `update` (just like `create`)

## Why are we making these changes?

So that users can specify all Waiter fields on `update`s.