### PR TITLE
Makes test_kill_services_sorted more reliable

### DIFF
--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -621,6 +621,8 @@ class WaiterCliTest(util.WaiterTest):
             self.assertIn(service_id_1, stdout)
             self.assertIn(service_id_2, stdout)
             self.assertLess(stdout.index(service_id_2), stdout.index(service_id_1))
+            util.wait_until_routers_recognize_service_killed(self.waiter_url, service_id_1)
+            util.wait_until_routers_recognize_service_killed(self.waiter_url, service_id_2)
 
             # Re-create the same two services, in the opposite order
             util.post_token(self.waiter_url, token_name, service_description_2)

--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -237,11 +237,15 @@ def ping_token(waiter_url, token_name, expected_status_code=200):
     return service_id
 
 
+def wait_until_routers_recognize_service_killed(waiter_url, service_id):
+    wait_until_routers(waiter_url, lambda services: not any(s['service-id'] == service_id for s in services))
+
+
 def kill_service(waiter_url, service_id):
     headers = {'x-cid': cid()}
     response = session.delete(f'{waiter_url}/apps/{service_id}', headers=headers)
     assert 200 == response.status_code, f'Expected 200, got {response.status_code} with body {response.text}'
-    wait_until_routers(waiter_url, lambda services: not any(s['service-id'] == service_id for s in services))
+    wait_until_routers_recognize_service_killed(waiter_url, service_id)
 
 
 def services_for_token(waiter_url, token_name, assert_response=True, expected_status_code=200, log_services=False):


### PR DESCRIPTION
## Changes proposed in this PR

- extracting function `util.wait_until_routers_recognize_service_killed`
- calling it between the `kill` and the re-pinging

## Why are we making these changes?

To avoid cross-router races, e.g. the kill request comes in one router and the subsequent ping request comes in on a different router that is not yet aware of the service being killed.
