### PR TITLE
Fixes bug in ping due to connection error

### DIFF
--- a/cli/waiter/subcommands/ping.py
+++ b/cli/waiter/subcommands/ping.py
@@ -110,7 +110,7 @@ def ping_token_on_cluster(cluster, token_name, health_check_endpoint, timeout, w
 def service_is_active(cluster, service_id):
     """If the given service id is active, returns the service, else None"""
     service = get_service(cluster, service_id)
-    return service if service['status'] != 'Inactive' else None
+    return service if (service and service['status'] != 'Inactive') else None
 
 
 def ping_service_on_cluster(cluster, service_id, health_check_endpoint, timeout, wait_for_request):

--- a/cli/waiter/subcommands/ping.py
+++ b/cli/waiter/subcommands/ping.py
@@ -110,7 +110,7 @@ def ping_token_on_cluster(cluster, token_name, health_check_endpoint, timeout, w
 def service_is_active(cluster, service_id):
     """If the given service id is active, returns the service, else None"""
     service = get_service(cluster, service_id)
-    return service if (service and service['status'] != 'Inactive') else None
+    return service if (service and service.get('status') != 'Inactive') else None
 
 
 def ping_service_on_cluster(cluster, service_id, health_check_endpoint, timeout, wait_for_request):


### PR DESCRIPTION
## Changes proposed in this PR

- checking for `None` when retrieving the service in `ping`

## Why are we making these changes?

If there is a connection error, `get_service` returns `None`, and we need to handle that cleanly.
