### PR TITLE
Improves CLI's implicit arg handling

### DIFF
--- a/cli/waiter/cli.py
+++ b/cli/waiter/cli.py
@@ -78,6 +78,14 @@ def run(args):
     sub-commands (actions) if necessary.
     """
     args, unknown_args = parser.parse_known_args(args)
+    verbose = args.verbose
+    if verbose:
+        log_format = '%(asctime)s [%(levelname)s] [%(name)s] %(message)s'
+        logging.getLogger('').handlers = []
+        logging.basicConfig(format=log_format, level=logging.DEBUG)
+    else:
+        logging.disable(logging.FATAL)
+
     if args.action:
         add_implicit_arguments = actions[args.action].get('implicit-args-function', None)
         if add_implicit_arguments:
@@ -85,17 +93,8 @@ def run(args):
 
     args = parser.parse_args()
     args = vars(args)
-
-    verbose = args.pop('verbose')
-
-    log_format = '%(asctime)s [%(levelname)s] [%(name)s] %(message)s'
-    if verbose:
-        logging.getLogger('').handlers = []
-        logging.basicConfig(format=log_format, level=logging.DEBUG)
-    else:
-        logging.disable(logging.FATAL)
-
     logging.debug('args: %s' % args)
+    args.pop('verbose')
 
     action = args.pop('action')
     config_path = args.pop('config')

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -174,6 +174,24 @@ def register_argument_parser(add_parser, action):
                       'you can pass --grace-period-secs 10.')
 
 
+def possible_int(arg):
+    """Attempts to parse arg as an int, returning the string otherwise"""
+    try:
+        return int(arg)
+    except ValueError:
+        logging.info(f'failed to parse {arg} as an int, treating it as a string')
+        return arg
+
+
+def possible_float(arg):
+    """Attempts to parse arg as a float, returning the string otherwise"""
+    try:
+        return float(arg)
+    except ValueError:
+        logging.info(f'failed to parse {arg} as a float, treating it as a string')
+        return arg
+
+
 def add_implicit_arguments(unknown_args, parser):
     """
     Given the list of "unknown" args, dynamically adds proper arguments to
@@ -183,10 +201,12 @@ def add_implicit_arguments(unknown_args, parser):
     for i in range(num_unknown_args):
         arg = unknown_args[i]
         if arg.startswith(("-", "--")):
-            if arg.endswith('-secs') or arg.endswith('-mins') or arg.endswith('-instances'):
-                arg_type = int
-            elif arg.endswith('-factor'):
-                arg_type = float
+            if arg.endswith('-secs') or arg.endswith('-mins') or arg.endswith('-instances') or \
+                    arg.endswith('-index') or arg.endswith('-level') or \
+                    arg.endswith('-failures') or arg.endswith('-length'):
+                arg_type = possible_int
+            elif arg.endswith('-factor') or arg.endswith('-rate') or arg.endswith('-threshold'):
+                arg_type = possible_float
             elif (i + 1) < num_unknown_args and unknown_args[i + 1].lower() in BOOL_STRINGS:
                 arg_type = str2bool
             else:

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -11,6 +11,8 @@ from waiter.util import FALSE_STRINGS, print_info, response_message, TRUE_STRING
     load_json_file
 
 BOOL_STRINGS = TRUE_STRINGS + FALSE_STRINGS
+INT_PARAM_SUFFIXES = ['-failures', '-index', '-instances', '-length', '-level', '-mins', '-secs']
+FLOAT_PARAM_SUFFIXES = ['-factor', '-rate', '-threshold']
 
 
 class Action(Enum):
@@ -201,11 +203,9 @@ def add_implicit_arguments(unknown_args, parser):
     for i in range(num_unknown_args):
         arg = unknown_args[i]
         if arg.startswith(("-", "--")):
-            if arg.endswith('-secs') or arg.endswith('-mins') or arg.endswith('-instances') or \
-                    arg.endswith('-index') or arg.endswith('-level') or \
-                    arg.endswith('-failures') or arg.endswith('-length'):
+            if any(arg.endswith(suffix) for suffix in INT_PARAM_SUFFIXES):
                 arg_type = possible_int
-            elif arg.endswith('-factor') or arg.endswith('-rate') or arg.endswith('-threshold'):
+            elif any(arg.endswith(suffix) for suffix in FLOAT_PARAM_SUFFIXES):
                 arg_type = possible_float
             elif (i + 1) < num_unknown_args and unknown_args[i + 1].lower() in BOOL_STRINGS:
                 arg_type = str2bool


### PR DESCRIPTION
## Changes proposed in this PR

- adding suffixes for implicit arg handling: `-index`, `-level`, `-failures`, `-length`, `-rate`, `-threshold`
- making it so that if `int` or `float` parsing fails, the arg is passed as a string

## Why are we making these changes?

The additions are to support existing service parameters that we want to allow the CLI to take in as command line args. The more lenient parsing is so that future parameters can use these suffixes even if their values are strings.
