### PR TITLE
handles exceptions reported in ctrl channel

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -41,7 +41,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20190607_230136-gaa94652"
+                 [twosigma/jet "0.7.10-20190608_080540-ge8d4383"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]


### PR DESCRIPTION
## Changes proposed in this PR

- handles exceptions reported in ctrl channel
- updates jet for [improved errors on ctrl chan](https://github.com/twosigma/jet/pull/26)

## Why are we making these changes?

Make it easier to display the stack trace of exceptions thrown while processing a request.

