### PR TITLE
avoids sending custom user-agent headers to the backend

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -67,6 +67,7 @@
         (let [request-headers (assoc request-headers :accept "text/plain")
               {:keys [body headers]} (make-kitchen-request waiter-url request-headers :path "/request-info")
               body-json (json/read-str (str body))]
+          (is (= (some-> http1-client .getUserAgentField .getValue) (get-in body-json ["headers" "user-agent"])) (str body))
           (is (= "application/json" (get headers "content-type")) (str headers))
           (is (every? #(get-in body-json ["headers" %]) ["authorization" "x-cid" "x-waiter-auth-principal"]) (str body))
           (is (nil? (get-in body-json ["headers" "content-type"])) (str body))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -535,12 +535,10 @@
                           (utils/create-component entitlement-config))
    :fallback-state-atom (pc/fnk [] (atom {:available-service-ids #{}
                                           :healthy-service-ids #{}}))
-   :http-clients (pc/fnk [[:settings [:instance-request-properties connection-timeout-ms]]
-                          server-name]
+   :http-clients (pc/fnk [[:settings [:instance-request-properties connection-timeout-ms]]]
                    (http-utils/prepare-http-clients
                      {:conn-timeout connection-timeout-ms
-                      :follow-redirects? false
-                      :user-agent server-name}))
+                      :follow-redirects? false}))
    :instance-rpc-chan (pc/fnk [] (async/chan 1024)) ; TODO move to service-chan-maintainer
    :interstitial-state-atom (pc/fnk [] (atom {:initialized? false
                                               :service-id->interstitial-promise {}}))


### PR DESCRIPTION
## Changes proposed in this PR

- avoids sending custom user-agent headers to the backend

## Why are we making these changes?

Some backends, e.g. grpc servers, are sensitive to the presence of multiple `user-agent` headers in the request and fail the request. Hence, we avoid sending any additional `user-agent` headers to the backend.
