### PR TITLE
avoids 500 error when invalid owner name is provided

### DIFF
--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -201,9 +201,9 @@
     "List all tokens for a given user."
     [kv-store owner]
     (let [owner->owner-key (kv/fetch kv-store token-owners-key)]
-      (if-let [owner-key (owner->owner-key owner)]
+      (if-let [owner-key (get owner->owner-key owner)]
         (kv/fetch kv-store owner-key)
-        (throw (ex-info "no owner-key found" {:owner owner :status 500})))))
+        (log/info "no owner-key found for owner" owner))))
 
   (defn list-token-owners
     "List token owners."

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -1880,7 +1880,7 @@
                            (f)))
         kv-store (kv/->LocalKeyValueStore (atom {}))
         entitlement-manager (reify authz/EntitlementManager
-                              (authorized? [_ _ _ _] (throw (UnsupportedOperationException. "enexpected call"))))
+                              (authorized? [_ _ _ _] (throw (UnsupportedOperationException. "unexpected call"))))
         handle-list-tokens-request (wrap-handler-json-response handle-list-tokens-request)
         last-update-time-seed (clock-millis)
         token->token-hash (fn [token] (sd/token-data->token-hash (kv/fetch kv-store token)))]
@@ -1992,6 +1992,10 @@
                 "owner" "owner1"
                 "token" "token2"}}
              (set (json/read-str body)))))
+    (let [request {:query-string "owner=does-not-exist" :request-method :get}
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+      (is (= 200 status))
+      (is (= [] (json/read-str body))))
     (let [request {:headers {"accept" "application/json"}
                    :request-method :post}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)


### PR DESCRIPTION
## Changes proposed in this PR

- avoids 500 error when invalid owner name is provided

## Why are we making these changes?

An invalid owner in the query string should not result in a server error, instead should return an empty result.

