### PR TITLE
Don't retry k8s watch returning failure status

### DIFF
--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -1276,7 +1276,7 @@
         ;; which lets us test the watch-retries behavior here
         pods-watch-query-count (atom 0)
         pods-watch-stream (make-watch-stream pods-watch-updates watch-update-signals)
-        pods-watch-query-fn (fn pods-watch-query-fn [watch-url]
+        pods-watch-query-fn (fn pods-watch-query-fn [_ watch-url]
                               (swap! pods-watch-query-count inc)
                               (let [last-resource-version (->> watch-url
                                                                (re-find #"(?<=[&?]resourceVersion=)\d+")


### PR DESCRIPTION
## Changes proposed in this PR

- Generally improve handling of errors in the k8s watch threads
- Specifically handle "resource version too old" errors by immediately falling back to a global state query

## Why are we making these changes?

Currently, we always exhaust our watch `iter` retry limit before falling back to a global query, even when our current resource version is too old (and thus we know all retries will fail until we do a global sync). This bad behavior was caused by refactoring #568. This patch cleans up the error handling code, improves logging, and specifically addresses the "resource version too old" error case.