### PR TITLE
Update authentication_test.clj

### DIFF
--- a/waiter/integration/waiter/authentication_test.clj
+++ b/waiter/integration/waiter/authentication_test.clj
@@ -88,8 +88,7 @@
                     "form input[name=SAMLResponse]" (reaver/attr :value)
                     "form input[name=RelayState]" (reaver/attr :value))))
 
-;; need to temporarily turn off this test until ADFS setting is updated
-(deftest ^:parallel ^:integration-fast ^:explicit test-saml-authentication
+(deftest ^:parallel ^:integration-fast test-saml-authentication
   (testing-using-waiter-url
     (when (using-composite-authenticator? waiter-url)
       (let [auth-principal (or (System/getenv "SAML_AUTH_USER") (retrieve-username))


### PR DESCRIPTION
 ADFS configuration fixed, re-enabling test

## Changes proposed in this PR

- re-enable saml test

## Why are we making these changes?

re-enable saml test

