### PR TITLE
Makes small UX improvements to show, create

### DIFF
--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -179,6 +179,11 @@ class WaiterCliTest(util.WaiterTest):
         finally:
             util.delete_token(self.waiter_url, token_name)
 
+    def test_create_help_text(self):
+        cp = cli.create(create_flags='--help')
+        self.assertEqual(0, cp.returncode, cp.stderr)
+        self.assertIn('memory (in MiB) to reserve', cli.stdout(cp))
+
     def test_basic_show(self):
         token_name = self.token_name()
         cp = cli.show(self.waiter_url, token_name)
@@ -189,7 +194,8 @@ class WaiterCliTest(util.WaiterTest):
             'health-check-url': '/foo',
             'min-instances': 1,
             'max-instances': 2,
-            'permitted-user': '*'
+            'permitted-user': '*',
+            'mem': 1024
         }
         util.post_token(self.waiter_url, token_name, token_definition)
         try:
@@ -202,6 +208,8 @@ class WaiterCliTest(util.WaiterTest):
             self.assertIn('Minimum instances', cli.stdout(cp))
             self.assertIn('Maximum instances', cli.stdout(cp))
             self.assertIn('Permitted user(s)', cli.stdout(cp))
+            self.assertIn(f'=== {self.waiter_url} / {token_name} ===', cli.stdout(cp))
+            self.assertIn('1 GiB', cli.stdout(cp))
         finally:
             util.delete_token(self.waiter_url, token_name)
 

--- a/cli/waiter/format.py
+++ b/cli/waiter/format.py
@@ -2,9 +2,9 @@ import arrow
 import humanfriendly
 
 
-def format_memory_amount(megabytes):
-    """Formats an amount, in MB, to be human-readable"""
-    return humanfriendly.format_size(megabytes * 1000 * 1000)
+def format_memory_amount(mebibytes):
+    """Formats an amount, in MiB, to be human-readable"""
+    return humanfriendly.format_size(mebibytes * 1024 * 1024, binary=True)
 
 
 def format_mem_field(job):

--- a/cli/waiter/subcommands/create.py
+++ b/cli/waiter/subcommands/create.py
@@ -93,7 +93,7 @@ def register(add_parser):
     create_parser.add_argument('--cmd', '-C', help='command to start service')
     create_parser.add_argument('--cmd-type', '-t', help='command type of service (e.g. "shell")', dest='cmd-type')
     create_parser.add_argument('--cpus', '-c', help='cpus to reserve for service', type=float)
-    create_parser.add_argument('--mem', '-m', help='memory to reserve for service', type=int)
+    create_parser.add_argument('--mem', '-m', help='memory (in MiB) to reserve for service', type=int)
     create_parser.add_argument('--ports', help='number of ports to reserve for service', type=int)
     create_parser.add_argument('token', nargs=1)
     return create

--- a/cli/waiter/subcommands/show.py
+++ b/cli/waiter/subcommands/show.py
@@ -2,6 +2,7 @@ import json
 
 from tabulate import tabulate
 
+from waiter import terminal
 from waiter.format import format_mem_field, format_timestamp_string, format_field_name
 from waiter.querying import print_no_data, query_token
 from waiter.util import guard_no_cluster
@@ -9,8 +10,7 @@ from waiter.util import guard_no_cluster
 
 def tabulate_token(cluster_name, token, token_name):
     """Given a token, returns a string containing tables for the fields"""
-    table = [['Cluster', cluster_name],
-             ['Owner', token['owner']]]
+    table = [['Owner', token['owner']]]
     if token.get('name'):
         table.append(['Name', token['name']])
     if token.get('cpus'):
@@ -48,7 +48,7 @@ def tabulate_token(cluster_name, token, token_name):
     last_update_time = format_timestamp_string(token['last-update-time'])
     last_update_user = token['last-update-user']
     return f'\n' \
-           f'=== Token: {token_name} ===\n' \
+           f'=== {terminal.bold(cluster_name)} / {terminal.bold(token_name)} ===\n' \
            f'\n' \
            f'Last Updated: {last_update_time} ({last_update_user})\n' \
            f'\n' \


### PR DESCRIPTION
## Changes proposed in this PR

- adding units to the `--mem` field help text
- making the mem display in binary (e.g. `1 GiB` instead of `1.02 GB`)
- moving the cluster to a more prominent position in the `show` output, e.g.:

```bash
$ waiter show demo

=== dev0 / demo ===

Last Updated: 21 minutes ago (dpo)

Owner                  dpo
CPUs                   0.2
Memory                 1 GiB
Health check endpoint  /status
Version                v0.0.2

Command:
/home/dpo/source/waiter/test-apps/kitchen/bin/kitchen -p $PORT0


=== dev1 / demo ===

Last Updated: 5 hours ago (dpo)

Owner    dpo
CPUs     0.1
Memory   128 MiB
Version  v0.0.2

Command:
/home/dpo/source/waiter/test-apps/kitchen/bin/kitchen -p $PORT0
```

instead of:

```bash
$ waiter show demo

=== Token: demo ===

Last Updated: 21 minutes ago (dpo)

Cluster                dev0
Owner                  dpo
CPUs                   0.2
Memory                 1 GiB
Health check endpoint  /status
Version                v0.0.2

Command:
/home/dpo/source/waiter/test-apps/kitchen/bin/kitchen -p $PORT0


=== Token: demo ===

Last Updated: 5 hours ago (dpo)

Cluster  dev1
Owner    dpo
CPUs     0.1
Memory   128 MiB
Version  v0.0.2

Command:
/home/dpo/source/waiter/test-apps/kitchen/bin/kitchen -p $PORT0
```

## Why are we making these changes?

To improve the user experience of the CLI.
