### PR TITLE
Skips ping on non-"home" clusters

### DIFF
--- a/cli/.waiter.json
+++ b/cli/.waiter.json
@@ -1,13 +1,13 @@
 {
   "clusters": [
     {
-      "name": "dev0",
+      "name": "WAITER1",
       "url": "http://127.0.0.1:9091/",
       "disabled": false,
       "default-for-create": true
     },
     {
-      "name": "dev1",
+      "name": "WAITER2",
       "url": "http://127.0.0.1:9191/",
       "disabled": true
     }

--- a/cli/bin/ci/run-integration-tests.sh
+++ b/cli/bin/ci/run-integration-tests.sh
@@ -15,11 +15,11 @@ nc -kl localhost ${GRAPHITE_SERVER_PORT} > /dev/null &
 
 # Start waiter
 : ${WAITER_PORT:=9091}
-${ROOT_DIR}/waiter/bin/run-using-shell-scheduler.sh ${WAITER_PORT} &
+${ROOT_DIR}/waiter/bin/run-using-shell-scheduler.sh ${WAITER_PORT} waiter1 &
 
 # Start a second waiter
 : ${WAITER_PORT_2:=9191}
-${ROOT_DIR}/waiter/bin/run-using-shell-scheduler.sh ${WAITER_PORT_2} &
+${ROOT_DIR}/waiter/bin/run-using-shell-scheduler.sh ${WAITER_PORT_2} waiter2 &
 
 function wait_for_waiter {
     URI=${1}

--- a/waiter/bin/run-using-shell-scheduler.sh
+++ b/waiter/bin/run-using-shell-scheduler.sh
@@ -2,14 +2,16 @@
 # Usage: run-using-shell-scheduler.sh [PORT] [RECOMPILE]
 #
 # Examples:
-#   run-using-shell-scheduler.sh 9091 1
+#   run-using-shell-scheduler.sh 9091 waiter 1
+#   run-using-shell-scheduler.sh 9091 waiter
 #   run-using-shell-scheduler.sh 9091
 #   run-using-shell-scheduler.sh
 #
 # Runs Waiter, configured to use the local "shell scheduler" (not for production use).
 
 export WAITER_PORT=${1:-9091}
-export RECOMPILE=${2:-1}
+export WAITER_CLUSTER_NAME=${2:-waiter}
+export RECOMPILE=${3:-1}
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/waiter/config-shell.edn
+++ b/waiter/config-shell.edn
@@ -1,22 +1,11 @@
 {
  ; ---------- Cluster ----------
 
+ :cluster-config {:name #config/env "WAITER_CLUSTER_NAME"}
+
  :zookeeper {
              ;; Use an in-process ZK (not for production use):
              :connect-string :in-process}
-
- ; ---------- Metrics - Internal ----------
-
- :metrics-config {
-                  :codahale-reporters {
-                                       :graphite {
-                                                  :factory-fn waiter.reporter/graphite-reporter
-                                                  :filter-regex #config/regex "^jvm.*|^waiter.*"
-                                                  :host "localhost"
-                                                  :period-ms 6000
-                                                  :pickled? true
-                                                  :prefix "waiter-internal"
-                                                  :port #config/env-int "GRAPHITE_SERVER_PORT"}}}
 
  ; ---------- Network ----------
 

--- a/waiter/test/waiter/settings_test.clj
+++ b/waiter/test/waiter/settings_test.clj
@@ -269,20 +269,20 @@
 
 (deftest test-validate-shell-settings
   (testing "Test validating shell scheduler settings"
-    (let [graphite-server-port 5555
-          port 12345
-          run-as-user "foo"]
+    (let [port 12345
+          run-as-user "foo"
+          cluster-name "bar"]
       (with-redefs [env (fn [name _]
                           (case name
-                            "GRAPHITE_SERVER_PORT" (str graphite-server-port)
                             "WAITER_PORT" (str port)
                             "WAITER_AUTH_RUN_AS_USER" run-as-user
+                            "WAITER_CLUSTER_NAME" cluster-name
                             (throw (ex-info "Unexpected environment variable" {:name name}))))]
         (let [settings (load-shell-settings)]
           (is (nil? (s/check settings-schema settings)))
-          (is (= graphite-server-port (get-in settings [:metrics-config :codahale-reporters :graphite :port])))
           (is (= port (:port settings)))
-          (is (= run-as-user (get-in settings [:authenticator-config :one-user :run-as-user]))))))))
+          (is (= run-as-user (get-in settings [:authenticator-config :one-user :run-as-user])))
+          (is (= cluster-name (get-in settings [:cluster-config :name]))))))))
 
 (deftest test-validate-composite-settings
   (testing "Test validating composite scheduler settings"


### PR DESCRIPTION
## Changes proposed in this PR

- avoids pinging the token on clusters where the token was not explicitly created

## Why are we making these changes?

In some environments, offline processes can create tokens (e.g. to keep them synchronized between clusters). When this happens, we only want to ping in the cluster(s) where an end-user created the token.