### PR TITLE
adds grpc status to the request log

### DIFF
--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -51,7 +51,7 @@
   [{:keys [authorization/principal backend-response-latency-ns descriptor latest-service-id get-instance-latency-ns
            handle-request-latency-ns headers instance protocol status] :as response}]
   (let [{:keys [service-id service-description]} descriptor
-        {:strs [content-type server]} headers]
+        {:strs [content-type grpc-status server]} headers]
     (cond-> {:status (or status 200)}
       backend-response-latency-ns (assoc :backend-response-latency-ns backend-response-latency-ns)
       content-type (assoc :response-content-type content-type)
@@ -59,6 +59,7 @@
                         :service-id service-id
                         :service-name (get service-description "name")
                         :service-version (get service-description "version"))
+      grpc-status (assoc :grpc-status grpc-status)
       instance (assoc :instance-host (:host instance)
                       :instance-id (:id instance)
                       :instance-port (:port instance)

--- a/waiter/test/waiter/request_log_test.clj
+++ b/waiter/test/waiter/request_log_test.clj
@@ -57,6 +57,7 @@
                   :get-instance-latency-ns 500
                   :handle-request-latency-ns 2000
                   :headers {"content-type" "application/xml"
+                            "grpc-status" "13"
                             "server" "foo-bar"}
                   :instance {:host "instance-host"
                              :id "instance-id"
@@ -67,6 +68,7 @@
     (is (= {:backend-response-latency-ns 1000
             :backend-protocol "HTTP/2.0"
             :get-instance-latency-ns 500
+            :grpc-status "13"
             :handle-request-latency-ns 2000
             :instance-host "instance-host"
             :instance-id "instance-id"


### PR DESCRIPTION
## Changes proposed in this PR

- adds grpc status to the request log

## Why are we making these changes?

Allows us to track the status of gRPC requests proxied by Waiter.
The `grpc-status` is [returned as response header](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#example).
