### PR TITLE
Adds ping --service-id to CLI

### DIFF
--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -244,9 +244,9 @@ def delete(waiter_url=None, token_name=None, flags=None, delete_flags=None):
     return cp
 
 
-def ping(waiter_url=None, token_name=None, flags=None, ping_flags=None):
+def ping(waiter_url=None, token_name_or_service_id=None, flags=None, ping_flags=None):
     """Pings a token via the CLI"""
-    args = f'ping {token_name or ""} {ping_flags or ""}'
+    args = f'ping {token_name_or_service_id or ""} {ping_flags or ""}'
     cp = cli(args, waiter_url, flags)
     return cp
 

--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -246,6 +246,6 @@ def delete(waiter_url=None, token_name=None, flags=None, delete_flags=None):
 
 def ping(waiter_url=None, token_name=None, flags=None, ping_flags=None):
     """Pings a token via the CLI"""
-    args = f'ping {token_name} {ping_flags or ""}'
+    args = f'ping {token_name or ""} {ping_flags or ""}'
     cp = cli(args, waiter_url, flags)
     return cp

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -461,7 +461,7 @@ class WaiterCliTest(util.WaiterTest):
             cp = cli.ping(self.waiter_url, token_name)
             self.assertEqual(0, cp.returncode, cp.stderr)
             self.assertIn('Pinging token', cli.stdout(cp))
-            self.assertIn('Successfully pinged', cli.stdout(cp))
+            self.assertIn('successful', cli.stdout(cp))
             self.assertEqual(1, len(util.services_for_token(self.waiter_url, token_name)))
         finally:
             util.delete_token(self.waiter_url, token_name)
@@ -493,7 +493,6 @@ class WaiterCliTest(util.WaiterTest):
             self.assertEqual(0, cp.returncode, cp.stderr)
             self.assertIn('Pinging token', cli.stdout(cp))
             self.assertIn('/sleep', cli.stdout(cp))
-            self.assertIn('Successfully pinged', cli.stdout(cp))
             self.assertEqual(1, len(util.services_for_token(self.waiter_url, token_name)))
         finally:
             util.delete_token(self.waiter_url, token_name)
@@ -505,7 +504,6 @@ class WaiterCliTest(util.WaiterTest):
         try:
             cp = cli.ping(self.waiter_url, token_name, ping_flags='--timeout 300')
             self.assertEqual(0, cp.returncode, cp.stderr)
-            self.assertIn('Successfully pinged', cli.stdout(cp))
             util.kill_services_using_token(self.waiter_url, token_name)
             cp = cli.ping(self.waiter_url, token_name, ping_flags='--timeout 10')
             self.assertEqual(1, cp.returncode, cp.stderr)

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -618,7 +618,7 @@ class WaiterCliTest(util.WaiterTest):
             service_id = util.ping_token(self.waiter_url, token_name)
             util.kill_services_using_token(self.waiter_url, token_name)
             self.assertEqual(0, len(util.services_for_token(self.waiter_url, token_name)))
-            cp = cli.ping(self.waiter_url, ping_flags=f'--service-id {service_id}')
+            cp = cli.ping(self.waiter_url, service_id, ping_flags='--service-id')
             self.assertEqual(0, cp.returncode, cp.stderr)
             self.assertIn('Pinging service', cli.stdout(cp))
             self.assertEqual(1, len(util.services_for_token(self.waiter_url, token_name)))
@@ -627,11 +627,8 @@ class WaiterCliTest(util.WaiterTest):
 
     def test_ping_invalid_args(self):
         cp = cli.ping(self.waiter_url)
-        self.assertEqual(1, cp.returncode, cp.stderr)
-        self.assertIn('must provide either a token name or service id', cli.stderr(cp))
-        cp = cli.ping(self.waiter_url, token_name='foo', ping_flags='--service-id bar')
-        self.assertEqual(1, cp.returncode, cp.stderr)
-        self.assertIn('cannot provide both a token name and a service id', cli.stderr(cp))
+        self.assertEqual(2, cp.returncode, cp.stderr)
+        self.assertIn('the following arguments are required: token-or-service-id', cli.stderr(cp))
 
     def test_ping_correct_endpoint(self):
         token_name = self.token_name()
