### PR TITLE
Adds --no-wait to waiter ping

### DIFF
--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -680,6 +680,13 @@ class WaiterCliTest(util.WaiterTest):
             self.assertEqual(0, cp.returncode, cp.stderr)
             self.assertIn('Service is currently Starting', cli.stdout(cp))
             util.wait_until_services_for_token(self.waiter_url, token_name, 1)
+
+            util.kill_services_using_token(self.waiter_url, token_name)
+            util.post_token(self.waiter_url, token_name, {'cpus': 0.1})
+            cp = cli.ping(self.waiter_url, token_name, ping_flags='--no-wait')
+            self.assertEqual(1, cp.returncode, cp.stderr)
+            self.assertNotIn('Service is currently', cli.stdout(cp))
+            util.wait_until_no_services_for_token(self.waiter_url, token_name)
         finally:
             util.kill_services_using_token(self.waiter_url, token_name)
             util.delete_token(self.waiter_url, token_name)

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1,3 +1,4 @@
+import datetime
 import getpass
 import json
 import logging
@@ -1035,3 +1036,71 @@ class WaiterCliTest(util.WaiterTest):
             cp = cli.create(self.waiter_url, create_flags=f'--json {path}')
             self.assertEqual(1, cp.returncode, cp.stderr)
             self.assertIn('must specify the token name', cli.stderr(cp))
+
+    def test_show_service_current(self):
+        token_name_1 = self.token_name()
+        token_name_2 = self.token_name()
+        custom_fields = {
+            'owner': getpass.getuser(),
+            'cluster': 'test_show_service_current',
+            'root': 'test_show_service_current',
+            'last-update-user': getpass.getuser(),
+            'last-update-time': datetime.datetime.utcnow().isoformat()
+        }
+        token_definition = util.minimal_service_description(**custom_fields)
+
+        # Post two identical tokens with different names
+        util.post_token(self.waiter_url, token_name_1, token_definition, update_mode_admin=True, assert_response=False)
+        util.post_token(self.waiter_url, token_name_2, token_definition, update_mode_admin=True, assert_response=False)
+        try:
+            # Assert that their etags match
+            etag_1 = util.load_token_with_headers(self.waiter_url, token_name_1)[1]['ETag']
+            etag_2 = util.load_token_with_headers(self.waiter_url, token_name_2)[1]['ETag']
+            self.assertEqual(etag_1, etag_2)
+
+            # Create service A from the two tokens
+            service_id_a = util.ping_token(self.waiter_url, f'{token_name_1},{token_name_2}')
+
+            # Update token #2 only and assert that their etags don't match
+            token_definition['cpus'] += 0.1
+            util.post_token(self.waiter_url, token_name_2, token_definition, update_mode_admin=True,
+                            assert_response=False, etag=etag_1)
+            etag_1 = util.load_token_with_headers(self.waiter_url, token_name_1)[1]['ETag']
+            etag_2 = util.load_token_with_headers(self.waiter_url, token_name_2)[1]['ETag']
+            self.assertNotEqual(etag_1, etag_2)
+
+            # Create service B from the two tokens
+            service_id_b = util.ping_token(self.waiter_url, f'{token_name_1},{token_name_2}')
+
+            # Update token #1 to match token #2 and assert that their etags match
+            util.post_token(self.waiter_url, token_name_1, token_definition, update_mode_admin=True,
+                            assert_response=False, etag=etag_1)
+            etag_1 = util.load_token_with_headers(self.waiter_url, token_name_1)[1]['ETag']
+            etag_2 = util.load_token_with_headers(self.waiter_url, token_name_2)[1]['ETag']
+            self.assertEqual(etag_1, etag_2)
+
+            # Update token #2 only and assert that their etags don't match
+            token_definition['cpus'] += 0.1
+            util.post_token(self.waiter_url, token_name_2, token_definition, update_mode_admin=True,
+                            assert_response=False, etag=etag_1)
+            etag_1 = util.load_token_with_headers(self.waiter_url, token_name_1)[1]['ETag']
+            etag_2 = util.load_token_with_headers(self.waiter_url, token_name_2)[1]['ETag']
+            self.assertNotEqual(etag_1, etag_2)
+
+            # Create service C from the two tokens
+            service_id_c = util.ping_token(self.waiter_url, f'{token_name_1},{token_name_2}')
+
+            # For both tokens, only service C should be "current"
+            cp = cli.show(self.waiter_url, token_name_1)
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            self.assertIsNotNone(re.search(f'^{service_id_a}.+Running.+Not Current$', cli.stdout(cp), re.MULTILINE))
+            self.assertIsNotNone(re.search(f'^{service_id_b}.+Running.+Not Current$', cli.stdout(cp), re.MULTILINE))
+            self.assertIsNotNone(re.search(f'^{service_id_c}.+Running.+Current$', cli.stdout(cp), re.MULTILINE))
+            cp = cli.show(self.waiter_url, token_name_2)
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            self.assertIsNotNone(re.search(f'^{service_id_a}.+Running.+Not Current$', cli.stdout(cp), re.MULTILINE))
+            self.assertIsNotNone(re.search(f'^{service_id_b}.+Running.+Not Current$', cli.stdout(cp), re.MULTILINE))
+            self.assertIsNotNone(re.search(f'^{service_id_c}.+Running.+Current$', cli.stdout(cp), re.MULTILINE))
+        finally:
+            util.delete_token(self.waiter_url, token_name_1, kill_services=True)
+            util.delete_token(self.waiter_url, token_name_2, kill_services=True)

