### PR TITLE
Add WAITER_SANDBOX environment variable

### DIFF
--- a/containers/test-apps/Dockerfile
+++ b/containers/test-apps/Dockerfile
@@ -10,4 +10,5 @@ COPY nginx/bin/run-nginx-server.sh /opt/nginx/bin/run-nginx-server.sh
 COPY nginx/data/nginx-template.conf /opt/nginx/data/nginx-template.conf
 COPY sediment/bin/run-sediment-server.sh /opt/sediment/bin/run-sediment-server.sh
 COPY sediment/data/sediment-uberjar.jar /opt/sediment/data/sediment-uberjar.jar
-COPY waiter-init/bin/waiter-init /usr/bin/waiter-init
+COPY waiter-init/bin/waiter-k8s-init /usr/bin/waiter-k8s-init
+COPY waiter-init/bin/waiter-mesos-init /usr/bin/waiter-mesos-init

--- a/containers/test-apps/waiter-init/bin/test-waiter-k8s-init
+++ b/containers/test-apps/waiter-init/bin/test-waiter-k8s-init
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-: ${TARGET:=./bin/waiter-init}
+: ${TARGET:=./bin/waiter-k8s-init}
 failures=0
 
 start_test() {

--- a/containers/test-apps/waiter-init/bin/waiter-k8s-init
+++ b/containers/test-apps/waiter-init/bin/waiter-k8s-init
@@ -14,7 +14,7 @@ waiter_child_pid=
 
 # Log a message to stderr
 waiter_init_log() {
-    printf '%s waiter-init> %s\n' "$(date +'%Y-%m-%dT%H:%M:%S%z')" "$1" >&2
+    printf '%s waiter-k8s-init> %s\n' "$(date +'%Y-%m-%dT%H:%M:%S%z')" "$1" >&2
 }
 
 # Catch the first SIGTERM sent by Kubernetes on pod deletion,

--- a/containers/test-apps/waiter-init/bin/waiter-mesos-init
+++ b/containers/test-apps/waiter-init/bin/waiter-mesos-init
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# A wrapper script for the Waiter-specific setup for a user command in a Waiter Mesos container.
+# The script is usually invoked by prepending it to the user's Waiter command array.
+#
+# A single argument is expected: the user's command string,
+# which is executed as its own bash shell process.
+
+export WAITER_SANDBOX="$MESOS_SANDBOX"
+exec /bin/bash -c "$1"

--- a/waiter/bin/ci/run-integration-tests-k8s-scheduler.sh
+++ b/waiter/bin/ci/run-integration-tests-k8s-scheduler.sh
@@ -32,14 +32,14 @@ fi
 ${CONTAINERS_DIR}/bin/build-docker-images.sh
 
 # Start waiter
-export WAITER_PORT=9091
+: ${WAITER_PORT:=9091}
 ${WAITER_DIR}/bin/run-using-k8s.sh ${WAITER_PORT} &
 
 # Start monitoring state of Kubernetes pods
 bash +x ${DIR}/monitor-pods.sh &
 
 # Run the integration tests
-export INTEGRATION_TEST_CUSTOM_IMAGE="twosigma/integration"
+export INTEGRATION_TEST_CUSTOM_IMAGE="twosigma/integration:latest"
 export INTEGRATION_TEST_CUSTOM_IMAGE_ALIAS="alias/integration"
 export INTEGRATION_TEST_KITCHEN_IMAGE="twosigma/waiter-test-apps"
 export LEIN_TEST_THREADS=4

--- a/waiter/bin/ci/run-integration-tests-k8s-scheduler.sh
+++ b/waiter/bin/ci/run-integration-tests-k8s-scheduler.sh
@@ -39,7 +39,7 @@ ${WAITER_DIR}/bin/run-using-k8s.sh ${WAITER_PORT} &
 bash +x ${DIR}/monitor-pods.sh &
 
 # Run the integration tests
-export INTEGRATION_TEST_CUSTOM_IMAGE="twosigma/integration:latest"
+export INTEGRATION_TEST_CUSTOM_IMAGE="twosigma/integration"
 export INTEGRATION_TEST_CUSTOM_IMAGE_ALIAS="alias/integration"
 export INTEGRATION_TEST_KITCHEN_IMAGE="twosigma/waiter-test-apps"
 export LEIN_TEST_THREADS=4

--- a/waiter/bin/ci/run-integration-tests-marathon-scheduler.sh
+++ b/waiter/bin/ci/run-integration-tests-marathon-scheduler.sh
@@ -11,7 +11,7 @@
 
 set -e
 
-export WAITER_PORT=9091
+: ${WAITER_PORT:=9091}
 TEST_COMMAND=${1:-parallel-test}
 TEST_SELECTOR=${2:-integration}
 

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -382,6 +382,10 @@
                                                            ;; Since this map is passed as the context argument to the factory function,
                                                            ;; any additional configuration data needed for the implementation should be included here.
                                                            :factory-fn waiter.scheduler.kubernetes/default-replicaset-builder
+                                                           ;; Vector of commands with which to prefix the user's cmd string when launching the container.
+                                                           ;; E.g., it may be necessary to delegate launching the user's command to a waiter-init script,
+                                                           ;; which is in turn launched by dumb-init for zombie process handling.
+                                                           :container-init-commands ["waiter-k8s-init"]
                                                            ;; The default factory function accepts an option for the docker container to use in the pod.
                                                            :default-container-image "twosigma/waiter-test-apps:latest"
                                                            ;; Map of image aliases. One of these aliases can be specified in the `image` field and the
@@ -495,7 +499,10 @@
 
                                :marathon-descriptor-builder {;; Factory function which creates a descriptor used by Marathon to create new apps.
                                                              ;; Any additional configuration data needed for the implementation should be included here.
-                                                             :factory-fn waiter.scheduler.marathon/default-marathon-descriptor-builder}
+                                                             :factory-fn waiter.scheduler.marathon/default-marathon-descriptor-builder
+                                                             ;; Vector of commands with which to prefix the user's cmd string when launching the container.
+                                                             ;; E.g., it may be necessary to delegate launching the user's command to a waiter-init script.
+                                                             :container-init-commands ["waiter-mesos-init"]}
 
                                ;; The port on which the mesos agents are listening.
                                ;; This is an optional parameter.

