### PR TITLE
updates jet dependency to handle NoSuchElementException from DeferredContentProviderIterator

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -41,7 +41,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20190608_080540-ge8d4383"
+                 [twosigma/jet "0.7.10-20190610_212308-g550b820"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]


### PR DESCRIPTION
## Changes proposed in this PR

- updates [jet dependency](https://github.com/twosigma/jet/pull/24) to handle NoSuchElementException from DeferredContentProviderIterator using solution suggested in [relevant Jetty issue](https://github.com/eclipse/jetty.project/issues/3753).

## Why are we making these changes?

Filed [bug in Jetty](https://github.com/eclipse/jetty.project/issues/3753) for a proper fix, this is a temporary workaround.

Avoid the following error:

Error stacktrace:
```
 #error {
 :cause nil
 :via
 [{:type clojure.lang.ExceptionInfo
   :message Request to service backend failed
   :data {:instances-blacklisted 0, :instances-failed 0, :outstanding-requests 9, :service-id waiter-test-2984rx71298616293h6, :slots-assigned 13, :slots-available 4, :status 502}
   :at [waiter.process_request$handle_response_error invokeStatic process_request.clj 185]}
  {:type java.util.NoSuchElementException
   :message nil
   :at [org.eclipse.jetty.client.util.DeferredContentProvider$DeferredContentProviderIterator next DeferredContentProvider.java 265]}]
 :trace
 [[org.eclipse.jetty.client.util.DeferredContentProvider$DeferredContentProviderIterator next DeferredContentProvider.java 265]
  [org.eclipse.jetty.client.util.DeferredContentProvider$DeferredContentProviderIterator next DeferredContentProvider.java 241]
  [qbits.jet.client.http$wrap_iterator$reify__18786 next http.clj 311]
  [org.eclipse.jetty.client.HttpContent advance HttpContent.java 156]
  [org.eclipse.jetty.client.HttpContent advance HttpContent.java 149]
  [org.eclipse.jetty.client.HttpSender$ContentCallback process HttpSender.java 849]
  [org.eclipse.jetty.util.IteratingCallback processing IteratingCallback.java 241]
  [org.eclipse.jetty.util.IteratingCallback succeeded IteratingCallback.java 365]
  [org.eclipse.jetty.client.HttpSender$ContentCallback succeeded HttpSender.java 907]
  [org.eclipse.jetty.http2.HTTP2Stream succeeded HTTP2Stream.java 530]
  [org.eclipse.jetty.util.Callback$Nested succeeded Callback.java 261]
  [org.eclipse.jetty.http2.HTTP2Session$DataEntry succeeded HTTP2Session.java 1461]
  [java.lang.Iterable forEach Iterable.java 75]
  [org.eclipse.jetty.http2.HTTP2Flusher finish HTTP2Flusher.java 276]
  [org.eclipse.jetty.http2.HTTP2Flusher succeeded HTTP2Flusher.java 268]
  [org.eclipse.jetty.io.WriteFlusher write WriteFlusher.java 293]
  [org.eclipse.jetty.io.AbstractEndPoint write AbstractEndPoint.java 380]
  [org.eclipse.jetty.http2.HTTP2Flusher process HTTP2Flusher.java 247]
  [org.eclipse.jetty.util.IteratingCallback processing IteratingCallback.java 241]
  [org.eclipse.jetty.util.IteratingCallback iterate IteratingCallback.java 224]
  [org.eclipse.jetty.http2.HTTP2Session newStream HTTP2Session.java 569]
  [org.eclipse.jetty.http2.client.http.HttpSenderOverHTTP2 sendHeaders HttpSenderOverHTTP2.java 95]
  [org.eclipse.jetty.client.HttpSender send HttpSender.java 214]
  [org.eclipse.jetty.http2.client.http.HttpChannelOverHTTP2 send HttpChannelOverHTTP2.java 96]
  [org.eclipse.jetty.client.HttpChannel send HttpChannel.java 128]
  [org.eclipse.jetty.client.HttpConnection send HttpConnection.java 201]
  [org.eclipse.jetty.http2.client.http.HttpConnectionOverHTTP2 send HttpConnectionOverHTTP2.java 77]
  [org.eclipse.jetty.http2.client.http.HttpDestinationOverHTTP2 send HttpDestinationOverHTTP2.java 38]
  [org.eclipse.jetty.client.HttpDestination process HttpDestination.java 346]
  [org.eclipse.jetty.client.HttpDestination process HttpDestination.java 304]
  [org.eclipse.jetty.client.HttpDestination send HttpDestination.java 294]
  [org.eclipse.jetty.client.HttpDestination send HttpDestination.java 269]
  [org.eclipse.jetty.client.HttpDestination send HttpDestination.java 246]
  [org.eclipse.jetty.client.HttpClient send HttpClient.java 576]
  [org.eclipse.jetty.client.HttpRequest send HttpRequest.java 726]
  [org.eclipse.jetty.client.HttpRequest send HttpRequest.java 718]
  [qbits.jet.client.http$request invokeStatic http.clj 487]
  [qbits.jet.client.http$request invoke http.clj 346]
  [waiter.process_request$make_http_request invokeStatic process_request.clj 350]
  [waiter.process_request$make_http_request invoke process_request.clj 338]
  [waiter.process_request$make_request invokeStatic process_request.clj 396]
  [waiter.process_request$make_request invoke process_request.clj 367]
  [waiter.core$fn__45623$fnk45619_positional__45624$make_request_fn__45625 invoke core.clj 1229]
  [waiter.process_request$fn__29498$process__29500$fn__29712$state_machine__8937__auto____29761$fn__29764 invoke process_request.clj 644]
  [waiter.process_request$fn__29498$process__29500$fn__29712$state_machine__8937__auto____29761 invoke process_request.clj 593]
  [clojure.core.async.impl.ioc_macros$run_state_machine invokeStatic ioc_macros.clj 973]
  [clojure.core.async.impl.ioc_macros$run_state_machine invoke ioc_macros.clj 972]
  [clojure.core.async.impl.ioc_macros$run_state_machine_wrapped invokeStatic ioc_macros.clj 977]
  [clojure.core.async.impl.ioc_macros$run_state_machine_wrapped invoke ioc_macros.clj 975]
  [clojure.core.async.impl.ioc_macros$take_BANG_$fn__8955 invoke ioc_macros.clj 986]
  [clojure.core.async.impl.channels.ManyToManyChannel$fn__4617$fn__4618 invoke channels.clj 95]
  [clojure.lang.AFn run AFn.java 22]
  [java.util.concurrent.ThreadPoolExecutor runWorker ThreadPoolExecutor.java 1149]
  [java.util.concurrent.ThreadPoolExecutor$Worker run ThreadPoolExecutor.java 624]
  [java.lang.Thread run Thread.java 748]]}
```