--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -267,8 +267,8 @@ def kill_services_using_token(waiter_url, token_name):
 
 
 def wait_until_services_for_token(waiter_url, token_name, expected_num_services):
-    wait_until(lambda: services_for_token(waiter_url, token_name, log_services=True),
-               lambda svcs: len(svcs) == expected_num_services)
+    return wait_until(lambda: services_for_token(waiter_url, token_name, log_services=True),
+                      lambda svcs: len(svcs) == expected_num_services)
 
 
 def wait_until_no_services_for_token(waiter_url, token_name):

--- a/cli/waiter/subcommands/ping.py
+++ b/cli/waiter/subcommands/ping.py
@@ -88,7 +88,7 @@ def token_has_current_service(cluster, token_name, current_token_etag):
     """If the given token has a "current" service, returns that service else None"""
     services = get_services_using_token(cluster, token_name)
     if services is not None:
-        services = [s for s in services if is_service_current(s, current_token_etag)]
+        services = [s for s in services if is_service_current(s, current_token_etag, token_name)]
         return services[0] if len(services) > 0 else False
     else:
         cluster_name = cluster['name']

--- a/cli/waiter/subcommands/ping.py
+++ b/cli/waiter/subcommands/ping.py
@@ -29,7 +29,8 @@ def ping_on_cluster(cluster, health_check_endpoint, timeout, wait_for_request, t
         except Exception:
             message = f'Encountered error while pinging in {cluster_name}.'
             logging.exception(message)
-            # print_error(message)
+            if wait_for_request:
+                print_error(message)
 
         return False
 

--- a/cli/waiter/subcommands/ping.py
+++ b/cli/waiter/subcommands/ping.py
@@ -1,49 +1,93 @@
 import logging
+import threading
 
 from waiter import http_util, terminal
-from waiter.querying import query_token, print_no_data, query_service
-from waiter.util import guard_no_cluster, response_message, print_error, check_positive
+from waiter.format import format_status
+from waiter.querying import query_token, print_no_data, query_service, get_services_using_token, get_service
+from waiter.util import guard_no_cluster, response_message, print_error, check_positive, wait_until, is_service_current
 
 
-def ping_on_cluster(cluster, health_check_endpoint, timeout, token_name):
+def ping_on_cluster(cluster, health_check_endpoint, timeout, wait_for_request, token_name, service_exists_fn):
     """Pings using the given token name (or ^SERVICE-ID#) in the given cluster."""
     cluster_name = cluster['name']
-    try:
-        headers = {
-            'X-Waiter-Token': token_name,
-            'X-Waiter-Fallback-Period-Secs': '0'
-        }
-        resp = http_util.get(cluster, health_check_endpoint, headers=headers, read_timeout=timeout)
-        logging.debug(f'Response status code: {resp.status_code}')
-        if resp.status_code == 200:
-            print(terminal.success(f'Ping successful.'))
-            print(resp.text)
-            return True
-        else:
-            print_error(response_message(resp.json()))
-            return False
-    except Exception:
-        message = f'Encountered error while pinging in {cluster_name}.'
-        logging.exception(message)
-        print_error(message)
+
+    def perform_ping():
+        try:
+            headers = {
+                'X-Waiter-Token': token_name,
+                'X-Waiter-Fallback-Period-Secs': '0'
+            }
+            read_timeout = timeout if wait_for_request else 5
+            resp = http_util.get(cluster, health_check_endpoint, headers=headers, read_timeout=read_timeout)
+            logging.debug(f'Response status code: {resp.status_code}')
+            if resp.status_code == 200:
+                print(terminal.success(f'Ping successful.'))
+                print(resp.text)
+                return True
+            else:
+                print_error(response_message(resp.json()))
+        except Exception:
+            message = f'Encountered error while pinging in {cluster_name}.'
+            logging.exception(message)
+            # print_error(message)
+
+        return False
+
+    if wait_for_request:
+        return perform_ping()
+    else:
+        thread = threading.Thread(target=perform_ping)
+        try:
+            thread.start()
+            service = wait_until(service_exists_fn, timeout=timeout, interval=5)
+            if service:
+                print(f'Service is currently {format_status(service["status"])}.')
+                return True
+            else:
+                print_error('Timeout waiting for service to exist.')
+                return False
+        finally:
+            thread.join()
 
 
-def ping_token_on_cluster(cluster, token_name, health_check_endpoint, timeout):
+def token_has_current_service(cluster, token_name, current_token_etag):
+    """TODO(DPO)"""
+    services = get_services_using_token(cluster, token_name)
+    if services is not None:
+        services = [s for s in services if is_service_current(s, current_token_etag)]
+        # print(json.dumps(services, indent=2))
+        return services[0] if len(services) > 0 else False
+    else:
+        cluster_name = cluster['name']
+        print_error(f'Unable to retrieve services using token {token_name} in {cluster_name}.')
+        return False
+
+
+def ping_token_on_cluster(cluster, token_name, health_check_endpoint, timeout, wait_for_request,
+                          current_token_etag):
     """Pings the token with the given token name in the given cluster."""
     cluster_name = cluster['name']
     print(f'Pinging token {terminal.bold(token_name)} '
           f'at {terminal.bold(health_check_endpoint)} '
           f'in {terminal.bold(cluster_name)}...')
-    return ping_on_cluster(cluster, health_check_endpoint, timeout, token_name)
+    return ping_on_cluster(cluster, health_check_endpoint, timeout, wait_for_request,
+                           token_name, lambda: token_has_current_service(cluster, token_name, current_token_etag))
 
 
-def ping_service_on_cluster(cluster, service_id, health_check_endpoint, timeout):
+def service_is_active(cluster, service_id):
+    """TODO(DPO)"""
+    service = get_service(cluster, service_id)
+    return service if service['status'] != 'Inactive' else False
+
+
+def ping_service_on_cluster(cluster, service_id, health_check_endpoint, timeout, wait_for_request):
     """Pings the service with the given service id in the given cluster."""
     cluster_name = cluster['name']
     print(f'Pinging service {terminal.bold(service_id)} '
           f'at {terminal.bold(health_check_endpoint)} '
           f'in {terminal.bold(cluster_name)}...')
-    return ping_on_cluster(cluster, health_check_endpoint, timeout, f'^SERVICE-ID#{service_id}')
+    return ping_on_cluster(cluster, health_check_endpoint, timeout, wait_for_request,
+                           f'^SERVICE-ID#{service_id}', lambda: service_is_active(cluster, service_id))
 
 
 def ping(clusters, args, _):
@@ -61,6 +105,7 @@ def ping(clusters, args, _):
         return 1
 
     timeout = args.get('timeout', None)
+    wait_for_request = args.get('wait', True)
     http_util.set_retries(0)
     cluster_data_pairs = sorted(query_result['clusters'].items())
     clusters_by_name = {c['name']: c for c in clusters}
@@ -69,15 +114,18 @@ def ping(clusters, args, _):
         cluster = clusters_by_name[cluster_name]
         if is_service_id:
             health_check_endpoint = data['service']['effective-parameters']['health-check-url']
-            success = ping_service_on_cluster(cluster, token_name_or_service_id, health_check_endpoint, timeout)
+            success = ping_service_on_cluster(cluster, token_name_or_service_id, health_check_endpoint,
+                                              timeout, wait_for_request)
         else:
             token_data = data['token']
+            token_etag = data['etag']
             token_cluster_name = token_data['cluster'].upper()
             if len(clusters) == 1 or token_explicitly_created_on_cluster(cluster, token_cluster_name):
                 # We are hard-coding the default health-check-url here to /status; this could
                 # alternatively be retrieved from /settings, but we want to skip the extra request
                 health_check_endpoint = token_data.get('health-check-url', '/status')
-                success = ping_token_on_cluster(cluster, token_name_or_service_id, health_check_endpoint, timeout)
+                success = ping_token_on_cluster(cluster, token_name_or_service_id, health_check_endpoint,
+                                                timeout, wait_for_request, token_etag)
             else:
                 print(f'Not pinging token {terminal.bold(token_name_or_service_id)} '
                       f'in {terminal.bold(cluster_name)} '
@@ -103,4 +151,6 @@ def register(add_parser):
                         type=check_positive, default=60)
     parser.add_argument('--service-id', '-s', help='ping by service id instead of token',
                         dest='is-service-id', action='store_true')
+    parser.add_argument('--no-wait', '-n', help='do not wait for ping request to return',
+                        dest='wait', action='store_false')
     return ping

--- a/cli/waiter/subcommands/show.py
+++ b/cli/waiter/subcommands/show.py
@@ -8,12 +8,12 @@ from waiter.format import format_field_name, format_last_request_time, format_me
     format_status, format_timestamp_string
 
 from waiter.querying import print_no_data, query_token
-from waiter.util import guard_no_cluster
+from waiter.util import guard_no_cluster, is_service_current
 
 
 def format_using_current_token(service, token_etag):
     """Formats the "Current?" column for the given service"""
-    is_current = any(token['version'] == token_etag for source in service['source-tokens'] for token in source)
+    is_current = is_service_current(service, token_etag)
     if is_current:
         return terminal.success('Current')
     else:

--- a/cli/waiter/subcommands/show.py
+++ b/cli/waiter/subcommands/show.py
@@ -11,16 +11,16 @@ from waiter.querying import print_no_data, query_token
 from waiter.util import guard_no_cluster, is_service_current
 
 
-def format_using_current_token(service, token_etag):
+def format_using_current_token(service, token_etag, token_name):
     """Formats the "Current?" column for the given service"""
-    is_current = is_service_current(service, token_etag)
+    is_current = is_service_current(service, token_etag, token_name)
     if is_current:
         return terminal.success('Current')
     else:
         return 'Not Current'
 
 
-def tabulate_token_services(services, token_etag):
+def tabulate_token_services(services, token_etag, token_name):
     """Returns a table displaying the service info"""
     num_services = len(services)
     if num_services > 0:
@@ -41,7 +41,7 @@ def tabulate_token_services(services, token_etag):
                                          ('Version', s['service-description']['version']),
                                          ('Status', format_status(s['status'])),
                                          ('Last request', format_last_request_time(s)),
-                                         ('Current?', format_using_current_token(s, token_etag))])
+                                         ('Current?', format_using_current_token(s, token_etag, token_name))])
                 for s in services]
         service_table = tabulate(rows, headers='keys', tablefmt='plain')
         return f'\n\n{summary_table}\n\n{service_table}'
