### PR TITLE
adds support for populating WAITER_CLUSTER environment variable

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -582,10 +582,10 @@
         (is (= 200 status))
         (testing "waiter configured environment variables"
           (is (every? #(contains? body-json %)
-                      ["HOME" "LOGNAME" "USER" "WAITER_CLUSTER_NAME" "WAITER_CONCURRENCY_LEVEL" "WAITER_CPUS"
+                      ["HOME" "LOGNAME" "USER" "WAITER_CLUSTER" "WAITER_CONCURRENCY_LEVEL" "WAITER_CPUS"
                        "WAITER_MEM_MB" "WAITER_SERVICE_ID" "WAITER_USERNAME"])
               (str body-json))
-          (is (= (setting waiter-url [:cluster-config :name]) (get body-json "WAITER_CLUSTER_NAME")))
+          (is (= (setting waiter-url [:cluster-config :name]) (get body-json "WAITER_CLUSTER")))
           (is (= service-id (get body-json "WAITER_SERVICE_ID"))))
         (testing "on-the-fly environment variables"
           (is (every? #(contains? body-json %) ["BEGIN_DATE" "END_DATE" "TIME2" "TIMESTAMP"])

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -582,8 +582,11 @@
         (is (= 200 status))
         (testing "waiter configured environment variables"
           (is (every? #(contains? body-json %)
-                      ["HOME" "LOGNAME" "USER" "WAITER_CONCURRENCY_LEVEL" "WAITER_CPUS" "WAITER_MEM_MB" "WAITER_SERVICE_ID" "WAITER_USERNAME"])
-              (str body-json)))
+                      ["HOME" "LOGNAME" "USER" "WAITER_CLUSTER_NAME" "WAITER_CONCURRENCY_LEVEL" "WAITER_CPUS"
+                       "WAITER_MEM_MB" "WAITER_SERVICE_ID" "WAITER_USERNAME"])
+              (str body-json))
+          (is (= (setting waiter-url [:cluster-config :name]) (get body-json "WAITER_CLUSTER_NAME")))
+          (is (= service-id (get body-json "WAITER_SERVICE_ID"))))
         (testing "on-the-fly environment variables"
           (is (every? #(contains? body-json %) ["BEGIN_DATE" "END_DATE" "TIME2" "TIMESTAMP"])
               (str body-json)))

--- a/waiter/src/waiter/config.clj
+++ b/waiter/src/waiter/config.clj
@@ -1,0 +1,37 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns waiter.config)
+
+(def ^:private config-promise (promise))
+
+(defn initialize-config
+  "Initializes the config."
+  [config-value]
+  (if-not (realized? config-promise)
+    (deliver config-promise config-value)
+    (throw (IllegalStateException. "The config has already been initialized"))))
+
+(defn- check-config-initialized
+  "Throws an exception if the config has not been initialized."
+  []
+  (when-not (realized? config-promise)
+    (throw (IllegalStateException. "The config has not been initialized"))))
+
+(defn retrieve-cluster-name
+  "Retrieves the configured cluster name."
+  []
+  (check-config-initialized)
+  (get-in @config-promise [:cluster-config :name]))

--- a/waiter/src/waiter/config.clj
+++ b/waiter/src/waiter/config.clj
@@ -18,20 +18,15 @@
 (def ^:private config-promise (promise))
 
 (defn initialize-config
-  "Initializes the config."
+  "Initializes the config that represents the settings used to launch the current Waiter router.
+   The config is constant for the lifetime of the Waiter router."
   [config-value]
-  (if-not (realized? config-promise)
-    (deliver config-promise config-value)
-    (throw (IllegalStateException. "The config has already been initialized"))))
-
-(defn- check-config-initialized
-  "Throws an exception if the config has not been initialized."
-  []
-  (when-not (realized? config-promise)
-    (throw (IllegalStateException. "The config has not been initialized"))))
+  (deliver config-promise config-value)
+  (when-not (= @config-promise config-value)
+    (throw (IllegalStateException. "The config has already been initialized to a different value"))))
 
 (defn retrieve-cluster-name
   "Retrieves the configured cluster name."
   []
-  (check-config-initialized)
+  {:pre [(realized? config-promise)]}
   (get-in @config-promise [:cluster-config :name]))

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -25,6 +25,7 @@
             [plumbing.graph :as graph]
             [qbits.jet.server :as server]
             [schema.core :as s]
+            [waiter.config :as config]
             [waiter.cors :as cors]
             [waiter.core :as core]
             [waiter.correlation-id :as cid]
@@ -110,6 +111,7 @@
                      :started-at (du/date-to-str (t/now)))]
       (log/info "core.async threadpool configured to use" async-threads "threads.")
       (log/info "loaded settings:\n" (with-out-str (clojure.pprint/pprint settings)))
