### PR TITLE
Makes create not patch

### DIFF
--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -87,11 +87,11 @@ def update(waiter_url=None, token_name=None, flags=None, create_flags=None):
 def create_or_update_from_service_description(subcommand, waiter_url, token_name, service, flags=None):
     """Creates or updates a token via the CLI, using the provided service fields"""
     create_flags = \
-        f"--cmd '{service['cmd']}' " \
-        f"--cpus {service['cpus']} " \
-        f"--mem {service['mem']} " \
-        f"--cmd-type {service['cmd-type']} " \
-        f"--version {service['version']}"
+        (f"--cmd '{service['cmd']}' " if 'cmd' in service else '') + \
+        (f"--cpus {service['cpus']} " if 'cpus' in service else '') + \
+        (f"--mem {service['mem']} " if 'mem' in service else '') + \
+        (f"--cmd-type {service['cmd-type']} " if 'cmd-type' in service else '') + \
+        (f"--version {service['version']}" if 'version' in service else '')
     cp = create_or_update(subcommand, waiter_url, token_name, flags=flags, create_flags=create_flags)
     return cp
 
@@ -99,6 +99,12 @@ def create_or_update_from_service_description(subcommand, waiter_url, token_name
 def create_from_service_description(waiter_url, token_name, service, flags=None):
     """Creates a token via the CLI, using the provided service fields"""
     cp = create_or_update_from_service_description('create', waiter_url, token_name, service, flags)
+    return cp
+
+
+def update_from_service_description(waiter_url, token_name, service, flags=None):
+    """Updates a token via the CLI, using the provided service fields"""
+    cp = create_or_update_from_service_description('update', waiter_url, token_name, service, flags)
     return cp
 
 

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -322,7 +322,7 @@ class WaiterCliTest(util.WaiterTest):
             # Use entry in base config file
             cp = cli.create_minimal(token_name=token_name)
             self.assertEqual(0, cp.returncode, cp.stderr)
-            self.assertIn(f'on {cluster_name_1} cluster', cli.decode(cp.stdout))
+            self.assertIn(f'on {cluster_name_1}', cli.decode(cp.stdout))
 
             # Overwrite "base" with specified config file
             cluster_name_2 = str(uuid.uuid4())
@@ -332,7 +332,7 @@ class WaiterCliTest(util.WaiterTest):
                 flags = '--config %s' % path
                 cp = cli.create_minimal(token_name=token_name, flags=flags)
                 self.assertEqual(0, cp.returncode, cp.stderr)
-                self.assertIn(f'on {cluster_name_2} cluster', cli.decode(cp.stdout))
+                self.assertIn(f'on {cluster_name_2}', cli.decode(cp.stdout))
 
     def test_avoid_exit_on_connection_error(self):
         token_name = self.token_name()

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -32,6 +32,7 @@ class WaiterCliTest(util.WaiterTest):
         cp = cli.create_minimal(self.waiter_url, token_name, flags=None, cmd=cmd, cpus=0.1, mem=128, version=version)
         self.assertEqual(0, cp.returncode, cp.stderr)
         try:
+            self.assertIn('Attempting to create', cli.stdout(cp))
             token_data = util.load_token(self.waiter_url, token_name)
             self.assertIsNotNone(token_data)
             self.assertEqual('shell', token_data['cmd-type'])
@@ -52,6 +53,7 @@ class WaiterCliTest(util.WaiterTest):
         cp = cli.update_minimal(self.waiter_url, token_name, flags=None, cmd=cmd, cpus=0.1, mem=128, version=version)
         self.assertEqual(0, cp.returncode, cp.stderr)
         try:
+            self.assertIn('Attempting to update', cli.stdout(cp))
             token_data = util.load_token(self.waiter_url, token_name)
             self.assertIsNotNone(token_data)
             self.assertEqual('shell', token_data['cmd-type'])

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -513,3 +513,27 @@ class WaiterCliTest(util.WaiterTest):
         finally:
             util.kill_services_using_token(self.waiter_url, token_name)
             util.delete_token(self.waiter_url, token_name)
+
+    def test_create_does_not_patch(self):
+        token_name = self.token_name()
+        util.post_token(self.waiter_url, token_name, {'cpus': 0.1})
+        try:
+            cp = cli.create_from_service_description(self.waiter_url, token_name, {'mem': 128})
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            token_data = util.load_token(self.waiter_url, token_name)
+            self.assertFalse('cpus' in token_data)
+            self.assertEqual(128, token_data['mem'])
+        finally:
+            util.delete_token(self.waiter_url, token_name)
+
+    def test_update_does_patch(self):
+        token_name = self.token_name()
+        util.post_token(self.waiter_url, token_name, {'cpus': 0.1})
+        try:
+            cp = cli.update_from_service_description(self.waiter_url, token_name, {'mem': 128})
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            token_data = util.load_token(self.waiter_url, token_name)
+            self.assertEqual(0.1, token_data['cpus'])
+            self.assertEqual(128, token_data['mem'])
+        finally:
+            util.delete_token(self.waiter_url, token_name)

--- a/cli/waiter/cli.py
+++ b/cli/waiter/cli.py
@@ -3,7 +3,7 @@ import logging
 from urllib.parse import urlparse
 
 from waiter import configuration, http_util, metrics, version
-from waiter.subcommands import create, delete, ping, show
+from waiter.subcommands import create, delete, ping, show, update
 
 parser = argparse.ArgumentParser(description='waiter is the Waiter CLI')
 parser.add_argument('--cluster', '-c', help='the name of the Waiter cluster to use')
@@ -16,13 +16,12 @@ parser.add_argument('--version', help='output version information and exit',
 
 subparsers = parser.add_subparsers(dest='action')
 
-create_or_update = create.register(subparsers.add_parser)
 actions = {
-    'create': create_or_update,
+    'create': create.register(subparsers.add_parser),
     'delete': delete.register(subparsers.add_parser),
     'ping': ping.register(subparsers.add_parser),
     'show': show.register(subparsers.add_parser),
-    'update': create_or_update
+    'update': update.register(subparsers.add_parser)
 }
 
 
@@ -57,8 +56,10 @@ def run(args):
     sub-commands (actions) if necessary.
     """
     args, unknown_args = parser.parse_known_args(args)
-    if args.action == 'create' or args.action == 'update':
+    if args.action == 'create':
         create.add_implicit_arguments(unknown_args)
+    elif args.action == 'update':
+        update.add_implicit_arguments(unknown_args)
     args = parser.parse_args()
     args = vars(args)
 

--- a/cli/waiter/subcommands/create.py
+++ b/cli/waiter/subcommands/create.py
@@ -1,6 +1,4 @@
 from functools import partial
-import argparse
-import logging
 
 from waiter import token_post
 
@@ -14,15 +12,6 @@ def register(add_parser):
     parser = token_post.register_argument_parser(add_parser, action)
     token_post.add_arguments(parser)
     return partial(token_post.create_or_update_token, action=action)
-
-
-def boolean_string(s):
-    """Converts the given string to a boolean, or raises"""
-    b = str2bool(s)
-    if b is None:
-        raise argparse.ArgumentTypeError('Boolean value expected.')
-    else:
-        return b
 
 
 def add_implicit_arguments(unknown_args):

--- a/cli/waiter/subcommands/update.py
+++ b/cli/waiter/subcommands/update.py
@@ -8,7 +8,7 @@ parser = None
 def register(add_parser):
     """Adds this sub-command's parser and returns the action function"""
     global parser
-    action = token_post.Action.CREATE
+    action = token_post.Action.UPDATE
     parser = token_post.register_argument_parser(add_parser, action)
     token_post.add_arguments(parser)
     return partial(token_post.create_or_update_token, action=action)

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -11,8 +11,14 @@ BOOL_STRINGS = TRUE_STRINGS + FALSE_STRINGS
 
 
 class Action(Enum):
-    CREATE = 1
-    UPDATE = 2
+    CREATE = 'create'
+    UPDATE = 'update'
+
+    def __str__(self):
+        return f'{self.value}'
+
+    def should_patch(self):
+        return self is Action.UPDATE
 
 
 def process_post_result(resp):
@@ -38,9 +44,8 @@ def create_or_update(cluster, token_name, token_fields, action):
 
     existing_token_data, existing_token_etag = get_token(cluster, token_name)
     try:
-        print_info(f'Attempting to {"create" if action == Action.CREATE else "update"} '
-                   f'token on {terminal.bold(cluster_name)}...')
-        json_body = existing_token_data if existing_token_data and action == Action.UPDATE else {}
+        print_info(f'Attempting to {action} token on {terminal.bold(cluster_name)}...')
+        json_body = existing_token_data if existing_token_data and action.should_patch() else {}
         json_body.update(token_fields)
         headers = {'If-Match': existing_token_etag or ''}
         resp = http_util.post(cluster, 'token', json_body, params={'token': token_name}, headers=headers)

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -1,0 +1,126 @@
+import logging
+from enum import Enum
+
+import requests
+
+from waiter import terminal, http_util
+from waiter.querying import get_token
+from waiter.util import FALSE_STRINGS, print_info, response_message, TRUE_STRINGS, guard_no_cluster, str2bool
+
+BOOL_STRINGS = TRUE_STRINGS + FALSE_STRINGS
+
+
+class Action(Enum):
+    CREATE = 1
+    UPDATE = 2
+
+
+def process_post_result(resp):
+    """Prints the result of a token POST"""
+    resp_json = resp.json()
+    if 'message' in resp_json:
+        message = resp_json['message']
+        print_info(f'{message}.')
+        return
+
+    raise Exception(f'{response_message(resp_json)}')
+
+
+def post_failed_message(cluster_name, reason):
+    """Generates a failed token post message with the given cluster name and reason"""
+    return f'Token post {terminal.failed("failed")} on {cluster_name}:\n{terminal.reason(reason)}'
+
+
+def create_or_update(cluster, token_name, token_fields, action):
+    """Creates (or updates) the given token on the given cluster"""
+    cluster_name = cluster['name']
+    cluster_url = cluster['url']
+
+    existing_token_data, existing_token_etag = get_token(cluster, token_name)
+    try:
+        print_info(f'Attempting to {"create" if action == Action.CREATE else "update"} '
+                   f'token on {terminal.bold(cluster_name)}...')
+        json_body = existing_token_data if existing_token_data and action == Action.UPDATE else {}
+        json_body.update(token_fields)
+        headers = {'If-Match': existing_token_etag or ''}
+        resp = http_util.post(cluster, 'token', json_body, params={'token': token_name}, headers=headers)
+        process_post_result(resp)
+        return 0
+    except requests.exceptions.ReadTimeout as rt:
+        logging.exception(rt)
+        print_info(terminal.failed(
+            f'Encountered read timeout with {cluster_name} ({cluster_url}). Your post may have completed.'))
+        return 1
+    except IOError as ioe:
+        logging.exception(ioe)
+        reason = f'Cannot connect to {cluster_name} ({cluster_url})'
+        message = post_failed_message(cluster_name, reason)
+        print_info(f'{message}\n')
+
+
+def create_or_update_token(clusters, args, _, action):
+    """Creates (or updates) a Waiter token"""
+    guard_no_cluster(clusters)
+    logging.debug('args: %s' % args)
+    if len(clusters) > 1:
+        default_for_create = [c for c in clusters if c.get('default-for-create', False)]
+        num_default_create_clusters = len(default_for_create)
+        if num_default_create_clusters == 0:
+            raise Exception('You must either specify a cluster via --cluster or set "default-for-create" to true for '
+                            'one of your configured clusters.')
+        elif num_default_create_clusters > 1:
+            raise Exception('You have "default-for-create" set to true for more than one cluster.')
+        else:
+            cluster = default_for_create[0]
+    else:
+        cluster = clusters[0]
+    token_name = args.pop('token')
+    token_fields = args
+    return create_or_update(cluster, token_name, token_fields, action)
+
+
+def add_arguments(parser):
+    """Adds arguments to the given parser"""
+    parser.add_argument('--name', '-n', help='name of service')
+    parser.add_argument('--version', '-v', help='version of service')
+    parser.add_argument('--cmd', '-C', help='command to start service')
+    parser.add_argument('--cmd-type', '-t', help='command type of service (e.g. "shell")', dest='cmd-type')
+    parser.add_argument('--cpus', '-c', help='cpus to reserve for service', type=float)
+    parser.add_argument('--mem', '-m', help='memory (in MiB) to reserve for service', type=int)
+    parser.add_argument('--ports', help='number of ports to reserve for service', type=int)
+    parser.add_argument('token', nargs=1)
+
+
+def register_argument_parser(add_parser, action):
+    """Calls add_parser for the given sub-command (create or update) and returns the parser"""
+    sub_command = 'create' if action == Action.CREATE else 'update'
+    return add_parser(sub_command,
+                      help=f'{sub_command} token',
+                      description=f'{sub_command.capitalize()} a Waiter token. '
+                      'In addition to the optional arguments '
+                      'explicitly listed below, '
+                      'you can optionally provide any Waiter '
+                      'token parameter as a flag. For example, '
+                      'to specify 10 seconds for the '
+                      'grace-period-secs parameter, '
+                      'you can pass --grace-period-secs 10.')
+
+
+def add_implicit_arguments(unknown_args, parser):
+    """
+    Given the list of "unknown" args, dynamically adds proper arguments to
+    the subparser, allowing us to support any token parameter as a flag
+    """
+    num_unknown_args = len(unknown_args)
+    for i in range(num_unknown_args):
+        arg = unknown_args[i]
+        if arg.startswith(("-", "--")):
+            if arg.endswith('-secs') or arg.endswith('-mins') or arg.endswith('-instances'):
+                arg_type = int
+            elif arg.endswith('-factor'):
+                arg_type = float
+            elif (i + 1) < num_unknown_args and unknown_args[i + 1].lower() in BOOL_STRINGS:
+                arg_type = str2bool
+            else:
+                arg_type = None
+            parser.add_argument(arg, dest=arg.lstrip('-'), type=arg_type)


### PR DESCRIPTION
## Changes proposed in this PR

- splitting `create` and `update` into two separate sub-commands
- moving the code that's shared between them into `token_post.py`
- making `create` not patch (i.e. it sends exactly the fields specified)
- (`update` still does the patch)

## Why are we making these changes?

Two reasons:

1. It's odd for `create` and `update` to be aliases
1. It allows for users to not patch, which can be useful
