### PR TITLE
Allows specifying token name in token json

### DIFF
--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -67,7 +67,7 @@ def cli(args, waiter_url=None, flags=None, stdin=None, env=None, wait_for_exit=T
 
 def create_or_update(subcommand, waiter_url=None, token_name=None, flags=None, create_flags=None):
     """Creates or updates a token via the CLI"""
-    args = f"{subcommand} {token_name} {create_flags or ''}"
+    args = f"{subcommand} {token_name or ''} {create_flags or ''}"
     cp = cli(args, waiter_url, flags)
     return cp
 


### PR DESCRIPTION
## Changes proposed in this PR

- adding support for specifying the token name in the token json instead of on the command line when doing a `create` or `update`

## Why are we making these changes?

Some users are used to specifying the token name in the json payload. This allows them to continue doing so, without having to also add it as a command-line argument.