### PR TITLE
WIP: enables http2 integration tests

### DIFF
--- a/waiter/integration/waiter/grpc_test.clj
+++ b/waiter/integration/waiter/grpc_test.clj
@@ -45,8 +45,7 @@
   [length]
   (apply str (take length (repeatedly #(char (+ (rand 26) 65))))))
 
-;; setting to explicit because of temporary haproxy misconfiguration
-(deftest ^:parallel ^:integration-fast ^:explicit test-basic-grpc-server
+(deftest ^:parallel ^:integration-fast test-basic-grpc-server
   (testing-using-waiter-url
     (GrpcClient/setLogFunction (reify Function
                                  (apply [_ message]

--- a/waiter/integration/waiter/proto_test.clj
+++ b/waiter/integration/waiter/proto_test.clj
@@ -80,8 +80,7 @@
     ;; PORT2 is running kitchen without SSL enabled
     (run-backend-proto-service-test waiter-url "h2" "https" 1 "https" "HTTP/2.0")))
 
-;; disabling http/2 tests temporarily
-(deftest ^:explicit ^:parallel ^:integration-fast test-internal-protocol
+(deftest ^:parallel ^:integration-fast test-internal-protocol
   (testing-using-waiter-url
     (let [{:keys [http2c? http2? ssl-port]} (:server-options (waiter-settings waiter-url))
           retrieve-client-protocol #(get-in % ["request-info" "client-protocol"])

--- a/waiter/integration/waiter/trailers_test.clj
+++ b/waiter/integration/waiter/trailers_test.clj
@@ -92,8 +92,7 @@
   (testing-using-waiter-url
     (run-sediment-trailers-support-test waiter-url "http")))
 
-;; disabling http/2 tests temporarily
-(deftest ^:explicit ^:parallel ^:integration-fast test-trailers-support-h2c-proto-sediment
+(deftest ^:parallel ^:integration-fast test-trailers-support-h2c-proto-sediment
   (testing-using-waiter-url
     (run-sediment-trailers-support-test waiter-url "h2c")))
 


### PR DESCRIPTION
## Changes proposed in this PR

- enables http2 integration tests

## Why are we making these changes?

We want to test and avoid regressions with end-to-end http/2 support.
