### PR TITLE
Prevents merging PRs that are not ready

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -1,0 +1,7 @@
+version: 2
+mergeable:
+  - when: pull_request.*
+    validate:
+      - do: label
+        must_include:
+          regex: 'internal-green'

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -4,4 +4,4 @@ mergeable:
     validate:
       - do: label
         must_include:
-          regex: 'internal-green'
+          regex: '^internal-green$'

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -5,3 +5,5 @@ mergeable:
       - do: label
         must_include:
           regex: '^internal-green$'
+        must_exclude:
+          regex: '^wip$'


### PR DESCRIPTION
## Changes proposed in this PR

- adding `mergeable.yml` that prevents merging PRs that don't have the `internal-green` label or that do have the `wip` label

## Why are we making these changes?

To prevent merging PRs that are works in progress or fail internal builds or tests.
