### PR TITLE
disable tests until we fully support mesos constraints

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -1026,10 +1026,10 @@
             (let [kitchen-image (System/getenv "INTEGRATION_TEST_KITCHEN_IMAGE")
                   _ (is (not (str/blank? kitchen-image)) "You must provide a kitchen image in the INTEGRATION_TEST_KITCHEN_IMAGE environment variable")]
               (make-kitchen-request-fn kitchen-image 200))
-            (using-marathon? waiter-url)
-            (let [custom-image-alias (System/getenv "INTEGRATION_TEST_IMAGE_CONSTRAINT_ALIAS")
-                  _ (is (not (str/blank? custom-image-alias)) "You must provide an image alias in the INTEGRATION_TEST_IMAGE_CONSTRAINT_ALIAS environment variable")]
-              (make-kitchen-request-fn custom-image-alias 200))
+            ;(using-marathon? waiter-url)
+            ;(let [custom-image-alias (System/getenv "INTEGRATION_TEST_IMAGE_CONSTRAINT_ALIAS")
+            ;      _ (is (not (str/blank? custom-image-alias)) "You must provide an image alias in the INTEGRATION_TEST_IMAGE_CONSTRAINT_ALIAS environment variable")]
+            ;  (make-kitchen-request-fn custom-image-alias 200))
             (or (using-cook? waiter-url)
                 (using-marathon? waiter-url)
                 (using-shell? waiter-url))

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -1026,10 +1026,6 @@
             (let [kitchen-image (System/getenv "INTEGRATION_TEST_KITCHEN_IMAGE")
                   _ (is (not (str/blank? kitchen-image)) "You must provide a kitchen image in the INTEGRATION_TEST_KITCHEN_IMAGE environment variable")]
               (make-kitchen-request-fn kitchen-image 200))
-            ;(using-marathon? waiter-url)
-            ;(let [custom-image-alias (System/getenv "INTEGRATION_TEST_IMAGE_CONSTRAINT_ALIAS")
-            ;      _ (is (not (str/blank? custom-image-alias)) "You must provide an image alias in the INTEGRATION_TEST_IMAGE_CONSTRAINT_ALIAS environment variable")]
-            ;  (make-kitchen-request-fn custom-image-alias 200))
             (or (using-cook? waiter-url)
                 (using-marathon? waiter-url)
                 (using-shell? waiter-url))

--- a/waiter/integration/waiter/marathon_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/marathon_scheduler_integration_test.clj
@@ -18,7 +18,7 @@
       (is (= constraint-value ((keyword constraint-attribute) attributes)))
       (delete-service waiter-url service-id))))
 
-(deftest ^:parallel ^:integration-slow test-marathon-image-alias
+(deftest ^:parallel ^:integration-slow ^:explicit test-marathon-image-alias
   (testing-using-waiter-url
     (when (using-marathon? waiter-url)
       (let [custom-image-alias (System/getenv "INTEGRATION_TEST_IMAGE_CONSTRAINT_ALIAS")
@@ -30,7 +30,7 @@
         (verify-marathon-image-alias waiter-url custom-image-alias constraint-attribute constraint-value)))))
 
 
-(deftest ^:parallel ^:integration-slow test-marathon-image-alias-2
+(deftest ^:parallel ^:integration-slow ^:explicit test-marathon-image-alias-2
   (testing-using-waiter-url
     (when (using-marathon? waiter-url)
       (let [custom-image-alias (System/getenv "INTEGRATION_TEST_IMAGE_CONSTRAINT_ALIAS_2")


### PR DESCRIPTION
## Changes proposed in this PR

- disable tests until we fully support mesos constraints

## Why are we making these changes?

we don't support different mesos platforms yet. tests will always fail