+      (config/initialize-config settings)
       (let [app-map (wire-app settings)]
         ((graph/eager-compile app-map) {})))
     (catch Throwable e

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -668,7 +668,7 @@
          {"HOME" home-path
           "LOGNAME" run-as-user
           "USER" run-as-user
-          "WAITER_CLUSTER_NAME" (str (config/retrieve-cluster-name))
+          "WAITER_CLUSTER" (str (config/retrieve-cluster-name))
           "WAITER_CONCURRENCY_LEVEL" (str concurrency-level)
           "WAITER_CPUS" (str cpus)
           "WAITER_MEM_MB" (str mem)

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -25,6 +25,7 @@
             [plumbing.core :as pc]
             [qbits.jet.client.http :as http]
             [slingshot.slingshot :as ss]
+            [waiter.config :as config]
             [waiter.correlation-id :as cid]
             [waiter.metrics :as metrics]
             [waiter.statsd :as statsd]
@@ -667,6 +668,7 @@
          {"HOME" home-path
           "LOGNAME" run-as-user
           "USER" run-as-user
+          "WAITER_CLUSTER_NAME" (str (config/retrieve-cluster-name))
           "WAITER_CONCURRENCY_LEVEL" (str concurrency-level)
           "WAITER_CPUS" (str cpus)
           "WAITER_MEM_MB" (str mem)

--- a/waiter/test/waiter/scheduler/cook_test.clj
+++ b/waiter/test/waiter/scheduler/cook_test.clj
@@ -290,7 +290,7 @@
                               "HOME" "/home/path/test-user"
                               "LOGNAME" "test-user"
                               "USER" "test-user"
-                              "WAITER_CLUSTER_NAME" "test-cluster"
+                              "WAITER_CLUSTER" "test-cluster"
                               "WAITER_CONCURRENCY_LEVEL" "1"
                               "WAITER_CPUS" "1"
                               "WAITER_MEM_MB" "1536"

--- a/waiter/test/waiter/scheduler/cook_test.clj
+++ b/waiter/test/waiter/scheduler/cook_test.clj
@@ -18,10 +18,10 @@
             [clj-time.core :as t]
             [clojure.string :as str]
             [clojure.test :refer :all]
+            [waiter.config :as config]
             [waiter.scheduler.cook :refer :all]
             [waiter.mesos.mesos :as mesos]
             [waiter.scheduler :as scheduler]
-            [waiter.test-helpers :as th]
             [waiter.util.date-utils :as du]
             [waiter.util.http-utils :as http-utils]
             [waiter.util.utils :as utils])
@@ -257,8 +257,7 @@
                                      :health-check-url "/healthy"}})))))
 
 (deftest test-create-job-description
-  (th/with-config
-    {:cluster-config {:name "test-cluster"}}
+  (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")]
     (let [service-id->password-fn (fn [service-id] (str service-id "-password"))
           home-path-prefix "/home/path/"
           service-id "test-service-1"

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -23,9 +23,9 @@
             [clojure.walk :as walk]
             [plumbing.core :as pc]
             [slingshot.slingshot :as ss]
+            [waiter.config :as config]
             [waiter.scheduler :as scheduler]
             [waiter.scheduler.kubernetes :refer :all]
-            [waiter.test-helpers :as th]
             [waiter.util.client-tools :as ct]
             [waiter.util.http-utils :as hu]
             [waiter.util.date-utils :as du])
@@ -109,8 +109,7 @@
      (is (= expected# actual#))))
 
 (deftest replicaset-spec-health-check-port-index
-  (th/with-config
-    {:cluster-config {:name "test-cluster"}}
+  (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")]
     (let [service-description (assoc dummy-service-description "health-check-port-index" 2 "ports" 3)
           scheduler (make-dummy-scheduler ["test-service-id"]
                                           {:service-id->service-description-fn (constantly service-description)})
@@ -120,15 +119,13 @@
              (get-in replicaset-spec [:spec :template :metadata :annotations]))))))
 
 (deftest replicaset-spec-no-image
-  (th/with-config
-    {:cluster-config {:name "test-cluster"}}
+  (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")]
     (let [scheduler (make-dummy-scheduler ["test-service-id"])
           replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler "test-service-id" dummy-service-description)]
       (is (= "twosigma/waiter-test-apps:latest" (get-in replicaset-spec [:spec :template :spec :containers 0 :image]))))))
 
 (deftest replicaset-spec-custom-image
-  (th/with-config
-    {:cluster-config {:name "test-cluster"}}
+  (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")]
     (let [scheduler (make-dummy-scheduler ["test-service-id"])
           replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler "test-service-id"
                             (assoc dummy-service-description "image" "custom/image"))]
@@ -574,8 +571,7 @@
         (is (= expected-result actual-result))))))
 
 (deftest test-create-app
-  (th/with-config
-    {:cluster-config {:name "test-cluster"}}
+  (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")]
     (let [service-id "test-service-id"
           service {:service-id service-id}
           descriptor {:service-description dummy-service-description
@@ -603,8 +599,7 @@
             (is (= service actual))))))))
 
 (deftest test-keywords-in-replicaset-spec
-  (th/with-config
-    {:cluster-config {:name "test-cluster"}}
+  (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")]
     (testing "namespaced keywords in annotation keys and values correctly converted"
       (let [service-id "test-service-id"
             descriptor {:service-description dummy-service-description

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -596,7 +596,7 @@
                               "HOME" "/home/path/test-user"
                               "LOGNAME" "test-user"
                               "USER" "test-user"
-                              "WAITER_CLUSTER_NAME" "test-cluster"
+                              "WAITER_CLUSTER" "test-cluster"
                               "WAITER_CONCURRENCY_LEVEL" "1"
                               "WAITER_CPUS" "1"
                               "WAITER_MEM_MB" "1536"

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -21,11 +21,11 @@
             [clojure.test :refer :all]
             [clojure.walk :as walk]
             [slingshot.slingshot :as ss]
+            [waiter.config :as config]
             [waiter.scheduler.marathon :refer :all]
             [waiter.mesos.marathon :as marathon]
             [waiter.mesos.mesos :as mesos]
             [waiter.scheduler :as scheduler]
-            [waiter.test-helpers :as th]
             [waiter.util.date-utils :as du]
             [waiter.util.utils :as utils])
   (:import waiter.scheduler.marathon.MarathonScheduler))
@@ -585,8 +585,7 @@
       map->MarathonScheduler))
 
 (deftest test-marathon-descriptor
-  (th/with-config
-    {:cluster-config {:name "test-cluster"}}
+  (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")]
     (let [service-id->password-fn (fn [service-id] (str service-id "-password"))]
       (testing "basic-test-with-defaults"
         (let [expected {:id "test-service-1"

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -412,7 +412,7 @@
                     :environment {"HOME" (work-dir)
                                   "LOGNAME" nil
                                   "USER" nil
-                                  "WAITER_CLUSTER_NAME" "test-cluster"
+                                  "WAITER_CLUSTER" "test-cluster"
                                   "WAITER_CONCURRENCY_LEVEL" "1"
                                   "WAITER_CPUS" "2"
                                   "WAITER_MEM_MB" "32"
@@ -436,7 +436,7 @@
                     :environment {"HOME" (work-dir)
                                   "LOGNAME" nil
                                   "USER" nil
-                                  "WAITER_CLUSTER_NAME" "test-cluster"
+                                  "WAITER_CLUSTER" "test-cluster"
                                   "WAITER_CONCURRENCY_LEVEL" "1"
                                   "WAITER_CPUS" "2"
                                   "WAITER_MEM_MB" "32"
@@ -460,7 +460,7 @@
                     :environment {"HOME" (work-dir)
                                   "LOGNAME" nil
                                   "USER" nil
-                                  "WAITER_CLUSTER_NAME" "test-cluster"
+                                  "WAITER_CLUSTER" "test-cluster"
                                   "WAITER_CONCURRENCY_LEVEL" "1"
                                   "WAITER_CPUS" "2"
                                   "WAITER_MEM_MB" "32"
@@ -501,7 +501,7 @@
                                       :environment {"HOME" (work-dir)
                                                     "LOGNAME" nil
                                                     "USER" nil
-                                                    "WAITER_CLUSTER_NAME" "test-cluster"
+                                                    "WAITER_CLUSTER" "test-cluster"
                                                     "WAITER_CONCURRENCY_LEVEL" "1"
                                                     "WAITER_CPUS" "2"
                                                     "WAITER_MEM_MB" "32"

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -22,9 +22,9 @@
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [qbits.jet.client.http :as http]
+            [waiter.config :as config]
             [waiter.scheduler :as scheduler]
             [waiter.scheduler.shell :refer :all]
-            [waiter.test-helpers :as th]
             [waiter.util.date-utils :as du]
             [waiter.util.utils :as utils])
   (:import clojure.lang.ExceptionInfo
@@ -162,8 +162,7 @@
             (is (= (map #(+ % port-range-start) (range 1 num-ports)) extra-ports))))))))
 
 (deftest test-directory-content
-  (th/with-config
-    {:cluster-config {:name "test-cluster"}}
+  (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")]
     (let [service-description {"backend-proto" "http"
                                "cmd" "echo Hello, World!"
                                "cpus" 4
@@ -251,8 +250,7 @@
                @port->reservation-atom))))))
 
 (deftest test-create-service-if-new
-  (th/with-config
-    {:cluster-config {:name "test-cluster"}}
+  (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")]
     (let [scheduler (create-shell-scheduler (common-scheduler-config))]
       (is (= {:success true, :result :created, :message "Created foo"}
              (create-test-service scheduler "foo")))
@@ -264,8 +262,7 @@
              (scheduler/delete-service scheduler "foo"))))))
 
 (deftest test-delete-service
-  (th/with-config
-    {:cluster-config {:name "test-cluster"}}
+  (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")]
     (let [scheduler (create-shell-scheduler (common-scheduler-config))]
       (is (= {:success true, :result :created, :message "Created foo"}
              (create-test-service scheduler "foo")))
@@ -277,8 +274,7 @@
       (is (not (scheduler/service-exists? scheduler "foo"))))))
 
 (deftest test-scale-service
-  (th/with-config
-    {:cluster-config {:name "test-cluster"}}
+  (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")]
     (let [scheduler-config (common-scheduler-config)
           scheduler (create-shell-scheduler scheduler-config)]
       ;; Bogus service
@@ -317,8 +313,7 @@
                (task-stats scheduler)))))))
 
 (deftest test-kill-instance
-  (th/with-config
-    {:cluster-config {:name "test-cluster"}}
+  (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")]
     (let [scheduler (create-shell-scheduler (common-scheduler-config))]
       (is (= {:success true, :result :created, :message "Created foo"}
              (create-test-service scheduler "foo")))
@@ -356,8 +351,7 @@
                    (vals @port-reservation-atom)))))))))
 
 (deftest test-health-check-instances
-  (th/with-config
-    {:cluster-config {:name "test-cluster"}}
+  (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")]
     (let [scheduler-config (common-scheduler-config)
           scheduler (create-shell-scheduler scheduler-config)
           health-check-count-atom (atom 0)]
@@ -383,8 +377,7 @@
         (is (= 1 @health-check-count-atom))))))
 
 (deftest test-should-update-task-stats-in-service
-  (th/with-config
-    {:cluster-config {:name "test-cluster"}}
+  (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")]
     (let [scheduler-config (common-scheduler-config)
           scheduler (create-shell-scheduler scheduler-config)]
       (is (= {:success true, :result :created, :message "Created foo"}
@@ -401,8 +394,7 @@
              (scheduler/delete-service scheduler "foo"))))))
 
 (deftest test-get-services
-  (th/with-config
-    {:cluster-config {:name "test-cluster"}}
+  (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")]
     (let [scheduler-config (common-scheduler-config)
           scheduler (create-shell-scheduler scheduler-config)]
       (is (= {:success true, :result :created, :message "Created foo"}
@@ -494,8 +486,7 @@
              (scheduler/delete-service scheduler "baz"))))))
 
 (deftest test-service-id->state
-  (th/with-config
-    {:cluster-config {:name "test-cluster"}}
+  (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")]
     (let [scheduler (create-shell-scheduler (common-scheduler-config))
           instance-id "bar"
           fake-pid 1234
@@ -585,8 +576,7 @@
             (is (= "Unable to reserve 20 ports" (.getMessage ex)))))))))
 
 (deftest test-retry-failed-instances
-  (th/with-config
-    {:cluster-config {:name "test-cluster"}}
+  (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")]
     (let [scheduler-config (common-scheduler-config)
           scheduler (create-shell-scheduler scheduler-config)]
       (is (= {:success true, :result :created, :message "Created foo"}
@@ -606,8 +596,7 @@
              (scheduler/delete-service scheduler "foo"))))))
 
 (deftest test-enforce-grace-period
-  (th/with-config
-    {:cluster-config {:name "test-cluster"}}
+  (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")]
     (let [scheduler-config (common-scheduler-config)
           scheduler (create-shell-scheduler scheduler-config)]
       (is (= {:success true, :result :created, :message "Created foo"}

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -24,6 +24,7 @@
             [qbits.jet.client.http :as http]
             [waiter.scheduler :as scheduler]
             [waiter.scheduler.shell :refer :all]
+            [waiter.test-helpers :as th]
             [waiter.util.date-utils :as du]
             [waiter.util.utils :as utils])
   (:import clojure.lang.ExceptionInfo
@@ -161,21 +162,23 @@
             (is (= (map #(+ % port-range-start) (range 1 num-ports)) extra-ports))))))))
 
 (deftest test-directory-content
-  (let [service-description {"backend-proto" "http"
-                             "cmd" "echo Hello, World!"
-                             "cpus" 4
-                             "mem" 256
-                             "ports" 1}
-        id->service (create-service {} "foo" service-description (constantly "password")
-                                    (work-dir) (atom {}) [0 0] (promise))
-        service-entry (get id->service "foo")
-        [instance-id instance] (-> service-entry :id->instance first)
-        content (directory-content service-entry instance-id "")]
-    (.waitFor (:shell-scheduler/process instance) 100 TimeUnit/MILLISECONDS)
-    (is (= 2 (count content)))
-    (is (some #(= "stdout" (:name %)) content))
-    (is (some #(= "stderr" (:name %)) content))
-    (is (= "Hello, World!\n" (slurp (:url (first (filter #(= "stdout" (:name %)) content))))))))
+  (th/with-config
+    {:cluster-config {:name "test-cluster"}}
+    (let [service-description {"backend-proto" "http"
+                               "cmd" "echo Hello, World!"
+                               "cpus" 4
+                               "mem" 256
+                               "ports" 1}
+          id->service (create-service {} "foo" service-description (constantly "password")
+                                      (work-dir) (atom {}) [0 0] (promise))
+          service-entry (get id->service "foo")
+          [instance-id instance] (-> service-entry :id->instance first)
+          content (directory-content service-entry instance-id "")]
+      (.waitFor (:shell-scheduler/process instance) 100 TimeUnit/MILLISECONDS)
+      (is (= 2 (count content)))
+      (is (some #(= "stdout" (:name %)) content))
+      (is (some #(= "stderr" (:name %)) content))
+      (is (= "Hello, World!\n" (slurp (:url (first (filter #(= "stdout" (:name %)) content)))))))))
 
 (deftest test-pid
   (testing "Getting the pid of a Process"
@@ -248,79 +251,87 @@
                @port->reservation-atom))))))
 
 (deftest test-create-service-if-new
-  (let [scheduler (create-shell-scheduler (common-scheduler-config))]
-    (is (= {:success true, :result :created, :message "Created foo"}
-           (create-test-service scheduler "foo")))
-    (ensure-agent-finished scheduler)
-    (is (= {:success false, :result :already-exists, :message "foo already exists!"}
-           (create-test-service scheduler "foo")))
-    (ensure-agent-finished scheduler)
-    (is (= {:success true, :result :deleted, :message "Deleted foo"}
-           (scheduler/delete-service scheduler "foo")))))
+  (th/with-config
+    {:cluster-config {:name "test-cluster"}}
+    (let [scheduler (create-shell-scheduler (common-scheduler-config))]
+      (is (= {:success true, :result :created, :message "Created foo"}
+             (create-test-service scheduler "foo")))
+      (ensure-agent-finished scheduler)
+      (is (= {:success false, :result :already-exists, :message "foo already exists!"}
+             (create-test-service scheduler "foo")))
+      (ensure-agent-finished scheduler)
+      (is (= {:success true, :result :deleted, :message "Deleted foo"}
+             (scheduler/delete-service scheduler "foo"))))))
 
 (deftest test-delete-service
-  (let [scheduler (create-shell-scheduler (common-scheduler-config))]
-    (is (= {:success true, :result :created, :message "Created foo"}
-           (create-test-service scheduler "foo")))
-    (ensure-agent-finished scheduler)
-    (is (scheduler/service-exists? scheduler "foo"))
-    (is (= {:success true, :result :deleted, :message "Deleted foo"}
-           (scheduler/delete-service scheduler "foo")))
-    (ensure-agent-finished scheduler)
-    (is (not (scheduler/service-exists? scheduler "foo")))))
-
-(deftest test-scale-service
-  (let [scheduler-config (common-scheduler-config)
-        scheduler (create-shell-scheduler scheduler-config)]
-    ;; Bogus service
-    (is (= {:success false, :result :no-such-service-exists, :message "bar does not exist!"}
-           (scheduler/scale-service scheduler "bar" 2 false)))
-    (with-redefs [perform-health-check (constantly true)]
-      ;; Create service, instances: 1
+  (th/with-config
+    {:cluster-config {:name "test-cluster"}}
+    (let [scheduler (create-shell-scheduler (common-scheduler-config))]
       (is (= {:success true, :result :created, :message "Created foo"}
-             (create-test-service scheduler "foo" {"cmd" "sleep 10000"})))
+             (create-test-service scheduler "foo")))
       (ensure-agent-finished scheduler)
       (is (scheduler/service-exists? scheduler "foo"))
-      ;; Scale up, instances: 2
-      (is (= {:success true, :result :scaled, :message "Scaled foo"}
-             (scheduler/scale-service scheduler "foo" 2 false)))
-      (force-maintain-instance-scale scheduler)
-      (force-update-service-health scheduler scheduler-config)
-      (is (= {:running 2, :healthy 2, :unhealthy 0, :staged 0}
-             (task-stats scheduler)))
-      ;; No need to scale down, instances: 2
-      (is (= {:success false, :result :scaling-not-needed, :message "Unable to scale foo"}
-             (scheduler/scale-service scheduler "foo" 1 false)))
+      (is (= {:success true, :result :deleted, :message "Deleted foo"}
+             (scheduler/delete-service scheduler "foo")))
       (ensure-agent-finished scheduler)
-      ;; Successfully kill one instance, instances: 1
-      (let [instance (-> (scheduler/service-id->state scheduler "foo") :id->instance vals first)]
-        (is (= {:killed? true, :success true, :result :deleted, :message (str "Deleted " (:id instance))}
-               (scheduler/kill-instance scheduler instance))))
-      (force-update-service-health scheduler scheduler-config)
-      (is (= {:running 1, :healthy 1, :unhealthy 0, :staged 0}
-             (task-stats scheduler)))
-      ;; Scale up, instances: 2
-      (is (= {:success true, :result :scaled, :message "Scaled foo"}
-             (scheduler/scale-service scheduler "foo" 2 false)))
-      (force-maintain-instance-scale scheduler)
-      (force-update-service-health scheduler scheduler-config)
-      (is (= {:running 2, :healthy 2, :unhealthy 0, :staged 0}
-             (task-stats scheduler))))))
+      (is (not (scheduler/service-exists? scheduler "foo"))))))
+
+(deftest test-scale-service
+  (th/with-config
+    {:cluster-config {:name "test-cluster"}}
+    (let [scheduler-config (common-scheduler-config)
+          scheduler (create-shell-scheduler scheduler-config)]
+      ;; Bogus service
+      (is (= {:success false, :result :no-such-service-exists, :message "bar does not exist!"}
+             (scheduler/scale-service scheduler "bar" 2 false)))
+      (with-redefs [perform-health-check (constantly true)]
+        ;; Create service, instances: 1
+        (is (= {:success true, :result :created, :message "Created foo"}
+               (create-test-service scheduler "foo" {"cmd" "sleep 10000"})))
+        (ensure-agent-finished scheduler)
+        (is (scheduler/service-exists? scheduler "foo"))
+        ;; Scale up, instances: 2
+        (is (= {:success true, :result :scaled, :message "Scaled foo"}
+               (scheduler/scale-service scheduler "foo" 2 false)))
+        (force-maintain-instance-scale scheduler)
+        (force-update-service-health scheduler scheduler-config)
+        (is (= {:running 2, :healthy 2, :unhealthy 0, :staged 0}
+               (task-stats scheduler)))
+        ;; No need to scale down, instances: 2
+        (is (= {:success false, :result :scaling-not-needed, :message "Unable to scale foo"}
+               (scheduler/scale-service scheduler "foo" 1 false)))
+        (ensure-agent-finished scheduler)
+        ;; Successfully kill one instance, instances: 1
+        (let [instance (-> (scheduler/service-id->state scheduler "foo") :id->instance vals first)]
+          (is (= {:killed? true, :success true, :result :deleted, :message (str "Deleted " (:id instance))}
+                 (scheduler/kill-instance scheduler instance))))
+        (force-update-service-health scheduler scheduler-config)
+        (is (= {:running 1, :healthy 1, :unhealthy 0, :staged 0}
+               (task-stats scheduler)))
+        ;; Scale up, instances: 2
+        (is (= {:success true, :result :scaled, :message "Scaled foo"}
+               (scheduler/scale-service scheduler "foo" 2 false)))
+        (force-maintain-instance-scale scheduler)
+        (force-update-service-health scheduler scheduler-config)
+        (is (= {:running 2, :healthy 2, :unhealthy 0, :staged 0}
+               (task-stats scheduler)))))))
 
 (deftest test-kill-instance
-  (let [scheduler (create-shell-scheduler (common-scheduler-config))]
-    (is (= {:success true, :result :created, :message "Created foo"}
-           (create-test-service scheduler "foo")))
-    (ensure-agent-finished scheduler)
-    (with-redefs [perform-health-check (constantly true)]
-      (let [instance (-> (scheduler/service-id->state scheduler "foo") :id->instance vals first)]
-        (is (= {:killed? true, :success true, :result :deleted, :message (str "Deleted " (:id instance))}
-               (scheduler/kill-instance scheduler instance)))
-        (is (= {:success true, :result :deleted, :message "Deleted foo"}
-               (scheduler/delete-service scheduler "foo")))
-        (ensure-agent-finished scheduler)
-        (is (= {:success false, :result :no-such-service-exists, :message "foo does not exist!"}
-               (scheduler/kill-instance scheduler instance)))))))
+  (th/with-config
+    {:cluster-config {:name "test-cluster"}}
+    (let [scheduler (create-shell-scheduler (common-scheduler-config))]
+      (is (= {:success true, :result :created, :message "Created foo"}
+             (create-test-service scheduler "foo")))
+      (ensure-agent-finished scheduler)
+      (with-redefs [perform-health-check (constantly true)]
+        (let [instance (-> (scheduler/service-id->state scheduler "foo") :id->instance vals first)]
+          (is (= {:killed? true, :success true, :result :deleted, :message (str "Deleted " (:id instance))}
+                 (scheduler/kill-instance scheduler instance)))
+          (is (= {:success true, :result :deleted, :message "Deleted foo"}
+                 (scheduler/delete-service scheduler "foo")))
+          (ensure-agent-finished scheduler)
+          (is (= {:success false, :result :no-such-service-exists, :message "foo does not exist!"}
+                 (scheduler/kill-instance scheduler instance))))))))
 
 (deftest test-kill-process
   (testing "Killing a process"
@@ -345,192 +356,204 @@
                    (vals @port-reservation-atom)))))))))
 
 (deftest test-health-check-instances
-  (let [scheduler-config (common-scheduler-config)
-        scheduler (create-shell-scheduler scheduler-config)
-        health-check-count-atom (atom 0)]
-    (is (= {:success true, :result :created, :message "Created foo"}
-           (create-test-service scheduler "foo" {"cmd" "sleep 100000"})))
-    (ensure-agent-finished scheduler)
-    (with-redefs [http/get (fn [_ _]
-                             (swap! health-check-count-atom inc)
-                             (let [c (async/chan)]
-                               (async/go (async/>! c {:status 200}))
-                               c))]
-      (let [instance (-> (scheduler/service-id->state scheduler "foo") :id->instance vals first)]
-        ;; We force a health check to occur
-        (force-update-service-health scheduler scheduler-config)
-        (is (= 1 @health-check-count-atom))
-        ;; Kill the single instance of our service
-        (is (= {:killed? true, :success true, :result :deleted, :message (str "Deleted " (:id instance))}
-               (scheduler/kill-instance scheduler instance))))
+  (th/with-config
+    {:cluster-config {:name "test-cluster"}}
+    (let [scheduler-config (common-scheduler-config)
+          scheduler (create-shell-scheduler scheduler-config)
+          health-check-count-atom (atom 0)]
+      (is (= {:success true, :result :created, :message "Created foo"}
+             (create-test-service scheduler "foo" {"cmd" "sleep 100000"})))
       (ensure-agent-finished scheduler)
-      ;; Force another health check attempt
-      (force-update-service-health scheduler scheduler-config)
-      ;; But, the health check shouldn't happen because the instance is killed
-      (is (= 1 @health-check-count-atom)))))
+      (with-redefs [http/get (fn [_ _]
+                               (swap! health-check-count-atom inc)
+                               (let [c (async/chan)]
+                                 (async/go (async/>! c {:status 200}))
+                                 c))]
+        (let [instance (-> (scheduler/service-id->state scheduler "foo") :id->instance vals first)]
+          ;; We force a health check to occur
+          (force-update-service-health scheduler scheduler-config)
+          (is (= 1 @health-check-count-atom))
+          ;; Kill the single instance of our service
+          (is (= {:killed? true, :success true, :result :deleted, :message (str "Deleted " (:id instance))}
+                 (scheduler/kill-instance scheduler instance))))
+        (ensure-agent-finished scheduler)
+        ;; Force another health check attempt
+        (force-update-service-health scheduler scheduler-config)
+        ;; But, the health check shouldn't happen because the instance is killed
+        (is (= 1 @health-check-count-atom))))))
 
 (deftest test-should-update-task-stats-in-service
-  (let [scheduler-config (common-scheduler-config)
-        scheduler (create-shell-scheduler scheduler-config)]
-    (is (= {:success true, :result :created, :message "Created foo"}
-           (create-test-service scheduler "foo" {"cmd" "sleep 10000"})))
-    (with-redefs [perform-health-check (constantly true)]
-      (force-update-service-health scheduler scheduler-config)
-      (is (= {:running 1, :healthy 1, :unhealthy 0, :staged 0}
-             (task-stats scheduler))))
-    (with-redefs [perform-health-check (constantly false)]
-      (force-update-service-health scheduler scheduler-config)
-      (is (= {:running 1, :healthy 0, :unhealthy 1, :staged 0}
-             (task-stats scheduler))))
-    (is (= {:success true, :result :deleted, :message "Deleted foo"}
-           (scheduler/delete-service scheduler "foo")))))
+  (th/with-config
+    {:cluster-config {:name "test-cluster"}}
+    (let [scheduler-config (common-scheduler-config)
+          scheduler (create-shell-scheduler scheduler-config)]
+      (is (= {:success true, :result :created, :message "Created foo"}
+             (create-test-service scheduler "foo" {"cmd" "sleep 10000"})))
+      (with-redefs [perform-health-check (constantly true)]
+        (force-update-service-health scheduler scheduler-config)
+        (is (= {:running 1, :healthy 1, :unhealthy 0, :staged 0}
+               (task-stats scheduler))))
+      (with-redefs [perform-health-check (constantly false)]
+        (force-update-service-health scheduler scheduler-config)
+        (is (= {:running 1, :healthy 0, :unhealthy 1, :staged 0}
+               (task-stats scheduler))))
+      (is (= {:success true, :result :deleted, :message "Deleted foo"}
+             (scheduler/delete-service scheduler "foo"))))))
 
 (deftest test-get-services
-  (let [scheduler-config (common-scheduler-config)
-        scheduler (create-shell-scheduler scheduler-config)]
-    (is (= {:success true, :result :created, :message "Created foo"}
-           (create-test-service scheduler "foo" {"cmd" "sleep 10000"})))
-    (is (= {:success true, :result :created, :message "Created bar"}
-           (create-test-service scheduler "bar" {"cmd" "sleep 10000"})))
-    (is (= {:success true, :result :created, :message "Created baz"}
-           (create-test-service scheduler "baz" {"cmd" "sleep 10000"})))
-    (ensure-agent-finished scheduler)
-    (is (= (map scheduler/map->Service
-                [{:id "foo"
-                  :instances 1
-                  :task-count 1
-                  :task-stats {:running 1, :healthy 0, :unhealthy 1, :staged 0}
-                  :environment {"HOME" (work-dir)
-                                "LOGNAME" nil
-                                "USER" nil
-                                "WAITER_CONCURRENCY_LEVEL" "1"
-                                "WAITER_CPUS" "2"
-                                "WAITER_MEM_MB" "32"
-                                "WAITER_PASSWORD" "foo.password"
-                                "WAITER_SERVICE_ID" "foo"
-                                "WAITER_USERNAME" "waiter"}
-                  :service-description {"backend-proto" "http"
-                                        "cmd" "sleep 10000"
-                                        "concurrency-level" 1
-                                        "cpus" 2
-                                        "grace-period-secs" 10
-                                        "health-check-port-index" 0
-                                        "health-check-url" "/health-check-url"
-                                        "mem" 32
-                                        "ports" 1}
-                  :shell-scheduler/mem 32}
-                 {:id "bar"
-                  :instances 1
-                  :task-count 1
-                  :task-stats {:running 1, :healthy 0, :unhealthy 1, :staged 0}
-                  :environment {"HOME" (work-dir)
-                                "LOGNAME" nil
-                                "USER" nil
-                                "WAITER_CONCURRENCY_LEVEL" "1"
-                                "WAITER_CPUS" "2"
-                                "WAITER_MEM_MB" "32"
-                                "WAITER_PASSWORD" "bar.password"
-                                "WAITER_SERVICE_ID" "bar"
-                                "WAITER_USERNAME" "waiter"}
-                  :service-description {"backend-proto" "http"
-                                        "cmd" "sleep 10000"
-                                        "concurrency-level" 1
-                                        "cpus" 2
-                                        "grace-period-secs" 10
-                                        "health-check-port-index" 0
-                                        "health-check-url" "/health-check-url"
-                                        "mem" 32
-                                        "ports" 1}
-                  :shell-scheduler/mem 32}
-                 {:id "baz"
-                  :instances 1
-                  :task-count 1
-                  :task-stats {:running 1, :healthy 0, :unhealthy 1, :staged 0}
-                  :environment {"HOME" (work-dir)
-                                "LOGNAME" nil
-                                "USER" nil
-                                "WAITER_CONCURRENCY_LEVEL" "1"
-                                "WAITER_CPUS" "2"
-                                "WAITER_MEM_MB" "32"
-                                "WAITER_PASSWORD" "baz.password"
-                                "WAITER_SERVICE_ID" "baz"
-                                "WAITER_USERNAME" "waiter"}
-                  :service-description {"backend-proto" "http"
-                                        "cmd" "sleep 10000"
-                                        "concurrency-level" 1
-                                        "cpus" 2
-                                        "grace-period-secs" 10
-                                        "health-check-port-index" 0
-                                        "health-check-url" "/health-check-url"
-                                        "mem" 32
-                                        "ports" 1}
-                  :shell-scheduler/mem 32}])
-           (scheduler/get-services scheduler)))
-    (is (= {:success true, :result :deleted, :message "Deleted foo"}
-           (scheduler/delete-service scheduler "foo")))
-    (is (= {:success true, :result :deleted, :message "Deleted bar"}
-           (scheduler/delete-service scheduler "bar")))
-    (is (= {:success true, :result :deleted, :message "Deleted baz"}
-           (scheduler/delete-service scheduler "baz")))))
+  (th/with-config
+    {:cluster-config {:name "test-cluster"}}
+    (let [scheduler-config (common-scheduler-config)
+          scheduler (create-shell-scheduler scheduler-config)]
+      (is (= {:success true, :result :created, :message "Created foo"}
+             (create-test-service scheduler "foo" {"cmd" "sleep 10000"})))
+      (is (= {:success true, :result :created, :message "Created bar"}
+             (create-test-service scheduler "bar" {"cmd" "sleep 10000"})))
+      (is (= {:success true, :result :created, :message "Created baz"}
+             (create-test-service scheduler "baz" {"cmd" "sleep 10000"})))
+      (ensure-agent-finished scheduler)
+      (is (= (map scheduler/map->Service
+                  [{:id "foo"
+                    :instances 1
+                    :task-count 1
+                    :task-stats {:running 1, :healthy 0, :unhealthy 1, :staged 0}
+                    :environment {"HOME" (work-dir)
+                                  "LOGNAME" nil
+                                  "USER" nil
+                                  "WAITER_CLUSTER_NAME" "test-cluster"
+                                  "WAITER_CONCURRENCY_LEVEL" "1"
+                                  "WAITER_CPUS" "2"
+                                  "WAITER_MEM_MB" "32"
+                                  "WAITER_PASSWORD" "foo.password"
+                                  "WAITER_SERVICE_ID" "foo"
+                                  "WAITER_USERNAME" "waiter"}
+                    :service-description {"backend-proto" "http"
+                                          "cmd" "sleep 10000"
+                                          "concurrency-level" 1
+                                          "cpus" 2
+                                          "grace-period-secs" 10
+                                          "health-check-port-index" 0
+                                          "health-check-url" "/health-check-url"
+                                          "mem" 32
+                                          "ports" 1}
+                    :shell-scheduler/mem 32}
+                   {:id "bar"
+                    :instances 1
+                    :task-count 1
+                    :task-stats {:running 1, :healthy 0, :unhealthy 1, :staged 0}
+                    :environment {"HOME" (work-dir)
+                                  "LOGNAME" nil
+                                  "USER" nil
+                                  "WAITER_CLUSTER_NAME" "test-cluster"
+                                  "WAITER_CONCURRENCY_LEVEL" "1"
+                                  "WAITER_CPUS" "2"
+                                  "WAITER_MEM_MB" "32"
+                                  "WAITER_PASSWORD" "bar.password"
+                                  "WAITER_SERVICE_ID" "bar"
+                                  "WAITER_USERNAME" "waiter"}
+                    :service-description {"backend-proto" "http"
+                                          "cmd" "sleep 10000"
+                                          "concurrency-level" 1
+                                          "cpus" 2
+                                          "grace-period-secs" 10
+                                          "health-check-port-index" 0
+                                          "health-check-url" "/health-check-url"
+                                          "mem" 32
+                                          "ports" 1}
+                    :shell-scheduler/mem 32}
+                   {:id "baz"
+                    :instances 1
+                    :task-count 1
+                    :task-stats {:running 1, :healthy 0, :unhealthy 1, :staged 0}
+                    :environment {"HOME" (work-dir)
+                                  "LOGNAME" nil
+                                  "USER" nil
+                                  "WAITER_CLUSTER_NAME" "test-cluster"
+                                  "WAITER_CONCURRENCY_LEVEL" "1"
+                                  "WAITER_CPUS" "2"
+                                  "WAITER_MEM_MB" "32"
+                                  "WAITER_PASSWORD" "baz.password"
+                                  "WAITER_SERVICE_ID" "baz"
+                                  "WAITER_USERNAME" "waiter"}
+                    :service-description {"backend-proto" "http"
+                                          "cmd" "sleep 10000"
+                                          "concurrency-level" 1
+                                          "cpus" 2
+                                          "grace-period-secs" 10
+                                          "health-check-port-index" 0
+                                          "health-check-url" "/health-check-url"
+                                          "mem" 32
+                                          "ports" 1}
+                    :shell-scheduler/mem 32}])
+             (scheduler/get-services scheduler)))
+      (is (= {:success true, :result :deleted, :message "Deleted foo"}
+             (scheduler/delete-service scheduler "foo")))
+      (is (= {:success true, :result :deleted, :message "Deleted bar"}
+             (scheduler/delete-service scheduler "bar")))
+      (is (= {:success true, :result :deleted, :message "Deleted baz"}
+             (scheduler/delete-service scheduler "baz"))))))
 
 (deftest test-service-id->state
-  (let [scheduler (create-shell-scheduler (common-scheduler-config))
-        instance-id "bar"
-        fake-pid 1234
-        started-at (t/now)
-        instance-dir (str (work-dir) "/foo/foo." instance-id)
-        port 10000
-        expected-state {:service (scheduler/make-Service
-                                   {:id "foo"
-                                    :instances 1
-                                    :task-count 1
-                                    :task-stats {:running 1, :healthy 0, :unhealthy 1, :staged 0}
-                                    :environment {"HOME" (work-dir)
-                                                  "LOGNAME" nil
-                                                  "USER" nil
-                                                  "WAITER_CONCURRENCY_LEVEL" "1"
-                                                  "WAITER_CPUS" "2"
-                                                  "WAITER_MEM_MB" "32"
-                                                  "WAITER_PASSWORD" "foo.password"
-                                                  "WAITER_SERVICE_ID" "foo"
-                                                  "WAITER_USERNAME" "waiter"}
-                                    :service-description {"backend-proto" "http"
-                                                          "cmd" "ls"
-                                                          "concurrency-level" 1
-                                                          "cpus" 2
-                                                          "grace-period-secs" 10
-                                                          "health-check-port-index" 0
-                                                          "health-check-url" "/health-check-url"
-                                                          "mem" 32
-                                                          "ports" 1}
-                                    :shell-scheduler/mem 32})
-                        :id->instance {"foo.bar"
-                                       (scheduler/make-ServiceInstance
-                                         {:id "foo.bar"
-                                          :service-id "foo"
-                                          :started-at started-at
-                                          :port port
-                                          :log-directory instance-dir
-                                          :shell-scheduler/working-directory instance-dir
-                                          :shell-scheduler/pid fake-pid})}
-                        :syncer {:syncer-state "foo"}}
-        process-keys [:id->instance "foo.bar" :shell-scheduler/process]
-        host-keys [:id->instance "foo.bar" :host]]
-    (with-redefs [pid (constantly fake-pid)
-                  utils/unique-identifier (constantly instance-id)
-                  t/now (constantly started-at)
-                  reserve-port! (constantly port)]
-      (is (= {:success true, :result :created, :message "Created foo"}
-             (create-test-service scheduler "foo"))))
-    (ensure-agent-finished scheduler)
-    (let [result (scheduler/service-id->state scheduler "foo")]
-      (log/debug "service state:" result)
-      (is (= (-> expected-state
-                 (assoc-in process-keys (get-in result process-keys))
-                 (assoc-in host-keys (get-in result host-keys)))
-             result)))
-    (is (= {:success true, :result :deleted, :message "Deleted foo"}
-           (scheduler/delete-service scheduler "foo")))))
+  (th/with-config
+    {:cluster-config {:name "test-cluster"}}
+    (let [scheduler (create-shell-scheduler (common-scheduler-config))
+          instance-id "bar"
+          fake-pid 1234
+          started-at (t/now)
+          instance-dir (str (work-dir) "/foo/foo." instance-id)
+          port 10000
+          expected-state {:service (scheduler/make-Service
+                                     {:id "foo"
+                                      :instances 1
+                                      :task-count 1
+                                      :task-stats {:running 1, :healthy 0, :unhealthy 1, :staged 0}
+                                      :environment {"HOME" (work-dir)
+                                                    "LOGNAME" nil
+                                                    "USER" nil
+                                                    "WAITER_CLUSTER_NAME" "test-cluster"
+                                                    "WAITER_CONCURRENCY_LEVEL" "1"
+                                                    "WAITER_CPUS" "2"
+                                                    "WAITER_MEM_MB" "32"
+                                                    "WAITER_PASSWORD" "foo.password"
+                                                    "WAITER_SERVICE_ID" "foo"
+                                                    "WAITER_USERNAME" "waiter"}
+                                      :service-description {"backend-proto" "http"
+                                                            "cmd" "ls"
+                                                            "concurrency-level" 1
+                                                            "cpus" 2
+                                                            "grace-period-secs" 10
+                                                            "health-check-port-index" 0
+                                                            "health-check-url" "/health-check-url"
+                                                            "mem" 32
+                                                            "ports" 1}
+                                      :shell-scheduler/mem 32})
+                          :id->instance {"foo.bar"
+                                         (scheduler/make-ServiceInstance
+                                           {:id "foo.bar"
+                                            :service-id "foo"
+                                            :started-at started-at
+                                            :port port
+                                            :log-directory instance-dir
+                                            :shell-scheduler/working-directory instance-dir
+                                            :shell-scheduler/pid fake-pid})}
+                          :syncer {:syncer-state "foo"}}
+          process-keys [:id->instance "foo.bar" :shell-scheduler/process]
+          host-keys [:id->instance "foo.bar" :host]]
+      (with-redefs [pid (constantly fake-pid)
+                    utils/unique-identifier (constantly instance-id)
+                    t/now (constantly started-at)
+                    reserve-port! (constantly port)]
+        (is (= {:success true, :result :created, :message "Created foo"}
+               (create-test-service scheduler "foo"))))
+      (ensure-agent-finished scheduler)
+      (let [result (scheduler/service-id->state scheduler "foo")]
+        (log/debug "service state:" result)
+        (is (= (-> expected-state
+                   (assoc-in process-keys (get-in result process-keys))
+                   (assoc-in host-keys (get-in result host-keys)))
+               result)))
+      (is (= {:success true, :result :deleted, :message "Deleted foo"}
+             (scheduler/delete-service scheduler "foo"))))))
 
 (deftest test-port-reserved?
   (let [port->reservation-atom (atom {})
@@ -562,36 +585,40 @@
             (is (= "Unable to reserve 20 ports" (.getMessage ex)))))))))
 
 (deftest test-retry-failed-instances
-  (let [scheduler-config (common-scheduler-config)
-        scheduler (create-shell-scheduler scheduler-config)]
-    (is (= {:success true, :result :created, :message "Created foo"}
-           (create-test-service scheduler "foo" {"cmd" "exit 1" "mem" 0.1})))
-    ;; Instance should get marked as failed
-    (force-update-service-health scheduler scheduler-config)
-    (let [instances (-> (scheduler/service-id->state scheduler "foo") :id->instance vals)
-          failed-instances (filter :failed? instances)]
-      (is (= 1 (count failed-instances))))
-    ;; Loop should continue to launch additional instances after initial failure
-    (force-maintain-instance-scale scheduler)
-    (force-update-service-health scheduler scheduler-config)
-    (let [instances (-> (scheduler/service-id->state scheduler "foo") :id->instance vals)
-          failed-instances (filter :failed? instances)]
-      (is (= 2 (count failed-instances))))
-    (is (= {:success true, :result :deleted, :message "Deleted foo"}
-           (scheduler/delete-service scheduler "foo")))))
+  (th/with-config
+    {:cluster-config {:name "test-cluster"}}
+    (let [scheduler-config (common-scheduler-config)
+          scheduler (create-shell-scheduler scheduler-config)]
+      (is (= {:success true, :result :created, :message "Created foo"}
+             (create-test-service scheduler "foo" {"cmd" "exit 1" "mem" 0.1})))
+      ;; Instance should get marked as failed
+      (force-update-service-health scheduler scheduler-config)
+      (let [instances (-> (scheduler/service-id->state scheduler "foo") :id->instance vals)
+            failed-instances (filter :failed? instances)]
+        (is (= 1 (count failed-instances))))
+      ;; Loop should continue to launch additional instances after initial failure
+      (force-maintain-instance-scale scheduler)
+      (force-update-service-health scheduler scheduler-config)
+      (let [instances (-> (scheduler/service-id->state scheduler "foo") :id->instance vals)
+            failed-instances (filter :failed? instances)]
+        (is (= 2 (count failed-instances))))
+      (is (= {:success true, :result :deleted, :message "Deleted foo"}
+             (scheduler/delete-service scheduler "foo"))))))
 
 (deftest test-enforce-grace-period
-  (let [scheduler-config (common-scheduler-config)
-        scheduler (create-shell-scheduler scheduler-config)]
-    (is (= {:success true, :result :created, :message "Created foo"}
-           (create-test-service scheduler "foo" {"cmd" "sleep 10000" "grace-period-secs" 0})))
-    ;; Instance should be marked as unhealthy and failed
-    (with-redefs [perform-health-check (constantly false)]
-      (force-update-service-health scheduler scheduler-config))
-    (let [instances (-> (scheduler/service-id->state scheduler "foo") :id->instance vals)
-          failed-instances (filter :failed? instances)]
-      (is (zero? (- (count instances) (count failed-instances))))
-      (is (= 1 (count failed-instances))))))
+  (th/with-config
+    {:cluster-config {:name "test-cluster"}}
+    (let [scheduler-config (common-scheduler-config)
+          scheduler (create-shell-scheduler scheduler-config)]
+      (is (= {:success true, :result :created, :message "Created foo"}
+             (create-test-service scheduler "foo" {"cmd" "sleep 10000" "grace-period-secs" 0})))
+      ;; Instance should be marked as unhealthy and failed
+      (with-redefs [perform-health-check (constantly false)]
+        (force-update-service-health scheduler scheduler-config))
+      (let [instances (-> (scheduler/service-id->state scheduler "foo") :id->instance vals)
+            failed-instances (filter :failed? instances)]
+        (is (zero? (- (count instances) (count failed-instances))))
+        (is (= 1 (count failed-instances)))))))
 
 (deftest test-pid->memory
   (with-redefs [sh/sh (fn [& _]

--- a/waiter/test/waiter/test_helpers.clj
+++ b/waiter/test/waiter/test_helpers.clj
@@ -236,12 +236,3 @@
       (throw (ex-info (str fail " failure(s)") m)))
     (when-not (zero? error)
       (throw (ex-info (str error " error(s)") m)))))
-
-(defmacro with-config
-  "Runs the body under the specified config."
-  [config-value & body]
-  `(let [test-config# (promise)
-         config-value# ~config-value]
-     (deliver test-config# config-value#)
-     (with-redefs [config/config-promise test-config#]
-       ~@body)))

--- a/waiter/test/waiter/test_helpers.clj
+++ b/waiter/test/waiter/test_helpers.clj
@@ -21,7 +21,6 @@
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [clojure.tools.namespace.find :as find]
-            [waiter.config :as config]
             [waiter.correlation-id :as cid]
             [waiter.util.client-tools :as ct])
   (:import java.io.ByteArrayOutputStream
@@ -236,3 +235,4 @@
       (throw (ex-info (str fail " failure(s)") m)))
     (when-not (zero? error)
       (throw (ex-info (str error " error(s)") m)))))
+

--- a/waiter/test/waiter/test_helpers.clj
+++ b/waiter/test/waiter/test_helpers.clj
@@ -21,6 +21,7 @@
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [clojure.tools.namespace.find :as find]
+            [waiter.config :as config]
             [waiter.correlation-id :as cid]
             [waiter.util.client-tools :as ct])
   (:import java.io.ByteArrayOutputStream
@@ -236,3 +237,11 @@
     (when-not (zero? error)
       (throw (ex-info (str error " error(s)") m)))))
 
+(defmacro with-config
+  "Runs the body under the specified config."
+  [config-value & body]
+  `(let [test-config# (promise)
+         config-value# ~config-value]
+     (deliver test-config# config-value#)
+     (with-redefs [config/config-promise test-config#]
+       ~@body)))


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for waiter cluster name env variable

## Why are we making these changes?

We would like to allow services launched via Waiter to know which Waiter cluster they are running on. This allows the service to make cluster-specific decisions inside its configuration.

### Note:

This PR also exposes the settings in a promise inside `config.clj` enabling mount-like behavior inside waiter for the settings which are effectively constants. This allows us to avoid threading through the cluster name across all the schedulers down to the function that builds the environment. The dependency on the need for the config is still explicit as the tests need to introduce the appropriate `with-redef`.