### PR TITLE
Adds support for token JSON file on create/update

### DIFF
--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -169,6 +169,28 @@ class temp_config_file:
         os.remove(self.path)
 
 
+class temp_token_file:
+    """
+    A context manager used to generate and subsequently delete a temporary
+    token JSON file for the CLI. Takes as input the token dictionary to use.
+    """
+
+    def __init__(self, token_data):
+        self.token_data = token_data
+
+    def write_temp_json(self):
+        path = tempfile.NamedTemporaryFile(delete=False).name
+        write_json(path, self.token_data)
+        return path
+
+    def __enter__(self):
+        self.path = self.write_temp_json()
+        return self.path
+
+    def __exit__(self, _, __, ___):
+        os.remove(self.path)
+
+
 def show(waiter_url=None, token_name=None, flags=None, show_flags=None):
     """Shows a token via the CLI"""
     args = f"show {token_name} {show_flags or ''}"

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -2,6 +2,7 @@ import getpass
 import json
 import logging
 import os
+import tempfile
 import threading
 import unittest
 import uuid
@@ -679,3 +680,42 @@ class WaiterCliTest(util.WaiterTest):
             self.assertEqual(128, token_data['mem'])
         finally:
             util.delete_token(self.waiter_url, token_name)
+
+    def test_create_token_json(self):
+        token_name = self.token_name()
+        with cli.temp_token_file({'cpus': 0.1, 'mem': 128}) as path:
+            cp = cli.create(self.waiter_url, token_name, create_flags=f'--json {path}')
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            try:
+                token_data = util.load_token(self.waiter_url, token_name)
+                self.assertEqual(0.1, token_data['cpus'])
+                self.assertEqual(128, token_data['mem'])
+            finally:
+                util.delete_token(self.waiter_url, token_name)
+
+    def test_update_token_json(self):
+        token_name = self.token_name()
+        util.post_token(self.waiter_url, token_name, {'cpus': 0.1, 'mem': 128, 'cmd': 'foo'})
+        try:
+            with cli.temp_token_file({'cpus': 0.2, 'mem': 256}) as path:
+                cp = cli.update(self.waiter_url, token_name, create_flags=f'--json {path}')
+                self.assertEqual(0, cp.returncode, cp.stderr)
+                token_data = util.load_token(self.waiter_url, token_name)
+                self.assertEqual(0.2, token_data['cpus'])
+                self.assertEqual(256, token_data['mem'])
+                self.assertEqual('foo', token_data['cmd'])
+        finally:
+            util.delete_token(self.waiter_url, token_name)
+
+    def test_post_token_json_and_flags(self):
+        token_name = self.token_name()
+        cp = cli.update(self.waiter_url, token_name, create_flags='--json foo.json --cpus 0.1')
+        self.assertEqual(1, cp.returncode, cp.stderr)
+        self.assertIn('cannot specify both a token JSON file and token field flags', cli.stderr(cp))
+
+    def test_post_token_json_invalid(self):
+        token_name = self.token_name()
+        with tempfile.NamedTemporaryFile(delete=True) as file:
+            cp = cli.update(self.waiter_url, token_name, create_flags=f'--json {file.name}')
+            self.assertEqual(1, cp.returncode, cp.stderr)
+            self.assertIn('Unable to load token JSON from', cli.stderr(cp))

--- a/cli/waiter/configuration.py
+++ b/cli/waiter/configuration.py
@@ -3,7 +3,7 @@ import logging
 import os
 import sys
 
-from waiter.util import deep_merge
+from waiter.util import deep_merge, load_json_file
 
 # Base locations to check for configuration files, relative to the executable.
 # Always tries to load these in.
@@ -25,28 +25,11 @@ DEFAULT_CONFIG = {'http': {'retries': 2,
                               'timeout': 0.15}}
 
 
-def __load_json_file(path):
-    """Decode a JSON formatted file."""
-    content = None
-
-    if os.path.isfile(path):
-        with open(path) as json_file:
-            try:
-                logging.debug(f'attempting to load json configuration from {path}')
-                content = json.load(json_file)
-            except Exception:
-                pass
-    else:
-        logging.info(f'{path} is not a file')
-
-    return content
-
-
 def __load_first_json_file(paths):
     """Returns the contents of the first parseable JSON file in a list of paths."""
     if paths is None:
         paths = []
-    contents = ((os.path.abspath(p), __load_json_file(os.path.abspath(p))) for p in paths if p)
+    contents = ((os.path.abspath(p), load_json_file(os.path.abspath(p))) for p in paths if p)
     return next(((p, c) for p, c in contents if c), (None, None))
 
 

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -5,7 +5,8 @@ import requests
 
 from waiter import terminal, http_util
 from waiter.querying import get_token
-from waiter.util import FALSE_STRINGS, print_info, response_message, TRUE_STRINGS, guard_no_cluster, str2bool
+from waiter.util import FALSE_STRINGS, print_info, response_message, TRUE_STRINGS, guard_no_cluster, str2bool, \
+    load_json_file
 
 BOOL_STRINGS = TRUE_STRINGS + FALSE_STRINGS
 
@@ -80,7 +81,16 @@ def create_or_update_token(clusters, args, _, action):
     else:
         cluster = clusters[0]
     token_name = args.pop('token')
-    token_fields = args
+    json_file = args.pop('json', None)
+    if json_file:
+        if len(args) > 0:
+            raise Exception('You cannot specify both a token JSON file and token field flags at the same time.')
+
+        token_fields = load_json_file(json_file)
+        if not token_fields:
+            raise Exception(f'Unable to load token JSON from {json_file}.')
+    else:
+        token_fields = args
     return create_or_update(cluster, token_name, token_fields, action)
 
 
@@ -93,6 +103,7 @@ def add_arguments(parser):
     parser.add_argument('--cpus', '-c', help='cpus to reserve for service', type=float)
     parser.add_argument('--mem', '-m', help='memory (in MiB) to reserve for service', type=int)
     parser.add_argument('--ports', help='number of ports to reserve for service', type=int)
+    parser.add_argument('--json', help='provide the data in a JSON file', dest='json')
     parser.add_argument('token', nargs=1)
 
 

--- a/cli/waiter/util.py
+++ b/cli/waiter/util.py
@@ -1,4 +1,6 @@
 import argparse
+import json
+import logging
 import os
 import sys
 import time
@@ -98,3 +100,20 @@ def check_positive(value):
     if integer <= 0:
         raise argparse.ArgumentTypeError(f'{value} is not a positive integer')
     return integer
+
+
+def load_json_file(path):
+    """Decode a JSON formatted file."""
+    content = None
+
+    if os.path.isfile(path):
+        with open(path) as json_file:
+            try:
+                logging.debug(f'attempting to load json from {path}')
+                content = json.load(json_file)
+            except Exception:
+                pass
+    else:
+        logging.info(f'{path} is not a file')
+
+    return content

--- a/cli/waiter/util.py
+++ b/cli/waiter/util.py
@@ -112,7 +112,7 @@ def load_json_file(path):
                 logging.debug(f'attempting to load json from {path}')
                 content = json.load(json_file)
             except Exception:
-                pass
+                logging.exception(f'encountered exception when loading json from {path}')
     else:
         logging.info(f'{path} is not a file')
 


### PR DESCRIPTION
## Changes proposed in this PR

- adding the `--json` flag to `create` and `update`, which allows you to provide a JSON file with the token fields

## Why are we making these changes?

Users may want to maintain their token definition in a file rather than providing the command-line flags on every invocation.
