### PR TITLE
Unset default nginx index file for k8s fileserver

### DIFF
--- a/kubernetes/fileserver-container/README.md
+++ b/kubernetes/fileserver-container/README.md
@@ -16,4 +16,4 @@ in the container's environment to the desired port number.
 
 ## Building the Docker image
 
-    docker build -t twosigma/waiter-fileserver .
+    docker build -t "twosigma/waiter-fileserver:$(date +%Y%m%d)" .

--- a/kubernetes/fileserver-container/nginx.conf
+++ b/kubernetes/fileserver-container/nginx.conf
@@ -15,6 +15,7 @@ http {
     location / {
       autoindex on;
       autoindex_format json;
+      index waiter_directory_index_disabled;
     }
   }
 }

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -343,7 +343,7 @@
                                                 :default {:factory-fn 'waiter.authorization/noop-authorizer}}
                                    :cluster-name "waiter"
                                    :fileserver {:cmd ["/bin/fileserver-start"]
-                                                :image "twosigma/waiter-fileserver:20190114"
+                                                :image "twosigma/waiter-fileserver:20190410"
                                                 :resources {:cpu 0.1 :mem 128}
                                                 :scheme "http"}
                                    :http-options {:conn-timeout 10000


### PR DESCRIPTION
## Changes proposed in this PR

Clobber the default `index.html` for index files in our Waiter-K8s nginx fileserver config.

## Why are we making these changes?

Using the default index configuration, creating the file `index.html` breaks the Waiter file listing API for the given directory.