### PR TITLE
Shows run-as-user in kill prompt

### DIFF
--- a/cli/integration/tests/waiter/test_cli_multi_cluster.py
+++ b/cli/integration/tests/waiter/test_cli_multi_cluster.py
@@ -202,6 +202,7 @@ class MultiWaiterCliTest(util.WaiterTest):
                     self.assertIn(f'{self.waiter_url_1}/apps/{service_id_1}', cli.stdout(cp))
                     self.assertIn(f'{self.waiter_url_2}/apps/{service_id_2}', cli.stdout(cp))
                     self.assertEqual(2, cli.stdout(cp).count('cannot be killed because it is already Inactive'))
+                    self.assertEqual(2, cli.stdout(cp).count('Run as user'))
             finally:
                 util.delete_token(self.waiter_url_2, token_name, kill_services=True)
         finally:

--- a/cli/waiter/subcommands/kill.py
+++ b/cli/waiter/subcommands/kill.py
@@ -104,10 +104,12 @@ def kill(clusters, args, _):
                 else:
                     last_request_time = 'n/a'
 
+                run_as_user = service['service-description']['run-as-user']
                 table = [['Status', status],
                          ['Healthy', healthy_count],
                          ['Unhealthy', unhealthy_count],
-                         ['URL', url]]
+                         ['URL', url],
+                         ['Run as user', run_as_user]]
                 table_text = tabulate(table, tablefmt='plain')
                 print(f'\n'
                       f'=== {terminal.bold(cluster_name)} / {terminal.bold(service_id)} ===\n'


### PR DESCRIPTION
## Changes proposed in this PR

- adding "Run as user" to the prompt you get asking if you want to kill a service

## Why are we making these changes?

This makes it much more convenient when you're killing a run-as-requester token with many underlying services.

## Example

```bash
$ waiter kill demo                                                                                                                                                                                                                                        
There are 3 services using token demo:

=== WAITER1 / waiter-service-2cc3a9d410dc610ba4f48d4442967351 ===

Last Request: just now

Status       Running
Healthy      1
Unhealthy    0
URL          http://127.0.0.1:9091/apps/waiter-service-2cc3a9d410dc610ba4f48d4442967351
Run as user  dpo

Kill service in WAITER1? 

=== WAITER1 / waiter-service-37a8e3dd725520a8760545313331ada5 ===

Last Request: 3 minutes ago

Status       Running
Healthy      1
Unhealthy    0
URL          http://127.0.0.1:9091/apps/waiter-service-37a8e3dd725520a8760545313331ada5
Run as user  dpo

Kill service in WAITER1? 

=== WAITER2 / waiter-service-2cc3a9d410dc610ba4f48d4442967351 ===

Last Request: seconds ago

Status       Running
Healthy      1
Unhealthy    0
URL          http://127.0.0.1:9191/apps/waiter-service-2cc3a9d410dc610ba4f48d4442967351
Run as user  dpo

Kill service in WAITER2? 
```