### PR TITLE
Fix deep-merge-settings

### DIFF
--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -460,21 +460,12 @@
                :mutex-timeout-ms 1000}})
 
 (defn deep-merge-settings
-  "Merges the two settings maps, with special handling for maps with :kind"
+  "Recursively merges the two settings maps"
   [map-1 map-2]
   (merge-with
     (fn [x y]
       (if (and (map? x) (map? y))
-        (let [x-kind (:kind x)
-              y-kind (:kind y)]
-          (if (and x-kind y-kind)
-            (let [kind y-kind
-                  x-sub-map (get x kind)
-                  y-sub-map (get y kind)]
-              (-> x
-                  (merge y)
-                  (assoc kind (deep-merge-settings x-sub-map y-sub-map))))
-            (deep-merge-settings x y)))
+        (deep-merge-settings x y)
         y))
     map-1 map-2))
 

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -99,8 +99,8 @@
         waiter-uri)
       (let [port WAITER-PORT]
         (if (utils/port-available? port)
-          (log/warn "port" port "is not in use, you may need to start Waiter.")
-          (log/info "port" port "is already in use, assuming Waiter is running."))
+          (log/warn "port" port "is not in use, you may need to start Waiter")
+          (log/info "port" port "is already in use, assuming Waiter is running"))
         (str (retrieve-hostname) ":" port)))))
 
 (defn retrieve-h2c-port

--- a/waiter/test/waiter/settings_test.clj
+++ b/waiter/test/waiter/settings_test.clj
@@ -213,7 +213,7 @@
                                            :work-directory "scheduler"}}}
                (deep-merge-settings defaults configured)))))
 
-    (testing "should not merge sub-maps not related to the configured :kind"
+    (testing "should merge sub-maps not related to the configured :kind"
       (let [defaults {:scheduler-config {:kind :foo
                                          :foo {:bar 1
                                                :baz 2}
@@ -223,7 +223,9 @@
                                            :qux {:two "c"}
                                            :foo {:other 3}}}]
         (is (= {:scheduler-config {:kind :qux
-                                   :foo {:other 3}
+                                   :foo {:bar 1
+                                         :baz 2
+                                         :other 3}
                                    :qux {:one "a"
                                          :two "c"}}}
                (deep-merge-settings defaults configured)))))


### PR DESCRIPTION
## Changes proposed in this PR

when merging settings maps we should not have special treatment for the value of :kind

## Why are we making these changes?

If we are specifying defaults for components, we should set the defaults even if the current :kind is a different component. The defaults are still valid
