### PR TITLE
Disable h2c tests

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -1047,7 +1047,7 @@
                 (using-shell? waiter-url))
             (make-kitchen-request-fn "dummy/image" 500)))))
 
-(deftest ^:parallel ^:integration-fast test-internal-protocol
+(deftest ^:parallel ^:integration-fast ^:explicit test-internal-protocol
   (testing-using-waiter-url
     (let [{:keys [http2c? http2? ssl-port]} (:server-options (waiter-settings waiter-url))
           retrieve-client-protocol #(get-in % ["request-info" "client-protocol"])

--- a/waiter/integration/waiter/trailers_test.clj
+++ b/waiter/integration/waiter/trailers_test.clj
@@ -92,7 +92,7 @@
   (testing-using-waiter-url
     (run-sediment-trailers-support-test waiter-url "http")))
 
-(deftest ^:parallel ^:integration-fast test-trailers-support-h2c-proto-sediment
+(deftest ^:parallel ^:integration-fast ^:explicit test-trailers-support-h2c-proto-sediment
   (testing-using-waiter-url
     (run-sediment-trailers-support-test waiter-url "h2c")))
 


### PR DESCRIPTION
## Changes proposed in this PR

Disable two integration tests:
- `test-internal-protocol`
- `test-trailers-support-h2c-proto-sediment`

## Why are we making these changes?

Waiting for a new haproxy version before re-enabling these tests.
