### PR TITLE
Allows providing token JSON from stdin

### DIFF
--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -4,13 +4,13 @@ import os
 import pty
 import shlex
 
-# Manually create a TTY that we can use as the default STDIN
 import subprocess
 import tempfile
 from fcntl import fcntl, F_GETFL, F_SETFL
 
 from tests.waiter import util
 
+# Manually create a TTY that we can use as the default STDIN
 _STDIN_TTY = pty.openpty()[1]
 
 
@@ -65,22 +65,22 @@ def cli(args, waiter_url=None, flags=None, stdin=None, env=None, wait_for_exit=T
     return cp
 
 
-def create_or_update(subcommand, waiter_url=None, token_name=None, flags=None, create_flags=None):
+def create_or_update(subcommand, waiter_url=None, token_name=None, flags=None, create_flags=None, stdin=None):
     """Creates or updates a token via the CLI"""
     args = f"{subcommand} {token_name or ''} {create_flags or ''}"
-    cp = cli(args, waiter_url, flags)
+    cp = cli(args, waiter_url, flags, stdin)
     return cp
 
 
-def create(waiter_url=None, token_name=None, flags=None, create_flags=None):
+def create(waiter_url=None, token_name=None, flags=None, create_flags=None, stdin=None):
     """Creates a token via the CLI"""
-    cp = create_or_update('create', waiter_url, token_name, flags, create_flags)
+    cp = create_or_update('create', waiter_url, token_name, flags, create_flags, stdin)
     return cp
 
 
-def update(waiter_url=None, token_name=None, flags=None, update_flags=None):
+def update(waiter_url=None, token_name=None, flags=None, update_flags=None, stdin=None):
     """Updates a token via the CLI"""
-    cp = create_or_update('update', waiter_url, token_name, flags, update_flags)
+    cp = create_or_update('update', waiter_url, token_name, flags, update_flags, stdin)
     return cp
 
 

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -746,6 +746,17 @@ class WaiterCliTest(util.WaiterTest):
 
     def test_post_token_json_invalid(self):
         token_name = self.token_name()
+
+        stdin = json.dumps([]).encode('utf8')
+        cp = cli.update(self.waiter_url, token_name, update_flags=f'--json -', stdin=stdin)
+        self.assertEqual(1, cp.returncode, cp.stderr)
+        self.assertIn('Token must be a dictionary', cli.stderr(cp))
+
+        stdin = '{"mem": 128'.encode('utf8')
+        cp = cli.update(self.waiter_url, token_name, update_flags=f'--json -', stdin=stdin)
+        self.assertEqual(1, cp.returncode, cp.stderr)
+        self.assertIn('Malformed JSON', cli.stderr(cp))
+
         with tempfile.NamedTemporaryFile(delete=True) as file:
             cp = cli.update(self.waiter_url, token_name, update_flags=f'--json {file.name}')
             self.assertEqual(1, cp.returncode, cp.stderr)

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -688,22 +688,47 @@ class WaiterCliTest(util.WaiterTest):
             util.delete_token(self.waiter_url, token_name)
 
     def test_create_token_json(self):
+        create_fields = {'cpus': 0.1, 'mem': 128}
+
+        # Test with json from stdin
         token_name = self.token_name()
-        with cli.temp_token_file({'cpus': 0.1, 'mem': 128}) as path:
-            cp = cli.create(self.waiter_url, token_name, create_flags=f'--json {path}')
-            self.assertEqual(0, cp.returncode, cp.stderr)
-            try:
+        stdin = json.dumps(create_fields).encode('utf8')
+        cp = cli.create(self.waiter_url, token_name, create_flags=f'--json -', stdin=stdin)
+        self.assertEqual(0, cp.returncode, cp.stderr)
+        try:
+            token_data = util.load_token(self.waiter_url, token_name)
+            self.assertEqual(0.1, token_data['cpus'])
+            self.assertEqual(128, token_data['mem'])
+
+            # Test with json from a file
+            util.delete_token(self.waiter_url, token_name)
+            with cli.temp_token_file(create_fields) as path:
+                cp = cli.create(self.waiter_url, token_name, create_flags=f'--json {path}')
+                self.assertEqual(0, cp.returncode, cp.stderr)
                 token_data = util.load_token(self.waiter_url, token_name)
                 self.assertEqual(0.1, token_data['cpus'])
                 self.assertEqual(128, token_data['mem'])
-            finally:
-                util.delete_token(self.waiter_url, token_name)
+        finally:
+            util.delete_token(self.waiter_url, token_name)
 
     def test_update_token_json(self):
         token_name = self.token_name()
-        util.post_token(self.waiter_url, token_name, {'cpus': 0.1, 'mem': 128, 'cmd': 'foo'})
+        create_fields = {'cpus': 0.1, 'mem': 128, 'cmd': 'foo'}
+        update_fields = {'cpus': 0.2, 'mem': 256}
+        util.post_token(self.waiter_url, token_name, create_fields)
         try:
-            with cli.temp_token_file({'cpus': 0.2, 'mem': 256}) as path:
+            # Test with json from stdin
+            stdin = json.dumps(update_fields).encode('utf8')
+            cp = cli.update(self.waiter_url, token_name, update_flags=f'--json -', stdin=stdin)
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            token_data = util.load_token(self.waiter_url, token_name)
+            self.assertEqual(0.2, token_data['cpus'])
+            self.assertEqual(256, token_data['mem'])
+            self.assertEqual('foo', token_data['cmd'])
+
+            # Test with json from a file
+            util.post_token(self.waiter_url, token_name, create_fields)
+            with cli.temp_token_file(update_fields) as path:
                 cp = cli.update(self.waiter_url, token_name, update_flags=f'--json {path}')
                 self.assertEqual(0, cp.returncode, cp.stderr)
                 token_data = util.load_token(self.waiter_url, token_name)

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -75,12 +75,13 @@ def parse_raw_token_spec(r):
     """
     try:
         content = json.loads(r)
-        if type(content) is dict:
-            return content
-        else:
-            raise ValueError('Invalid format for raw token')
     except Exception:
-        raise ValueError('Malformed JSON for raw token')
+        raise ValueError('Malformed JSON for raw token.')
+
+    if type(content) is dict:
+        return content
+    else:
+        raise ValueError('Token must be a dictionary of attributes.')
 
 
 def read_token_from_stdin():


### PR DESCRIPTION
## Changes proposed in this PR

- allowing for `-` to be used when passing `--json`, which causes the json to be read from stdin

## Why are we making these changes?

It's often convenient to provide the input on stdin instead of having to create a file.

## Demo

[![asciicast](https://asciinema.org/a/xnkmKb6ahT8GIJfxhxFrAOO3B.svg)](https://asciinema.org/a/xnkmKb6ahT8GIJfxhxFrAOO3B?autoplay=1)