### PR TITLE
enforces timeouts on health checks

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -32,7 +32,7 @@
 
   :dependencies [[bidi "2.1.5"
                   :exclusions [prismatic/schema ring/ring-core]]
-                 [twosigma/jet "0.7.10-20190417_013951-gef581db"
+                 [twosigma/jet "0.7.10-20190417_210947-g70a338b"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -700,8 +700,10 @@
                                                     {:conn-timeout health-check-timeout-ms
                                                      :socket-timeout health-check-timeout-ms
                                                      :user-agent (str "waiter-syncer/" (str/join (take 7 git-version)))})
-                                      available? (fn scheduler-available? [service-instance health-check-proto health-check-port-index health-check-path]
-                                                   (scheduler/available? http-client service-instance health-check-proto health-check-port-index health-check-path))]
+                                      available? (fn scheduler-available?
+                                                   [scheduler-name service-instance health-check-proto health-check-port-index health-check-path]
+                                                   (scheduler/available? http-client scheduler-name service-instance health-check-proto
+                                                                         health-check-port-index health-check-path))]
                                   (fn start-scheduler-syncer-fn
                                     [scheduler-name get-service->instances-fn scheduler-state-chan scheduler-syncer-interval-secs]
                                     (let [timeout-chan (->> (t/seconds scheduler-syncer-interval-secs)


### PR DESCRIPTION
## Changes proposed in this PR

- enforces timeouts on health check calls, aborting the requests when they take too long
- requires associated jet change to [support aborting requests](https://github.com/twosigma/jet/pull/19)

## Why are we making these changes?

We would like to avoid taking too long performing health checks as that can delay the scheduler syncer propagating updates.


### Example use of the abort channel:
```
(let [client (:http1-client (http-utils/prepare-http-clients {:conn-timeout 10000}))
      abort-ch (async/promise-chan)]
  (try
    (async/go
      (async/<! (async/timeout 5000))
      (println "aborting request")
      (async/>! abort-ch (Exception. "abort request please")))
    (.start client)
    (let [response (async/<!! (http/request client {:abort-ch abort-ch
                                                    :headers {:x-kitchen-delay-ms 10000}
                                                    :url "http://127.0.0.1:8080/request-info"}))]
      (println "Response keys:" (keys response))
      (println "ERROR:" (:error response))
      (println "Headers:" (:headers response))
      (println "Body:" (some-> response :body async/<!!)))
    (finally
      (.stop client))))
aborting request
Response keys: (:error)
ERROR: #error {
 :cause abort request please
 :via
 [{:type java.lang.Exception
   :message abort request please
   :at [waiter.main$eval50093$fn__50110$state_machine__10445__auto____50115$fn__50117 invoke form-init2625715241389359372.clj 6]}]
 :trace
 [[waiter.main$eval50093$fn__50110$state_machine__10445__auto____50115$fn__50117 invoke form-init2625715241389359372.clj 6]
  [waiter.main$eval50093$fn__50110$state_machine__10445__auto____50115 invoke form-init2625715241389359372.clj 4]
  [clojure.core.async.impl.ioc_macros$run_state_machine invokeStatic ioc_macros.clj 973]
  [clojure.core.async.impl.ioc_macros$run_state_machine invoke ioc_macros.clj 972]
  [clojure.core.async.impl.ioc_macros$run_state_machine_wrapped invokeStatic ioc_macros.clj 977]
  [clojure.core.async.impl.ioc_macros$run_state_machine_wrapped invoke ioc_macros.clj 975]
  [clojure.core.async.impl.ioc_macros$take_BANG_$fn__10463 invoke ioc_macros.clj 986]
  [clojure.core.async.impl.channels.ManyToManyChannel$fn__5472 invoke channels.clj 265]
  [clojure.lang.AFn run AFn.java 22]
  [java.util.concurrent.ThreadPoolExecutor runWorker ThreadPoolExecutor.java 1149]
  [java.util.concurrent.ThreadPoolExecutor$Worker run ThreadPoolExecutor.java 624]
  [java.lang.Thread run Thread.java 748]]}
Headers: nil
Body: nil
=> nil
```

