### PR TITLE
disable-grpc-test

### DIFF
--- a/waiter/integration/waiter/grpc_test.clj
+++ b/waiter/integration/waiter/grpc_test.clj
@@ -45,7 +45,8 @@
   [length]
   (apply str (take length (repeatedly #(char (+ (rand 26) 65))))))
 
-(deftest ^:parallel ^:integration-fast test-basic-grpc-server
+;; setting to explicit because of temporary haproxy misconfiguration
+(deftest ^:parallel ^:integration-fast ^:explicit test-basic-grpc-server
   (testing-using-waiter-url
     (GrpcClient/setLogFunction (reify Function
                                  (apply [_ message]


### PR DESCRIPTION
## Changes proposed in this PR

- disable-grpc-test

## Why are we making these changes?

test fails internally because of temporary haproxy misconfiguration
