### PR TITLE
Fix race in test-create-service-if-new unit test

### DIFF
--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -245,8 +245,10 @@
   (let [scheduler (create-shell-scheduler (common-scheduler-config))]
     (is (= {:success true, :result :created, :message "Created foo"}
            (create-test-service scheduler "foo")))
+    (ensure-agent-finished scheduler)
     (is (= {:success false, :result :already-exists, :message "foo already exists!"}
            (create-test-service scheduler "foo")))
+    (ensure-agent-finished scheduler)
     (is (= {:success true, :result :deleted, :message "Deleted foo"}
            (scheduler/delete-service scheduler "foo")))))
 


### PR DESCRIPTION
## Changes proposed in this PR

- Fix race with agent in `test-create-service-if-new` unit test.

## Why are we making these changes?

Deflake this unit test.