### PR TITLE
avoids IllegalStateException due to ReadListener already being set

### DIFF
--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -318,20 +318,7 @@
                                    (stream-http-request executor service-id metric-group error-handler-fn
                                                         input-stream body-ch 0)))]
     (try
-      (if (instance? ServletInputStream input-stream)
-        (.setReadListener ^ServletInputStream input-stream
-                          (reify ReadListener
-                            (onDataAvailable [_]
-                              ;; invoked by the container the *first* time when it is possible to read data
-                              (try
-                                (submit-request-streaming-task executor stream-http-request-fn)
-                                (catch Throwable throwable
-                                  (error-handler-fn throwable))))
-                            (onAllDataRead [_]
-                              (async/close! body-ch))
-                            (onError [_ throwable]
-                              (error-handler-fn throwable))))
-        (submit-request-streaming-task executor stream-http-request-fn))
+      (submit-request-streaming-task executor stream-http-request-fn)
       (catch Throwable throwable
         (error-handler-fn throwable)))
     body-ch))


### PR DESCRIPTION
## Changes proposed in this PR

- avoids IllegalStateException due to ReadListener already being set

## Why are we making these changes?

Avoid the exception and fall back to the generic approach of reading from the input stream.

```
java.lang.IllegalStateException: ReadListener already set
        at org.eclipse.jetty.server.HttpInput.setReadListener(HttpInput.java:763)
        at waiter.process_request$input_stream__GT_channel$fn__28730.invoke(process_request.clj:322)
        at waiter.process_request$input_stream__GT_channel.invokeStatic(process_request.clj:320)
        at waiter.process_request$input_stream__GT_channel.invoke(process_request.clj:302)
        at waiter.process_request$make_http_request.invokeStatic(process_request.clj:350)
        at waiter.process_request$make_http_request.invoke(process_request.clj:339)
        at waiter.process_request$make_request.invokeStatic(process_request.clj:397)
        at waiter.process_request$make_request.invoke(process_request.clj:368)
        at waiter.core$fn__45650$fnk45646_positional__45651$make_request_fn__45652.invoke(core.clj:1242)
        at waiter.process_request$fn__29527$process__29529$fn__29744$state_machine__8937__auto____29795$fn__29798.invoke(process_request.clj:647)
        at waiter.process_request$fn__29527$process__29529$fn__29744$state_machine__8937__auto____29795.invoke(process_request.clj:596)
        at clojure.core.async.impl.ioc_macros$run_state_machine.invokeStatic(ioc_macros.clj:973)
        at clojure.core.async.impl.ioc_macros$run_state_machine.invoke(ioc_macros.clj:972)
        at clojure.core.async.impl.ioc_macros$run_state_machine_wrapped.invokeStatic(ioc_macros.clj:977)
        at clojure.core.async.impl.ioc_macros$run_state_machine_wrapped.invoke(ioc_macros.clj:975)
        at clojure.core.async.impl.ioc_macros$take_BANG_$fn__8955.invoke(ioc_macros.clj:986)
        at clojure.core.async.impl.channels.ManyToManyChannel$fn__4617$fn__4618.invoke(channels.clj:95)
        at clojure.lang.AFn.run(AFn.java:22)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```