@@ -88,7 +88,7 @@ def tabulate_token(cluster_name, token, token_name, services, token_etag):
     table_text = tabulate(table, tablefmt='plain')
     last_update_time = format_timestamp_string(token['last-update-time'])
     last_update_user = f' ({token["last-update-user"]})' if 'last-update-user' in token else ''
-    service_table = tabulate_token_services(services, token_etag)
+    service_table = tabulate_token_services(services, token_etag, token_name)
     return f'\n' \
         f'=== {terminal.bold(cluster_name)} / {terminal.bold(token_name)} ===\n' \
         f'\n' \

--- a/cli/waiter/util.py
+++ b/cli/waiter/util.py
@@ -121,7 +121,7 @@ def load_json_file(path):
 
 def is_service_current(service, current_token_etag, token_name):
     """Returns True if any of the given service's source tokens is the current token"""
-    is_current = any(token['version'] == current_token_etag and token['token'] == token_name
-                     for source in service['source-tokens']
-                     for token in source)
+    is_current = any(source['version'] == current_token_etag and source['token'] == token_name
+                     for sources in service['source-tokens']
+                     for source in sources)
     return is_current

--- a/cli/waiter/util.py
+++ b/cli/waiter/util.py
@@ -120,6 +120,6 @@ def load_json_file(path):
 
 
 def is_service_current(service, current_token_etag):
