### PR TITLE
Includes request length in chunked encoding tests

### DIFF
--- a/containers/test-apps/kitchen/bin/kitchen
+++ b/containers/test-apps/kitchen/bin/kitchen
@@ -406,7 +406,7 @@ class Kitchen(HTTPWebSocketsHandler):
         else:
             self.logger().debug('Got data on websocket: {}'.format(in_data))
 
-        self.__request_buffer = in_data
+        self.__request_body_length = len(in_data)
 
         if opcode == self._opcode_binary:
             self.send_message(in_data, opcode)
@@ -498,7 +498,8 @@ class Kitchen(HTTPWebSocketsHandler):
             self.__excluded_headers = set()
             self.__exit_process = False
             self.__headers = make_default_response_headers(self.headers)
-            self.__request_buffer = bytearray()
+            self.__request_body_length = 0
+            self.__response_body_callback = None
             self.__response_bytes = None
             self.__response_length = max_response_size
             self.__status = 200
@@ -507,7 +508,6 @@ class Kitchen(HTTPWebSocketsHandler):
             self.__truncated_length = max_response_size + 1
 
             # Process Kitchen request options
-            self.__slurp_request()
             self.__process_path()
             self.__process_headers()
 
@@ -596,30 +596,6 @@ class Kitchen(HTTPWebSocketsHandler):
 
             self.logger().debug('Closed')
 
-    def __slurp_request(self):
-        # Slurp any posted data
-        content_length = self.headers.get('content-length')
-        if content_length is not None:
-            self.__slurp_bytes(int(content_length), self.__request_buffer)
-
-        elif self.headers.get('transfer-encoding') == 'chunked':
-            while True:
-                chunk_header = self.rfile.read(3)  # shortest possible header is b'0\r\n'
-
-                if not chunk_header:
-                    raise Exception('Connection closed early')
-
-                while not chunk_header.endswith(b'\r\n'):
-                    chunk_header += self.rfile.read(1)
-
-                # read the payload + '\r\n'
-                chunk_size = int(chunk_header[:-2], base=16)
-                self.__slurp_bytes(chunk_size, self.__request_buffer)
-                self.rfile.read(2)
-
-                if chunk_size == 0:
-                    break
-
     def __process_headers(self):
         """Handle logic for all supported Kitchen HTTP header values."""
         assert self.__path is not None, 'Processes headers AFTER processing the request path.'
@@ -690,9 +666,41 @@ class Kitchen(HTTPWebSocketsHandler):
 
         # Check if client requested echo server mode
         echo_server = self.headers.get('x-kitchen-echo') is not None
+        echo_buffer = bytearray() if echo_server else None
+
+        # Slurp any posted data
+        content_length = self.headers.get('content-length')
+        if content_length is not None:
+            content_length_int = int(content_length)
+            self.__slurp_bytes(content_length_int, echo_buffer)
+            self.__request_body_length = content_length_int
+
+        elif self.headers.get('transfer-encoding') == 'chunked':
+            while True:
+                chunk_header = self.rfile.read(3)  # shortest possible header is b'0\r\n'
+
+                if not chunk_header:
+                    raise Exception('Connection closed early')
+
+                while not chunk_header.endswith(b'\r\n'):
+                    chunk_header += self.rfile.read(1)
+
+                # read the payload + '\r\n'
+                chunk_size = int(chunk_header[:-2], base=16)
+                self.__slurp_bytes(chunk_size, echo_buffer)
+                self.__request_body_length += chunk_size
+                self.rfile.read(2)
+
+                if chunk_size == 0:
+                    break
+
         # Echo request body back to client
         if echo_server:
-            self.__set_response(self.__request_buffer)
+            self.__set_response(echo_buffer)
+
+        # If response callback is set use it
+        if self.__response_body_callback:
+            self.__response_body_callback()
 
         # Exclude some headers from response
         excluded_headers = self.headers.get('x-kitchen-exclude-headers')
@@ -788,8 +796,7 @@ class Kitchen(HTTPWebSocketsHandler):
 
         elif path == '/request-info':
             self.__headers['Content-Type'] = 'application/json'
-            info = self.__request_info()
-            self.__set_response(info.encode('utf-8'))
+            self.__response_body_callback = self.__set_request_info_in_response
 
         elif path == '/sleep':
             self.__status = int(query_params.get('status', 200))
@@ -894,7 +901,7 @@ class Kitchen(HTTPWebSocketsHandler):
         """Build request-info endpoint dict data JSON response."""
         info = { 'protocol-version': self.protocol_version,
                  'request-version': self.request_version,
-                 'request-length': len(self.__request_buffer),
+                 'request-length': self.__request_body_length,
                  'request-method': self.__method,
                  'uri': self.__path }
         if len(self.headers) > 0:
