### PR TITLE
upgrades to jetty version 9.4.19.v20190610

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -41,7 +41,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20190610_212308-g550b820"
+                 [twosigma/jet "0.7.10-20190612_154727-g9cb249e"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]


### PR DESCRIPTION
## Changes proposed in this PR

- updates jet version
- jetty version update in jet [upgrade PR](https://github.com/twosigma/jet/pull/28).

## Why are we making these changes?

Using the latest version of jetty gives us bug fixes.
