### PR TITLE
Exclude k8s service account injection for default namespace

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -747,7 +747,13 @@
                                     :labels {:app k8s-name
                                              :waiter-cluster cluster-name
                                              :waiter/user run-as-user}}
-                         :spec {:containers [{:command (conj (vec container-init-commands) cmd)
+                         :spec {;; Service account tokens allow easy access to the k8s api server,
+                                ;; but this is only enabled when the x-waiter-namespace is set explicitly
+                                ;; (i.e., don't give arbitrary users access to the default namespace's token).
+                                ;; Note that even if the run-as-user matches the default namespace,
+                                ;; the token is still not mounted unless the namespace was explicitly set.
+                                :automountServiceAccountToken (= namespace run-as-user)
+                                :containers [{:command (conj (vec container-init-commands) cmd)
                                               :env env
                                               :image (compute-image image default-container-image image-aliases)
                                               :imagePullPolicy "IfNotPresent"


### PR DESCRIPTION
## Changes proposed in this PR

Disable auto-mounting of service account credentials when the Kubernetes user running a container does not match the namespace (i.e., the container runAsUser is not the pod owner).

## Why are we making these changes?

Exposing the default namespace's Kubernetes credentials to containers running as arbitrary Waiter users is a potential security risk. See the official Kubernetes documentation for more details: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server