@@ -651,7 +648,7 @@ class WaiterCliTest(util.WaiterTest):
             self.assertIn('/status', cli.stdout(cp))
 
             # Pinging the service id should use /sleep
-            cp = cli.ping(self.waiter_url, ping_flags=f'--service-id {service_id}')
+            cp = cli.ping(self.waiter_url, service_id, ping_flags='--service-id')
             self.assertEqual(0, cp.returncode, cp.stderr)
             self.assertIn('/sleep', cli.stdout(cp))
         finally:

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -511,3 +511,49 @@ class WaiterCliTest(util.WaiterTest):
         finally:
             util.kill_services_using_token(self.waiter_url, token_name)
             util.delete_token(self.waiter_url, token_name)
+
+    def test_ping_service_id(self):
+        token_name = self.token_name()
+        util.post_token(self.waiter_url, token_name, util.minimal_service_description())
+        try:
+            service_id = util.ping_token(self.waiter_url, token_name)
+            util.kill_services_using_token(self.waiter_url, token_name)
+            self.assertEqual(0, len(util.services_for_token(self.waiter_url, token_name)))
+            cp = cli.ping(self.waiter_url, ping_flags=f'--service-id {service_id}')
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            self.assertIn('Pinging service', cli.stdout(cp))
+            self.assertEqual(1, len(util.services_for_token(self.waiter_url, token_name)))
+        finally:
+            util.delete_token(self.waiter_url, token_name, kill_services=True)
+
+    def test_ping_invalid_args(self):
+        cp = cli.ping(self.waiter_url)
+        self.assertEqual(1, cp.returncode, cp.stderr)
+        self.assertIn('must provide either a token name or service id', cli.stderr(cp))
+        cp = cli.ping(self.waiter_url, token_name='foo', ping_flags='--service-id bar')
+        self.assertEqual(1, cp.returncode, cp.stderr)
+        self.assertIn('cannot provide both a token name and a service id', cli.stderr(cp))
+
+    def test_ping_correct_endpoint(self):
+        token_name = self.token_name()
+        util.post_token(self.waiter_url, token_name,
+                        util.minimal_service_description(**{'health-check-url': '/sleep'}))
+        try:
+            # Grab the service id for the /sleep version
+            service_id = util.ping_token(self.waiter_url, token_name)
+
+            # Update the health check url to /status
+            util.post_token(self.waiter_url, token_name,
+                            util.minimal_service_description(**{'health-check-url': '/status'}))
+
+            # Pinging the token should use /status
+            cp = cli.ping(self.waiter_url, token_name)
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            self.assertIn('/status', cli.stdout(cp))
+
+            # Pinging the service id should use /sleep
+            cp = cli.ping(self.waiter_url, ping_flags=f'--service-id {service_id}')
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            self.assertIn('/sleep', cli.stdout(cp))
+        finally:
+            util.delete_token(self.waiter_url, token_name, kill_services=True)

--- a/cli/integration/tests/waiter/test_cli_multi_cluster.py
+++ b/cli/integration/tests/waiter/test_cli_multi_cluster.py
@@ -124,7 +124,7 @@ class MultiWaiterCliTest(util.WaiterTest):
                 config = self.__two_cluster_config()
                 with cli.temp_config_file(config) as path:
                     # Ping the token in both clusters
-                    cp = cli.ping(token_name=token_name, flags=f'--config {path}')
+                    cp = cli.ping(token_name_or_service_id=token_name, flags=f'--config {path}')
                     self.assertEqual(0, cp.returncode, cp.stderr)
                     self.assertIn('waiter1', cli.stdout(cp))
                     self.assertIn('waiter2', cli.stdout(cp))

--- a/cli/integration/tests/waiter/test_cli_multi_cluster.py
+++ b/cli/integration/tests/waiter/test_cli_multi_cluster.py
@@ -129,7 +129,6 @@ class MultiWaiterCliTest(util.WaiterTest):
                     self.assertIn('waiter1', cli.stdout(cp))
                     self.assertIn('waiter2', cli.stdout(cp))
                     self.assertEqual(2, cli.stdout(cp).count('Pinging token'))
-                    self.assertEqual(2, cli.stdout(cp).count('Successfully pinged'))
                     self.assertEqual(1, len(util.services_for_token(self.waiter_url_1, token_name)))
                     self.assertEqual(1, len(util.services_for_token(self.waiter_url_2, token_name)))
             finally:

