### PR TITLE
Adds kill sub-command to the CLI

### DIFF
--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -249,3 +249,10 @@ def ping(waiter_url=None, token_name=None, flags=None):
     args = f'ping {token_name}'
     cp = cli(args, waiter_url, flags)
     return cp
+
+
+def kill(waiter_url=None, token_name=None, flags=None, kill_flags=None):
+    """Kills services using a token via the CLI"""
+    args = f'kill {token_name} {kill_flags or ""}'
+    cp = cli(args, waiter_url, flags)
+    return cp

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -464,8 +464,7 @@ class WaiterCliTest(util.WaiterTest):
             self.assertIn('Successfully pinged', cli.stdout(cp))
             self.assertEqual(1, len(util.services_for_token(self.waiter_url, token_name)))
         finally:
-            util.kill_services_using_token(self.waiter_url, token_name)
-            util.delete_token(self.waiter_url, token_name)
+            util.delete_token(self.waiter_url, token_name, kill_services=True)
 
     def test_ping_error(self):
         token_name = self.token_name()
@@ -477,8 +476,7 @@ class WaiterCliTest(util.WaiterTest):
             self.assertIn('Pinging token', cli.stdout(cp))
             self.assertEqual(0, len(util.services_for_token(self.waiter_url, token_name)))
         finally:
-            util.kill_services_using_token(self.waiter_url, token_name)
-            util.delete_token(self.waiter_url, token_name)
+            util.delete_token(self.waiter_url, token_name, kill_services=True)
 
     def test_ping_non_existent_token(self):
         token_name = self.token_name()
@@ -498,8 +496,7 @@ class WaiterCliTest(util.WaiterTest):
             self.assertIn('Successfully pinged', cli.stdout(cp))
             self.assertEqual(1, len(util.services_for_token(self.waiter_url, token_name)))
         finally:
-            util.kill_services_using_token(self.waiter_url, token_name)
-            util.delete_token(self.waiter_url, token_name)
+            util.delete_token(self.waiter_url, token_name, kill_services=True)
 
     def test_kill_basic(self):
         token_name = self.token_name()
@@ -514,8 +511,7 @@ class WaiterCliTest(util.WaiterTest):
             self.assertIn('Successfully killed', cli.stdout(cp))
             self.assertEqual(0, len(util.services_for_token(self.waiter_url, token_name)))
         finally:
-            util.kill_services_using_token(self.waiter_url, token_name)
-            util.delete_token(self.waiter_url, token_name)
+            util.delete_token(self.waiter_url, token_name, kill_services=True)
 
     def test_kill_no_services(self):
         token_name = self.token_name()
@@ -544,5 +540,18 @@ class WaiterCliTest(util.WaiterTest):
             self.assertIn(service_id_2, cli.stdout(cp))
             self.assertEqual(0, len(util.services_for_token(self.waiter_url, token_name)))
         finally:
-            util.kill_services_using_token(self.waiter_url, token_name)
-            util.delete_token(self.waiter_url, token_name)
+            util.delete_token(self.waiter_url, token_name, kill_services=True)
+
+    def test_kill_timeout(self):
+        token_name = self.token_name()
+        util.post_token(self.waiter_url, token_name, util.minimal_service_description())
+        try:
+            service_id = util.ping_token(self.waiter_url, token_name)
+            self.assertEqual(1, len(util.services_for_token(self.waiter_url, token_name)))
+            cp = cli.kill(self.waiter_url, token_name, kill_flags='--timeout 1')
+            self.assertEqual(1, cp.returncode, cp.stderr)
+            self.assertIn('Killing service', cli.stdout(cp))
+            self.assertIn(service_id, cli.stdout(cp))
+            self.assertIn('Timeout waiting for service to die', cli.stderr(cp))
+        finally:
+            util.delete_token(self.waiter_url, token_name, kill_services=True)

--- a/cli/integration/tests/waiter/test_cli_multi_cluster.py
+++ b/cli/integration/tests/waiter/test_cli_multi_cluster.py
@@ -133,11 +133,9 @@ class MultiWaiterCliTest(util.WaiterTest):
                     self.assertEqual(1, len(util.services_for_token(self.waiter_url_1, token_name)))
                     self.assertEqual(1, len(util.services_for_token(self.waiter_url_2, token_name)))
             finally:
-                util.kill_services_using_token(self.waiter_url_2, token_name)
-                util.delete_token(self.waiter_url_2, token_name)
+                util.delete_token(self.waiter_url_2, token_name, kill_services=True)
         finally:
