### PR TITLE
Waits for test service to be present on all routers

### DIFF
--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -61,6 +61,7 @@ def cli(args, waiter_url=None, flags=None, stdin=None, env=None, wait_for_exit=T
     url_flag = f'--url {waiter_url}' if waiter_url else ''
     other_flags = f'{flags}' if flags else ''
     cp = sh(f'{command()} {url_flag} {other_flags} {args}', stdin, env, wait_for_exit)
+    logging.debug(output(cp))
     return cp
 
 

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -379,8 +379,7 @@ class WaiterCliTest(util.WaiterTest):
         util.post_token(self.waiter_url, token_name, util.minimal_service_description())
         try:
             self.logger.info(f'Token: {util.load_token(self.waiter_url, token_name)}')
-            resp = util.ping_token(self.waiter_url, token_name)
-            service_id = resp.headers['x-waiter-service-id']
+            service_id = util.ping_token(self.waiter_url, token_name)
             try:
                 cp = cli.delete(self.waiter_url, token_name)
                 self.assertEqual(1, cp.returncode, cli.output(cp))
@@ -397,13 +396,11 @@ class WaiterCliTest(util.WaiterTest):
         util.post_token(self.waiter_url, token_name, util.minimal_service_description())
         try:
             self.logger.info(f'Token: {util.load_token(self.waiter_url, token_name)}')
-            resp = util.ping_token(self.waiter_url, token_name)
-            service_id_1 = resp.headers['x-waiter-service-id']
+            service_id_1 = util.ping_token(self.waiter_url, token_name)
             try:
                 util.post_token(self.waiter_url, token_name, util.minimal_service_description())
                 self.logger.info(f'Token: {util.load_token(self.waiter_url, token_name)}')
-                resp = util.ping_token(self.waiter_url, token_name)
-                service_id_2 = resp.headers['x-waiter-service-id']
+                service_id_2 = util.ping_token(self.waiter_url, token_name)
                 try:
                     services_for_token = util.services_for_token(self.waiter_url, token_name)
                     self.logger.info(f'Services for token {token_name}: {json.dumps(services_for_token, indent=2)}')

--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -175,10 +175,11 @@ def ping_token(waiter_url, token_name):
     assert 200 == response.status_code, f'Expected 200, got {response.status_code} with body {response.text}'
     service_id = response.headers['x-waiter-service-id']
     max_wait_ms = session.get(f'{waiter_url}/settings').json()['scheduler-syncer-interval-secs'] * 2 * 1000
+    auth_cookie = {'x-waiter-auth': response.cookies['x-waiter-auth']}
     routers = session.get(f'{waiter_url}/state/maintainer').json()['state']['routers']
     for router_id, router_url in routers.items():
         logging.debug(f'Waiting for at most {max_wait_ms} ms for service to appear on {router_url}')
-        wait_until(lambda: requests.get(f'{router_url.rstrip("/")}/apps', cookies=response.cookies),
+        wait_until(lambda: requests.get(f'{router_url.rstrip("/")}/apps', cookies=auth_cookie),
                    lambda r: next(s['service-id'] for s in r.json() if s['service-id'] == service_id),
                    max_wait_ms=max_wait_ms)
     return service_id

--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -178,7 +178,7 @@ def ping_token(waiter_url, token_name):
     routers = session.get(f'{waiter_url}/state/maintainer').json()['state']['routers']
     for router_id, router_url in routers.items():
         logging.debug(f'Waiting for at most {max_wait_ms} ms for service to appear on {router_url}')
-        wait_until(lambda: session.get(f'{router_url.rstrip("/")}/apps', cookies=response.cookies),
+        wait_until(lambda: requests.get(f'{router_url.rstrip("/")}/apps', cookies=response.cookies),
                    lambda r: next(s['service-id'] for s in r.json() if s['service-id'] == service_id),
                    max_wait_ms=max_wait_ms)
     return service_id

--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -173,12 +173,12 @@ def ping_token(waiter_url, token_name):
     }
     response = session.get(f'{waiter_url}', headers=headers)
     assert 200 == response.status_code, f'Expected 200, got {response.status_code} with body {response.text}'
+    auth_cookie = {'x-waiter-auth': session.cookies['x-waiter-auth']}
     service_id = response.headers['x-waiter-service-id']
     max_wait_ms = session.get(f'{waiter_url}/settings').json()['scheduler-syncer-interval-secs'] * 2 * 1000
-    auth_cookie = {'x-waiter-auth': response.cookies['x-waiter-auth']}
     routers = session.get(f'{waiter_url}/state/maintainer').json()['state']['routers']
     for router_id, router_url in routers.items():
-        logging.debug(f'Waiting for at most {max_wait_ms} ms for service to appear on {router_url}')
+        logging.debug(f'Waiting for at most {max_wait_ms}ms for service to appear on {router_url}')
         wait_until(lambda: requests.get(f'{router_url.rstrip("/")}/apps', cookies=auth_cookie),
                    lambda r: next(s['service-id'] for s in r.json() if s['service-id'] == service_id),
                    max_wait_ms=max_wait_ms)


### PR DESCRIPTION
## Changes proposed in this PR

- making the CLI log its output when invoked from a test
- making `util.ping_token` wait until all routers recognize the new service

## Why are we making these changes?

In a multi-router environment, without this check, there can be races between routers that can cause test flakiness.