--- a/waiter/config-k8s.edn
+++ b/waiter/config-k8s.edn
@@ -40,7 +40,8 @@
                                  :log-bucket-sync-secs 5
                                  :log-bucket-url #config/env-default ["WAITER_S3_BUCKET" nil]
                                  :pod-sigkill-delay-secs 1
-                                 :replicaset-spec-builder {:image-aliases {"alias/integration" "twosigma/integration:latest"}}
+                                 :replicaset-spec-builder {:default-container-image "twosigma/waiter-test-apps"
+                                                           :image-aliases {"alias/integration" "twosigma/integration"}}
                                  :url "http://localhost:8001"}}
 
  ; ---------- Error Handling ----------

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -450,7 +450,7 @@
         (testing "waiter configured environment variables"
           (is (every? #(contains? body-json %)
                       ["HOME" "LOGNAME" "USER" "WAITER_CLUSTER" "WAITER_CONCURRENCY_LEVEL" "WAITER_CPUS"
-                       "WAITER_MEM_MB" "WAITER_SERVICE_ID" "WAITER_USERNAME"])
+                       "WAITER_MEM_MB" "WAITER_SANDBOX" "WAITER_SERVICE_ID" "WAITER_USERNAME"])
               (str body-json))
           (is (= (setting waiter-url [:cluster-config :name]) (get body-json "WAITER_CLUSTER")))
           (is (= service-id (get body-json "WAITER_SERVICE_ID"))))

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -688,7 +688,6 @@
    {:keys [container-init-commands default-container-image log-bucket-url image-aliases] :as context}]
   (let [work-path (str "/home/" run-as-user)
         home-path (str work-path "/latest")
-        base-command-vector (vec (or container-init-commands ["waiter-k8s-init"]))
         base-env (scheduler/environment service-id service-description
                                         service-id->password-fn home-path)
         ;; We include the default log-bucket-sync-secs value in the total-sigkill-delay-secs
@@ -737,7 +736,7 @@
                                                   :waiter/service-id service-id}
                                     :labels {:app k8s-name
                                              :waiter-cluster cluster-name}}
