### PR TITLE
updates jet version for improved trailers support

### DIFF
--- a/token-syncer/project.clj
+++ b/token-syncer/project.clj
@@ -14,7 +14,7 @@
 ;; limitations under the License.
 ;;
 (defproject token-syncer "0.1.0-SNAPSHOT"
-  :dependencies [[twosigma/jet "0.7.10-20190424_210833-g319cf92"]
+  :dependencies [[twosigma/jet "0.7.10-20190426_181314-g8d0a48b"]
                  [clj-time "0.15.1"]
                  [commons-codec/commons-codec "1.11"]
                  [org.clojure/clojure "1.10.0"]

--- a/token-syncer/project.clj
+++ b/token-syncer/project.clj
@@ -14,7 +14,7 @@
 ;; limitations under the License.
 ;;
 (defproject token-syncer "0.1.0-SNAPSHOT"
-  :dependencies [[twosigma/jet "0.7.10-20190417_013951-gef581db"]
+  :dependencies [[twosigma/jet "0.7.10-20190424_210833-g319cf92"]
                  [clj-time "0.15.1"]
                  [commons-codec/commons-codec "1.11"]
                  [org.clojure/clojure "1.10.0"]

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -32,7 +32,7 @@
 
   :dependencies [[bidi "2.1.5"
                   :exclusions [prismatic/schema ring/ring-core]]
-                 [twosigma/jet "0.7.10-20190424_210833-g319cf92"
+                 [twosigma/jet "0.7.10-20190426_181314-g8d0a48b"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -32,7 +32,7 @@
 
   :dependencies [[bidi "2.1.5"
                   :exclusions [prismatic/schema ring/ring-core]]
-                 [twosigma/jet "0.7.10-20190417_210947-g70a338b"
+                 [twosigma/jet "0.7.10-20190424_210833-g319cf92"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]


### PR DESCRIPTION
## Changes proposed in this PR

- updates jet version for [improved trailers support](https://github.com/twosigma/jet/pull/20)

## Why are we making these changes?

We want to avoid sending empty trailer Header frames for HTTP/2 requests when we know that there are no trailers. 
