### PR TITLE
supports reading the input stream in custom thread pool

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -830,11 +830,13 @@
             :not-found "Not found"
             :prestashed-tickets-not-available "Prestashed jobsystem tickets not available"}
 
- ;; Waiter launches a separate thread pool xecutor to perform blocking reads on incoming request bodies
+ ;; Waiter launches a separate thread pool executor to perform blocking reads on incoming request bodies
  :stream-reader {;; the maximum number of concurrent input stream reads allowed in the executor (default 150)
                  :concurrency-level 150
                  ;; the idle time before cached threads from the executor are terminated (default 5)
-                 :keep-alive-mins 5}
+                 :keep-alive-mins 5
+                 ;; the number of concurrent requests that are supported by the executor (default 50000)
+                 :queue-limit 50000}
 
  ;; Support information used to provide user guidance in error messages
  :support-info [{:label "Email Support Team" :link {:type :email :value "support@example.com"}}

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -136,8 +136,8 @@
                   ;; When SSL is enabled, the password to the keystore
                   :key-password "keystore-password"
 
-                  ;; The maximum number of threads to use (default 250)
-                  :max-threads 250
+                  ;; The maximum number of threads to use (default 200)
+                  :max-threads 200
 
                   ;; The maximum size in bytes of the request header.
                   ;; Larger headers will allow for more and/or larger cookies plus larger form content encoded in a URL.
@@ -829,6 +829,12 @@
             :not-enough-memory "Not enough memory allocated"
             :not-found "Not found"
             :prestashed-tickets-not-available "Prestashed jobsystem tickets not available"}
