### PR TITLE
verifies support for temporarily unhealthy instances

### DIFF
--- a/containers/test-apps/kitchen/bin/kitchen
+++ b/containers/test-apps/kitchen/bin/kitchen
@@ -57,6 +57,7 @@ _async_state_lock = threading.Lock()
 _async_state = {}
 
 _counter_lock = threading.Lock()
+_default_response_status = 200
 _pending_http_requests = 0
 _total_http_requests = 0
 _pending_ws_requests = 0
@@ -95,6 +96,13 @@ def terminate(source):
     """Forcefully terminate this server process."""
     kitchen_logger.info('Killed by {}'.format(source))
     os._exit(1)
+
+
+def reset_default_response_status(handler):
+    """Clears the status default value to 200 for all kitchen responses."""
+    global _default_response_status
+    handler.logger().info('Resetting default response status from {} to 200'.format(_default_response_status))
+    _default_response_status = 200
 
 
 _gzip_window_bits = 16 + zlib.MAX_WBITS
@@ -478,7 +486,7 @@ class Kitchen(HTTPWebSocketsHandler):
 
     def __handle_http_request(self):
         """Core logic for a Kitchen HTTP request (all verbs delegate to this handler)."""
-        global _pending_http_requests, _total_http_requests
+        global _default_response_status, _pending_http_requests, _total_http_requests
         with _counter_lock:
             _pending_http_requests += 1
             _total_http_requests += 1
@@ -502,7 +510,7 @@ class Kitchen(HTTPWebSocketsHandler):
             self.__response_body_callback = None
             self.__response_bytes = None
             self.__response_length = max_response_size
-            self.__status = 200
+            self.__status = _default_response_status
             self.__response_trailers = {}
             self.__trailer_delay_secs = 0
             self.__truncated_length = max_response_size + 1
@@ -599,6 +607,17 @@ class Kitchen(HTTPWebSocketsHandler):
     def __process_headers(self):
         """Handle logic for all supported Kitchen HTTP header values."""
         assert self.__path is not None, 'Processes headers AFTER processing the request path.'
+        global _default_response_status
+
+        # Temporarily set status on responses
+        default_status = self.headers.get('x-kitchen-default-status-value')
+        default_timeout = self.headers.get('x-kitchen-default-status-timeout')
+        if default_status is not None and default_timeout is not None:
+            self.logger().info('Changing default response status from {} to {} for {} ms'.
+                               format(_default_response_status, default_status, default_timeout))
+            _default_response_status = int(default_status)
+            self.__status = _default_response_status
+            run_after_ms(int(default_timeout), reset_default_response_status, self)
 
         # Respond with chunked encoding when request is chunked
         if self.headers.get('transfer-encoding') == 'chunked':

--- a/containers/test-apps/kitchen/bin/kitchen
+++ b/containers/test-apps/kitchen/bin/kitchen
@@ -491,7 +491,7 @@ class Kitchen(HTTPWebSocketsHandler):
 
     def __handle_http_request(self):
         """Core logic for a Kitchen HTTP request (all verbs delegate to this handler)."""
-        global _default_response_status, _pending_http_requests, _total_http_requests
+        global _pending_http_requests, _total_http_requests
         with _counter_lock:
             _pending_http_requests += 1
             _total_http_requests += 1
@@ -515,7 +515,7 @@ class Kitchen(HTTPWebSocketsHandler):
             self.__response_body_callback = None
             self.__response_bytes = None
             self.__response_length = max_response_size
-            self.__status = _default_response_status
+            self.__status = None
             self.__response_trailers = {}
             self.__trailer_delay_secs = 0
             self.__truncated_length = max_response_size + 1
@@ -613,23 +613,6 @@ class Kitchen(HTTPWebSocketsHandler):
         """Handle logic for all supported Kitchen HTTP header values."""
         assert self.__path is not None, 'Processes headers AFTER processing the request path.'
         global _default_response_status
-
-        # Temporarily set status on responses
-        default_status_value = self.headers.get('x-kitchen-default-status-value')
-        if default_status_value is not None:
-            if _allow_response_status_change:
-                self.logger().info('Changing default response status to {}'.format(default_status_value))
-                _default_response_status = int(default_status_value)
-                self.__status = _default_response_status
-
-                default_timeout = self.headers.get('x-kitchen-default-status-timeout')
-                if default_timeout is not None:
-                    default_timeout_ms = int(default_timeout)
-                    if default_timeout_ms > 0:
-                        self.logger().info('Will reset default response status after {} ms'.format(default_timeout_ms))
-                        run_after_ms(default_timeout_ms, reset_default_response_status, self)
-            else:
-                self.logger().info('Ignoring request to change the default response status')
 
         # Respond with chunked encoding when request is chunked
         if self.headers.get('transfer-encoding') == 'chunked':
