### PR TITLE
updates jet to 0.7.10-20190508_061258-gebd9d0a

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -32,7 +32,7 @@
 
   :dependencies [[bidi "2.1.5"
                   :exclusions [prismatic/schema ring/ring-core]]
-                 [twosigma/jet "0.7.10-20190426_181314-g8d0a48b"
+                 [twosigma/jet "0.7.10-20190508_061258-gebd9d0a"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]


### PR DESCRIPTION

## Changes proposed in this PR

- updates jet to 0.7.10-20190508_061258-gebd9d0a 
- updates jetty to 9.4.18.v20190429

## Why are we making these changes?

We would like to benefit from any bug fixes by running the latest version of our dependencies.