-            util.kill_services_using_token(self.waiter_url_1, token_name)
-            util.delete_token(self.waiter_url_1, token_name)
+            util.delete_token(self.waiter_url_1, token_name, kill_services=True)
 
     def test_federated_kill(self):
         # Create in cluster #1
@@ -163,8 +161,6 @@ class MultiWaiterCliTest(util.WaiterTest):
                     self.assertEqual(0, len(util.services_for_token(self.waiter_url_1, token_name)))
                     self.assertEqual(0, len(util.services_for_token(self.waiter_url_2, token_name)))
             finally:
-                util.kill_services_using_token(self.waiter_url_2, token_name)
-                util.delete_token(self.waiter_url_2, token_name)
+                util.delete_token(self.waiter_url_2, token_name, kill_services=True)
         finally:
-            util.kill_services_using_token(self.waiter_url_1, token_name)
-            util.delete_token(self.waiter_url_1, token_name)
+            util.delete_token(self.waiter_url_1, token_name, kill_services=True)

--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -64,7 +64,10 @@ def init_waiter_session(*waiter_urls):
         _wait_for_waiter(waiter_url)
 
 
-def delete_token(waiter_url, token_name, assert_response=True, expected_status_code=200):
+def delete_token(waiter_url, token_name, assert_response=True, expected_status_code=200, kill_services=False):
+    if kill_services:
+        kill_services_using_token(waiter_url, token_name)
+
     response = session.delete(f'{waiter_url}/token', headers={'X-Waiter-Token': token_name})
     if assert_response:
         logging.debug(f'Response status code: {response.status_code}')
@@ -216,4 +219,7 @@ def multi_cluster_tests_enabled():
 def kill_services_using_token(waiter_url, token_name):
     services = services_for_token(waiter_url, token_name)
     for service in services:
-        kill_service(waiter_url, service['service-id'])
+        try:
+            kill_service(waiter_url, service['service-id'])
+        except:
+            logging.exception(f'Encountered exception trying to kill service: {service}')

--- a/cli/waiter/cli.py
+++ b/cli/waiter/cli.py
@@ -3,7 +3,7 @@ import logging
 from urllib.parse import urlparse
 
 from waiter import configuration, http_util, metrics, version
-from waiter.subcommands import create, delete, ping, show
+from waiter.subcommands import create, delete, kill, ping, show
 
 parser = argparse.ArgumentParser(description='waiter is the Waiter CLI')
 parser.add_argument('--cluster', '-c', help='the name of the Waiter cluster to use')