@@ -771,6 +754,25 @@ class Kitchen(HTTPWebSocketsHandler):
         for name, value in self.headers.items() :
             if str(name).startswith('x-kitchen-trailer-'):
                 self.__response_trailers[name[len('x-kitchen-trailer-'):]] = value
+
+        # Process default response status
+        default_status_value = self.headers.get('x-kitchen-default-status-value')
+        if default_status_value is not None:
+            if _allow_response_status_change:
+                self.logger().info('Changing default response status to {}'.format(default_status_value))
+                _default_response_status = int(default_status_value)
+                default_timeout = self.headers.get('x-kitchen-default-status-timeout')
+                if default_timeout is not None:
+                    default_timeout_ms = int(default_timeout)
+                    if default_timeout_ms > 0:
+                        self.logger().info('Will reset default response status after {} ms'.format(default_timeout_ms))
+                        run_after_ms(default_timeout_ms, reset_default_response_status, self)
+            else:
+                self.logger().info('Ignoring request to change the default response status')
+
+        # Set the response status if it is not set
+        if self.__status is None:
+            self.__status = _default_response_status
 
     def __process_path(self):
         """Handle logic for all supported Kitchen endpoint paths."""

--- a/containers/test-apps/kitchen/bin/kitchen
+++ b/containers/test-apps/kitchen/bin/kitchen
@@ -56,8 +56,10 @@ _auth_handler = None
 _async_state_lock = threading.Lock()
 _async_state = {}
 
-_counter_lock = threading.Lock()
+_allow_response_status_change = False
 _default_response_status = 200
+
+_counter_lock = threading.Lock()
 _pending_http_requests = 0
 _total_http_requests = 0
 _pending_ws_requests = 0
@@ -101,8 +103,11 @@ def terminate(source):
 def reset_default_response_status(handler):
     """Clears the status default value to 200 for all kitchen responses."""
     global _default_response_status
-    handler.logger().info('Resetting default response status from {} to 200'.format(_default_response_status))
-    _default_response_status = 200
+    if _allow_response_status_change:
+        handler.logger().info('Resetting default response status from {} to 200'.format(_default_response_status))
+        _default_response_status = 200
+    else:
+        handler.logger().info('Ignroing request to reset default response status')
 
 
 _gzip_window_bits = 16 + zlib.MAX_WBITS
@@ -610,14 +615,21 @@ class Kitchen(HTTPWebSocketsHandler):
         global _default_response_status
 
         # Temporarily set status on responses
-        default_status = self.headers.get('x-kitchen-default-status-value')
-        default_timeout = self.headers.get('x-kitchen-default-status-timeout')
-        if default_status is not None and default_timeout is not None:
-            self.logger().info('Changing default response status from {} to {} for {} ms'.
-                               format(_default_response_status, default_status, default_timeout))
-            _default_response_status = int(default_status)
-            self.__status = _default_response_status
-            run_after_ms(int(default_timeout), reset_default_response_status, self)
+        default_status_value = self.headers.get('x-kitchen-default-status-value')
+        if default_status_value is not None:
+            if _allow_response_status_change:
+                self.logger().info('Changing default response status to {}'.format(default_status_value))
+                _default_response_status = int(default_status_value)
+                self.__status = _default_response_status
+
+                default_timeout = self.headers.get('x-kitchen-default-status-timeout')
+                if default_timeout is not None:
+                    default_timeout_ms = int(default_timeout)
+                    if default_timeout_ms > 0:
+                        self.logger().info('Will reset default response status after {} ms'.format(default_timeout_ms))
+                        run_after_ms(default_timeout_ms, reset_default_response_status, self)
+            else:
+                self.logger().info('Ignoring request to change the default response status')
 
         # Respond with chunked encoding when request is chunked
         if self.headers.get('transfer-encoding') == 'chunked':
@@ -991,8 +1003,10 @@ class BasicAuthHandler():
 
 
 def main():
-    global kitchen_logger, _auth_handler, binary_max_size, text_max_size
+    global kitchen_logger, _allow_response_status_change, _auth_handler, binary_max_size, text_max_size
     parser = argparse.ArgumentParser(description='A toy HTTP Service for testing the Waiter platform')
+    parser.add_argument('--enable-status-change', action='store_true', default=False,
+            help='Enables option to configure default response status using the x-kitchen-default-status-value header')
     parser.add_argument('--hostname', metavar='HOSTNAME', default='', help='Server host name')
     parser.add_argument('--log-output', metavar='LOG_OUTPUT', choices=['stdout', 'stderr', 'file'], default='stdout', help='Log output destination')
     parser.add_argument('-p', '--port', metavar='PORT_NUMBER', type=int, default=8080, help='Server port number')
