### PR TITLE
Removes jq from CLI test script

### DIFF
--- a/cli/bin/ci/run-integration-tests.sh
+++ b/cli/bin/ci/run-integration-tests.sh
@@ -45,8 +45,7 @@ if [[ $? -ne 0 ]]; then
   echo "$(date +%H:%M:%S) timed out waiting for waiter to start listening"
   exit 1
 fi
-curl -s ${WAITER_URI}/state | jq
-curl -s ${WAITER_URI}/settings | jq .port
+curl -s ${WAITER_URI}/state
 
 if [[ -z ${WAITER_URI_2+x} ]]; then
     export WAITER_URI_2=127.0.0.1:9191
@@ -61,8 +60,7 @@ if [[ $? -ne 0 ]]; then
   echo "$(date +%H:%M:%S) timed out waiting for waiter to start listening"
   exit 1
 fi
-curl -s ${WAITER_URI_2}/state | jq
-curl -s ${WAITER_URI_2}/settings | jq .port
+curl -s ${WAITER_URI_2}/state
 
 # Run the integration tests
 export WAITER_URI=127.0.0.1:${WAITER_PORT}


### PR DESCRIPTION
## Changes proposed in this PR

- removing the `jq` calls from `run-integration-tests.sh`

## Why are we making these changes?

To avoid:

```bash
21:32:31 connected to waiter on 127.0.0.1:9091!
jq - commandline JSON processor [version 1.5]
Usage: jq [options] <jq filter> [file...]
	jq is a tool for processing JSON inputs, applying the
	given filter to its JSON text inputs and producing the
	filter's results as JSON on standard output.
	The simplest filter is ., which is the identity filter,
	copying jq's input to its output unmodified (except for
	formatting).
	For more advanced filters see the jq(1) manpage ("man jq")
	and/or https://stedolan.github.io/jq
	Some of the options include:
	 -c		compact instead of pretty-printed output;
	 -n		use `null` as the single input value;
	 -e		set the exit status code based on the output;
	 -s		read (slurp) all inputs into an array; apply filter to it;
	 -r		output raw strings, not JSON texts;
	 -R		read raw strings, not JSON texts;
	 -C		colorize JSON;
	 -M		monochrome (don't colorize JSON);
	 -S		sort keys of objects on output;
	 --tab	use tabs for indentation;
	 --arg a v	set variable $a to value <v>;
	 --argjson a v	set variable $a to JSON value <v>;
	 --slurpfile a f	set variable $a to an array of JSON texts read from <f>;
	See the manpage for more options.
(23) Failed writing body
The command "./bin/ci/run-integration-tests.sh" exited with 2.
```