### PR TITLE
Handles gRPC deadline exceeded as client errors

### DIFF
--- a/containers/test-apps/courier/pom.xml
+++ b/containers/test-apps/courier/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>twosigma</groupId>
     <artifactId>courier</artifactId>
-    <version>1.2.1</version>
+    <version>1.3.1</version>
 
     <name>courier</name>
     <url>https://github.com/twosigma/waiter/tree/master/test-apps/courier</url>

--- a/containers/test-apps/courier/src/main/proto/courier.proto
+++ b/containers/test-apps/courier/src/main/proto/courier.proto
@@ -35,6 +35,7 @@ message CourierRequest {
     string id = 1;
     string from = 2;
     string message = 3;
+    int64 sleep_duration = 4;
 }
 
 // The response message containing the package response.

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -32,7 +32,7 @@
 
   :dependencies [[bidi "2.1.5"
                   :exclusions [prismatic/schema ring/ring-core]]
-                 [twosigma/courier "1.2.1"
+                 [twosigma/courier "1.3.1"
                   :exclusions [com.google.guava/guava io.grpc/grpc-core]
                   :scope "test"]
                  ;; avoids the following:

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1176,7 +1176,7 @@
                                      (let [password (first passwords)
                                            make-request-fn (fn make-ws-request
                                                              [instance request request-properties passthrough-headers end-route metric-group
-                                                              backend-proto proto-version]
+                                                              backend-proto proto-version _]
                                                              (ws/make-request websocket-client service-id->password-fn instance request request-properties
                                                                               passthrough-headers end-route metric-group backend-proto proto-version))
                                            process-request-fn (fn process-request-fn [request]
@@ -1237,12 +1237,13 @@
                                          service-id->password-fn start-new-service-fn]
                                         [:settings instance-request-properties]
                                         [:state http-clients instance-rpc-chan local-usage-agent stream-reader-executor]]
-                                 (let [make-request-fn (fn [instance request request-properties passthrough-headers end-route metric-group
-                                                            backend-proto proto-version]
+                                 (let [make-request-fn (fn make-process-request-handler-request-fn
+                                                         [instance request request-properties passthrough-headers end-route metric-group
+                                                          backend-proto proto-version reservation-status-promise]
                                                          (pr/make-request
                                                            stream-reader-executor http-clients make-basic-auth-fn service-id->password-fn
                                                            instance request request-properties passthrough-headers end-route metric-group
-                                                           backend-proto proto-version))
+                                                           backend-proto proto-version reservation-status-promise))
                                        process-response-fn (partial pr/process-http-response post-process-async-request-response-fn)]
                                    (fn inner-process-request [request]
                                      (pr/process make-request-fn instance-rpc-chan start-new-service-fn

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -142,13 +142,14 @@
                      :headers {"accept" "application/json"}
                      :request-method :http-method
                      :route-params (make-route-params "local")}
-            make-http-request-fn (fn [instance in-request end-route metric-group backend-proto]
+            make-http-request-fn (fn [instance in-request end-route metric-group backend-proto reservation-status-promise]
                                    (is (= {:host "host" :port "port" :service-id service-id}
                                           (select-keys instance [:host :port :service-id])))
                                    (is (= request in-request))
                                    (is (= (-> request :route-params :location) end-route))
                                    (is (= "test-metric-group" metric-group))
                                    (is (= "http" backend-proto))
+                                   (is (not (realized? reservation-status-promise)))
                                    (async/go {:error (ex-info "backend-status-error" {:status 502})}))
             async-trigger-terminate-fn (fn [in-router-id in-service-id in-request-id]
                                          (is (= my-router-id in-router-id))
@@ -190,13 +191,14 @@
                              :headers {"accept" "application/json"}
                              :request-method request-method,
                              :route-params (make-route-params router-type)}
-                    make-http-request-fn (fn [instance in-request end-route metric-group backend-proto]
+                    make-http-request-fn (fn [instance in-request end-route metric-group backend-proto reservation-status-promise]
                                            (is (= {:host "host" :port "port" :service-id service-id}
                                                   (select-keys instance [:host :port :service-id])))
                                            (is (= request in-request))
                                            (is (= (-> request :route-params :location) end-route))
                                            (is (= "test-metric-group" metric-group))
                                            (is (= "http" backend-proto))
+                                           (is (not (realized? reservation-status-promise)))
                                            (async/go {:body "async-result-response", :headers {}, :status return-status}))
                     {:keys [status headers]}
                     (async/<!!
@@ -297,13 +299,14 @@
                      :headers {"accept" "application/json"}
                      :route-params (make-route-params "local")
                      :request-method :http-method}
-            make-http-request-fn (fn [instance in-request end-route metric-group backend-proto]
+            make-http-request-fn (fn [instance in-request end-route metric-group backend-proto reservation-status-promise]
                                    (is (= {:host "host" :port "port" :service-id service-id}
                                           (select-keys instance [:host :port :service-id])))
                                    (is (= request in-request))
                                    (is (= (-> request :route-params :location) end-route))
                                    (is (= "test-metric-group" metric-group))
                                    (is (= "http" backend-proto))
+                                   (is (not (realized? reservation-status-promise)))
                                    (async/go {:error (ex-info "backend-status-error" {:status 400})}))
             async-trigger-terminate-fn nil
             {:keys [body headers status]} (async/<!! (async-status-handler async-trigger-terminate-fn make-http-request-fn service-id->service-description-fn request))]
@@ -349,13 +352,14 @@
                              :authorization/user "test-user"
                              :request-method request-method
                              :route-params (make-route-params router-type)}
-                    make-http-request-fn (fn [instance in-request end-route metric-group backend-proto]
+                    make-http-request-fn (fn [instance in-request end-route metric-group backend-proto reservation-status-promise]
                                            (is (= {:host "host" :port "port" :service-id service-id}
                                                   (select-keys instance [:host :port :service-id])))
                                            (is (= request in-request))
                                            (is (= (-> request :route-params :location) end-route))
                                            (is (= "test-metric-group" metric-group))
                                            (is (= "http" backend-proto))
+                                           (is (not (realized? reservation-status-promise)))
                                            (async/go {:body "status-check-response"
                                                       :headers (if (= return-status 303) {"location" (or result-location (result-location-fn router-type))} {})
                                                       :status return-status}))


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for sleep while processing messages in gRPC server
- adds test for gRPC intergation test for a client with deadline exceeded
- handles client errors while streaming request body

## Why are we making these changes?

We should attribute requests that close their connection as client errors.

### Previous error stack trace on timeouts at waiter routers

```
2019-06-12 23:26:24,198 ERROR waiter.util.utils [async-dispatch-51] - [CID=testbasicgrpcservershamsimam2243260] #error {
 :cause cancel_stream_error
 :via
 [{:type clojure.lang.ExceptionInfo
   :message Request to service backend failed
   :data {:instances-blacklisted 0, :instances-failed 0, :outstanding-requests 2, :service-id w9091-testbasicgrpcservershamsimam277951-5393ee54d25ed7362098be0f360958c8, :slots-assigned 1, :slots-available 0, :status 502}
   :at [waiter.process_request$handle_response_error invokeStatic process_request.clj 186]}
  {:type java.io.IOException
   :message cancel_stream_error
   :at [org.eclipse.jetty.http2.client.http.HttpReceiverOverHTTP2 onReset HttpReceiverOverHTTP2.java 169]}]
 :trace
 [[org.eclipse.jetty.http2.client.http.HttpReceiverOverHTTP2 onReset HttpReceiverOverHTTP2.java 169]
  [org.eclipse.jetty.http2.api.Stream$Listener onReset Stream.java 177]
  [org.eclipse.jetty.http2.HTTP2Stream notifyReset HTTP2Stream.java 574]
  [org.eclipse.jetty.http2.HTTP2Stream onReset HTTP2Stream.java 343]
  [org.eclipse.jetty.http2.HTTP2Stream process HTTP2Stream.java 252]
  [org.eclipse.jetty.http2.HTTP2Session onReset HTTP2Session.java 294]
  [org.eclipse.jetty.http2.parser.Parser$Listener$Wrapper onReset Parser.java 368]
  [org.eclipse.jetty.http2.parser.BodyParser notifyReset BodyParser.java 139]
  [org.eclipse.jetty.http2.parser.ResetBodyParser onReset ResetBodyParser.java 97]
  [org.eclipse.jetty.http2.parser.ResetBodyParser parse ResetBodyParser.java 66]
...
```