@@ -1035,6 +1049,7 @@ def main():
         kitchen_logger.info('Sleeping for {}ms...'.format(args.start_up_sleep_ms))
         time.sleep(args.start_up_sleep_ms / 1000.0)
 
+    _allow_response_status_change = args.enable_status_change
     binary_max_size = args.ws_max_binary_message_size
     text_max_size = args.ws_max_text_message_size
 

--- a/waiter/integration/waiter/health_check_test.clj
+++ b/waiter/integration/waiter/health_check_test.clj
@@ -199,8 +199,8 @@
             #(make-kitchen-request waiter-url % :path "/hello"))
           check-filtered-instances (fn [target-url healthy-filter-fn]
                                      (let [instance-ids (->> (active-instances target-url service-id :cookies cookies)
-                                                   (healthy-filter-fn :healthy?)
-                                                   (map :id))]
+                                                          (healthy-filter-fn :healthy?)
+                                                          (map :id))]
                                        (and (= 1 (count instance-ids))
                                             (= instance-id (first instance-ids)))))]
       (assert-response-status canary-response 200)

--- a/waiter/integration/waiter/health_check_test.clj
+++ b/waiter/integration/waiter/health_check_test.clj
@@ -189,31 +189,37 @@
 
 (deftest test-temporarily-unhealthy-instance
   (testing-using-waiter-url
-    (let [{:keys [cookies service-id request-headers] :as canary-response}
+    (let [{:keys [cookies instance-id request-headers service-id] :as canary-response}
           (make-request-with-debug-info
-            {:x-waiter-concurrency-level 128
+            {:x-waiter-cmd (kitchen-cmd "--enable-status-change -p $PORT0")
+             :x-waiter-concurrency-level 128
              :x-waiter-health-check-interval-secs 5
              :x-waiter-health-check-max-consecutive-failures 10
              :x-waiter-name (rand-name)}
             #(make-kitchen-request waiter-url % :path "/hello"))
-          count-instances (fn [target-url healthy-filter-fn]
-                            (->> (active-instances target-url service-id :cookies cookies)
-                              (healthy-filter-fn :healthy?)
-                              count))]
+          check-filtered-instances (fn [target-url healthy-filter-fn]
+                                     (let [instance-ids (->> (active-instances target-url service-id :cookies cookies)
+                                                   (healthy-filter-fn :healthy?)
+                                                   (map :id))]
+                                       (and (= 1 (count instance-ids))
+                                            (= instance-id (first instance-ids)))))]
       (assert-response-status canary-response 200)
       (is service-id)
       (with-service-cleanup
         service-id
         (doseq [[_ router-url] (routers waiter-url)]
-          (is (wait-for #(= 1 (count-instances router-url filter)))))
+          (is (wait-for #(check-filtered-instances router-url filter)))
+          (is (= 1 (count (active-instances router-url service-id :cookies cookies)))))
         (let [request-headers (assoc request-headers
                                 :x-kitchen-default-status-timeout 20000
                                 :x-kitchen-default-status-value 400)
               response (make-kitchen-request waiter-url request-headers :path "/hello")]
           (assert-response-status response 400))
         (doseq [[_ router-url] (routers waiter-url)]
-          (is (wait-for #(= 1 (count-instances router-url remove)))))
+          (is (wait-for #(check-filtered-instances router-url remove)))
+          (is (= 1 (count (active-instances router-url service-id :cookies cookies)))))
         (let [response (make-kitchen-request waiter-url request-headers :path "/hello")]
           (assert-response-status response 200))
         (doseq [[_ router-url] (routers waiter-url)]
-          (is (wait-for #(= 1 (count-instances router-url filter)))))))))
+          (is (wait-for #(check-filtered-instances router-url filter)))
+          (is (= 1 (count (active-instances router-url service-id :cookies cookies)))))))))

--- a/waiter/integration/waiter/health_check_test.clj
+++ b/waiter/integration/waiter/health_check_test.clj
@@ -187,7 +187,7 @@
         (finally
           (delete-token-and-assert waiter-url token))))))
 
-(deftest test-temporarily-unhealthy-instance
+(deftest ^:parallel ^:integration-fast test-temporarily-unhealthy-instance
   (testing-using-waiter-url
     (let [{:keys [cookies instance-id request-headers service-id] :as canary-response}
           (make-request-with-debug-info


### PR DESCRIPTION
## Changes proposed in this PR

- verifies support for temporarily unhealthy instances via integration test
- allows temporarily setting the default response status for all kitchen requests

## Why are we making these changes?

We would like to confirm, via an integration test, support for temporarily unhealthy service instances.

