### PR TITLE
Removes 'force' from token JSON file

### DIFF
--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -719,7 +719,7 @@ class WaiterCliTest(util.WaiterTest):
             cp = cli.update(self.waiter_url, token_name, update_flags=f'--json {file.name}')
             self.assertEqual(1, cp.returncode, cp.stderr)
             self.assertIn('Unable to load token JSON from', cli.stderr(cp))
-            
+
     def test_kill_service_id(self):
         token_name = self.token_name()
         util.post_token(self.waiter_url, token_name, util.minimal_service_description())
@@ -755,7 +755,8 @@ class WaiterCliTest(util.WaiterTest):
     def test_init_basic(self):
         token_name = self.token_name()
         with tempfile.NamedTemporaryFile(delete=True) as file:
-            cp = cli.init(self.waiter_url, init_flags=f"--cmd '{util.default_cmd()}' --file {file.name} --force")
+            flags = f"--cmd '{util.default_cmd()}' --file {file.name} --force --cmd-type shell"
+            cp = cli.init(self.waiter_url, init_flags=flags)
             self.assertEqual(0, cp.returncode, cp.stderr)
             self.assertIn('Writing token JSON', cli.stdout(cp))
             token_definition = util.load_json_file(file.name)

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -754,12 +754,13 @@ class WaiterCliTest(util.WaiterTest):
 
     def test_init_basic(self):
         token_name = self.token_name()
-        with tempfile.NamedTemporaryFile(delete=True) as file:
-            flags = f"--cmd '{util.default_cmd()}' --file {file.name} --force --cmd-type shell"
-            cp = cli.init(self.waiter_url, init_flags=flags)
-            self.assertEqual(0, cp.returncode, cp.stderr)
-            self.assertIn('Writing token JSON', cli.stdout(cp))
-            token_definition = util.load_json_file(file.name)
+        filename = str(uuid.uuid4())
+        flags = f"--cmd '{util.default_cmd()}' --file {filename} --cmd-type shell"
+        cp = cli.init(self.waiter_url, init_flags=flags)
+        self.assertEqual(0, cp.returncode, cp.stderr)
+        self.assertIn('Writing token JSON', cli.stdout(cp))
+        try:
+            token_definition = util.load_json_file(filename)
             self.logger.info(f'Token definition: {json.dumps(token_definition, indent=2)}')
             util.post_token(self.waiter_url, token_name, token_definition)
             try:
@@ -767,6 +768,8 @@ class WaiterCliTest(util.WaiterTest):
                 self.assertEqual(1, len(util.services_for_token(self.waiter_url, token_name)))
             finally:
                 util.delete_token(self.waiter_url, token_name, kill_services=True)
+        finally:
+            os.remove(filename)
 
     def test_implicit_init_args(self):
         cp = cli.init(init_flags='--help')

--- a/cli/waiter/subcommands/init.py
+++ b/cli/waiter/subcommands/init.py
@@ -20,7 +20,8 @@ def init_token_json(_, args, __):
     """Creates (or updates) a Waiter token"""
     logging.debug('args: %s' % args)
     file = os.path.abspath(args.pop('file'))
-    if os.path.isfile(file) and not args.pop('force'):
+    should_overwrite = args.pop('force')
+    if os.path.isfile(file) and not should_overwrite:
         raise Exception(f'There is already a file at {file}. Use --force if you want to overwrite it.')
     else:
         print(f'Writing token JSON to {file}.')


### PR DESCRIPTION
## Changes proposed in this PR

- fixing bug where `force` flag was being added to the generated JSON file (only when the file at the path in question did not already exist)
- adding command type `shell` to the token created in `test_init_basic`

## Why are we making these changes?

The bug fix is needed so that we generate valid token JSON.

The explicit command type is needed because in environments where `shell` is not configured as the default command type, we need this test to still pass.