+
+ ;; Waiter launches a separate thread pool xecutor to perform blocking reads on incoming request bodies
+ :stream-reader {;; the maximum number of concurrent input stream reads allowed in the executor (default 150)
+                 :concurrency-level 150
+                 ;; the idle time before cached threads from the executor are terminated (default 5)
+                 :keep-alive-mins 5}
 
  ;; Support information used to provide user guidance in error messages
  :support-info [{:label "Email Support Team" :link {:type :email :value "support@example.com"}}

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -32,7 +32,7 @@
 
   :dependencies [[bidi "2.1.5"
                   :exclusions [prismatic/schema ring/ring-core]]
-                 [twosigma/jet "0.7.10-20190508_061258-gebd9d0a"
+                 [twosigma/jet "0.7.10-20190516_132201-g55d7a39"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -582,8 +582,8 @@
    :start-service-cache (pc/fnk []
                           (cu/cache-factory {:threshold 100
                                              :ttl (-> 1 t/minutes t/in-millis)}))
-   :stream-reader-executor (pc/fnk [[:settings [:stream-reader concurrency-level keep-alive-mins]]]
-                             (pr/make-stream-reader-executor concurrency-level keep-alive-mins))
+   :stream-reader-executor (pc/fnk [[:settings [:stream-reader concurrency-level keep-alive-mins queue-limit]]]
+                             (pr/make-stream-reader-executor concurrency-level keep-alive-mins queue-limit))
    :token-cluster-calculator (pc/fnk [[:settings [:cluster-config name] [:token-config cluster-calculator]]]
                                (utils/create-component
                                  cluster-calculator :context {:default-cluster name}))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -582,6 +582,8 @@
    :start-service-cache (pc/fnk []
                           (cu/cache-factory {:threshold 100
                                              :ttl (-> 1 t/minutes t/in-millis)}))
+   :stream-reader-executor (pc/fnk [[:settings [:stream-reader concurrency-level keep-alive-mins]]]
+                             (pr/make-stream-reader-executor concurrency-level keep-alive-mins))
    :token-cluster-calculator (pc/fnk [[:settings [:cluster-config name] [:token-config cluster-calculator]]]
                                (utils/create-component
                                  cluster-calculator :context {:default-cluster name}))
@@ -780,11 +782,12 @@
                          (fn make-basic-auth-fn [uri username password]
                            (BasicAuthentication$BasicResult. (URI. uri) username password)))
    :make-http-request-fn (pc/fnk [[:settings instance-request-properties]
-                                  [:state http-clients]
+                                  [:state http-clients stream-reader-executor]
                                   make-basic-auth-fn service-id->password-fn]
-                           (handler/async-make-request-helper
-                             http-clients instance-request-properties make-basic-auth-fn service-id->password-fn
-                             pr/prepare-request-properties pr/make-request))
+                           (let [make-request-fn (partial pr/make-request stream-reader-executor)]
+                             (handler/async-make-request-helper
+                               http-clients instance-request-properties make-basic-auth-fn service-id->password-fn
+                               pr/prepare-request-properties make-request-fn)))
    :make-inter-router-requests-async-fn (pc/fnk [[:curator discovery]
                                                  [:settings [:instance-request-properties initial-socket-timeout-ms]]
                                                  [:state http-clients passwords router-id]
@@ -1192,14 +1195,16 @@
    :process-request-fn (pc/fnk [[:routines determine-priority-fn make-basic-auth-fn post-process-async-request-response-fn
                                  service-id->password-fn start-new-service-fn]
                                 [:settings instance-request-properties]
-                                [:state http-clients instance-rpc-chan local-usage-agent interstitial-state-atom]
+                                [:state http-clients instance-rpc-chan local-usage-agent interstitial-state-atom
+                                 stream-reader-executor]
                                 wrap-auth-bypass-fn wrap-descriptor-fn wrap-https-redirect-fn wrap-secure-request-fn
                                 wrap-service-discovery-fn]
                          (let [make-request-fn (fn [instance request request-properties passthrough-headers end-route metric-group
                                                     backend-proto proto-version]
-                                                 (pr/make-request http-clients make-basic-auth-fn service-id->password-fn
-                                                                  instance request request-properties passthrough-headers
-                                                                  end-route metric-group backend-proto proto-version))
+                                                 (pr/make-request
+                                                   stream-reader-executor http-clients make-basic-auth-fn service-id->password-fn
+                                                   instance request request-properties passthrough-headers end-route metric-group
+                                                   backend-proto proto-version))
                                process-response-fn (partial pr/process-http-response post-process-async-request-response-fn)
                                inner-process-request-fn (fn inner-process-request [request]
                                                           (pr/process make-request-fn instance-rpc-chan start-new-service-fn

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -41,10 +41,13 @@
             [waiter.util.ring-utils :as ru]
             [waiter.util.utils :as utils])
   (:import (java.io InputStream IOException)
-           (java.util.concurrent TimeoutException)
+           (java.nio ByteBuffer)
+           (java.util.concurrent LinkedBlockingQueue ThreadPoolExecutor TimeoutException TimeUnit)
+           (javax.servlet ServletInputStream ReadListener)
            (org.eclipse.jetty.client HttpClient)
            (org.eclipse.jetty.io EofException)
-           (org.eclipse.jetty.server HttpChannel HttpOutput)))
+           (org.eclipse.jetty.server HttpChannel HttpOutput)
+           (org.eclipse.jetty.util BufferUtil)))
 
 (defn check-control [control-chan]
   (let [state (au/poll! control-chan :still-running)]
@@ -180,17 +183,121 @@
     (deliver reservation-status-promise promise-value)
     (utils/exception->response (ex-info message (assoc metrics-map :status status) error) request)))
 
+(defn make-stream-reader-executor
+  "Creates and returns the ThreadPoolExecutor used for reading the input stream."
+  [concurrency-level keep-alive-mins]
+  (let [queue (LinkedBlockingQueue.)
+        executor (ThreadPoolExecutor. concurrency-level concurrency-level keep-alive-mins TimeUnit/MINUTES queue)]
+    (metrics/waiter-gauge #(.getActiveCount executor)
+                          "core" "stream-reader" "active-thread-count")
+    (metrics/waiter-gauge #(- concurrency-level (.getActiveCount executor))
+                          "core" "stream-reader" "available-thread-count")
+    (metrics/waiter-gauge #(.getMaximumPoolSize executor)
+                          "core" "stream-reader" "max-thread-count")
+    (metrics/waiter-gauge #(-> executor .getQueue .size)
+                          "core" "stream-reader" "pending-task-count")
+    (metrics/waiter-gauge #(.getTaskCount executor)
+                          "core" "stream-reader" "scheduled-task-count")
+    executor))
+
+(defn stream-http-request
+  "Reads data from the input stream and queues it into the provided body channel as a ByteBuffer.
+   When no more data is available on the input stream, an asynchronous task is scheduled
+   on the provided executor to read data from the input stream later.
+   Reports an error to the error handler whenever:
+   - there is an error trying to read from the input channel,
+   - the body channel fails to accept the byte buffer that was read from the input stream."
+  [executor service-id metric-group error-handler-fn ^InputStream input-stream body-ch bytes-streamed]
+  (let [bytes-streamed-atom (atom bytes-streamed)
+        correlation-id (cid/get-correlation-id)]
+    (try
+      (loop [unreported-bytes-to-statsd 0]
+        ;; TODO potential optimization to size the buffer based on available bytes
+        (let [buffer-bytes (byte-array 4096)
+              bytes-read (.read input-stream buffer-bytes)]
+          (if (neg? bytes-read)
+            (let [bytes-streamed @bytes-streamed-atom]
+              (log/info bytes-streamed "bytes streamed from request")
+              (histograms/update! (metrics/service-histogram service-id "request-size") @bytes-streamed-atom)
+              (async/close! body-ch))
+            (if (async/put! body-ch (if (pos? bytes-read)
+                                      (ByteBuffer/wrap buffer-bytes 0 bytes-read)
+                                      BufferUtil/EMPTY_BUFFER))
+              (let [unreported-bytes-to-statsd' (+ unreported-bytes-to-statsd bytes-read)]
+                (swap! bytes-streamed-atom + bytes-read)
+                (if (pos? (.available input-stream))
+                  (do
+                    (if (>= unreported-bytes-to-statsd' 1000000)
+                      (do
+                        (statsd/inc! metric-group "request_bytes" unreported-bytes-to-statsd')
+                        (recur 0))
+                      (recur unreported-bytes-to-statsd')))
+                  (do
+                    (when (pos? unreported-bytes-to-statsd')
+                      (statsd/inc! metric-group "request_bytes" unreported-bytes-to-statsd'))
+                    (.execute
+                      executor
+                      (fn stream-http-request-task []
+                        (cid/with-correlation-id
+                          correlation-id
+                          (stream-http-request executor service-id metric-group error-handler-fn
+                                               input-stream body-ch @bytes-streamed-atom)))))))
+              (let [description-map {:bytes-pending bytes-read :bytes-streamed bytes-streamed}]
+                (log/error "unable to stream request bytes" description-map)
+                (throw (ex-info "unable to stream request bytes" description-map)))))))
+      (catch Throwable th
+        (histograms/update! (metrics/service-histogram service-id "request-size") @bytes-streamed-atom)
+        (async/close! body-ch)
+        (error-handler-fn th)))))
+
+(defn input-stream->channel
+  "Returns a channel that will contain the ByteBuffers read from the input stream.
+   The input stream is read asynchronously by creating tasks on the provided executor.
+   It will report any errors while reading data on the provided abort channel."
+  [^ThreadPoolExecutor executor service-id metric-group abort-ch ^InputStream input-stream]
+  (let [correlation-id (cid/get-correlation-id)
+        body-ch (async/chan 2048)
+        error-handler-fn (fn handle-request-streaming-error [throwable]
+                           (cid/with-correlation-id
+                             correlation-id
+                             (log/error throwable "unable to stream request bytes, aborting request")
+                             (async/>!! abort-ch throwable)))
+        stream-http-request-fn (fn stream-http-request-fn []
+                                 (cid/with-correlation-id
+                                   correlation-id
+                                   (stream-http-request executor service-id metric-group error-handler-fn
+                                                        input-stream body-ch 0)))]
+    (if (instance? ServletInputStream input-stream)
+      (.setReadListener ^ServletInputStream input-stream
+                        (reify ReadListener
+                          (onDataAvailable [_]
+                            ;; invoked by the container the *first* time when it is possible to read data
+                            (.execute executor stream-http-request-fn))
+                          (onAllDataRead [_]
+                            (async/close! body-ch))
+                          (onError [_ throwable]
+                            (error-handler-fn throwable))))
+      (.execute executor stream-http-request-fn))
+    body-ch))
+
 (defn- make-http-request
   "Makes an asynchronous request to the endpoint using Basic authentication."
-  [^HttpClient http-client make-basic-auth-fn request-method endpoint query-string headers body trailers-fn
-   service-password {:keys [username principal]} idle-timeout output-buffer-size proto-version]
+  [^ThreadPoolExecutor executor ^HttpClient http-client make-basic-auth-fn
+   request-method endpoint query-string headers body trailers-fn
+   service-id service-password metric-group {:keys [username principal]}
+   idle-timeout output-buffer-size proto-version]
   (let [auth (make-basic-auth-fn endpoint "waiter" service-password)
-        headers (headers/assoc-auth-headers headers username principal)]
+        headers (headers/assoc-auth-headers headers username principal)
+        abort-ch (async/promise-chan)
+        body' (cond->> body
+                (instance? InputStream body)
+                (input-stream->channel executor service-id metric-group abort-ch))]
     (http/request
       http-client
-      {:as :bytes
+      {:abort-ch abort-ch
+       :as :bytes
        :auth auth
-       :body body
+       :body body'
        :headers headers
        :fold-chunked-response? true
        :fold-chunked-response-buffer-size output-buffer-size
@@ -204,7 +311,7 @@
 
 (defn make-request
   "Makes an asynchronous http request to the instance endpoint and returns a channel."
-  [http-clients make-basic-auth-fn service-id->password-fn {:keys [host port] :as instance}
+  [executor http-clients make-basic-auth-fn service-id->password-fn {:keys [host port] :as instance}
    {:keys [body query-string request-method trailers-fn] :as request}
    {:keys [initial-socket-timeout-ms output-buffer-size]} passthrough-headers end-route metric-group backend-proto proto-version]
   (let [instance-endpoint (scheduler/end-point-url backend-proto host port end-route)
@@ -221,17 +328,17 @@
             content-length (if content-length-str (Long/parseLong content-length-str) 0)]
         (when (and (integer? content-length) (pos? content-length))
           ; computing the actual bytes will currently require synchronously reading all data in the request body
-          (histograms/update! (metrics/service-histogram service-id "request-size") content-length)
-          (statsd/inc! metric-group "request_bytes" content-length)))
+          (histograms/update! (metrics/service-histogram service-id "request-content-length") content-length)
+          (statsd/inc! metric-group "request_content_length" content-length)))
       (catch Exception e
         (log/error e "Unable to track content-length on request")))
     (when waiter-debug-enabled?
       (log/info "connecting to" instance-endpoint "using" proto-version))
-    (-> backend-proto
-        (hu/select-http-client http-clients)
-        (make-http-request
-          make-basic-auth-fn request-method instance-endpoint query-string headers body trailers-fn service-password
-          (handler/make-auth-user-map request) initial-socket-timeout-ms output-buffer-size proto-version))))
+    (let [auth-user-map (handler/make-auth-user-map request)
+          http-client (hu/select-http-client backend-proto http-clients)]
+      (make-http-request
+        executor http-client make-basic-auth-fn request-method instance-endpoint query-string headers body trailers-fn
+        service-id service-password metric-group auth-user-map initial-socket-timeout-ms output-buffer-size proto-version))))
 
 (defn extract-async-request-response-data
   "Helper function that inspects the response and returns the location and query-string if the response

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -259,6 +259,7 @@
                 (log/error "unable to stream request bytes" description-map)
                 (throw (ex-info "unable to stream request bytes" description-map)))))))
       (catch Throwable th
+        (log/info "request failed after streaming" @bytes-streamed-atom "bytes")
         (histograms/update! (metrics/service-histogram service-id "request-size") @bytes-streamed-atom)
         (error-handler-fn th)))))
 

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -160,7 +160,8 @@
                                        (s/required-key :server) schema/non-empty-string
                                        (s/required-key :sync-instances-interval-ms) schema/positive-int})
    (s/required-key :stream-reader) {(s/required-key :concurrency-level) schema/positive-int
-                                    (s/required-key :keep-alive-mins) schema/positive-int}
+                                    (s/required-key :keep-alive-mins) schema/positive-int
+                                    (s/required-key :queue-limit) schema/positive-int}
    (s/required-key :support-info) [{(s/required-key :label) schema/non-empty-string
                                     (s/required-key :link) {(s/required-key :type) s/Keyword
                                                             (s/required-key :value) schema/non-empty-string}}]
@@ -430,7 +431,8 @@
                                   "scale-up-factor" 0.1}
    :statsd :disabled
    :stream-reader {:concurrency-level 150
-                   :keep-alive-mins 5}
+                   :keep-alive-mins 5
+                   :queue-limit 50000}
    :support-info [{:label "Waiter on GitHub"
                    :link {:type :url
                           :value "http://github.com/twosigma/waiter"}}]

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -159,6 +159,8 @@
                                        (s/required-key :publish-interval-ms) schema/positive-int
                                        (s/required-key :server) schema/non-empty-string
                                        (s/required-key :sync-instances-interval-ms) schema/positive-int})
