### PR TITLE
avoids folding chunked responses for http/2

### DIFF
--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -319,7 +319,7 @@
        :auth auth
        :body body'
        :headers headers
-       :fold-chunked-response? true
+       :fold-chunked-response? (not (hu/http2? proto-version))
        :fold-chunked-response-buffer-size output-buffer-size
        :follow-redirects? false
        :idle-timeout idle-timeout

--- a/waiter/src/waiter/util/http_utils.clj
+++ b/waiter/src/waiter/util/http_utils.clj
@@ -127,3 +127,8 @@
     "h2" "https"
     "h2c" "http"
     backend-proto))
+
+(defn http2?
+  "Returns true if the http versions represents a http2 request"
+  [version]
+  (= "HTTP/2.0" version))


### PR DESCRIPTION
## Changes proposed in this PR

- avoids folding chunked responses for http/2

## Why are we making these changes?

http/2 requests can be interactive. In such scenarios, folding responses can prevent the response from being propagated to the client.


