### PR TITLE
Runs tests with tight token-update loops serially

### DIFF
--- a/cli/bin/ci/run-integration-tests.sh
+++ b/cli/bin/ci/run-integration-tests.sh
@@ -67,4 +67,5 @@ export WAITER_URI=127.0.0.1:${WAITER_PORT}
 export WAITER_CLI_TEST_DEFAULT_CMD="${ROOT_DIR}/containers/test-apps/kitchen/bin/kitchen --port \${PORT0}"
 export WAITER_TEST_MULTI_CLUSTER=true
 cd ${CLI_DIR}/integration
-pytest
+pytest -m "not serial"
+pytest -m "serial" -n0

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -287,6 +287,7 @@ class WaiterCliTest(util.WaiterTest):
         finally:
             util.delete_token(self.waiter_url, token_name)
 
+    @pytest.mark.serial
     def test_create_if_match(self):
 
         def encountered_stale_token_error(cp):
@@ -424,6 +425,7 @@ class WaiterCliTest(util.WaiterTest):
         finally:
             util.delete_token(self.waiter_url, token_name)
 
+    @pytest.mark.serial
     def test_delete_if_match(self):
 
         def encountered_stale_token_error(cp):


### PR DESCRIPTION
## Changes proposed in this PR

- adding the `serial` mark to the two integration tests with tight token-update loops
- run the `serial` tests as a separate step

## Why are we making these changes?

We've seen `Could not acquire lock` errors from ZooKeeper, and we suspect these tests are causing other tests to get these timeouts from ZK.

## Example

```bash
========================= 59 passed in 140.36 seconds ==========================
============================= test session starts ==============================
platform linux -- Python 3.6.3, pytest-4.3.0, py-1.8.0, pluggy-0.9.0 -- /opt/pyenv/versions/3.6.3/bin/python3.6
cachedir: .pytest_cache
rootdir: /home/travis/build/twosigma/waiter/cli/integration, inifile: setup.cfg
plugins: xdist-1.20.1, forked-1.0.2
collected 61 items / 59 deselected / 2 selected                                
tests/waiter/test_cli.py::WaiterCliTest::test_create_if_match PASSED     [ 50%]
tests/waiter/test_cli.py::WaiterCliTest::test_delete_if_match PASSED     [100%]
=================== 2 passed, 59 deselected in 4.22 seconds ====================
The command "./bin/ci/run-integration-tests.sh" exited with 0.
```