### PR TITLE
Adds logging and checks to util.post_token

### DIFF
--- a/waiter/integration/waiter/websocket_integration_test.clj
+++ b/waiter/integration/waiter/websocket_integration_test.clj
@@ -219,7 +219,7 @@
                     (t/equal? minimum-last-request-time service-last-request-time))
                 (str [minimum-last-request-time service-last-request-time]))))))))
 
-(deftest ^:parallel ^:integration-fast test-request-socket-timeout
+(deftest ^:parallel ^:integration-fast ^:explicit test-request-socket-timeout
   (testing-using-waiter-url
     (let [auth-cookie-value (auth-cookie waiter-url)
           send-success-after-timeout-atom (atom true)


### PR DESCRIPTION
## Changes proposed in this PR

- logging the response headers from posting a token
- after posting a token, fetching it and asserting that it has the expected fields

## Why are we making these changes?

To make debugging failed tests easier.
