### PR TITLE
adds the service description to the ping response

### DIFF
--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -785,9 +785,10 @@
   [process-request-handler-fn service-state-fn {:keys [descriptor headers] :as request}]
   (async/go
     (try
-      (let [{:keys [service-id]} descriptor
+      (let [{:keys [core-service-description service-id]} descriptor
             idle-timeout-ms (Integer/parseInt (get headers "x-waiter-timeout" "300000"))
             ping-response (make-health-check-request process-request-handler-fn idle-timeout-ms request)]
         (utils/clj->json-response
           {:ping-response (async/<! ping-response)
+           :service-description core-service-description
            :service-state (service-state-fn service-id)})))))


### PR DESCRIPTION
## Changes proposed in this PR

- adds the service description to the ping response

## Why are we making these changes?

Enables inspecting the service description used to make the ping request to the backend.

