### PR TITLE
Adds support for killing by service id

### DIFF
--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -257,8 +257,8 @@ def ping(waiter_url=None, token_name_or_service_id=None, flags=None, ping_flags=
     return cp
 
 
-def kill(waiter_url=None, token_name=None, flags=None, kill_flags=None):
+def kill(waiter_url=None, token_name_or_service_id=None, flags=None, kill_flags=None):
     """Kills services using a token via the CLI"""
-    args = f'kill {token_name} {kill_flags or ""}'
+    args = f'kill {token_name_or_service_id} {kill_flags or ""}'
     cp = cli(args, waiter_url, flags)
     return cp

--- a/cli/waiter/querying.py
+++ b/cli/waiter/querying.py
@@ -82,6 +82,8 @@ def get_service_on_cluster(cluster, service_id):
     service = get_service(cluster, service_id)
     if service:
         return {'count': 1, 'service': service}
+    else:
+        return {'count': 0}
                      
                      
 def get_services_using_token(cluster, token_name):

--- a/cli/waiter/terminal.py
+++ b/cli/waiter/terminal.py
@@ -31,6 +31,10 @@ def running(s):
     return colorize(s, Color.CYAN)
 
 
+def inactive(s):
+    return colorize(s, Color.YELLOW)
+
+
 def reason(s):
     return colorize(s, Color.RED)
 


### PR DESCRIPTION
## Changes proposed in this PR

- adding `--service-id`, allowing users to kill by service id

## Why are we making these changes?

This allows users to kill a specific service, rather than all services that are using a token.