### PR TITLE
Add WAITER_CONCURRENCY_LEVEL environment variable

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -582,7 +582,7 @@
         (is (= 200 status))
         (testing "waiter configured environment variables"
           (is (every? #(contains? body-json %)
-                      ["HOME" "LOGNAME" "USER" "WAITER_CPUS" "WAITER_MEM_MB" "WAITER_SERVICE_ID" "WAITER_USERNAME"])
+                      ["HOME" "LOGNAME" "USER" "WAITER_CONCURRENCY_LEVEL" "WAITER_CPUS" "WAITER_MEM_MB" "WAITER_SERVICE_ID" "WAITER_USERNAME"])
               (str body-json)))
         (testing "on-the-fly environment variables"
           (is (every? #(contains? body-json %) ["BEGIN_DATE" "END_DATE" "TIME2" "TIMESTAMP"])

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -662,11 +662,12 @@
 
 (defn environment
   "Returns a new environment variable map with some basic variables added in"
-  [service-id {:strs [cpus env mem run-as-user]} service-id->password-fn home-path]
+  [service-id {:strs [concurrency-level cpus env mem run-as-user]} service-id->password-fn home-path]
   (merge env
          {"HOME" home-path
           "LOGNAME" run-as-user
           "USER" run-as-user
+          "WAITER_CONCURRENCY_LEVEL" (str concurrency-level)
           "WAITER_CPUS" (str cpus)
           "WAITER_MEM_MB" (str mem)
           "WAITER_PASSWORD" (service-id->password-fn service-id)

--- a/waiter/test/waiter/scheduler/cook_test.clj
+++ b/waiter/test/waiter/scheduler/cook_test.clj
@@ -261,6 +261,7 @@
         service-id "test-service-1"
         service-description {"backend-proto" "http"
                              "cmd" "test-command"
+                             "concurrency-level" 1
                              "cpus" 1
                              "mem" 1536
                              "run-as-user" "test-user"
@@ -287,6 +288,7 @@
                             "HOME" "/home/path/test-user"
                             "LOGNAME" "test-user"
                             "USER" "test-user"
+                            "WAITER_CONCURRENCY_LEVEL" "1"
                             "WAITER_CPUS" "1"
                             "WAITER_MEM_MB" "1536"
                             "WAITER_PASSWORD" "test-service-1-password"

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -594,6 +594,7 @@
                             "HOME" "/home/path/test-user"
                             "LOGNAME" "test-user"
                             "USER" "test-user"
+                            "WAITER_CONCURRENCY_LEVEL" "1"
                             "WAITER_CPUS" "1"
                             "WAITER_MEM_MB" "1536"
                             "WAITER_PASSWORD" "test-service-1-password"
@@ -618,6 +619,7 @@
             service-id "test-service-1"
             service-description {"backend-proto" "http"
                                  "cmd" "test-command"
+                                 "concurrency-level" 1
                                  "cpus" 1
                                  "mem" 1536
                                  "run-as-user" "test-user"

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -43,6 +43,7 @@
   ([scheduler service-id custom-service-description]
    (let [descriptor {:service-description (merge {"backend-proto" "http"
                                                   "cmd" "ls"
+                                                  "concurrency-level" 1
                                                   "cpus" 2
                                                   "grace-period-secs" 10
                                                   "health-check-port-index" 0
@@ -402,6 +403,7 @@
                   :environment {"HOME" (work-dir)
                                 "LOGNAME" nil
                                 "USER" nil
+                                "WAITER_CONCURRENCY_LEVEL" "1"
                                 "WAITER_CPUS" "2"
                                 "WAITER_MEM_MB" "32"
                                 "WAITER_PASSWORD" "foo.password"
@@ -409,6 +411,7 @@
                                 "WAITER_USERNAME" "waiter"}
                   :service-description {"backend-proto" "http"
                                         "cmd" "sleep 10000"
+                                        "concurrency-level" 1
                                         "cpus" 2
                                         "grace-period-secs" 10
                                         "health-check-port-index" 0
@@ -423,6 +426,7 @@
                   :environment {"HOME" (work-dir)
                                 "LOGNAME" nil
                                 "USER" nil
+                                "WAITER_CONCURRENCY_LEVEL" "1"
                                 "WAITER_CPUS" "2"
                                 "WAITER_MEM_MB" "32"
                                 "WAITER_PASSWORD" "bar.password"
@@ -430,6 +434,7 @@
                                 "WAITER_USERNAME" "waiter"}
                   :service-description {"backend-proto" "http"
                                         "cmd" "sleep 10000"
+                                        "concurrency-level" 1
                                         "cpus" 2
                                         "grace-period-secs" 10
                                         "health-check-port-index" 0
@@ -444,6 +449,7 @@
                   :environment {"HOME" (work-dir)
                                 "LOGNAME" nil
                                 "USER" nil
+                                "WAITER_CONCURRENCY_LEVEL" "1"
                                 "WAITER_CPUS" "2"
                                 "WAITER_MEM_MB" "32"
                                 "WAITER_PASSWORD" "baz.password"
@@ -451,6 +457,7 @@
                                 "WAITER_USERNAME" "waiter"}
                   :service-description {"backend-proto" "http"
                                         "cmd" "sleep 10000"
+                                        "concurrency-level" 1
                                         "cpus" 2
                                         "grace-period-secs" 10
                                         "health-check-port-index" 0
@@ -481,6 +488,7 @@
                                     :environment {"HOME" (work-dir)
                                                   "LOGNAME" nil
                                                   "USER" nil
+                                                  "WAITER_CONCURRENCY_LEVEL" "1"
                                                   "WAITER_CPUS" "2"
                                                   "WAITER_MEM_MB" "32"
                                                   "WAITER_PASSWORD" "foo.password"
@@ -488,6 +496,7 @@
                                                   "WAITER_USERNAME" "waiter"}
                                     :service-description {"backend-proto" "http"
                                                           "cmd" "ls"
+                                                          "concurrency-level" 1
                                                           "cpus" 2
                                                           "grace-period-secs" 10
                                                           "health-check-port-index" 0


### PR DESCRIPTION
## Changes proposed in this PR

Add `WAITER_CONCURRENCY_LEVEL` environment variable.

## Why are we making these changes?

Waiter services can use `WAITER_CONCURRENCY_LEVEL` for automatic tuning, e.g., configuring number of worker threads.