### PR TITLE
Makes test_ping_basic more reliable

### DIFF
--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -471,7 +471,7 @@ class WaiterCliTest(util.WaiterTest):
             self.assertEqual(0, cp.returncode, cp.stderr)
             self.assertIn('Pinging token', cli.stdout(cp))
             self.assertIn('successful', cli.stdout(cp))
-            self.assertEqual(1, len(util.services_for_token(self.waiter_url, token_name)))
+            util.wait_until_services_for_token(self.waiter_url, token_name, 1)
         finally:
             util.delete_token(self.waiter_url, token_name, kill_services=True)
 

--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -238,5 +238,10 @@ def kill_services_using_token(waiter_url, token_name):
             logging.exception(f'Encountered exception trying to kill service: {service}')
 
 
+def wait_until_services_for_token(waiter_url, token_name, expected_num_services):
+    wait_until(lambda: services_for_token(waiter_url, token_name, log_services=True),
+               lambda svcs: len(svcs) == expected_num_services)
+
+
 def wait_until_no_services_for_token(waiter_url, token_name):
-    wait_until(lambda: services_for_token(waiter_url, token_name, log_services=True), lambda svcs: len(svcs) == 0)
+    wait_until_services_for_token(waiter_url, token_name, 0)


### PR DESCRIPTION
## Changes proposed in this PR

- changing a single `assert` to the wait-until pattern in `test_ping_basic`

## Why are we making these changes?

In multi-router environments, the call to get the number of services for the token can hit a different router than the one that was `ping`ed, which creates a race and can cause the test to fail. This change allows us to simply poll until we get back 1 service running.