### PR TITLE
Minor integration test changes

### DIFF
--- a/waiter/integration/waiter/health_check_test.clj
+++ b/waiter/integration/waiter/health_check_test.clj
@@ -22,9 +22,9 @@
 
 (defn assert-ping-response
   [waiter-url health-check-protocol idle-timeout service-id response]
+  (assert-response-status response 200)
   (let [{:keys [ping-response service-description service-state]}
         (some-> response :body json/read-str walk/keywordize-keys)]
-    (assert-response-status response 200)
     (is (seq service-description) (str service-description))
     (is (= (service-id->service-description waiter-url service-id) service-description))
     (if (nil? idle-timeout)

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -348,10 +348,12 @@
   "Asserts the response status and includes CID in failed message log"
   [response expected-status]
   `(let [response-cid# (get-in ~response [:headers "x-cid"] "unknown")
+         response-server# (get-in ~response [:headers "server"] "unknown")
          actual-status# (:status ~response)
          response-body# (:body ~response)
          response-error# (:error ~response)
-         assertion-message# (str "[CID=" response-cid# "] Expected status: " ~expected-status
+         assertion-message# (str "[CID=" response-cid# ", server=" response-server# "] "
+                                 "Expected status: " ~expected-status
                                  ", actual: " actual-status# "\r\n Body:" response-body#
                                  (when response-error# (str "\r\n Error: " response-error#)))]
      (when (not= ~expected-status actual-status#)


### PR DESCRIPTION
## Changes proposed in this PR

- moves response assertion before attempt to parse json
- includes response server in failed assertion message

## Why are we making these changes?

Makes it easier to debug failed response assertions.

