### PR TITLE
Adds support for publishing CLI to pypi

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -46,3 +46,13 @@ All global options (`--cluster`, `--config`, etc.) can be provided when using su
 
 - `create`: You can create a token with `create`. 
 - `show`: You can view a token's details with `show`.
+
+### Publishing to PyPi
+
+Use the following commands to publish the CLI to PyPi (https://pypi.org/project/waiter-client/):
+
+```bash
+# Run from the cli directory
+$ rm -rf dist/ && python3 setup.py sdist bdist_wheel
+$ python3 -m twine upload dist/*
+```

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python3
+import os
 
 from setuptools import setup
 
-from waiter import version
-
 requirements = [
-    'arrow',
-    'humanfriendly',
-    'requests',
-    'tabulate'
+    'arrow==0.13.1',
+    'humanfriendly==4.18',
+    'requests==2.20.0',
+    'tabulate==0.8.3'
 ]
 
 test_requirements = [
@@ -20,9 +19,19 @@ extras = {
     'test': test_requirements,
 }
 
+
+def get_version():
+    this_file = os.path.dirname(os.path.abspath(__file__))
+    version_file = os.path.join(this_file, 'waiter', 'version.py')
+    with open(version_file, 'r') as f:
+        version_string = f.read().strip().split('=')[1].strip().strip("'")
+        print(f'waiter version is {version_string}')
+        return version_string
+
+
 setup(
     name='waiter_client',
-    version=version.VERSION,
+    version=get_version(),
     description="Two Sigma's Waiter CLI",
     long_description="This package contains Two Sigma's Waiter command line interface, waiter. waiter allows you to "
                      "create/update/delete/view tokens and also view services across multiple Waiter clusters.",

--- a/cli/waiter/version.py
+++ b/cli/waiter/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.5.1-dev'
+VERSION = '0.5.6-dev'


### PR DESCRIPTION
## Changes proposed in this PR

- adding instructions for publishing to pypi
- adding version numbers for the dependencies in `setup.py`
- changing the version code in `setup.py` to not require importing the `version` module

## Why are we making these changes?

The overall change is to support publishing the CLI to pypi. This will allow users to  easily pull it into their own environment. The `get_version` change was needed because in some environments, importing the `version` module fails from `setup.py`.

## Published package

https://pypi.org/project/waiter-client/