### PR TITLE
Adds --timeout flag to waiter ping

### DIFF
--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -244,8 +244,8 @@ def delete(waiter_url=None, token_name=None, flags=None, delete_flags=None):
     return cp
 
 
-def ping(waiter_url=None, token_name=None, flags=None):
+def ping(waiter_url=None, token_name=None, flags=None, ping_flags=None):
     """Pings a token via the CLI"""
-    args = f'ping {token_name}'
+    args = f'ping {token_name} {ping_flags or ""}'
     cp = cli(args, waiter_url, flags)
     return cp

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -500,13 +500,14 @@ class WaiterCliTest(util.WaiterTest):
 
     def test_ping_timeout(self):
         token_name = self.token_name()
-        util.post_token(self.waiter_url, token_name, util.minimal_service_description())
+        command = f'{util.minimal_service_cmd()} --start-up-sleep-ms 20000'
+        util.post_token(self.waiter_url, token_name, util.minimal_service_description(cmd=command))
         try:
-            cp = cli.ping(self.waiter_url, token_name, ping_flags='--timeout 50')
+            cp = cli.ping(self.waiter_url, token_name, ping_flags='--timeout 300')
             self.assertEqual(0, cp.returncode, cp.stderr)
             self.assertIn('Successfully pinged', cli.stdout(cp))
             util.kill_services_using_token(self.waiter_url, token_name)
-            cp = cli.ping(self.waiter_url, token_name, ping_flags='--timeout 1')
+            cp = cli.ping(self.waiter_url, token_name, ping_flags='--timeout 10')
             self.assertEqual(1, cp.returncode, cp.stderr)
             self.assertIn('Encountered error', cli.stderr(cp))
         finally:

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -497,3 +497,18 @@ class WaiterCliTest(util.WaiterTest):
             self.assertEqual(1, len(util.services_for_token(self.waiter_url, token_name)))
         finally:
             util.delete_token(self.waiter_url, token_name)
+
+    def test_ping_timeout(self):
+        token_name = self.token_name()
+        util.post_token(self.waiter_url, token_name, util.minimal_service_description())
+        try:
+            cp = cli.ping(self.waiter_url, token_name, ping_flags='--timeout 50')
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            self.assertIn('Successfully pinged', cli.stdout(cp))
+            util.kill_services_using_token(self.waiter_url, token_name)
+            cp = cli.ping(self.waiter_url, token_name, ping_flags='--timeout 1')
+            self.assertEqual(1, cp.returncode, cp.stderr)
+            self.assertIn('Encountered error', cli.stderr(cp))
+        finally:
+            util.kill_services_using_token(self.waiter_url, token_name)
+            util.delete_token(self.waiter_url, token_name)

--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -1,5 +1,6 @@
 import functools
 import importlib
+import inspect
 import json
 import logging
 import os
@@ -95,13 +96,12 @@ def post_token(waiter_url, token_name, token_definition, assert_response=True, e
     return response.json()
 
 
-def minimal_service_cmd(response_text=None):
-    if response_text is None:
-        response_text = 'OK'
-    return f'RESPONSE="HTTP/1.1 200 OK\\r\\n\\r\\n{response_text}"; ' \
-           'while { printf "$RESPONSE"; } | nc -l "$PORT0"; do ' \
-           '  echo "====="; ' \
-           'done'
+def minimal_service_cmd():
+    this_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+    kitchen = os.path.join(this_dir, os.pardir, os.pardir, os.pardir, os.pardir,
+                           'test-apps', 'kitchen', 'bin', 'kitchen')
+    kitchen = os.path.abspath(kitchen)
+    return f'{kitchen} -p $PORT0'
 
 
 def minimal_service_description(**kwargs):
@@ -209,3 +209,12 @@ def multi_cluster_tests_enabled():
     indicating that multiple Waiter instances are running.
     """
     return os.getenv('WAITER_TEST_MULTI_CLUSTER', None) == 'true'
+
+
+def kill_services_using_token(waiter_url, token_name):
+    services = services_for_token(waiter_url, token_name)
+    for service in services:
+        service_id = service['service-id']
+        kill_service(waiter_url, service_id)
+        wait_until(lambda: services_for_token(waiter_url, token_name),
+                   lambda svcs: service_id not in [s['service-id'] for s in svcs])

--- a/cli/waiter/util.py
+++ b/cli/waiter/util.py
@@ -62,3 +62,14 @@ def response_message(resp_json):
     else:
         message = 'Encountered unexpected error.'
     return message
+
+
+def check_positive(value):
+    """Checks that the given value is a positive integer"""
+    try:
+        integer = int(value)
+    except:
+        raise argparse.ArgumentTypeError(f'{value} is not an integer')
+    if integer <= 0:
+        raise argparse.ArgumentTypeError(f'{value} is not a positive integer')
+    return integer


### PR DESCRIPTION
## Changes proposed in this PR

- adding (optional) `--timeout` flag to `waiter ping`

## Why are we making these changes?

Services running on Waiter can have start-up times that vary significantly. We want to allow users to choose a read timeout for `ping` that is appropriate for the service they are `ping`ing.