@@ -912,6 +919,10 @@ class Kitchen(HTTPWebSocketsHandler):
             self.__response_length = response_length
         # Limit response length to the maximum supported size
         self.__response_length = min(max_response_size, self.__response_length)
+
+    def __set_request_info_in_response(self):
+        info = self.__request_info()
+        self.__set_response(info.encode('utf-8'))
 
     def __slurp_bytes(self, bytes_to_read, output_buffer=None):
         """Consume (and throw away) data from the request body."""

--- a/containers/test-apps/kitchen/bin/kitchen
+++ b/containers/test-apps/kitchen/bin/kitchen
@@ -406,6 +406,8 @@ class Kitchen(HTTPWebSocketsHandler):
         else:
             self.logger().debug('Got data on websocket: {}'.format(in_data))
 
+        self.__request_buffer = in_data
+
         if opcode == self._opcode_binary:
             self.send_message(in_data, opcode)
             self.logger().debug('Sent echo bytes response')
@@ -496,6 +498,7 @@ class Kitchen(HTTPWebSocketsHandler):
             self.__excluded_headers = set()
             self.__exit_process = False
             self.__headers = make_default_response_headers(self.headers)
+            self.__request_buffer = bytearray()
             self.__response_bytes = None
             self.__response_length = max_response_size
             self.__status = 200
@@ -504,6 +507,7 @@ class Kitchen(HTTPWebSocketsHandler):
             self.__truncated_length = max_response_size + 1
 
             # Process Kitchen request options
+            self.__slurp_request()
             self.__process_path()
             self.__process_headers()
 
@@ -592,6 +596,30 @@ class Kitchen(HTTPWebSocketsHandler):
 
             self.logger().debug('Closed')
 
+    def __slurp_request(self):
+        # Slurp any posted data
+        content_length = self.headers.get('content-length')
+        if content_length is not None:
+            self.__slurp_bytes(int(content_length), self.__request_buffer)
+
+        elif self.headers.get('transfer-encoding') == 'chunked':
+            while True:
+                chunk_header = self.rfile.read(3)  # shortest possible header is b'0\r\n'
+
+                if not chunk_header:
+                    raise Exception('Connection closed early')
+
+                while not chunk_header.endswith(b'\r\n'):
+                    chunk_header += self.rfile.read(1)
+
+                # read the payload + '\r\n'
+                chunk_size = int(chunk_header[:-2], base=16)
+                self.__slurp_bytes(chunk_size, self.__request_buffer)
+                self.rfile.read(2)
+
+                if chunk_size == 0:
+                    break
+
     def __process_headers(self):
         """Handle logic for all supported Kitchen HTTP header values."""
         assert self.__path is not None, 'Processes headers AFTER processing the request path.'
@@ -662,34 +690,9 @@ class Kitchen(HTTPWebSocketsHandler):
 
         # Check if client requested echo server mode
         echo_server = self.headers.get('x-kitchen-echo') is not None
-        echo_buffer = bytearray() if echo_server else None
-
-        # Slurp any posted data
-        content_length = self.headers.get('content-length')
-        if content_length is not None:
-            self.__slurp_bytes(int(content_length), echo_buffer)
-
-        elif self.headers.get('transfer-encoding') == 'chunked':
-            while True:
-                chunk_header = self.rfile.read(3)  # shortest possible header is b'0\r\n'
-
-                if not chunk_header:
-                    raise Exception('Connection closed early')
-
-                while not chunk_header.endswith(b'\r\n'):
-                    chunk_header += self.rfile.read(1)
-
-                # read the payload + '\r\n'
-                chunk_size = int(chunk_header[:-2], base=16)
-                self.__slurp_bytes(chunk_size, echo_buffer)
-                self.rfile.read(2)
-
-                if chunk_size == 0:
-                    break
-
         # Echo request body back to client
         if echo_server:
-            self.__set_response(echo_buffer)
+            self.__set_response(self.__request_buffer)
 
         # Exclude some headers from response
         excluded_headers = self.headers.get('x-kitchen-exclude-headers')
@@ -891,6 +894,7 @@ class Kitchen(HTTPWebSocketsHandler):
         """Build request-info endpoint dict data JSON response."""
         info = { 'protocol-version': self.protocol_version,
                  'request-version': self.request_version,
+                 'request-length': len(self.__request_buffer),
                  'request-method': self.__method,
                  'uri': self.__path }
         if len(self.headers) > 0:


### PR DESCRIPTION
## Changes proposed in this PR

- includes request length in chunked encoding tests
- adds support for request body length in kitchen

## Why are we making these changes?

We would like to verify that the correct number of bytes are being transferred to the backend regardless of the transfer encoding being used.