-                         :spec {:containers [{:command (conj base-command-vector cmd)
+                         :spec {:containers [{:command (conj (vec container-init-commands) cmd)
                                               :env env
                                               :image (compute-image image default-container-image image-aliases)
                                               :imagePullPolicy "IfNotPresent"

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -246,8 +246,9 @@
 
 (defn default-marathon-descriptor-builder
   "Returns the descriptor to be used by Marathon to create new apps."
-  [home-path-prefix service-id->password-fn {:keys [service-id service-description]} _]
-  (let [health-check-url (sd/service-description->health-check-url service-description)
+  [home-path-prefix service-id->password-fn {:keys [service-id service-description]} {:keys [container-init-commands]}]
+  (let [base-command-vector (vec (or container-init-commands ["waiter-mesos-init"]))
+        health-check-url (sd/service-description->health-check-url service-description)
         {:strs [backend-proto cmd cmd-type cpus disk grace-period-secs health-check-interval-secs
                 health-check-max-consecutive-failures health-check-port-index health-check-proto
                 mem ports restart-backoff-factor run-as-user]} service-description
@@ -260,7 +261,7 @@
     {:id service-id
      :env (scheduler/environment service-id service-description service-id->password-fn home-path)
      :user run-as-user
-     :cmd cmd
+     :args (conj base-command-vector cmd)
      :disk disk
      :mem mem
      :ports (-> ports (repeat 0) vec)

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -247,8 +247,7 @@
 (defn default-marathon-descriptor-builder
   "Returns the descriptor to be used by Marathon to create new apps."
   [home-path-prefix service-id->password-fn {:keys [service-id service-description]} {:keys [container-init-commands]}]
-  (let [base-command-vector (vec (or container-init-commands ["waiter-mesos-init"]))
-        health-check-url (sd/service-description->health-check-url service-description)
+  (let [health-check-url (sd/service-description->health-check-url service-description)
         {:strs [backend-proto cmd cmd-type cpus disk grace-period-secs health-check-interval-secs
                 health-check-max-consecutive-failures health-check-port-index health-check-proto
                 mem ports restart-backoff-factor run-as-user]} service-description
@@ -261,7 +260,7 @@
     {:id service-id
      :env (scheduler/environment service-id service-description service-id->password-fn home-path)
      :user run-as-user
-     :args (conj base-command-vector cmd)
+     :args (conj (vec container-init-commands) cmd)
      :disk disk
      :mem mem
      :ports (-> ports (repeat 0) vec)

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -83,9 +83,9 @@
     (doseq [[env-key env-val] (seq environment)]
       (when-not (nil? env-val)
         (.put process-env env-key env-val)))
-    ;; TODO maybe some day this will be WAITER_SANDBOX
     (when-not (contains? process-env "MESOS_SANDBOX")
       (.put process-env "MESOS_SANDBOX" (.getAbsolutePath working-dir)))
+    (.put process-env "WAITER_SANDBOX" (.getAbsolutePath working-dir))
     (.directory pb working-dir)
     (.redirectOutput pb (File. working-dir "stdout"))
     (.redirectError pb (File. working-dir "stderr"))

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -358,6 +358,7 @@
                                    :pod-suffix-length 5
                                    :replicaset-api-version "extensions/v1beta1"
                                    :replicaset-spec-builder {:factory-fn 'waiter.scheduler.kubernetes/default-replicaset-builder
+                                                             :container-init-commands ["waiter-k8s-init"]
                                                              :default-container-image "twosigma/waiter-test-apps:latest"}}
                       :marathon {:factory-fn 'waiter.scheduler.marathon/marathon-scheduler
                                  :authorizer {:kind :default
@@ -366,7 +367,8 @@
                                  :http-options {:conn-timeout 10000
                                                 :socket-timeout 10000
                                                 :spnego-auth false}
-                                 :marathon-descriptor-builder {:factory-fn 'waiter.scheduler.marathon/default-marathon-descriptor-builder}
+                                 :marathon-descriptor-builder {:factory-fn 'waiter.scheduler.marathon/default-marathon-descriptor-builder
+                                                               :container-init-commands ["waiter-mesos-init"]}
                                  :force-kill-after-ms 60000
                                  :framework-id-ttl 900000
                                  :sync-deployment {:interval-ms (-> 15 t/seconds t/in-millis)

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -62,7 +62,8 @@
       :replicaset-api-version "extensions/v1beta1"
       :replicaset-spec-builder-fn #(waiter.scheduler.kubernetes/default-replicaset-builder
                                      %1 %2 %3
-                                     {:default-container-image "twosigma/waiter-test-apps:latest"})
+                                     {:container-init-commands ["waiter-k8s-init"]
+                                      :default-container-image "twosigma/waiter-test-apps:latest"})
       :service-id->failed-instances-transient-store (atom {})
       :service-id->password-fn #(str "password-" %)
       :service-id->service-description-fn (pc/map-from-keys (constantly {"health-check-port-index" 0
@@ -792,6 +793,7 @@
                     :pod-suffix-length default-pod-suffix-length
                     :replicaset-api-version "extensions/v1beta1"
                     :replicaset-spec-builder {:factory-fn 'waiter.scheduler.kubernetes/default-replicaset-builder
+                                              :container-init-commands ["waiter-k8s-init"]
                                               :default-container-image "twosigma/waiter-test-apps:latest"}
                     :url "http://127.0.0.1:8001"}
         base-config (merge context k8s-config)]

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -754,7 +754,8 @@
                                          :default {:factory-fn 'waiter.authorization/noop-authorizer}}
                             :force-kill-after-ms 60000
                             :framework-id-ttl 900000
-                            :marathon-descriptor-builder {:factory-fn 'waiter.scheduler.marathon/default-marathon-descriptor-builder}
+                            :marathon-descriptor-builder {:factory-fn 'waiter.scheduler.marathon/default-marathon-descriptor-builder
+                                                          :container-init-commands ["waiter-mesos-init"]}
                             :home-path-prefix "/home/"
                             :http-options {:conn-timeout 10000 :socket-timeout 10000}
                             :mesos-slave-port 5051

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -586,7 +586,8 @@
 
 (deftest test-marathon-descriptor
   (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")]
-    (let [service-id->password-fn (fn [service-id] (str service-id "-password"))]
+    (let [service-id->password-fn (fn [service-id] (str service-id "-password"))
+          descriptor-builder-ctx {:container-init-commands ["waiter-mesos-init"]}]
       (testing "basic-test-with-defaults"
         (let [expected {:id "test-service-1"
                         :labels {:source "waiter"
@@ -635,7 +636,8 @@
                                           "BAZ" "quux"}}
               actual (default-marathon-descriptor-builder
                        home-path-prefix service-id->password-fn
-                       {:service-id service-id, :service-description service-description} nil)]
+                       {:service-id service-id, :service-description service-description}
+                       descriptor-builder-ctx)]
           (is (= expected actual))
 
           (testing "health-check-port-index of 2"
@@ -646,7 +648,7 @@
                      home-path-prefix service-id->password-fn
                      (->> (assoc service-description "health-check-port-index" 2 "ports" 3)
                           (assoc {:service-id service-id} :service-description))
-                     nil)))))))))
+                     descriptor-builder-ctx)))))))))
 
 (deftest test-kill-instance-last-force-kill-time-store
   (let [current-time (t/now)

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -603,7 +603,7 @@
                               "WAITER_PASSWORD" "test-service-1-password"
                               "WAITER_SERVICE_ID" "test-service-1"
                               "WAITER_USERNAME" "waiter"}
-                        :cmd "test-command"
+                        :args ["waiter-mesos-init" "test-command"]
                         :cpus 1
                         :disk nil
                         :mem 1536


### PR DESCRIPTION
## Changes proposed in this PR

- Add `WAITER_SANDBOX` environment variable
- Rename existing waiter-init -> waiter-k8s-init
- Add waiter-mesos-init
- Update docker containers with both new scripts

## Why are we making these changes?

We want a `WAITER_SANDBOX` environment variable that apps can use across both Mesos and Kubernetes instead of using `MESOS_SANDBOX`.