### PR TITLE
Marks test-request-instance-death as explicit

### DIFF
--- a/waiter/integration/waiter/websocket_integration_test.clj
+++ b/waiter/integration/waiter/websocket_integration_test.clj
@@ -252,7 +252,12 @@
         (finally
           (delete-service waiter-url waiter-headers))))))
 
-(deftest ^:parallel ^:integration-slow test-request-instance-death
+; FAIL in (test-request-instance-death) (websocket_integration_test.clj:296)
+; test-request-instance-death
+; expected: [:qbits.jet.websocket/close 1006 "Disconnected"]
+;   actual: [:qbits.jet.websocket/error #error {
+;  :cause "Idle timeout expired: 120000/120000 ms"
+(deftest ^:parallel ^:integration-slow ^:explicit test-request-instance-death
   (testing-using-waiter-url
     (let [auth-cookie-value (auth-cookie waiter-url)
           send-success-after-timeout-atom (atom true)


### PR DESCRIPTION
## Changes proposed in this PR

- marking `test-request-instance-death` as explicit

## Why are we making these changes?

It's failed multiple times with:

```bash
***** Kubernetes pod state at 23:07:10 *****
NAME                                                              READY     STATUS        RESTARTS   AGE
testbasicshellcommandtra-2cab35e63ade572b2860bd49aa8a289a-jvgkx   0/2       Pending       0          47s
testimagefieldvalidation-dbee3fa43589aa7a5c20cefec98df5cf-lx7z5   0/2       Terminating   0          11m
testrequestinstancedeath-edab377e03fb80e478303a7c5ad78143-zlw8s   0/2       Pending       0          1m
lein parallel-test :only waiter.websocket-integration-test/test-request-instance-death
FAIL in (test-request-instance-death) (websocket_integration_test.clj:296)
test-request-instance-death
expected: [:qbits.jet.websocket/close 1006 "Disconnected"]
  actual: [:qbits.jet.websocket/error #error {
 :cause "Idle timeout expired: 120000/120000 ms"
 :via
 [{:type org.eclipse.jetty.websocket.api.CloseException
   :message "java.util.concurrent.TimeoutException: Idle timeout expired: 120000/120000 ms"
   :at [org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection onReadTimeout "AbstractWebSocketConnection.java" 488]}
  {:type java.util.concurrent.TimeoutException
   :message "Idle timeout expired: 120000/120000 ms"
   :at [org.eclipse.jetty.io.IdleTimeout checkIdleTimeout "IdleTimeout.java" 166]}]
 :trace
 [[org.eclipse.jetty.io.IdleTimeout checkIdleTimeout "IdleTimeout.java" 166]
  [org.eclipse.jetty.io.IdleTimeout$1 run "IdleTimeout.java" 50]
  [java.util.concurrent.Executors$RunnableAdapter call "Executors.java" 511]
  [java.util.concurrent.FutureTask run "FutureTask.java" 266]
  [java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask access$201 "ScheduledThreadPoolExecutor.java" 180]
  [java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask run "ScheduledThreadPoolExecutor.java" 293]
  [java.util.concurrent.ThreadPoolExecutor runWorker "ThreadPoolExecutor.java" 1149]
  [java.util.concurrent.ThreadPoolExecutor$Worker run "ThreadPoolExecutor.java" 624]
  [java.lang.Thread run "Thread.java" 748]]}]
	 FINISH: waiter.basic-test/test-basic-shell-command 68s {:test 102, :pass 3142, :fail 1, :error 0, :running 1}
	 FINISH: waiter.websocket-integration-test/test-request-instance-death 134s {:test 102, :pass 3144, :fail 1, :error 0, :running 0}
Longest running tests:
waiter.autoscaling-test/test-expired-instance 301s
waiter.instance-reservation-test/test-instance-reservation 221s
waiter.basic-test/test-list-apps 208s
waiter.basic-test/test-basic-backoff-config 160s
waiter.new-app-test/test-new-app-gc 146s
waiter.websocket-integration-test/test-request-instance-death 134s
waiter.deployment-errors-test/test-health-check-timed-out 111s
waiter.deployment-errors-test/test-invalid-health-check-response 109s
waiter.token-request-test/test-token-param-support 103s
waiter.deployment-errors-test/test-cannot-connect 79s
Ran 102 tests containing 3145 assertions.
1 failures, 0 errors.
Tests failed.
Error encountered performing task 'parallel-test' with profile(s): 'base,system,user,provided,dev,test-log'
Tests failed.
Uploading logs...
***** Kubernetes pod state at 23:07:41 *****
NAME                                                              READY     STATUS        RESTARTS   AGE
testbasicshellcommandtra-2cab35e63ade572b2860bd49aa8a289a-jvgkx   0/2       Terminating   0          1m
testimagefieldvalidation-dbee3fa43589aa7a5c20cefec98df5cf-lx7z5   0/2       Terminating   0          11m
testrequestinstancedeath-edab377e03fb80e478303a7c5ad78143-zlw8s   0/2       Terminating   1          2m
```