### PR TITLE
avoids TE hop-by-hop removal for grpc requests

### DIFF
--- a/waiter/test/waiter/headers_test.clj
+++ b/waiter/test/waiter/headers_test.clj
@@ -155,8 +155,8 @@
 
 (deftest test-dissoc-hop-by-hop-headers
   (let [headers {"connection" "keep-alive, foo, lorem, ipsum"
-                 "content" "text/html"
                  "content-encoding" "gzip"
+                 "content-type" "text/html"
                  "bar" "bar-value"
                  "foo" "foo-value"
                  "lorem" "lorem-value"
@@ -167,15 +167,23 @@
                  "transfer-encoding" "trailers, deflate"
                  "upgrade" "http/2.0, https/1.3, irc/6.9, rta/x11, websocket"}]
     (is (= {"bar" "bar-value"
-            "content" "text/html"
             "content-encoding" "gzip"
+            "content-type" "text/html"
+            "proxy-connection" "keep-alive"
+            "referer" "http://www.test-referer.com"}
+           (dissoc-hop-by-hop-headers headers "HTTP/2.0")))
+    (is (= {"bar" "bar-value"
+            "content-encoding" "gzip"
+            "content-type" "application/grpc"
             "proxy-connection" "keep-alive"
             "referer" "http://www.test-referer.com"
             "te" "trailers, deflate"}
-           (dissoc-hop-by-hop-headers headers "HTTP/2.0")))
+           (-> headers
+             (assoc "content-type" "application/grpc")
+             (dissoc-hop-by-hop-headers "HTTP/2.0"))))
     (is (= {"bar" "bar-value"
-            "content" "text/html"
             "content-encoding" "gzip"
+            "content-type" "text/html"
             "proxy-connection" "keep-alive"
             "referer" "http://www.test-referer.com"}
            (dissoc-hop-by-hop-headers headers "HTTP/1.0")))))

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -324,10 +324,10 @@
                                         (is (:auth request-config))
                                         (is (= "body" (:body request-config)))
                                         (is (= 654321 (:idle-timeout request-config)))
-                                        (is (= (-> (apply dissoc passthrough-headers (if (= proto-version "HTTP/2.0") [] ["te"]))
+                                        (is (= (-> passthrough-headers
                                                    (dissoc "expect" "authorization"
                                                            "connection" "keep-alive" "proxy-authenticate" "proxy-authorization"
-                                                           "trailers" "transfer-encoding" "upgrade")
+                                                           "te" "trailers" "transfer-encoding" "upgrade")
                                                    (merge {"x-waiter-auth-principal" "test-user"
                                                            "x-waiter-authenticated-principal" "test-user@test.com"}))
                                                (:headers request-config)))


### PR DESCRIPTION
## Changes proposed in this PR

- avoids TE hop-by-hop removal for grpc requests

## Why are we making these changes?

Be more specific in the handling of the TE headers and special treatment for GRPC requests.

