### PR TITLE
restricts variations in test metric groups

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -198,8 +198,8 @@
               (assert-response-status response 200)
               (is (not (str/starts-with? (str (get headers "server")) "waiter")) (str "headers:" headers))))))
 
-      (testing "metric group should be waiter_kitchen_test"
-        (is (= "waiter_kitchen_test" (service-id->metric-group waiter-url service-id))
+      (testing "metric group should be waiter_test"
+        (is (= "waiter_test" (service-id->metric-group waiter-url service-id))
             (str "Invalid metric group for " service-id)))
 
       (testing "trailers support in"
@@ -229,7 +229,7 @@
                    :health-check-proto "h2"
                    :health-check-url "/status"
                    :mem 512
-                   :metric-group "baz"
+                   :metric-group "waiter_test"
                    :name (rand-name)
                    :ports 2
                    :version "1"}
@@ -910,7 +910,7 @@
                                          (assoc
                                            :concurrency-level 20
                                            :interstitial-secs interstitial-secs
-                                           :metric-group "waiter_kitchen_test"
+                                           :metric-group "waiter_test"
                                            :name token
                                            :permitted-user (retrieve-username)
                                            :run-as-user (retrieve-username)

--- a/waiter/integration/waiter/statsd_support_test.clj
+++ b/waiter/integration/waiter/statsd_support_test.clj
@@ -21,11 +21,11 @@
 (deftest ^:parallel ^:integration-fast test-header-metric-group
   (testing-using-waiter-url
     (let [headers {:x-waiter-name (rand-name)
-                   :x-waiter-metric-group "foo"}
+                   :x-waiter-metric-group "waiter_test_foo"}
           {:keys [status service-id] :as response} (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))
           value (:metric-group (response->service-description waiter-url response))]
       (is (= 200 status))
-      (is (= "foo" value))
+      (is (= "waiter_test_foo" value))
       (delete-service waiter-url service-id))))
 
 (defn statsd-enabled?

--- a/waiter/integration/waiter/websocket_integration_test.clj
+++ b/waiter/integration/waiter/websocket_integration_test.clj
@@ -69,7 +69,7 @@
     (let [auth-cookie-value (auth-cookie waiter-url)
           ws-response-atom (atom [])
           waiter-headers (assoc (kitchen-request-headers)
-                           "x-waiter-metric-group" "test-ws-support"
+                           "x-waiter-metric-group" "waiter_ws_test"
                            "x-waiter-name" (rand-name))]
       (is auth-cookie-value)
       (try
@@ -103,7 +103,7 @@
     (let [auth-cookie-value (auth-cookie waiter-url)
           ws-response-atom (atom [])
           waiter-headers (assoc (kitchen-request-headers)
-                           "x-waiter-metric-group" "test-ws-support"
+                           "x-waiter-metric-group" "waiter_ws_test"
                            "x-waiter-name" (rand-name))]
       (is auth-cookie-value)
       (try
@@ -139,7 +139,7 @@
     (let [auth-cookie-value (auth-cookie waiter-url)
           ws-response-atom (atom [])
           waiter-headers (assoc (kitchen-request-headers)
-                           "x-waiter-metric-group" "test-ws-support"
+                           "x-waiter-metric-group" "waiter_ws_test"
                            "x-waiter-name" (rand-name))]
       (is auth-cookie-value)
       (try
@@ -172,7 +172,7 @@
           inter-request-interval-ms (+ metrics-sync-interval-ms 1000)
           auth-cookie-value (auth-cookie waiter-url)
           waiter-headers (assoc (kitchen-request-headers)
-                           :x-waiter-metric-group "test-ws-support"
+                           :x-waiter-metric-group "waiter_ws_test"
                            :x-waiter-name (rand-name))
           _ (make-kitchen-request waiter-url waiter-headers :method :get)
           {:keys [headers service-id] :as canary-response}
@@ -224,7 +224,7 @@
     (let [auth-cookie-value (auth-cookie waiter-url)
           send-success-after-timeout-atom (atom true)
           waiter-headers (assoc (kitchen-request-headers)
-                           "x-waiter-metric-group" "test-ws-support"
+                           "x-waiter-metric-group" "waiter_ws_test"
                            "x-waiter-name" (rand-name))]
       (is auth-cookie-value)
       (try
@@ -262,7 +262,7 @@
     (let [auth-cookie-value (auth-cookie waiter-url)
           send-success-after-timeout-atom (atom true)
           waiter-headers (assoc (kitchen-request-headers)
-                           "x-waiter-metric-group" "test-ws-support"
+                           "x-waiter-metric-group" "waiter_ws_test"
                            "x-waiter-name" (rand-name)
                            "x-waiter-max-instances" "1"
                            "x-waiter-concurrency-level" "20")]
@@ -316,7 +316,7 @@
           process-mem 1024
           waiter-headers (-> (kitchen-request-headers)
                              (assoc :x-waiter-mem process-mem
-                                    :x-waiter-metric-group "test-ws-support"
+                                    :x-waiter-metric-group "waiter_ws_test"
                                     :x-waiter-name (rand-name))
                              (update :x-waiter-cmd
                                      (fn [cmd] (str cmd ;; on-the-fly doesn't support x-waiter-env
@@ -366,7 +366,7 @@
     (let [auth-cookie-value (auth-cookie waiter-url)
           uncorrupted-data-streamed-atom (atom false)
           waiter-headers (assoc (kitchen-request-headers)
-                           "x-waiter-metric-group" "test-ws-support"
+                           "x-waiter-metric-group" "waiter_ws_test"
                            "x-waiter-name" (rand-name))]
       (is auth-cookie-value)
       (try
@@ -463,7 +463,7 @@
           iteration-results-atom (atom {})
           concurrency-level 3
           waiter-headers (assoc (kitchen-request-headers)
-                           "x-waiter-metric-group" "test-ws-support"
+                           "x-waiter-metric-group" "waiter_ws_test"
                            "x-waiter-name" (rand-name)
                            "x-waiter-concurrency-level" concurrency-level
                            "x-waiter-scale-up-factor" 0.99

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -360,7 +360,7 @@
    :health-check-url "/status"
    :idle-timeout-mins 10
    :mem 256
-   :metric-group "waiter_kitchen_test"
+   :metric-group "waiter_test"
    :version "version-does-not-matter"})
 
 (defn kitchen-request-headers
@@ -421,7 +421,7 @@
     waiter-url
     (merge
       {:x-waiter-cmd (kitchen-cmd "-p $PORT0")
-       :x-waiter-metric-group "waiter_kitchen_test"}
+       :x-waiter-metric-group "waiter_test"}
       custom-headers)
     :body body
     :cookies cookies


### PR DESCRIPTION
## Changes proposed in this PR

- restricts variations in test metric groups

## Why are we making these changes?

Avoids explosion in the number of metrics groups created over time.
