### PR TITLE
convert root-regex to regular expression before creating the component

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -46,7 +46,9 @@
         cluster-calculator-config (-> settings-json
                                       (get-in [:token-config :cluster-calculator])
                                       (update :kind keyword)
-                                      (as-> $ (update-in $ [(:kind $) :factory-fn] symbol)))
+                                      (as-> $ (cond-> (update-in $ [(:kind $) :factory-fn] symbol)
+                                                (= :regex (:kind $))
+                                                (update-in [:regex :root-regex] re-pattern))))
         cluster-calculator (utils/create-component cluster-calculator-config
                                                    :context {:default-cluster default-cluster})]
     (token/calculate-cluster cluster-calculator {:headers {"host" waiter-url}})))


### PR DESCRIPTION
## Changes proposed in this PR

- convert root-regex to regular expression before creating the component

## Why are we making these changes?

We would like to correctly determine the token cluster in the integration tests.