--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -64,7 +64,10 @@ def init_waiter_session(*waiter_urls):
         _wait_for_waiter(waiter_url)
 
 
-def delete_token(waiter_url, token_name, assert_response=True, expected_status_code=200):
+def delete_token(waiter_url, token_name, assert_response=True, expected_status_code=200, kill_services=False):
+    if kill_services:
+        kill_services_using_token(waiter_url, token_name)
+
     response = session.delete(f'{waiter_url}/token', headers={'X-Waiter-Token': token_name})
     if assert_response:
         logging.debug(f'Response status code: {response.status_code}')

--- a/cli/waiter/querying.py
+++ b/cli/waiter/querying.py
@@ -67,3 +67,30 @@ def query_token(clusters, token):
         return executor.submit(get_token_on_cluster, cluster, token)
 
     return query_across_clusters(clusters, submit)
+
+
+def get_service(cluster, service_id):
+    """Retrieves the service with the given service id"""
+    params = {'effective-parameters': True}
+    endpoint = f'/apps/{service_id}'
+    service, _ = http_util.make_data_request(cluster, lambda: http_util.get(cluster, endpoint, params=params))
+    return service
+
+
+def get_service_on_cluster(cluster, service_id):
+    """Gets the service with the given service id on the given cluster"""
+    service = get_service(cluster, service_id)
+    if service:
+        return {'count': 1, 'service': service}
+    else:
+        return {'count': 0}
+
+
+def query_service(clusters, service_id):
+    """
+    Uses query_across_clusters to make the service
+    requests in parallel across the given clusters
+    """
+    return query_across_clusters(
+        clusters,
+        lambda cluster, executor: executor.submit(get_service_on_cluster, cluster, service_id))

--- a/cli/waiter/subcommands/ping.py
+++ b/cli/waiter/subcommands/ping.py
@@ -1,17 +1,14 @@
 import logging
 
 from waiter import http_util, terminal
-from waiter.querying import query_token, print_no_data
+from waiter.querying import query_token, print_no_data, query_service
 from waiter.util import guard_no_cluster, response_message, print_error, check_positive
 
 
-def ping_token_on_cluster(cluster, token_name, health_check_endpoint, timeout):
-    """Pings the token with the given token name in the given cluster."""
+def ping_on_cluster(cluster, health_check_endpoint, timeout, token_name):
+    """Pings using the given headers in the given cluster."""
     cluster_name = cluster['name']
     try:
