### PR TITLE
avoids race in kitchen starting up before nginx proxy

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -377,7 +377,7 @@
 (deftest ^:parallel ^:integration-fast test-health-check-proto
   (testing-using-waiter-url
     ;; PORT2 is running kitchen without SSL enabled
-    (run-backend-proto-service-test waiter-url "h2" "http" 2 "https" "HTTP/2.0")))
+    (run-backend-proto-service-test waiter-url "h2" "https" 1 "https" "HTTP/2.0")))
 
 (deftest ^:parallel ^:integration-fast test-basic-unsupported-command-type
   (testing-using-waiter-url


### PR DESCRIPTION
## Changes proposed in this PR

- avoids race in kitchen starting up before nginx proxy

## Why are we making these changes?

The test is currently flaky since the nginx proxy starts up after the kitchen server. Since the health checks run against kitchen, it can trigger sending a request from Waiter to the nginx port and cause the connection to fail.

