### PR TITLE
adds support for filtering metrics by name

### DIFF
--- a/waiter/integration/waiter/metrics_output_test.clj
+++ b/waiter/integration/waiter/metrics_output_test.clj
@@ -100,50 +100,73 @@
 
 (deftest ^:parallel ^:integration-slow test-metrics-output
   (testing-using-waiter-url
-    (let [router->endpoint (routers waiter-url)
+    (let [all-service-ids-atom (atom #{})
+          router->endpoint (routers waiter-url)
           router-urls (vec (vals router->endpoint))
-          service-id (rand-name)
-          headers {:x-waiter-name service-id}
-          {:keys [service-id cookies]} (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))
+          headers-1 {:x-waiter-name (rand-name)}
+          headers-2 {:x-waiter-name (rand-name)}
+          {:keys [cookies] :as response-1} (make-request-with-debug-info headers-1 #(make-kitchen-request waiter-url %))
+          service-id-1 (:service-id response-1)
+          _ (swap! all-service-ids-atom conj service-id-1)
+          response-2 (make-request-with-debug-info headers-2 #(make-kitchen-request waiter-url % :cookies cookies))
+          service-id-2 (:service-id response-2)
+          _ (swap! all-service-ids-atom conj service-id-2)
           num-requests 100]
+      (is (= 2 (count @all-service-ids-atom)))
+
       ; make requests to the app from various routers to make sure we have metrics
       (dotimes [n num-requests]
         (let [router-url (nth router-urls (mod n (count router-urls)))]
-          (make-kitchen-request router-url headers :cookies cookies)))
+          (make-kitchen-request router-url headers-1 :cookies cookies)
+          (make-kitchen-request router-url headers-2 :cookies cookies)))
 
       ; ensure each router has had a chance to publish its local metrics
       (let [waiter-settings (waiter-settings waiter-url)
             metrics-sync-interval-ms (get-in waiter-settings [:metrics-config :metrics-sync-interval-ms] 1)]
         (Thread/sleep (max (* 10 metrics-sync-interval-ms) 10000)))
 
-      (doall (map (fn [router-id]
-                    (let [router-url (str (get router->endpoint router-id))
-                          metrics-json-response (make-request router-url "/metrics")
-                          metrics-response (try-parse-json (:body metrics-json-response))
-                          service-metrics (get-in metrics-response ["services" service-id])]
-                      (log/info "asserting jvm metrics output for" router-url)
-                      (assert-metrics-output (get metrics-response "jvm") jvm-metrics-schema)
-                      (log/info "asserting service metrics output for" router-url)
-                      (assert-metrics-output service-metrics service-metrics-schema)
-                      (log/info "asserting waiter metrics output for" router-url)
-                      (assert-metrics-output (get metrics-response "waiter") waiter-metrics-schema)))
-                  (keys router->endpoint)))
+      (doseq [router-id (keys router->endpoint)]
+        (let [router-url (str (get router->endpoint router-id))]
+          (let [metrics-response (try-parse-json (:body (make-request router-url "/metrics" :query-params {})))
+                services-metrics (get metrics-response "services")]
+            (log/info "asserting jvm metrics output for" router-url)
+            (assert-metrics-output (get metrics-response "jvm") jvm-metrics-schema)
+            (log/info "asserting more than one service metrics were reported")
+            (is (> (count services-metrics) 1) (str metrics-response))
+            (doseq [service-id @all-service-ids-atom]
+              (log/info "asserting service metrics output for" router-url)
+              (assert-metrics-output (get-in metrics-response ["services" service-id]) service-metrics-schema))
+            (log/info "asserting waiter metrics output for" router-url)
+            (assert-metrics-output (get metrics-response "waiter") waiter-metrics-schema))
 
-      (let [apps-response (service-settings waiter-url service-id :keywordize-keys false)
-            routers->metrics (get-in apps-response ["metrics" "routers"])
-            aggregate-metrics (get-in apps-response ["metrics" "aggregate"])]
-        (when (get apps-response "error-messages")
-          (log/info "error messages from /apps:" (get apps-response "error-messages")))
-        (is (pos? (count routers->metrics)))
-        (doseq [[router-id metrics] routers->metrics]
-          (log/info "asserting /apps output for" router-id)
-          (assert-metrics-output metrics service-metrics-schema))
-        (log/info "asserting aggregate /apps output")
-        (assert-metrics-output aggregate-metrics service-metrics-schema)
-        (is (number? (get aggregate-metrics "routers-sent-requests-to")))
-        (is (>= (get-in aggregate-metrics ["counters" "request-counts" "total"]) num-requests)))
+          (let [metrics-response (try-parse-json (:body (make-request router-url "/metrics" :query-params {"name" service-id-2})))
+                services-metrics (get metrics-response "services")]
+            (log/info "asserting no jvm metrics output for" router-url)
+            (is (empty? (get metrics-response "jvm")) (str metrics-response))
+            (log/info "asserting only one service metrics were reported")
+            (is (= 1 (count services-metrics)) (str metrics-response))
+            (log/info "asserting service metrics output for" router-url)
+            (assert-metrics-output (get services-metrics service-id-2) service-metrics-schema)
+            (log/info "asserting no waiter metrics output for" router-url)
+            (is (empty? (get metrics-response "waiter")) (str metrics-response)))))
 
-      (delete-service waiter-url service-id))))
+      (doseq [service-id @all-service-ids-atom]
+        (let [apps-response (service-settings waiter-url service-id :keywordize-keys false)
+              routers->metrics (get-in apps-response ["metrics" "routers"])
+              aggregate-metrics (get-in apps-response ["metrics" "aggregate"])]
+          (when (get apps-response "error-messages")
+            (log/info "error messages from /apps:" (get apps-response "error-messages")))
+          (is (pos? (count routers->metrics)))
+          (doseq [[router-id metrics] routers->metrics]
+            (log/info "asserting /apps output for" router-id)
+            (assert-metrics-output metrics service-metrics-schema))
+          (log/info "asserting aggregate /apps output")
+          (assert-metrics-output aggregate-metrics service-metrics-schema)
+          (is (number? (get aggregate-metrics "routers-sent-requests-to")))
+          (is (>= (get-in aggregate-metrics ["counters" "request-counts" "total"]) num-requests))))
+
+      (doseq [service-id @all-service-ids-atom]
+        (delete-service waiter-url service-id)))))
 
 (defmacro get-percentile-value
   "Look up percentile from metric, also asserting that it's present.
@@ -175,10 +198,7 @@
 
 (deftest ^:parallel ^:integration-slow test-launch-metrics-output
   (testing-using-waiter-url
-    (let [waiter-settings (waiter-settings waiter-url)
-          metrics-sync-interval-ms (get-in waiter-settings [:metrics-config :metrics-sync-interval-ms])
-          router->endpoint (routers waiter-url)
-          router-urls (vals router->endpoint)
+    (let [router->endpoint (routers waiter-url)
           service-name (rand-name)
           sleep-millis 20000
           min-startup-seconds 10 ; 20s +/- 10s for 2 polls with 5s granularity
@@ -188,14 +208,14 @@
                        :x-waiter-cmd-type "shell"
                        :x-waiter-min-instances instance-count
                        :x-waiter-name service-name}
-          {:keys [cookies headers request-headers service-id] :as first-response}
+          {:keys [cookies service-id] :as first-response}
           (make-request-with-debug-info req-headers #(make-kitchen-request waiter-url % :method :get))]
       (with-service-cleanup
         service-id
         ; ensure the first request succeded before continuing with testing
         (assert-response-status first-response 200)
         ; on each router, check that the launch-metrics are present and have sane values
-        (doseq [[router-id router-url] router->endpoint]
+        (doseq [[_ router-url] router->endpoint]
           (is (wait-for #(n-healthy-instances-observed? router-url cookies service-id instance-count)
                         :interval 1 :timeout (* 2 max-startup-seconds)))
           (let [metrics-response (->> "/metrics"

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -216,7 +216,7 @@
                     exclude-services (metrics/get-waiter-metrics)
                     (and (not exclude-services) service-id) (metrics/get-service-metrics service-id)
                     include-jvm-metrics (metrics/get-jvm-metrics)
-                    :else (metrics/get-metrics))]
+                    :else (metrics/get-metrics (metrics/contains-metrics-filter (str (get request-params "name")))))]
       (utils/clj->streaming-json-response metrics))
     (catch Exception ex
       (utils/exception->response ex request))))

--- a/waiter/src/waiter/metrics.clj
+++ b/waiter/src/waiter/metrics.clj
@@ -161,7 +161,8 @@
 
 (defn get-metrics
   "Return a nested map of metrics data."
-  ([] (get-metrics mc/default-registry MetricFilter/ALL))
+  ([] (get-metrics MetricFilter/ALL))
+  ([^MetricFilter metric-filter] (get-metrics mc/default-registry metric-filter))
   ([^MetricRegistry registry ^MetricFilter metric-filter]
    (utils/keys->nested-map
      (metric-registry->metric-filter->metric-map registry metric-filter)
@@ -199,12 +200,19 @@
                          (persistent!))))
                  service-id->codahale-metrics)))
 
-(defn- prefix-metrics-filter
-  "Creates a MetricFilter that filters by the provided prefix"
+(defn prefix-metrics-filter
+  "Creates a MetricFilter that filters by the provided prefix on metric names."
   [prefix-string]
   (reify MetricFilter
     (matches [_ name _]
       (str/starts-with? name prefix-string))))
+
+(defn contains-metrics-filter
+  "Creates a MetricFilter that filters by the provided substring on metric names."
+  [candidate-substring]
+  (reify MetricFilter
+    (matches [_ name _]
+      (str/includes? name candidate-substring))))
 
 (defn get-service-metrics
   "Retrieves the metrics for a sepcific service-id available at this router."

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -791,7 +791,7 @@
         waiter-request?-fn (fn [_] true)
         ring-handler (wrap-handler-json-response (ring-handler-factory waiter-request?-fn handlers))]
     (testing "metrics-request-handler:all-metrics"
-      (with-redefs [metrics/get-metrics (fn get-metrics [] {:data "metrics-from-get-metrics"})]
+      (with-redefs [metrics/get-metrics (fn get-metrics [_] {:data "metrics-from-get-metrics"})]
         (let [request {:headers {"accept" "application/json"}
                        :request-method :get
                        :uri "/metrics"}
@@ -801,7 +801,7 @@
           (is (str/includes? (str body) "metrics-from-get-metrics")))))
 
     (testing "metrics-request-handler:all-metrics:error"
-      (with-redefs [metrics/get-metrics (fn get-metrics [] (throw (Exception. "get-metrics")))]
+      (with-redefs [metrics/get-metrics (fn get-metrics [_] (throw (Exception. "get-metrics")))]
         (let [request {:headers {"accept" "application/json"}
                        :request-method :get
                        :uri "/metrics"}


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for filtering metrics by name

## Why are we making these changes?

We would like the /metrics endpoint less heavy to load by being more specific about the metrics we are interested in.
