### PR TITLE
Fixes test_ping_timeout command

### DIFF
--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -500,7 +500,7 @@ class WaiterCliTest(util.WaiterTest):
 
     def test_ping_timeout(self):
         token_name = self.token_name()
-        command = f'{util.minimal_service_cmd()} --start-up-sleep-ms 20000'
+        command = f'{util.default_cmd()} --start-up-sleep-ms 20000'
         util.post_token(self.waiter_url, token_name, util.minimal_service_description(cmd=command))
         try:
             cp = cli.ping(self.waiter_url, token_name, ping_flags='--timeout 300')

--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -106,7 +106,7 @@ def minimal_service_cmd():
 
 def minimal_service_description(**kwargs):
     service = {
-        'cmd': os.getenv('WAITER_CLI_TEST_DEFAULT_CMD', minimal_service_cmd()),
+        'cmd': default_cmd(),
         'cpus': float(os.getenv('WAITER_TEST_DEFAULT_CPUS', 1.0)),
         'mem': int(os.getenv('WAITER_TEST_DEFAULT_MEM_MB', 256)),
         'version': str(uuid.uuid4()),
@@ -114,6 +114,10 @@ def minimal_service_description(**kwargs):
     }
     service.update(kwargs)
     return service
+
+
+def default_cmd():
+    return os.getenv('WAITER_CLI_TEST_DEFAULT_CMD', minimal_service_cmd())
 
 
 def wait_until(query, predicate, max_wait_ms=DEFAULT_TIMEOUT_MS, wait_interval_ms=DEFAULT_WAIT_INTERVAL_MS):


### PR DESCRIPTION
## Changes proposed in this PR

- using the default command in `test_ping_timeout`

## Why are we making these changes?

If the tester sets `WAITER_CLI_TEST_DEFAULT_CMD`, we need to use that command instead of the one that is hard-coded for local dev environments.