### PR TITLE
adds match->cluster to further limit the values produced by a regex-cluster-calculator

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -843,20 +843,13 @@
 
  :token-config {
                 ;; Define the calculator that compute the root assigned to a token when they are created.
-                :cluster-calculator {;; :kind :configured create a calculator that always assigns root as :cluster-config :name
+                :cluster-calculator {;; :kind :configured create a calculator that looks up the cluster name using a configured map.
+                                     ;; When not matching entry is found in the map, the cluster is defined as :cluster-config :name
                                      :kind :configured
-                                     :configured {:factory-fn 'waiter.token/new-configured-cluster-calculator}
-
-                                     ;; :kind :regex create a calculator that uses a regex and a map to determine the cluster name
-                                     ;; :kind :regex
-                                     :regex {:factory-fn 'waiter.token/new-regex-cluster-calculator
-                                             ;; A regex to determine the root from the incoming request host header.
-                                             ;; The first group from the match is used to determine the root using match->cluster.
-                                             ;; If no match is found, it defaults to the :cluster-config :name.
-                                             :host-regex #config/regex "^waiter-([a-zA-Z][0-9a-zA-Z\\-]*)"
-                                             ;; The entry against the first group of the regex match is used to determine the cluster
-                                             :match->cluster {"alias" "name"
-                                                              "name" "name"}}}
+                                     :configured {:factory-fn 'waiter.token/new-configured-cluster-calculator
+                                                  ;; The map that contains supported host to cluster name mappings.
+                                                  :host->cluster {"waiter-alias.example.com" "foo"
+                                                                  "waiter-foo.example.com" "foo"}}}
 
                 ;; Configures the amount of history we store for a token.
                 ;; It must be a positive integer.

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -847,13 +847,16 @@
                                      :kind :configured
                                      :configured {:factory-fn 'waiter.token/new-configured-cluster-calculator}
 
-                                     ;; :kind :configured create a calculator that always assigns root as :cluster-config :name
+                                     ;; :kind :regex create a calculator that uses a regex and a map to determine the cluster name
                                      ;; :kind :regex
                                      :regex {:factory-fn 'waiter.token/new-regex-cluster-calculator
                                              ;; A regex to determine the root from the incoming request host header.
-                                             ;; The first group from the match is used to determine the root.
+                                             ;; The first group from the match is used to determine the root using match->cluster.
                                              ;; If no match is found, it defaults to the :cluster-config :name.
-                                             :root-regex #config/regex "^waiter-([a-zA-Z][0-9a-zA-Z\\-]*)"}}
+                                             :host-regex #config/regex "^waiter-([a-zA-Z][0-9a-zA-Z\\-]*)"
+                                             ;; The entry against the first group of the regex match is used to determine the cluster
+                                             :match->cluster {"alias" "name"
+                                                              "name" "name"}}}
 
                 ;; Configures the amount of history we store for a token.
                 ;; It must be a positive integer.

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -46,9 +46,7 @@
         cluster-calculator-config (-> settings-json
                                       (get-in [:token-config :cluster-calculator])
                                       (update :kind keyword)
-                                      (as-> $ (cond-> (update-in $ [(:kind $) :factory-fn] symbol)
-                                                (= :regex (:kind $))
-                                                (update-in [:regex :root-regex] re-pattern))))
+                                      (as-> $ (update-in $ [(:kind $) :factory-fn] symbol)))
         cluster-calculator (utils/create-component cluster-calculator-config
                                                    :context {:default-cluster default-cluster})]
     (token/calculate-cluster cluster-calculator {:headers {"host" waiter-url}})))

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -429,11 +429,8 @@
                    :link {:type :url
                           :value "http://github.com/twosigma/waiter"}}]
    :token-config {:cluster-calculator {:kind :configured
-                                       :configured {:factory-fn 'waiter.token/new-configured-cluster-calculator}
-                                       :regex {:factory-fn 'waiter.token/new-regex-cluster-calculator
-                                               :host-regex #"^waiter-([a-zA-Z][0-9a-zA-Z\\-]*)"
-                                               :match->cluster {"alias" "name"
-                                                                "name" "name"}}}
+                                       :configured {:factory-fn 'waiter.token/new-configured-cluster-calculator
+                                                    :host->cluster {}}}
                   :history-length 5
                   :limit-per-owner 1000
                   :token-defaults {"fallback-period-secs" (-> 5 t/minutes t/in-seconds)

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -431,7 +431,9 @@
    :token-config {:cluster-calculator {:kind :configured
                                        :configured {:factory-fn 'waiter.token/new-configured-cluster-calculator}
                                        :regex {:factory-fn 'waiter.token/new-regex-cluster-calculator
-                                               :root-regex #"^waiter-([a-zA-Z][0-9a-zA-Z\\-]*)"}}
+                                               :host-regex #"^waiter-([a-zA-Z][0-9a-zA-Z\\-]*)"
+                                               :match->cluster {"alias" "name"
+                                                                "name" "name"}}}
                   :history-length 5
                   :limit-per-owner 1000
                   :token-defaults {"fallback-period-secs" (-> 5 t/minutes t/in-seconds)

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -54,51 +54,30 @@
 
 (deftest test-constant-cluster-calculator
   (let [default-cluster "test-cluster"
-        cluster-calculator (new-configured-cluster-calculator {:default-cluster default-cluster})]
-    (is (= default-cluster (get-default-cluster cluster-calculator)))
-    (is (= default-cluster (calculate-cluster cluster-calculator {})))
-    (is (= default-cluster (calculate-cluster cluster-calculator {:headers {"host" "test.com"}})))
-    (is (= default-cluster (calculate-cluster cluster-calculator {:headers {"host" "waiter.localtest.me"}})))
-    (is (= default-cluster (calculate-cluster cluster-calculator {:headers {"host" "waiter-foo.localtest.me"}})))
-    (is (= default-cluster (calculate-cluster cluster-calculator {:headers {"host" "waiter-foo-bar.localtest.me:1234"}})))
-    (is (= default-cluster (calculate-cluster cluster-calculator {:headers {"host" "waiter-foo.bar.localtest.me"}})))))
-
-(deftest test-regex-cluster-calculator
-  (let [root-regex #"waiter-(.*).localtest.me*(:.*)?"
-        default-cluster "test-cluster"]
-    (testing "regex group matches"
-      (let [cluster-calculator (new-regex-cluster-calculator {:default-cluster default-cluster
-                                                              :host-regex root-regex
-                                                              :match->cluster identity})]
-        (is (= default-cluster (get-default-cluster cluster-calculator)))
-        (is (= default-cluster (calculate-cluster cluster-calculator {})))
-        (is (= default-cluster (calculate-cluster cluster-calculator {:headers {"host" "test.com"}})))
-        (is (= default-cluster (calculate-cluster cluster-calculator {:headers {"host" "waiter.localtest.me"}})))
-        (is (= "foo" (calculate-cluster cluster-calculator {:headers {"host" "waiter-foo.localtest.me"}})))
-        (is (= "foo-bar" (calculate-cluster cluster-calculator {:headers {"host" "waiter-foo-bar.localtest.me"}})))
-        (is (= "foo.bar" (calculate-cluster cluster-calculator {:headers {"host" "waiter-foo.bar.localtest.me"}})))
-        (is (= default-cluster (calculate-cluster cluster-calculator {:headers {"host" "test.com:1234"}})))
-        (is (= default-cluster (calculate-cluster cluster-calculator {:headers {"host" "waiter.localtest.me:1234"}})))
-        (is (= "foo" (calculate-cluster cluster-calculator {:headers {"host" "waiter-foo.localtest.me:1234"}})))
-        (is (= "foo-bar" (calculate-cluster cluster-calculator {:headers {"host" "waiter-foo-bar.localtest.me:1234"}})))
-        (is (= "foo.bar" (calculate-cluster cluster-calculator {:headers {"host" "waiter-foo.bar.localtest.me:1234"}})))))
-    (testing "match to cluster mapping"
-      (let [cluster-calculator (new-regex-cluster-calculator {:default-cluster default-cluster
-                                                              :host-regex root-regex
-                                                              :match->cluster {"foo" "lorem"
-                                                                               "foo-bar" "foo-bar"}})]
-        (is (= "lorem" (calculate-cluster cluster-calculator {:headers {"host" "waiter-foo.localtest.me"}})))
-        (is (= "foo-bar" (calculate-cluster cluster-calculator {:headers {"host" "waiter-foo-bar.localtest.me"}})))
-        (is (= default-cluster (calculate-cluster cluster-calculator {:headers {"host" "waiter-foo.bar.localtest.me"}})))
-        (is (= default-cluster (calculate-cluster cluster-calculator {:headers {"host" "test.com:1234"}})))
-        (is (= default-cluster (calculate-cluster cluster-calculator {:headers {"host" "waiter.localtest.me:1234"}})))
-        (is (= "lorem" (calculate-cluster cluster-calculator {:headers {"host" "waiter-foo.localtest.me:1234"}})))
-        (is (= "foo-bar" (calculate-cluster cluster-calculator {:headers {"host" "waiter-foo-bar.localtest.me:1234"}})))
-        (is (= default-cluster (calculate-cluster cluster-calculator {:headers {"host" "waiter-foo.bar.localtest.me:1234"}})))))))
+        cluster-calculator-1 (new-configured-cluster-calculator {:default-cluster default-cluster
+                                                               :host->cluster {}})
+        cluster-calculator-2 (new-configured-cluster-calculator {:default-cluster default-cluster
+                                                                 :host->cluster {"waiter.localtest.me" "bar"
+                                                                                 "waiter-foo.localtest.me" "foo"}})]
+    (is (= default-cluster (get-default-cluster cluster-calculator-1)))
+    (is (= default-cluster (get-default-cluster cluster-calculator-2)))
+    (is (= default-cluster (calculate-cluster cluster-calculator-1 {})))
+    (is (= default-cluster (calculate-cluster cluster-calculator-2 {})))
+    (is (= default-cluster (calculate-cluster cluster-calculator-1 {:headers {"host" "test.com"}})))
+    (is (= default-cluster (calculate-cluster cluster-calculator-2 {:headers {"host" "test.com"}})))
+    (is (= default-cluster (calculate-cluster cluster-calculator-1 {:headers {"host" "waiter.localtest.me"}})))
+    (is (= "bar" (calculate-cluster cluster-calculator-2 {:headers {"host" "waiter.localtest.me"}})))
+    (is (= default-cluster (calculate-cluster cluster-calculator-1 {:headers {"host" "waiter-foo.localtest.me"}})))
+    (is (= "foo" (calculate-cluster cluster-calculator-2 {:headers {"host" "waiter-foo.localtest.me"}})))
+    (is (= default-cluster (calculate-cluster cluster-calculator-1 {:headers {"host" "waiter-foo-bar.localtest.me:1234"}})))
+    (is (= default-cluster (calculate-cluster cluster-calculator-2 {:headers {"host" "waiter-foo-bar.localtest.me:1234"}})))
+    (is (= default-cluster (calculate-cluster cluster-calculator-1 {:headers {"host" "waiter-foo.bar.localtest.me"}})))
+    (is (= default-cluster (calculate-cluster cluster-calculator-2 {:headers {"host" "waiter-foo.bar.localtest.me"}})))))
 
 (defn- run-handle-token-request
   [kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn validate-service-description-fn request]
-  (let [cluster-calculator (new-configured-cluster-calculator {:default-cluster (str token-root "-cluster")})]
+  (let [cluster-calculator (new-configured-cluster-calculator {:default-cluster (str token-root "-cluster")
+                                                               :host->cluster {}})]
     (handle-token-request clock synchronize-fn kv-store cluster-calculator token-root history-length limit-per-owner
                           waiter-hostnames entitlement-manager make-peer-requests-fn validate-service-description-fn
                           request)))


### PR DESCRIPTION

## Changes proposed in this PR

- adds match->cluster to further limit the values produced by a regex-cluster-calculator

## Why are we making these changes?

We would like to restrict the cluster names produced by the regex-based calculator.

