### PR TITLE
add response to k8s malformed request

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -261,8 +261,8 @@
                                       (and (not content-type) body) (assoc :content-type "application/json"))))]
       (scheduler/log "response from K8s API server:" result)
       result)
-    (catch [:status 400] _
-      (log/error "malformed K8s API request: " url options))
+    (catch [:status 400] response
+      (log/error "malformed K8s API request: " url options response))
     (catch [:client http-client] response
       (log/error "request to K8s API server failed: " url options body response)
       (ss/throw+ response))))


### PR DESCRIPTION
## Changes proposed in this PR

- log response when making a malformed kubernetes API request

## Why are we making these changes?

The response from kubernetes is not logged currently if the request is malformed. we want to log it to make it easier to debug