-        print(f'Pinging token {terminal.bold(token_name)} '
-              f'at {terminal.bold(health_check_endpoint)} '
-              f'in {terminal.bold(cluster_name)}...')
         headers = {
             'X-Waiter-Token': token_name,
             'X-Waiter-Fallback-Period-Secs': '0'
@@ -19,35 +16,65 @@ def ping_token_on_cluster(cluster, token_name, health_check_endpoint, timeout):
         resp = http_util.get(cluster, health_check_endpoint, headers=headers, read_timeout=timeout)
         logging.debug(f'Response status code: {resp.status_code}')
         if resp.status_code == 200:
-            print(terminal.success(f'Successfully pinged {token_name} in {cluster_name}.'))
+            print(terminal.success(f'Ping successful.'))
             print(resp.text)
             return True
         else:
             print_error(response_message(resp.json()))
             return False
     except Exception:
-        message = f'Encountered error while pinging token {token_name} in {cluster_name}.'
+        message = f'Encountered error while pinging in {cluster_name}.'
         logging.exception(message)
         print_error(message)
+
+
+def ping_token_on_cluster(cluster, token_name, health_check_endpoint, timeout):
+    """Pings the token with the given token name in the given cluster."""
+    cluster_name = cluster['name']
+    print(f'Pinging token {terminal.bold(token_name)} '
+          f'at {terminal.bold(health_check_endpoint)} '
+          f'in {terminal.bold(cluster_name)}...')
+    return ping_on_cluster(cluster, health_check_endpoint, timeout, token_name)
+
+
+def ping_service_on_cluster(cluster, service_id, health_check_endpoint, timeout):
+    """Pings the service with the given service id in the given cluster."""
+    cluster_name = cluster['name']
+    print(f'Pinging service {terminal.bold(service_id)} '
+          f'at {terminal.bold(health_check_endpoint)} '
+          f'in {terminal.bold(cluster_name)}...')
+    return ping_on_cluster(cluster, health_check_endpoint, timeout, f'^SERVICE-ID#{service_id}')
 
 
 def ping(clusters, args, _):
     """Pings the token with the given token name."""
     guard_no_cluster(clusters)
-    token_name = args.get('token')[0]
-    query_result = query_token(clusters, token_name)
+    token_name = args.get('token')
+    service_id = args.get('service-id', None)
+    if token_name:
+        query_result = query_token(clusters, token_name)
+    elif service_id:
+        query_result = query_service(clusters, service_id)
+    else:
+        raise Exception('You must provide either a token name or service id (via --service-id).')
+
     if query_result['count'] == 0:
         print_no_data(clusters)
         return 1
 
+    timeout = args.get('timeout', None)
     http_util.set_retries(0)
     cluster_data_pairs = sorted(query_result['clusters'].items())
     clusters_by_name = {c['name']: c for c in clusters}
     overall_success = True
     for cluster_name, data in cluster_data_pairs:
         cluster = clusters_by_name[cluster_name]
-        health_check_endpoint = data['token'].get('health-check-url', '/status')
-        success = ping_token_on_cluster(cluster, token_name, health_check_endpoint, args.get('timeout', None))
+        if service_id:
+            health_check_endpoint = data['service']['effective-parameters'].get('health-check-url', '/status')
+            success = ping_service_on_cluster(cluster, service_id, health_check_endpoint, timeout)
+        else:
+            health_check_endpoint = data['token'].get('health-check-url', '/status')
+            success = ping_token_on_cluster(cluster, token_name, health_check_endpoint, timeout)
         overall_success = overall_success and success
     return 0 if overall_success else 1
 
@@ -55,7 +82,8 @@ def ping(clusters, args, _):
 def register(add_parser):
     """Adds this sub-command's parser and returns the action function"""
     parser = add_parser('ping', help='ping token by name')
-    parser.add_argument('token', nargs=1)
+    parser.add_argument('token', nargs='?')
     parser.add_argument('--timeout', '-t', help='read timeout (in seconds) for ping request',
                         type=check_positive, default=60)
+    parser.add_argument('--service-id', '-s', help='service id for ping request', dest='service-id')
     return ping

--- a/cli/waiter/subcommands/ping.py
+++ b/cli/waiter/subcommands/ping.py
@@ -6,7 +6,7 @@ from waiter.util import guard_no_cluster, response_message, print_error, check_p
 
 
 def ping_on_cluster(cluster, health_check_endpoint, timeout, token_name):
-    """Pings using the given headers in the given cluster."""
+    """Pings using the given token name (or ^SERVICE-ID#) in the given cluster."""
     cluster_name = cluster['name']
     try:
         headers = {
@@ -51,6 +51,10 @@ def ping(clusters, args, _):
     guard_no_cluster(clusters)
     token_name = args.get('token')
     service_id = args.get('service-id', None)
+
+    if token_name and service_id:
+        raise Exception('You cannot provide both a token name and a service id.')
+
     if token_name:
         query_result = query_token(clusters, token_name)
     elif service_id:

--- a/cli/waiter/subcommands/ping.py
+++ b/cli/waiter/subcommands/ping.py
@@ -68,9 +68,11 @@ def ping(clusters, args, _):
     for cluster_name, data in cluster_data_pairs:
         cluster = clusters_by_name[cluster_name]
         if is_service_id:
-            health_check_endpoint = data['service']['effective-parameters'].get('health-check-url', '/status')
+            health_check_endpoint = data['service']['effective-parameters']['health-check-url']
             success = ping_service_on_cluster(cluster, token_name_or_service_id, health_check_endpoint, timeout)
         else:
+            # We are hard-coding the default health-check-url here to /status; this could
+            # alternatively be retrieved from /settings, but we want to skip the extra request
             health_check_endpoint = data['token'].get('health-check-url', '/status')
             success = ping_token_on_cluster(cluster, token_name_or_service_id, health_check_endpoint, timeout)
         overall_success = overall_success and success


### PR DESCRIPTION
## Changes proposed in this PR

- adding the `--service-id` flag to the `ping` sub-command

## Why are we making these changes?

So that users can optionally choose a specific service to ping, rather than a token, which can "map" to multiple services.
