### PR TITLE
marks test-trailers-support-h2c-proto-sediment as explicit

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -467,7 +467,7 @@
   (testing-using-waiter-url
     (run-sediment-trailers-support-test waiter-url "http")))
 
-(deftest ^:parallel ^:integration-fast test-trailers-support-h2c-proto-sediment
+(deftest ^:parallel ^:integration-fast ^:explicit test-trailers-support-h2c-proto-sediment
   (testing-using-waiter-url
     (run-sediment-trailers-support-test waiter-url "h2c")))
 


### PR DESCRIPTION
## Changes proposed in this PR

- marks test-trailers-support-h2c-proto-sediment as explicit

## Why are we making these changes?

We want to avoid a failing build while this test is debugged and complete http/2 support is available.
