### PR TITLE
avoids fatal error for services with unknown service descriptions

### DIFF
--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -771,12 +771,10 @@
   (->> service-ids
        (filter
          (fn [service-id]
-           (if (or (fetch-core kv-store service-id :refresh false)
-                   (do
-                     (log/info "refreshing the service description for" service-id)
-                     (fetch-core kv-store service-id :refresh true)))
-             true
-             (log/warn "filtering" service-id "as no matching service description was found"))))
+           (or (fetch-core kv-store service-id :refresh false)
+               (log/info "refreshing the service description for" service-id)
+               (fetch-core kv-store service-id :refresh true)
+               (log/warn "filtering" service-id "as no matching service description was found"))))
        set))
 
 (let [service-id->key #(str "^STATUS#" %)]

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -1651,11 +1651,10 @@
     (is (nil? (kv/fetch cache-kv-store (service-id->key service-id-3))))
     (is (= (service-id->service-description service-id-4) (kv/fetch cache-kv-store (service-id->key service-id-4))))
 
-    (let [service-ids #{service-id-1 service-id-2 service-id-3 service-id-4}]
-      (->> (conj service-ids "service-id-unknown1" "service-id-unknown2")
-           (refresh-service-descriptions cache-kv-store)
-           (= service-ids)
-           (is)))
+    (let [service-ids #{service-id-1 service-id-2 service-id-3 service-id-4}
+          service-ids-in (conj service-ids "service-id-unknown1" "service-id-unknown2")
+          service-ids-out (refresh-service-descriptions cache-kv-store service-ids-in)]
+      (is (= service-ids service-ids-out)))
 
     (is (= (service-id->service-description service-id-1) (kv/fetch cache-kv-store (service-id->key service-id-1))))
     (is (= (service-id->service-description service-id-2) (kv/fetch cache-kv-store (service-id->key service-id-2))))

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -1651,7 +1651,11 @@
     (is (nil? (kv/fetch cache-kv-store (service-id->key service-id-3))))
     (is (= (service-id->service-description service-id-4) (kv/fetch cache-kv-store (service-id->key service-id-4))))
 
-    (refresh-service-descriptions cache-kv-store #{service-id-1 service-id-2 service-id-3 service-id-4})
+    (let [service-ids #{service-id-1 service-id-2 service-id-3 service-id-4}]
+      (->> (conj service-ids "service-id-unknown1" "service-id-unknown2")
+           (refresh-service-descriptions cache-kv-store)
+           (= service-ids)
+           (is)))
 
     (is (= (service-id->service-description service-id-1) (kv/fetch cache-kv-store (service-id->key service-id-1))))
     (is (= (service-id->service-description service-id-2) (kv/fetch cache-kv-store (service-id->key service-id-2))))


### PR DESCRIPTION
## Changes proposed in this PR

- avoids fatal error for services with unknown service descriptions

## Why are we making these changes?

We should be resilient to invalid services showing up in scheduler queries.

Resolves #719.
