### PR TITLE
adds principal and backend properties to the request log for waiter-ping

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1200,7 +1200,7 @@
    :not-found-handler-fn (pc/fnk [] handler/not-found-handler)
    :ping-service-handler (pc/fnk [[:daemons router-state-maintainer]
                                   [:state fallback-state-atom]
-                                  process-request-handler-fn process-request-wrapper-fn]
+                                  process-request-handler-fn process-request-wrapper-fn wrap-secure-request-fn]
                            (let [{{:keys [query-state-fn]} :maintainer} router-state-maintainer
                                  handler (process-request-wrapper-fn
                                            (fn inner-ping-service-handler [request]
@@ -1213,10 +1213,11 @@
                                                         :service-id service-id
                                                         :status (service/retrieve-service-status-label service-id global-state)}))]
                                                (pr/ping-service process-request-handler-fn service-state-fn request))))]
-                             (fn ping-service-handler [request]
-                               (-> request
-                                 (update :headers assoc "x-waiter-fallback-period-secs" "0")
-                                 (handler)))))
+                             (wrap-secure-request-fn
+                               (fn ping-service-handler [request]
+                                 (-> request
+                                   (update :headers assoc "x-waiter-fallback-period-secs" "0")
+                                   (handler))))))
    :process-request-fn (pc/fnk [process-request-handler-fn process-request-wrapper-fn]
                          (process-request-wrapper-fn process-request-handler-fn))
    :process-request-handler-fn (pc/fnk [[:routines determine-priority-fn make-basic-auth-fn post-process-async-request-response-fn


### PR DESCRIPTION
## Changes proposed in this PR

- requires authentication in the ping handler
- adds backend request properties in the request log for ping requests

## Why are we making these changes?

Introducing the following fields in the request log has the corresponding benefits:
- principal: allows us to see who triggered a ping request
- backend-proto: which protocol was used to trigger the health check request
- backend-response-latency-ns: how responsive the backend is to health checks


Example request log:
```
{
	"backend-protocol": "HTTP/1.1",
	"backend-response-latency-ns": 24537389,
	"cid": "test-ping-h2c-http-port2-11f546c3608cd-3290a037e8d7a9d9",
	"client-protocol": "HTTP/1.1",
	"get-instance-latency-ns": 4730040704,
	"handle-request-latency-ns": 4903103143,
	"host": "127.0.0.1:9091",
	"instance-host": "127.0.0.4",
	"instance-id": "w9091-testpingh2chttpport2shamsimam927839-813ce75889defea5cfe929dad294f479.11f54d989c796-418560883dc011cc",
	"instance-port": 10500,
	"internal-protocol": "HTTP/1.1",
	"latest-service-id": "w9091-testpingh2chttpport2shamsimam927839-813ce75889defea5cfe929dad294f479",
	"method": "POST",
	"metric-group": "waiter_test",
	"path": "/waiter-ping",
	"principal": "shamsimam",
	"remote-addr": "127.0.0.1",
	"request-id": "11f546f31884f-6c09d56d922f381b-http",
	"request-time": "2019-05-30T16:42:12.380Z",
	"response-content-type": "application/json",
	"scheme": "http",
	"server": "waiter/657dc23",
	"service-id": "w9091-testpingh2chttpport2shamsimam927839-813ce75889defea5cfe929dad294f479",
	"service-name": "testpingh2chttpport2shamsimam927839",
	"service-version": "version-does-not-matter",
	"status": 200,
	"user-agent": "waiter-test/waiter-ping-secure.http1"
}
```

where the following entries are new: `backend-protocol`, `backend-response-latency-ns`, `instance-*`, and `principal`.