@@ -20,6 +20,7 @@ create_or_update = create.register(subparsers.add_parser)
 actions = {
     'create': create_or_update,
     'delete': delete.register(subparsers.add_parser),
+    'kill': kill.register(subparsers.add_parser),
     'ping': ping.register(subparsers.add_parser),
     'show': show.register(subparsers.add_parser),
     'update': create_or_update

--- a/cli/waiter/http_util.py
+++ b/cli/waiter/http_util.py
@@ -94,6 +94,8 @@ def get(cluster, endpoint, params=None, headers=None):
 
 def delete(cluster, endpoint, params=None, headers=None):
     """DELETEs data corresponding to the given params on cluster at /endpoint"""
+    if headers is None:
+        headers = {}
     url = __make_url(cluster, endpoint)
     default_headers = {'Accept': 'application/json'}
     resp = __delete(url, params, headers={**default_headers, **headers})
@@ -128,4 +130,4 @@ def make_data_request(cluster, make_request_fn):
         logging.exception(ioe)
     except json.decoder.JSONDecodeError as jde:
         logging.exception(jde)
-    return [], {}
+    return None, {}

--- a/cli/waiter/querying.py
+++ b/cli/waiter/querying.py
@@ -82,7 +82,6 @@ def get_services_on_cluster(cluster, token_name):
     if services:
         return {'count': len(services), 'services': services}
     else:
-        logging.info(f'Unable to retrieve services information on {cluster["name"]} ({cluster["url"]}).')
         return {'count': 0}
 
 

--- a/cli/waiter/querying.py
+++ b/cli/waiter/querying.py
@@ -67,3 +67,32 @@ def query_token(clusters, token):
         return executor.submit(get_token_on_cluster, cluster, token)
 
     return query_across_clusters(clusters, submit)
+
+
+def services_using_token(cluster, token_name):
+    """Retrieves all services that are using the token"""
+    params = {'token': token_name}
+    services, _ = http_util.make_data_request(cluster, lambda: http_util.get(cluster, 'apps', params=params))
+    return services
+
+
+def get_services_on_cluster(cluster, token_name):
+    """Gets the service(s) using the given token name on the given cluster"""
+    services = services_using_token(cluster, token_name)
+    if services:
+        return {'count': len(services), 'services': services}
+    else:
+        logging.info(f'Unable to retrieve services information on {cluster["name"]} ({cluster["url"]}).')
+        return {'count': 0}
+
+
+def query_services(clusters, token_name):
+    """
+    Uses query_across_clusters to make the service
+    requests in parallel across the given clusters
+    """
+
+    def submit(cluster, executor):
+        return executor.submit(get_services_on_cluster, cluster, token_name)
+
+    return query_across_clusters(clusters, submit)

--- a/cli/waiter/querying.py
+++ b/cli/waiter/querying.py
@@ -69,7 +69,7 @@ def query_token(clusters, token):
     return query_across_clusters(clusters, submit)
 
 
-def services_using_token(cluster, token_name):
+def get_services_using_token(cluster, token_name):
     """Retrieves all services that are using the token"""
     params = {'token': token_name}
     services, _ = http_util.make_data_request(cluster, lambda: http_util.get(cluster, 'apps', params=params))
@@ -78,7 +78,7 @@ def services_using_token(cluster, token_name):
 
 def get_services_on_cluster(cluster, token_name):
     """Gets the service(s) using the given token name on the given cluster"""
-    services = services_using_token(cluster, token_name)
+    services = get_services_using_token(cluster, token_name)
     if services:
         return {'count': len(services), 'services': services}
     else:
@@ -90,8 +90,6 @@ def query_services(clusters, token_name):
     Uses query_across_clusters to make the service
     requests in parallel across the given clusters
     """
-
-    def submit(cluster, executor):
-        return executor.submit(get_services_on_cluster, cluster, token_name)
-
-    return query_across_clusters(clusters, submit)
+    return query_across_clusters(
+        clusters,
+        lambda cluster, executor: executor.submit(get_services_on_cluster, cluster, token_name))

--- a/cli/waiter/subcommands/create.py
+++ b/cli/waiter/subcommands/create.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 
 import requests
@@ -99,6 +100,15 @@ def register(add_parser):
     return create
 
 
+def boolean_string(s):
+    """Converts the given string to a boolean, or raises"""
+    b = str2bool(s)
+    if b is None:
+        raise argparse.ArgumentTypeError('Boolean value expected.')
+    else:
+        return b
+
+
 def add_implicit_arguments(unknown_args):
     """
     Given the list of "unknown" args, dynamically adds proper arguments to
@@ -113,7 +123,7 @@ def add_implicit_arguments(unknown_args):
             elif arg.endswith('-factor'):
                 arg_type = float
             elif (i + 1) < num_unknown_args and unknown_args[i + 1].lower() in BOOL_STRINGS:
-                arg_type = str2bool
+                arg_type = boolean_string
             else:
                 arg_type = None
             create_parser.add_argument(arg, dest=arg.lstrip('-'), type=arg_type)

--- a/cli/waiter/subcommands/delete.py
+++ b/cli/waiter/subcommands/delete.py
@@ -1,7 +1,7 @@
 import logging
 
 from waiter import http_util, terminal
-from waiter.querying import query_token, print_no_data
+from waiter.querying import query_token, print_no_data, services_using_token
 from waiter.util import guard_no_cluster, str2bool, response_message, print_error
 
 
@@ -10,9 +10,8 @@ def delete_token_on_cluster(cluster, token_name, token_etag):
     cluster_name = cluster['name']
     try:
         # Retrieve all services that are using the token
-        resp = http_util.get(cluster, '/apps', params={'token': token_name})
-        if resp.status_code == 200:
-            services = resp.json()
+        services = services_using_token(cluster, token_name)
+        if services is not None:
             num_services = len(services)
             if num_services > 0:
                 if num_services == 1:
@@ -27,7 +26,7 @@ def delete_token_on_cluster(cluster, token_name, token_etag):
                     print_error('\nPlease kill these services before deleting the token they rely on.')
                 return False
         else:
-            print_error(response_message(resp.json()))
+            print_error(f'Unable to retrieve services using token {token_name} in {cluster_name}.')
             return False
 
         # Delete the token

--- a/cli/waiter/subcommands/delete.py
+++ b/cli/waiter/subcommands/delete.py
@@ -1,7 +1,7 @@
 import logging
 
 from waiter import http_util, terminal
-from waiter.querying import query_token, print_no_data, services_using_token
+from waiter.querying import query_token, print_no_data, get_services_using_token
 from waiter.util import guard_no_cluster, str2bool, response_message, print_error
 
 
@@ -10,7 +10,7 @@ def delete_token_on_cluster(cluster, token_name, token_etag):
     cluster_name = cluster['name']
     try:
         # Retrieve all services that are using the token
-        services = services_using_token(cluster, token_name)
+        services = get_services_using_token(cluster, token_name)
         if services is not None:
             num_services = len(services)
             if num_services > 0:

--- a/cli/waiter/subcommands/kill.py
+++ b/cli/waiter/subcommands/kill.py
@@ -1,0 +1,62 @@
+import logging
+
+from waiter import http_util, terminal
+from waiter.querying import print_no_data, query_services
+from waiter.util import guard_no_cluster, str2bool, response_message, print_error
+
+
+def kill_service_on_cluster(cluster, service_id):
+    """Kills the service with the given service id in the given cluster."""
+    cluster_name = cluster['name']
+    try:
+        print(f'Killing service {terminal.bold(service_id)} in {terminal.bold(cluster_name)}...')
+        resp = http_util.delete(cluster, f'/apps/{service_id}')
+        logging.debug(f'Response status code: {resp.status_code}')
+        if resp.status_code == 200:
+            print(f'Successfully killed {service_id} in {cluster_name}.')
+            return True
+        else:
+            print_error(response_message(resp.json()))
+            return False
+    except Exception as e:
+        message = f'Encountered error while killing {service_id} in {cluster_name}.'
+        logging.error(e, message)
+        print_error(message)
+
+
+def kill(clusters, args, _):
+    """Kills the service(s) using the given token name."""
+    guard_no_cluster(clusters)
+    token_name = args.get('token')[0]
+    query_result = query_services(clusters, token_name)
+    num_services = query_result['count']
+    if num_services == 0:
+        print_no_data(clusters)
+        return 1
+    elif num_services > 1:
+        print(f'There are {num_services} services using token {terminal.bold(token_name)}.')
+
+    cluster_data_pairs = sorted(query_result['clusters'].items())
+    clusters_by_name = {c['name']: c for c in clusters}
+    overall_success = True
+    for cluster_name, data in cluster_data_pairs:
+        for service in data['services']:
+            service_id = service["service-id"]
+            if args.get('force', False) or num_services == 1:
+                should_kill = True
+            else:
+                answer = input(f'Kill service {terminal.bold(service_id)} in {terminal.bold(cluster_name)}? ')
+                should_kill = str2bool(answer)
+            if should_kill:
+                cluster = clusters_by_name[cluster_name]
+                success = kill_service_on_cluster(cluster, service_id)
+                overall_success = overall_success and success
+    return 0 if overall_success else 1
+
+
+def register(add_parser):
+    """Adds this sub-command's parser and returns the action function"""
+    parser = add_parser('kill', help='kill services')
+    parser.add_argument('token', nargs=1)
+    parser.add_argument('--force', '-f', help='kill all services, never prompt', dest='force', action='store_true')
+    return kill

--- a/cli/waiter/subcommands/kill.py
+++ b/cli/waiter/subcommands/kill.py
@@ -1,27 +1,47 @@
 import logging
 
+from tabulate import tabulate
+
 from waiter import http_util, terminal
-from waiter.querying import print_no_data, query_services
-from waiter.util import guard_no_cluster, str2bool, response_message, print_error
+from waiter.format import format_timestamp_string
+from waiter.querying import query_services, services_using_token
+from waiter.util import guard_no_cluster, str2bool, response_message, print_error, wait_until
 
 
-def kill_service_on_cluster(cluster, service_id):
+def kill_service_on_cluster(cluster, service_id, token_name):
     """Kills the service with the given service id in the given cluster."""
+
+    def service_is_killed():
+        return service_id not in [s['service-id'] for s in services_using_token(cluster, token_name)]
+
     cluster_name = cluster['name']
     try:
         print(f'Killing service {terminal.bold(service_id)} in {terminal.bold(cluster_name)}...')
         resp = http_util.delete(cluster, f'/apps/{service_id}')
         logging.debug(f'Response status code: {resp.status_code}')
         if resp.status_code == 200:
-            print(f'Successfully killed {service_id} in {cluster_name}.')
-            return True
+            killed = wait_until(service_is_killed, timeout=30, interval=1)
+            if killed:
+                print(f'Successfully killed {service_id} in {cluster_name}.')
+                return True
+            else:
+                print_error('Timeout waiting for service to die.')
+                return False
         else:
             print_error(response_message(resp.json()))
             return False
-    except Exception as e:
+    except Exception:
         message = f'Encountered error while killing {service_id} in {cluster_name}.'
-        logging.error(e, message)
+        logging.exception(message)
         print_error(message)
+
+
+def format_status(status):
+    """Formats service status"""
+    if status == 'Running':
+        return terminal.running(status)
+    else:
+        return status
 
 
 def kill(clusters, args, _):
@@ -31,25 +51,42 @@ def kill(clusters, args, _):
     query_result = query_services(clusters, token_name)
     num_services = query_result['count']
     if num_services == 0:
-        print_no_data(clusters)
+        clusters_text = ' / '.join([terminal.bold(c['name']) for c in clusters])
+        print(f'There are no services using token {terminal.bold(token_name)} in {clusters_text}.')
         return 1
     elif num_services > 1:
-        print(f'There are {num_services} services using token {terminal.bold(token_name)}.')
+        print(f'There are {num_services} services using token {terminal.bold(token_name)}:')
 
     cluster_data_pairs = sorted(query_result['clusters'].items())
     clusters_by_name = {c['name']: c for c in clusters}
     overall_success = True
     for cluster_name, data in cluster_data_pairs:
         for service in data['services']:
-            service_id = service["service-id"]
+            service_id = service['service-id']
             if args.get('force', False) or num_services == 1:
                 should_kill = True
             else:
-                answer = input(f'Kill service {terminal.bold(service_id)} in {terminal.bold(cluster_name)}? ')
+                status = format_status(service['status'])
+                healthy_count = service['instance-counts']['healthy-instances']
+                unhealthy_count = service['instance-counts']['unhealthy-instances']
+                last_request_time = format_timestamp_string(service['last-request-time'])
+                url = service['url']
+                table = [['Status', status],
+                         ['Healthy', healthy_count],
+                         ['Unhealthy', unhealthy_count],
+                         ['URL', url]]
+                table_text = tabulate(table, tablefmt='plain')
+                print(f'\n'
+                      f'=== {terminal.bold(cluster_name)} / {terminal.bold(service_id)} ===\n'
+                      f'\n'
+                      f'Last Request: {last_request_time}\n'
+                      f'\n'
+                      f'{table_text}\n')
+                answer = input(f'Kill service in {terminal.bold(cluster_name)}? ')
                 should_kill = str2bool(answer)
             if should_kill:
                 cluster = clusters_by_name[cluster_name]
-                success = kill_service_on_cluster(cluster, service_id)
+                success = kill_service_on_cluster(cluster, service_id, token_name)
                 overall_success = overall_success and success
     return 0 if overall_success else 1
 

--- a/cli/waiter/subcommands/kill.py
+++ b/cli/waiter/subcommands/kill.py
@@ -4,15 +4,15 @@ from tabulate import tabulate
 
 from waiter import http_util, terminal
 from waiter.format import format_timestamp_string
-from waiter.querying import query_services, services_using_token
-from waiter.util import guard_no_cluster, str2bool, response_message, print_error, wait_until
+from waiter.querying import query_services, get_services_using_token
+from waiter.util import guard_no_cluster, str2bool, response_message, print_error, wait_until, check_positive
 
 
-def kill_service_on_cluster(cluster, service_id, token_name):
+def kill_service_on_cluster(cluster, service_id, token_name, timeout_seconds):
     """Kills the service with the given service id in the given cluster."""
 
     def service_is_killed():
-        return service_id not in [s['service-id'] for s in services_using_token(cluster, token_name)]
+        return not any(s['service-id'] == service_id for s in get_services_using_token(cluster, token_name))
 
     cluster_name = cluster['name']
     try:
@@ -20,7 +20,7 @@ def kill_service_on_cluster(cluster, service_id, token_name):
         resp = http_util.delete(cluster, f'/apps/{service_id}')
         logging.debug(f'Response status code: {resp.status_code}')
         if resp.status_code == 200:
-            killed = wait_until(service_is_killed, timeout=30, interval=1)
+            killed = wait_until(service_is_killed, timeout=timeout_seconds, interval=1)
             if killed:
                 print(f'Successfully killed {service_id} in {cluster_name}.')
                 return True
@@ -86,7 +86,7 @@ def kill(clusters, args, _):
                 should_kill = str2bool(answer)
             if should_kill:
                 cluster = clusters_by_name[cluster_name]
-                success = kill_service_on_cluster(cluster, service_id, token_name)
+                success = kill_service_on_cluster(cluster, service_id, token_name, args['timeout'])
                 overall_success = overall_success and success
     return 0 if overall_success else 1
 
@@ -96,4 +96,6 @@ def register(add_parser):
     parser = add_parser('kill', help='kill services')
     parser.add_argument('token', nargs=1)
     parser.add_argument('--force', '-f', help='kill all services, never prompt', dest='force', action='store_true')
+    parser.add_argument('--timeout', '-t', help='timeout (in seconds) for kill to complete',
+                        type=check_positive, default=30)
     return kill

--- a/cli/waiter/subcommands/kill.py
+++ b/cli/waiter/subcommands/kill.py
@@ -1,4 +1,5 @@
 import logging
+from operator import itemgetter
 
 from tabulate import tabulate
 
@@ -61,7 +62,8 @@ def kill(clusters, args, _):
     clusters_by_name = {c['name']: c for c in clusters}
     overall_success = True
     for cluster_name, data in cluster_data_pairs:
-        for service in data['services']:
+        services = sorted(data['services'], key=itemgetter('last-request-time'), reverse=True)
+        for service in services:
             service_id = service['service-id']
             if args.get('force', False) or num_services == 1:
                 should_kill = True

--- a/cli/waiter/terminal.py
+++ b/cli/waiter/terminal.py
@@ -27,6 +27,10 @@ def success(s):
     return colorize(s, Color.GREEN)
 
 
+def running(s):
+    return colorize(s, Color.CYAN)
+
+
 def reason(s):
     return colorize(s, Color.RED)
 

--- a/cli/waiter/util.py
+++ b/cli/waiter/util.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import sys
 import time
@@ -86,3 +87,14 @@ def wait_until(pred, timeout=30, interval=5):
         time.sleep(interval)
 
     return result
+
+
+def check_positive(value):
+    """Checks that the given value is a positive integer"""
+    try:
+        integer = int(value)
+    except:
+        raise argparse.ArgumentTypeError(f'{value} is not an integer')
+    if integer <= 0:
+        raise argparse.ArgumentTypeError(f'{value} is not a positive integer')
+    return integer

--- a/cli/waiter/util.py
+++ b/cli/waiter/util.py
@@ -1,9 +1,9 @@
-import argparse
 import os
 import sys
+import time
+from datetime import datetime, timedelta
 
 from waiter import terminal
-
 
 TRUE_STRINGS = ('yes', 'true', 'y')
 FALSE_STRINGS = ('no', 'false', 'n')
@@ -44,13 +44,13 @@ def guard_no_cluster(clusters):
 
 
 def str2bool(v):
-    """Converts the given string to a boolean, or raises"""
+    """Converts the given string to a boolean, or returns None"""
     if v.lower() in TRUE_STRINGS:
         return True
     elif v.lower() in FALSE_STRINGS:
         return False
     else:
-        raise argparse.ArgumentTypeError('Boolean value expected.')
+        return None
 
 
 def response_message(resp_json):
@@ -62,3 +62,27 @@ def response_message(resp_json):
     else:
         message = 'Encountered unexpected error.'
     return message
+
+
+def wait_until(pred, timeout=30, interval=5):
+    """
+    Wait, retrying a predicate until it is True, or the
+    timeout value has been exceeded.
+    """
+    if timeout:
+        finish = datetime.now() + timedelta(seconds=timeout)
+    else:
+        finish = None
+
+    while True:
+        result = pred()
+
+        if result:
+            break
+
+        if finish and datetime.now() >= finish:
+            break
+
+        time.sleep(interval)
+
+    return result


### PR DESCRIPTION
## Changes proposed in this PR

- adding `waiter kill`

## Why are we making these changes?

To allow users to kill services via the Waiter CLI.

## Demo

[![asciicast](https://asciinema.org/a/BR8Q0F07wYQrXv6pfOlT6lwbW.svg)](https://asciinema.org/a/BR8Q0F07wYQrXv6pfOlT6lwbW?autoplay=1)