### PR TITLE
adds support for request and response content-type in the request log

### DIFF
--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -30,7 +30,7 @@
 (defn request->context
   "Convert a request into a context suitable for logging."
   [{:keys [client-protocol headers internal-protocol query-string remote-addr request-id request-method request-time uri] :as request}]
-  (let [{:strs [host origin user-agent x-cid x-forwarded-for]} headers]
+  (let [{:strs [content-type host origin user-agent x-cid x-forwarded-for]} headers]
     (cond-> {:cid x-cid
              :host host
              :path uri
@@ -42,6 +42,7 @@
       client-protocol (assoc :client-protocol client-protocol)
       internal-protocol (assoc :internal-protocol internal-protocol)
       query-string (assoc :query-string query-string)
+      content-type (assoc :request-content-type content-type)
       request-time (assoc :request-time (du/date-to-str request-time))
       user-agent (assoc :user-agent user-agent))))
 
@@ -50,9 +51,10 @@
   [{:keys [authorization/principal backend-response-latency-ns descriptor latest-service-id get-instance-latency-ns
            handle-request-latency-ns headers instance protocol status] :as response}]
   (let [{:keys [service-id service-description]} descriptor
-        server (get headers "server")]
+        {:strs [content-type server]} headers]
     (cond-> {:status (or status 200)}
       backend-response-latency-ns (assoc :backend-response-latency-ns backend-response-latency-ns)
+      content-type (assoc :response-content-type content-type)
       descriptor (assoc :metric-group (get service-description "metric-group")
                         :service-id service-id
                         :service-name (get service-description "name")

--- a/waiter/test/waiter/request_log_test.clj
+++ b/waiter/test/waiter/request_log_test.clj
@@ -56,7 +56,8 @@
                                                      "version" "service-version"}}
                   :get-instance-latency-ns 500
                   :handle-request-latency-ns 2000
-                  :headers {"server" "foo-bar"}
+                  :headers {"content-type" "application/xml"
+                            "server" "foo-bar"}
                   :instance {:host "instance-host"
                              :id "instance-id"
                              :port 123}
@@ -73,6 +74,7 @@
             :latest-service-id "latest-service-id"
             :metric-group "service-metric-group"
             :principal "principal@DOMAIN.COM"
+            :response-content-type "application/xml"
             :server "foo-bar"
             :service-id "service-id"
             :service-name "service-name"
@@ -85,8 +87,9 @@
     (with-redefs [log (fn [log-data]
                         (swap! log-entries conj log-data))]
       (let [handler (wrap-log (fn [_] {:status 200}))
-            request {:headers {"x-cid" "123"
-                               "host" "host"}
+            request {:headers {"content-type" "text/plain"
+                               "host" "host"
+                               "x-cid" "123"}
                      :remote-addr "127.0.0.1"
                      :request-id "abc"
                      :scheme :http
@@ -99,6 +102,7 @@
                 :host "host"
                 :path "/path"
                 :remote-addr "127.0.0.1"
+                :request-content-type "text/plain"
                 :request-id "abc"
                 :scheme "http"
                 :status 200}


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for request and response content-type in the request log

## Why are we making these changes?

It helps us answer more questions about our requests from the request log.

