### PR TITLE
adds support for naming http clients

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -32,7 +32,7 @@
 
   :dependencies [[bidi "2.1.5"
                   :exclusions [prismatic/schema ring/ring-core]]
-                 [twosigma/jet "0.7.10-20190516_132201-g55d7a39"
+                 [twosigma/jet "0.7.10-20190518_074946-g399eb7b"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -537,7 +537,8 @@
                                           :healthy-service-ids #{}}))
    :http-clients (pc/fnk [[:settings [:instance-request-properties connection-timeout-ms]]]
                    (http-utils/prepare-http-clients
-                     {:conn-timeout connection-timeout-ms
+                     {:client-name "waiter-client"
+                      :conn-timeout connection-timeout-ms
                       :follow-redirects? false}))
    :instance-rpc-chan (pc/fnk [] (async/chan 1024)) ; TODO move to service-chan-maintainer
    :interstitial-state-atom (pc/fnk [] (atom {:initialized? false
@@ -697,7 +698,8 @@
                                        [:state clock]
                                        service-id->service-description-fn*]
                                 (let [http-client (http-utils/http-client-factory
-                                                    {:conn-timeout health-check-timeout-ms
+                                                    {:client-name (str "waiter-syncer-" (str/join (take 7 git-version)))
+                                                     :conn-timeout health-check-timeout-ms
                                                      :socket-timeout health-check-timeout-ms
                                                      :user-agent (str "waiter-syncer/" (str/join (take 7 git-version)))})
                                       available? (fn scheduler-available?

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -86,7 +86,8 @@
 
 ;; Instance health checks
 
-(let [http-client (http-utils/http-client-factory {:conn-timeout 10000
+(let [http-client (http-utils/http-client-factory {:client-name "waiter-cook-health-check"
+                                                   :conn-timeout 10000
                                                    :socket-timeout 10000
                                                    :spnego-auth false
                                                    :user-agent "waiter-cook-health-check"})
@@ -532,8 +533,9 @@
          (pos-int? scheduler-syncer-interval-secs)
          (fn? start-scheduler-syncer-fn)]}
   (let [http-client (-> http-options
-                        (utils/assoc-if-absent :user-agent "waiter-cook")
-                        http-utils/http-client-factory)
+                      (utils/assoc-if-absent :client-name "waiter-cook")
+                      (utils/assoc-if-absent :user-agent "waiter-cook")
+                      http-utils/http-client-factory)
         cook-api {:http-client http-client
                   :impersonate impersonate
                   :slave-port mesos-slave-port

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -1025,8 +1025,9 @@
          (or (nil? watch-retries) (integer? watch-retries))]}
   (let [authorizer (utils/create-component authorizer)
         http-client (-> http-options
-                        (utils/assoc-if-absent :user-agent "waiter-k8s")
-                        http-utils/http-client-factory)
+                      (utils/assoc-if-absent :client-name "waiter-k8s")
+                      (utils/assoc-if-absent :user-agent "waiter-k8s")
+                      http-utils/http-client-factory)
         service-id->failed-instances-transient-store (atom {})
         replicaset-spec-builder-ctx (assoc replicaset-spec-builder
                                       :log-bucket-sync-secs log-bucket-sync-secs

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -608,8 +608,9 @@
     (log/info "scheduler mesos-slave-port or slave-directory is missing, log directory and url support will be disabled"))
   (let [authorizer (utils/create-component authorizer)
         http-client (-> http-options
-                        (utils/assoc-if-absent :user-agent "waiter-marathon")
-                        hu/http-client-factory)
+                      (utils/assoc-if-absent :client-name "waiter-marathon")
+                      (utils/assoc-if-absent :user-agent "waiter-marathon")
+                      hu/http-client-factory)
         marathon-api (marathon/api-factory http-client http-options url)
         mesos-api (mesos/api-factory http-client http-options mesos-slave-port slave-directory)
         service-id->failed-instances-transient-store (atom {})

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -855,7 +855,8 @@
                                   :id->service-agent id->service-agent
                                   :retrieve-syncer-state-fn retrieve-syncer-state-fn))
         http-client (http-utils/http-client-factory
-                      {:conn-timeout health-check-timeout-ms
+                      {:client-name "waiter-shell"
+                       :conn-timeout health-check-timeout-ms
                        :socket-timeout health-check-timeout-ms
                        :user-agent "waiter-shell"})]
     (when backup-file-name

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -207,7 +207,8 @@
 (defn make-http-clients
   "Instantiates and returns http1 and http2 clients without a cookie store"
   []
-  (http-utils/prepare-http-clients {:clear-content-decoders false
+  (http-utils/prepare-http-clients {:client-name (str "waiter-test-" (retrieve-git-branch))
+                                    :clear-content-decoders false
                                     :conn-timeout 10000
                                     :user-agent (str "waiter-test/" (retrieve-git-branch))}))
 


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for naming http clients

## Why are we making these changes?

Using individual names for the http clients allows us to map corresponding threads for the client from thread dumps.

### Jet change

Jet needs to [support the new `:client-name` configuration](https://github.com/twosigma/jet/pull/23).

### Example thread names

```
waiter-client-http1-15
...
waiter-client-http1-22
...
waiter-client-http2-30
waiter-shell-54
...
waiter-shell-76
waiter-syncer-526be9f-43
...
waiter-syncer-526be9f-50
```