-    """TODO(DPO)"""
+    """Returns True if any of the given service's source tokens is the current token"""
     is_current = any(token['version'] == current_token_etag for source in service['source-tokens'] for token in source)
     return is_current

--- a/cli/waiter/util.py
+++ b/cli/waiter/util.py
@@ -119,7 +119,9 @@ def load_json_file(path):
     return content
 
 
-def is_service_current(service, current_token_etag):
+def is_service_current(service, current_token_etag, token_name):
     """Returns True if any of the given service's source tokens is the current token"""
-    is_current = any(token['version'] == current_token_etag for source in service['source-tokens'] for token in source)
+    is_current = any(token['version'] == current_token_etag and token['token'] == token_name
+                     for source in service['source-tokens']
+                     for token in source)
     return is_current

--- a/cli/waiter/util.py
+++ b/cli/waiter/util.py
@@ -117,3 +117,9 @@ def load_json_file(path):
         logging.info(f'{path} is not a file')
 
     return content
+
+
+def is_service_current(service, current_token_etag):
+    """TODO(DPO)"""
+    is_current = any(token['version'] == current_token_etag for source in service['source-tokens'] for token in source)
+    return is_current


### PR DESCRIPTION
## Changes proposed in this PR

- adding `--no-wait` to `waiter ping`, which allows for not waiting until the request returns

## Why are we making these changes?

If a service takes a long time to start, users may want to trigger the service to start without actually blocking until it's healthy.
