### PR TITLE
Uses /waiter-ping endpoint from CLI ping

### DIFF
--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -711,7 +711,7 @@ class WaiterCliTest(util.WaiterTest):
             util.wait_until_services_for_token(self.waiter_url, token_name, 1)
 
             util.kill_services_using_token(self.waiter_url, token_name)
-            util.post_token(self.waiter_url, token_name, {'cpus': 0.1})
+            util.post_token(self.waiter_url, token_name, {'cpus': 0.1, 'cmd-type': 'shell'})
             cp = cli.ping(self.waiter_url, token_name, ping_flags='--no-wait')
             self.assertEqual(1, cp.returncode, cp.stderr)
             self.assertNotIn('Service is currently', cli.stdout(cp))

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -534,7 +534,6 @@ class WaiterCliTest(util.WaiterTest):
             cp = cli.ping(self.waiter_url, token_name)
             self.assertEqual(0, cp.returncode, cp.stderr)
             self.assertIn('Pinging token', cli.stdout(cp))
-            self.assertIn('/sleep', cli.stdout(cp))
             self.assertEqual(1, len(util.services_for_token(self.waiter_url, token_name)))
         finally:
             util.delete_token(self.waiter_url, token_name, kill_services=True)
@@ -648,7 +647,7 @@ class WaiterCliTest(util.WaiterTest):
             util.kill_services_using_token(self.waiter_url, token_name)
             cp = cli.ping(self.waiter_url, token_name, ping_flags='--timeout 10')
             self.assertEqual(1, cp.returncode, cp.stderr)
-            self.assertIn('Encountered error', cli.stderr(cp))
+            self.assertIn('Ping request timed out', cli.stderr(cp))
         finally:
             util.kill_services_using_token(self.waiter_url, token_name)
             util.delete_token(self.waiter_url, token_name)
@@ -687,12 +686,10 @@ class WaiterCliTest(util.WaiterTest):
             # Pinging the token should use /status
             cp = cli.ping(self.waiter_url, token_name)
             self.assertEqual(0, cp.returncode, cp.stderr)
-            self.assertIn('/status', cli.stdout(cp))
 
             # Pinging the service id should use /sleep
             cp = cli.ping(self.waiter_url, service_id, ping_flags='--service-id')
             self.assertEqual(0, cp.returncode, cp.stderr)
-            self.assertIn('/sleep', cli.stdout(cp))
         finally:
             util.delete_token(self.waiter_url, token_name, kill_services=True)
 
@@ -718,6 +715,11 @@ class WaiterCliTest(util.WaiterTest):
             cp = cli.ping(self.waiter_url, token_name, ping_flags='--no-wait')
             self.assertEqual(1, cp.returncode, cp.stderr)
             self.assertNotIn('Service is currently', cli.stdout(cp))
+            self.assertIn('Service description', cli.decode(cp.stderr))
+            self.assertIn('improper', cli.decode(cp.stderr))
+            self.assertIn('cmd must be a non-empty string', cli.decode(cp.stderr))
+            self.assertIn('version must be a non-empty string', cli.decode(cp.stderr))
+            self.assertIn('mem must be a positive number', cli.decode(cp.stderr))
             util.wait_until_no_services_for_token(self.waiter_url, token_name)
         finally:
             util.kill_services_using_token(self.waiter_url, token_name)

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -647,7 +647,11 @@ class WaiterCliTest(util.WaiterTest):
             util.kill_services_using_token(self.waiter_url, token_name)
             cp = cli.ping(self.waiter_url, token_name, ping_flags='--timeout 10')
             self.assertEqual(1, cp.returncode, cp.stderr)
-            self.assertIn('Ping request timed out', cli.stderr(cp))
+            self.assertTrue(
+                # Either Waiter will inform us that the ping timed out
+                'Ping request timed out' in cli.stderr(cp) or
+                # Or, the read from Waiter will time out
+                'Encountered error while pinging' in cli.stderr(cp))
         finally:
             util.kill_services_using_token(self.waiter_url, token_name)
             util.delete_token(self.waiter_url, token_name)
@@ -695,7 +699,7 @@ class WaiterCliTest(util.WaiterTest):
 
     def test_ping_no_wait(self):
         token_name = self.token_name()
-        command = f'{util.default_cmd()} --start-up-sleep-ms {util.DEFAULT_TEST_TIMEOUT_SECS*2*1000}'
+        command = f'{util.default_cmd()} --start-up-sleep-ms {util.DEFAULT_TEST_TIMEOUT_SECS * 2 * 1000}'
         util.post_token(self.waiter_url, token_name, util.minimal_service_description(cmd=command))
         try:
             cp = cli.ping(self.waiter_url, token_name, ping_flags='--no-wait')
@@ -1077,7 +1081,7 @@ class WaiterCliTest(util.WaiterTest):
         self.assertIn('Unsupported key(s)', cli.stderr(cp))
         self.assertIn('foo-level', cli.stderr(cp))
         self.assertIn('bar-rate', cli.stderr(cp))
-        
+
     def test_show_service_current(self):
         token_name_1 = self.token_name()
         token_name_2 = self.token_name()

--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -110,6 +110,12 @@ def load_token_with_headers(waiter_url, token_name, assert_response=True, expect
     return response.json(), response.headers
 
 
+def log_curl(waiter_url, endpoint, headers, params, payload):
+    curl_header_flags = ' '.join(f"-H '{k}: {v}'" for k, v in headers.items())
+    curl_url = f'{waiter_url}{endpoint}?{"&".join((k + "=" + v) for k, v in params.items())}'
+    logging.debug(f'curl -XPOST {curl_header_flags} -d \'{json.dumps(payload)}\' \'{curl_url}\'')
+
+
 def post_token(waiter_url, token_name, token_definition, assert_response=True,
                expected_status_code=200, update_mode_admin=False, etag=None):
     headers = {
@@ -120,6 +126,8 @@ def post_token(waiter_url, token_name, token_definition, assert_response=True,
     if update_mode_admin:
         params['update-mode'] = 'admin'
         headers['If-Match'] = etag
+
+    log_curl(waiter_url, '/token', headers, params, token_definition)
     response = session.post(f'{waiter_url}/token', headers=headers, json=token_definition, params=params)
     logging.debug(f'Response headers: {response.headers}')
     response_json = response.json()

--- a/cli/waiter/subcommands/ping.py
+++ b/cli/waiter/subcommands/ping.py
@@ -18,7 +18,7 @@ def ping_on_cluster(cluster, timeout, wait_for_request, token_name, service_exis
                 'X-Waiter-Token': token_name,
                 'X-Waiter-Timeout': str(timeout_seconds * 1000)
             }
-            read_timeout = timeout_seconds + 10
+            read_timeout = timeout_seconds if wait_for_request else (timeout_seconds + 5)
             resp = http_util.get(cluster, '/waiter-ping', headers=headers, read_timeout=read_timeout)
             logging.debug(f'Response status code: {resp.status_code}')
             resp_json = resp.json()


### PR DESCRIPTION
## Changes proposed in this PR

- making the `ping` sub-command use the new `/waiter-ping` endpoint

## Why are we making these changes?

To allow easier support for the new complexities involved in making a request to a service's health check -- `health-check-port-index`, `health-check-proto`.