### PR TITLE
Uses 'Current' and 'Not Current' for the services table

### DIFF
--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -873,11 +873,12 @@ class WaiterCliTest(util.WaiterTest):
             cp = cli.show(self.waiter_url, token_name)
             self.assertEqual(0, cp.returncode, cp.stderr)
             self.assertIsNotNone(re.search('^# Services\\s+2$', cli.stdout(cp), re.MULTILINE))
-            self.assertIsNotNone(re.search('^# Failing\\s+(0|1)$', cli.stdout(cp), re.MULTILINE))
+            self.assertIsNotNone(re.search('^# Failing\\s+([01])$', cli.stdout(cp), re.MULTILINE))
             self.assertIsNotNone(re.search('^Total Memory\\s+384 MiB$', cli.stdout(cp), re.MULTILINE))
             self.assertIsNotNone(re.search('^Total CPUs\\s+0\\.3$', cli.stdout(cp), re.MULTILINE))
-            self.assertIsNotNone(re.search(f'^{service_id_1}.+Running.+✗$', cli.stdout(cp), re.MULTILINE))
-            self.assertIsNotNone(re.search(f'^{service_id_2}.+(Failing|Starting).+✔$', cli.stdout(cp), re.MULTILINE))
+            self.assertIsNotNone(re.search(f'^{service_id_1}.+Running.+Not Current$', cli.stdout(cp), re.MULTILINE))
+            self.assertIsNotNone(re.search(f'^{service_id_2}.+(Failing|Starting).+Current$',
+                                           cli.stdout(cp), re.MULTILINE))
 
             # Run show without --json and with --no-services
             cp = cli.show(self.waiter_url, token_name, show_flags='--no-services')

--- a/cli/waiter/subcommands/show.py
+++ b/cli/waiter/subcommands/show.py
@@ -15,9 +15,9 @@ def format_using_current_token(service, token_etag):
     """Formats the "Current?" column for the given service"""
     is_current = any(token['version'] == token_etag for source in service['source-tokens'] for token in source)
     if is_current:
-        return terminal.success(u'\u2714')  # ✔
+        return terminal.success('Current')
     else:
-        return u'\u2717'  # ✗
+        return 'Not Current'
 
 
 def tabulate_token_services(services, token_etag):


### PR DESCRIPTION
## Changes proposed in this PR

- changing from using unicode characters to simply `Current` and `Not Current`

## Why are we making these changes?

First, some users' terminals may not be able to display the unicode characters. Second, it's more clear what the value means, especially if you can't see the table header.

## Example

```bash
$ waiter show demo                                                                                                                                                                                                                                        

=== WAITER2 / demo ===

Last Updated: seconds ago (dpo)

Owner    dpo
CPUs     0.1
Memory   128 MiB
Version  foo

Command:
/home/dpo/source/waiter/containers/test-apps/kitchen/bin/kitchen -p $PORT0

# Services    2
# Failing     1
Total Memory  256 MiB
Total CPUs    0.2

Service Id                                       Run as user      CPUs  Memory    Version    Status    Last request    Current?
waiter-service-e7f9b94ddbf9cee0c130c3285d2790e3  dpo               0.1  128 MiB   foo        Running   just now        Current
waiter-service-a664bc6d0aaaa498b3acdc94bfd2bfda  dpo               0.1  128 MiB   foo        Failing   a minute ago    Not Current
```