### PR TITLE
Add JSON spec to create Kitchen service via waiter cli

### DIFF
--- a/containers/test-apps/kitchen/README.md
+++ b/containers/test-apps/kitchen/README.md
@@ -69,3 +69,18 @@ $ ./bin/kitchen -p 8080 &
 $ KITCHEN_AUTOSTART=false KITCHEN_HOST=localhost KITCHEN_PORT=8080 pytest
 ...
 ```
+
+# Testing in Waiter
+
+For convenience, a Waiter token specification for the Kitchen app is included in `kitchen.json`.
+This makes it simple to start up an instance of Kitchen using the Waiter CLI:
+
+```bash
+$ waiter create --json ./kitchen.json
+Attempting to create token on dev0...
+Successfully created kitchen.
+$ waiter ping kitchen
+Pinging token kitchen at /status in dev0...
+Ping successful.
+Hello World
+```

--- a/containers/test-apps/kitchen/kitchen.json
+++ b/containers/test-apps/kitchen/kitchen.json
@@ -1,0 +1,10 @@
+{
+    "name": "kitchen",
+    "cmd": "/opt/kitchen/kitchen -p $PORT0",
+    "cmd-type": "shell",
+    "cpus": 0.1,
+    "health-check-url": "/status",
+    "mem": 128,
+    "token": "kitchen",
+    "version": "0"
+}


### PR DESCRIPTION
## Changes proposed in this PR

- Add JSON spec to create Kitchen service via waiter cli

## Why are we making these changes?

This makes it easier to test Waiter in a local dev environment by creating the Kitchen test service.