### PR TITLE
Removes token name validation from fetch path

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -918,12 +918,12 @@
 
     (testing "can't use invalid token"
       (let [response (make-request waiter-url "/pathabc" :headers {"X-Waiter-Token" "bad/token"})]
-        (is (str/includes? (:body response) "Token must match pattern"))
+        (is (str/includes? (:body response) "Token not found: bad/token"))
         (assert-response-status response 400)))
 
     (testing "can't use invalid token with host set"
       (let [response (make-request waiter-url "/pathabc" :headers {"host" "missing_token" "X-Waiter-Token" "bad/token"})]
-        (is (str/includes? (:body response) "Token must match pattern"))
+        (is (str/includes? (:body response) "Token not found: bad/token"))
         (assert-response-status response 400)))
 
     (testing "can't use missing token with host set"

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -600,6 +600,8 @@
   [kv-store ^String token allowed-keys error-on-missing include-deleted]
   (let [{:strs [deleted run-as-user] :as token-data}
         (when token
+          (when error-on-missing
+            (validate-token token))
           (try
             (kv/fetch kv-store token)
             (catch Exception e
@@ -607,7 +609,6 @@
                 (do
                   ; Check whether the exception is because the token is invalid
                   (log/info e "Error in kv-store fetch")
-                  (validate-token token)
                   ; Token was valid, re-throw exception
                   (throw e))
                 (log/info e "Ignoring kv-store fetch exception")))))

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -600,17 +600,13 @@
   [kv-store ^String token allowed-keys error-on-missing include-deleted]
   (let [{:strs [deleted run-as-user] :as token-data}
         (when token
-          (when error-on-missing
-            (validate-token token))
           (try
             (kv/fetch kv-store token)
             (catch Exception e
               (if error-on-missing
                 (do
-                  ; Check whether the exception is because the token is invalid
                   (log/info e "Error in kv-store fetch")
-                  ; Token was valid, re-throw exception
-                  (throw e))
+                  (throw (ex-info (str "Token not found: " token) {:status 400} e)))
                 (log/info e "Ignoring kv-store fetch exception")))))
         token-data (when (seq token-data) ; populate token owner for backwards compatibility
                      (-> token-data

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -1570,7 +1570,7 @@
                                  (is (= "invalid-format/token" in-token))
                                  (kv/validate-zk-key in-token))]
           (is (empty? (token->service-parameter-template kv-store "invalid-format/token" :error-on-missing false)))
-          (is (thrown-with-msg? ExceptionInfo #"Token must match pattern" (token->service-parameter-template kv-store "invalid-format/token")))))
+          (is (thrown-with-msg? ExceptionInfo #"Token not found: invalid-format/token" (token->service-parameter-template kv-store "invalid-format/token")))))
 
       (testing "test:token->service-description-2"
         (let [{:keys [service-parameter-template token-metadata]} (token->token-description kv-store token)


### PR DESCRIPTION
## Changes proposed in this PR

- removing the call to `validate-token` after a failed `kv-fetch`
- wrapping the underlying store's exception in our own

## Why are we making these changes?

We want the error when a token name is not present to be consistent regardless of how each of the different `kv` implementations works internally.