### PR TITLE
propagate exception cause better

### DIFF
--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -529,5 +529,5 @@
   "Updates an exception, regardless of whether it's an ExceptionInfo or just Exception."
   [^Exception e update-fn]
   (if (instance? ExceptionInfo e)
-    (ex-info (.getMessage e) (update-fn (ex-data e)) (.getCause e))
+    (ex-info (.getMessage e) (update-fn (ex-data e)) (or (.getCause e) e))
     (ex-info (.getMessage e) (update-fn {}) e)))


### PR DESCRIPTION
## Changes proposed in this PR

- propagate exception cause better by returning ExceptionInfo itself as the cause

## Why are we making these changes?


