### PR TITLE
Token syncer additional success scenarios

### DIFF
--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -446,7 +446,7 @@
           (cleanup-token waiter-api waiter-urls token-name))))))
 
 (deftest ^:integration test-token-different-roots
-  (testing "token sync update with different owners and different roots"
+  (testing "token sync update with different roots"
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
           limit 10
@@ -523,6 +523,189 @@
                         (is (= {:description (assoc basic-description
                                                "cluster" (waiter-url->cluster waiter-url)
                                                "cpus" (inc index)
+                                               "last-update-time" token-last-modified-time
+                                               "last-update-user" "auth-user"
+                                               "owner" "test-user"
+                                               "previous" {"last-update-time" (- current-time-ms 30000)
+                                                           "last-update-user" "foo-user"}
+                                               "root" waiter-url)
+                                :headers {"content-type" "application/json"
+                                          "etag" token-etag}
+                                :status 200
+                                :token-etag token-etag}
+                               (load-token waiter-url token-name)))))
+                    waiter-urls))))))
+        (finally
+          (cleanup-token waiter-api waiter-urls token-name))))))
+
+(deftest ^:integration test-token-different-roots-and-deleted
+  (testing "token sync update deleted tokens with different different roots"
+    (let [waiter-urls (waiter-urls)
+          {:keys [load-token store-token] :as waiter-api} (waiter-api)
+          limit 10
+          token-name (str "test-token-different-roots-and-deleted-" (UUID/randomUUID))]
+      (try
+        ;; ARRANGE
+        (let [current-time-ms (System/currentTimeMillis)
+              last-update-time-ms (- current-time-ms 10000)]
+
+          (doall
+            (map-indexed
+              (fn [index waiter-url]
+                (store-token waiter-url token-name nil
+                             (assoc basic-description
+                               "cluster" (waiter-url->cluster waiter-url)
+                               "cpus" (inc index)
+                               "deleted" true
+                               "last-update-time" (- last-update-time-ms index)
+                               "last-update-user" "auth-user"
+                               "owner" "test-user"
+                               "previous" {"last-update-time" (- current-time-ms 30000)
+                                           "last-update-user" "foo-user"}
+                               "root" waiter-url)))
+              waiter-urls))
+
+          (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
+
+            ;; ACT
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit)]
+
+              ;; ASSERT
+              (let [latest-description (assoc basic-description
+                                         "cluster" (waiter-url->cluster (first waiter-urls))
+                                         "cpus" 1
+                                         "deleted" true
+                                         "last-update-time" last-update-time-ms
+                                         "last-update-user" "auth-user"
+                                         "owner" "test-user"
+                                         "previous" {"last-update-time" (- current-time-ms 30000)
+                                                     "last-update-user" "foo-user"}
+                                         "root" (first waiter-urls))
+                    sync-result (->> (rest waiter-urls)
+                                     (map-indexed
+                                       (fn [index waiter-url]
+                                         [waiter-url
+                                          {:code :error/root-mismatch
+                                           :details {:cluster (assoc basic-description
+                                                                "cluster" (waiter-url->cluster waiter-url)
+                                                                "cpus" (+ index 2)
+                                                                "deleted" true
+                                                                "last-update-time" (- last-update-time-ms index 1)
+                                                                "last-update-user" "auth-user"
+                                                                "owner" "test-user"
+                                                                "previous" {"last-update-time" (- current-time-ms 30000)
+                                                                            "last-update-user" "foo-user"}
+                                                                "root" waiter-url)
+                                                     :latest latest-description}}]))
+                                     (into {}))
+                    expected-result {:details {token-name {:latest {:cluster-url (first waiter-urls)
+                                                                    :description latest-description
+                                                                    :token-etag token-etag}
+                                                           :sync-result sync-result}}
+                                     :summary {:sync {:failed #{token-name}
+                                                      :unmodified #{}
+                                                      :updated #{}}
+                                               :tokens {:pending {:count 1 :value #{token-name}}
+                                                        :previously-synced {:count 0 :value #{}}
+                                                        :processed {:count 1 :value #{token-name}}
+                                                        :selected {:count 1 :value #{token-name}}
+                                                        :total {:count 1 :value #{token-name}}}}}]
+                (is (= expected-result actual-result))
+                (doall
+                  (map-indexed
+                    (fn [index waiter-url]
+                      (let [token-last-modified-time (- last-update-time-ms index)]
+                        (is (= {:description (assoc basic-description
+                                               "cluster" (waiter-url->cluster waiter-url)
+                                               "cpus" (inc index)
+                                               "deleted" true
+                                               "last-update-time" token-last-modified-time
+                                               "last-update-user" "auth-user"
+                                               "owner" "test-user"
+                                               "previous" {"last-update-time" (- current-time-ms 30000)
+                                                           "last-update-user" "foo-user"}
+                                               "root" waiter-url)
+                                :headers {"content-type" "application/json"}
+                                :status 200 }
+                               (load-token waiter-url token-name)))))
+                    waiter-urls))))))
+        (finally
+          (cleanup-token waiter-api waiter-urls token-name))))))
+
+(deftest ^:integration test-token-different-root-and-system-metadata-only
+  (testing "token sync update with different difference only in roots and system metadata"
+    (let [waiter-urls (waiter-urls)
+          {:keys [load-token store-token] :as waiter-api} (waiter-api)
+          limit 10
+          token-name (str "test-token-different-root-and-metadata-only-" (UUID/randomUUID))]
+      (try
+        ;; ARRANGE
+        (let [current-time-ms (System/currentTimeMillis)
+              last-update-time-ms (- current-time-ms 10000)]
+
+          (doall
+            (map-indexed
+              (fn [index waiter-url]
+                (store-token waiter-url token-name nil
+                             (assoc basic-description
+                               "cluster" (waiter-url->cluster waiter-url)
+                               "last-update-time" (- last-update-time-ms index)
+                               "last-update-user" "auth-user"
+                               "owner" "test-user"
+                               "previous" {"last-update-time" (- current-time-ms 30000)
+                                           "last-update-user" "foo-user"}
+                               "root" waiter-url)))
+              waiter-urls))
+
+          (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
+
+            ;; ACT
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit)]
+
+              ;; ASSERT
+              (let [latest-description (assoc basic-description
+                                         "cluster" (waiter-url->cluster (first waiter-urls))
+                                         "last-update-time" last-update-time-ms
+                                         "last-update-user" "auth-user"
+                                         "owner" "test-user"
+                                         "previous" {"last-update-time" (- current-time-ms 30000)
+                                                     "last-update-user" "foo-user"}
+                                         "root" (first waiter-urls))
+                    sync-result (->> (rest waiter-urls)
+                                     (map-indexed
+                                       (fn [index waiter-url]
+                                         [waiter-url
+                                          {:code :error/root-mismatch
+                                           :details {:cluster (assoc basic-description
+                                                                "cluster" (waiter-url->cluster waiter-url)
+                                                                "last-update-time" (- last-update-time-ms index 1)
+                                                                "last-update-user" "auth-user"
+                                                                "owner" "test-user"
+                                                                "previous" {"last-update-time" (- current-time-ms 30000)
+                                                                            "last-update-user" "foo-user"}
+                                                                "root" waiter-url)
+                                                     :latest latest-description}}]))
+                                     (into {}))
+                    expected-result {:details {token-name {:latest {:cluster-url (first waiter-urls)
+                                                                    :description latest-description
+                                                                    :token-etag token-etag}
+                                                           :sync-result sync-result}}
+                                     :summary {:sync {:failed #{token-name}
+                                                      :unmodified #{}
+                                                      :updated #{}}
+                                               :tokens {:pending {:count 1 :value #{token-name}}
+                                                        :previously-synced {:count 0 :value #{}}
+                                                        :processed {:count 1 :value #{token-name}}
+                                                        :selected {:count 1 :value #{token-name}}
+                                                        :total {:count 1 :value #{token-name}}}}}]
+                (is (= expected-result actual-result))
+                (doall
+                  (map-indexed
+                    (fn [index waiter-url]
+                      (let [token-last-modified-time (- last-update-time-ms index)
+                            token-etag (token->etag waiter-api waiter-url token-name)]
+                        (is (= {:description (assoc basic-description
+                                               "cluster" (waiter-url->cluster waiter-url)
                                                "last-update-time" token-last-modified-time
                                                "last-update-user" "auth-user"
                                                "owner" "test-user"

--- a/token-syncer/src/token_syncer/commands/syncer.clj
+++ b/token-syncer/src/token_syncer/commands/syncer.clj
@@ -106,7 +106,7 @@
                   (and (get latest-token-description "deleted")
                        (get description "deleted"))
                   {:code :error/tokens-deleted
-                   :details {:message "token deleted on both clusters should be handled separately"}}
+                   :details {:message "soft-deleted tokens should have already been hard-deleted"}}
 
                   ;; active token, content the same irrespective of system metadata keys but roots different
                   (and (seq description)

--- a/token-syncer/test/token_syncer/commands/syncer_test.clj
+++ b/token-syncer/test/token_syncer/commands/syncer_test.clj
@@ -301,7 +301,7 @@
                                                           :status 200}}]
         (is (= {"www.cluster-1.com" {:code :success/token-match}
                 "www.cluster-2.com" {:code :error/tokens-deleted
-                                     :details {:message "token deleted on both clusters should be handled separately"}}}
+                                     :details {:message "soft-deleted tokens should have already been hard-deleted"}}}
                (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 cluster-url->token-data)))))
 
     (testing "sync cluster same owner, different parameters and root"

--- a/token-syncer/test/token_syncer/commands/syncer_test.clj
+++ b/token-syncer/test/token_syncer/commands/syncer_test.clj
@@ -261,9 +261,7 @@
                                                           :token-etag (str test-token-etag ".2")
                                                           :status 200}}]
         (is (= {"www.cluster-1.com" {:code :success/token-match}
-                "www.cluster-2.com" {:code :success/sync-update
-                                     :details {:etag (str test-token-etag ".2.new")
-                                               :status 200}}}
+                "www.cluster-2.com" {:code :skip/token-sync}}
                (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 cluster-url->token-data)))))
 
     (testing "sync cluster same owner, soft-deleted on one and different root"
@@ -285,6 +283,25 @@
                 "www.cluster-2.com" {:code :error/root-mismatch
                                      :details {:cluster token-description-2
                                                :latest token-description-1}}}
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 cluster-url->token-data)))))
+
+    (testing "sync cluster different root and parameters, deleted on both"
+      (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
+            test-token "test-token-1"
+            token-description {"mem" 1024
+                               "name" "test-name"
+                               "owner" "test-user-1"}
+            token-description-1 (assoc token-description "cpus" 1 "deleted" true "root" "cluster-1")
+            token-description-2 (assoc token-description "cpus" 2 "deleted" true "root" "cluster-2")
+            cluster-url->token-data {"www.cluster-1.com" {:description token-description-1
+                                                          :token-etag (str test-token-etag ".1")
+                                                          :status 200}
+                                     "www.cluster-2.com" {:description token-description-2
+                                                          :token-etag (str test-token-etag ".2")
+                                                          :status 200}}]
+        (is (= {"www.cluster-1.com" {:code :success/token-match}
+                "www.cluster-2.com" {:code :error/tokens-deleted
+                                     :details {:message "token deleted on both clusters should be handled separately"}}}
                (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 cluster-url->token-data)))))
 
     (testing "sync cluster same owner, different parameters and root"
@@ -509,9 +526,9 @@
         cluster-2 "www.cluster-2.com"
         cluster-3 "www.cluster-3.com"
         cluster-urls [cluster-1 cluster-2 cluster-3]
-        cluster-url->tokens {cluster-1 ["token-1" "token-2"]
-                             cluster-2 ["token-1" "token-2" "token-3" "token-4"]
-                             cluster-3 ["token-1" "token-3"]}
+        cluster-url->tokens {cluster-1 ["token-1" "token-2" "token-5" "token-6"]
+                             cluster-2 ["token-1" "token-2" "token-3" "token-4" "token-5" "token-6"]
+                             cluster-3 ["token-1" "token-3" "token-5" "token-6"]}
         token-desc-1 {"last-update-time" current-time-ms
                       "name" "t1-all-synced"}
         token-desc-2 {"last-update-time" current-time-ms
@@ -545,6 +562,26 @@
                                                    cluster-2 {:description token-desc-4
                                                               :token-etag current-time-ms}
                                                    cluster-3 {:description token-desc-4
+                                                              :token-etag current-time-ms}}
+                                        "token-5" {cluster-1 {:description (assoc token-desc-4
+                                                                             "cpus" 1
+                                                                             "root" cluster-1)
+                                                              :token-etag current-time-ms}
+                                                   cluster-2 {:description (assoc token-desc-4
+                                                                             "cpus" 2
+                                                                             "last-update-time" previous-time-ms
+                                                                             "root" cluster-2)
+                                                              :token-etag current-time-ms}
+                                                   cluster-3 {:description (assoc token-desc-4
+                                                                             "cpus" 3
+                                                                             "last-update-time" previous-time-ms
+                                                                             "root" cluster-1)
+                                                              :token-etag previous-time-ms}}
+                                        "token-6" {cluster-1 {:description (assoc token-desc-1 "cpus" 6 "root" cluster-1)
+                                                              :token-etag current-time-ms}
+                                                   cluster-2 {:description (assoc token-desc-1 "cpus" 6 "root" cluster-2)
+                                                              :token-etag current-time-ms}
+                                                   cluster-3 {:description (assoc token-desc-1 "cpus" 6 "root" cluster-3)
                                                               :token-etag current-time-ms}}}
         token->latest-description {"token-1" {:cluster-url cluster-1
                                               :description token-desc-1
@@ -557,7 +594,13 @@
                                               :token-etag (str (get token-desc-3 "last-update-time"))}
                                    "token-4" {:cluster-url cluster-1
                                               :description token-desc-4
-                                              :token-etag (str (get token-desc-4 "last-update-time"))}}
+                                              :token-etag (str (get token-desc-4 "last-update-time"))}
+                                   "token-5" {:cluster-url cluster-1
+                                              :description (assoc token-desc-4 "cpus" 1 "root" "c2")
+                                              :token-etag (str (get token-desc-4 "last-update-time"))}
+                                   "token-6" {:cluster-url cluster-1
+                                              :description (assoc token-desc-1 "cpus" 6 "root" cluster-1)
+                                              :token-etag (str (get token-desc-1 "last-update-time"))}}
         compute-sync-result (fn [cluster-urls token code]
                               (pc/map-from-keys
                                 (fn [cluster-url]
@@ -579,7 +622,7 @@
                              vec)))}]
     (with-redefs [retrieve-token->url->token-data (fn [_ in-cluster-urls all-tokens]
                                                     (is (= (set cluster-urls) in-cluster-urls))
-                                                    (is (= #{"token-2" "token-3" "token-4"}
+                                                    (is (= #{"token-2" "token-3" "token-4" "token-5"}
                                                            (set all-tokens)))
                                                     token->cluster-url->token-data)
                   retrieve-token->latest-description (fn [in-token->cluster-url->token-data]
@@ -604,16 +647,19 @@
                                             (compute-sync-result "token-3" :success/soft-delete))}
                 "token-4" {:latest (token->latest-description "token-4")
                            :sync-result (-> [cluster-1 cluster-2 cluster-3]
-                                            (compute-sync-result "token-4" :success/hard-delete))}}
+                                            (compute-sync-result "token-4" :success/hard-delete))}
+                "token-5" {:latest (token->latest-description "token-5")
+                           :sync-result (-> [cluster-1 cluster-2 cluster-3]
+                                            (compute-sync-result "token-5" :success/hard-delete))}}
                details))
         (is (= {:sync {:failed #{}
                        :unmodified #{}
-                       :updated #{"token-2" "token-3" "token-4"}}
-                :tokens {:pending {:count 3 :value #{"token-2" "token-3" "token-4"}}
-                         :previously-synced {:count 1 :value #{"token-1"}}
-                         :processed {:count 3 :value #{"token-2" "token-3" "token-4"}}
-                         :selected {:count 3 :value #{"token-2" "token-3" "token-4"}}
-                         :total {:count 4 :value #{"token-1" "token-2" "token-3" "token-4"}}}}
+                       :updated #{"token-2" "token-3" "token-4" "token-5"}}
+                :tokens {:pending {:count 4 :value #{"token-2" "token-3" "token-4" "token-5"}}
+                         :previously-synced {:count 2 :value #{"token-1" "token-6"}}
+                         :processed {:count 4 :value #{"token-2" "token-3" "token-4" "token-5"}}
+                         :selected {:count 4 :value #{"token-2" "token-3" "token-4" "token-5"}}
+                         :total {:count 6 :value #{"token-1" "token-2" "token-3" "token-4" "token-5" "token-6"}}}}
                summary))))))
 
 (deftest test-parse-sync-clusters-cli-options


### PR DESCRIPTION
## Changes proposed in this PR

- handles skipping syncing tokens if the user-specified keys are the same
- handles hard-deleting tokens if they are already soft-deleted, irrespective of other parameters

## Why are we making these changes?

Reduces the number of failure scenarios in the token syncer.


