### PR TITLE
adds support for delayed scheduler synced results in ping tests

### DIFF
--- a/waiter/integration/waiter/health_check_test.clj
+++ b/waiter/integration/waiter/health_check_test.clj
@@ -31,7 +31,9 @@
                (get-in ping-response [:headers :x-kitchen-protocol-version]))
             (str ping-response))
         (is (= "get" (get-in ping-response [:headers :x-kitchen-request-method])) (str ping-response))
-        (is (= {:exists? true :healthy? true :service-id service-id :status "Running"} service-state)))
+        (is (or (= {:exists? true :healthy? true :service-id service-id :status "Running"} service-state)
+                (= {:exists? true :healthy? false :service-id service-id :status "Starting"} service-state))
+            (str service-state)))
       (do
         (is (= "timed-out" (get ping-response :result)) (str ping-response))
         (is (= {:exists? true :healthy? false :service-id service-id :status "Starting"} service-state))))))


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for delayed scheduler synced results in ping tests

## Why are we making these changes?

We want our tests to be less flaky.