+   (s/required-key :stream-reader) {(s/required-key :concurrency-level) schema/positive-int
+                                    (s/required-key :keep-alive-mins) schema/positive-int}
    (s/required-key :support-info) [{(s/required-key :label) schema/non-empty-string
                                     (s/required-key :link) {(s/required-key :type) s/Keyword
                                                             (s/required-key :value) schema/non-empty-string}}]
@@ -389,7 +391,7 @@
    :scheduler-syncer-interval-secs 5
    :server-options {:http2? false
                     :http2c? true
-                    :max-threads 250
+                    :max-threads 200
                     :request-header-size 32768
                     :response-header-size 8192
                     :send-date-header? false}
@@ -427,6 +429,8 @@
                                   "scale-factor" 1
                                   "scale-up-factor" 0.1}
    :statsd :disabled
+   :stream-reader {:concurrency-level 150
+                   :keep-alive-mins 5}
    :support-info [{:label "Waiter on GitHub"
                    :link {:type :url
                           :value "http://github.com/twosigma/waiter"}}]


### PR DESCRIPTION
This PR needs an associated jet change for [improved AsyncContentProvider support](https://github.com/twosigma/jet/pull/22).

## Changes proposed in this PR

- supports reading the input stream in a custom thread pool
- report request body length for all requests in the metrics (codahale and statsd) and logs

## Why are we making these changes?

InputStreamContentProvider, used for InputStreams by jet, uses an iterator that blocks while determining if more content is available. This blocking is problematic for interactive clients who send some data and then expect a response from the server before sending the next chunk of data. In particular, in such scenarios, this leads to a deadlock in org.eclipse.jetty.client.HttpContent.advance(java.util.Iterator<java.nio.ByteBuffer>) which cannot return when it makes the second call to iterator.hasNext().

Using a DeferredContentProvider with asynchronous population of chunks avoids the aforementioned deadlock. In addition, we use a custom thread pool to avoid exhausting threads from Jetty's or core.async's thread pools while reading from the input stream.


