### PR TITLE
use the session-not-on-or-after field for auth expiry time

### DIFF
--- a/waiter/integration/waiter/authentication_test.clj
+++ b/waiter/integration/waiter/authentication_test.clj
@@ -1,5 +1,6 @@
 (ns waiter.authentication-test
-  (:require [clojure.data.json :as json]
+  (:require [clj-time.core :as t]
+            [clojure.data.json :as json]
             [clojure.string :as string]
             [clojure.test :refer :all]
             [reaver :as reaver]
@@ -124,8 +125,7 @@
             cookie-fn (fn [cookies name] (some #(when (= name (:name %)) %) cookies))
             auth-cookie (cookie-fn cookies "x-waiter-auth")
             _ (is (not (nil? auth-cookie)))
-            one-hour-in-secs (* 60 60)
-            _ (is (> (:max-age auth-cookie) one-hour-in-secs))
+            _ (is (> (:max-age auth-cookie) (-> 1 t/hour t/in-seconds)))
             _ (is (= (str "http://" waiter-url "/request-info") (get headers "location")))
             {:keys [body service-id] :as response} (make-request-with-debug-info
                                                      {:x-waiter-token token}

--- a/waiter/integration/waiter/authentication_test.clj
+++ b/waiter/integration/waiter/authentication_test.clj
@@ -121,6 +121,11 @@
                                                                  :headers {"content-type" "application/x-www-form-urlencoded"}
                                                                  :method :post)
             _ (assert-response-status response 303)
+            cookie-fn (fn [cookies name] (some #(when (= name (:name %)) %) cookies))
+            auth-cookie (cookie-fn cookies "x-waiter-auth")
+            _ (is (not (nil? auth-cookie)))
+            one-hour (* 60 60)
+            _ (is (> (:max-age auth-cookie) one-hour))
             _ (is (= (str "http://" waiter-url "/request-info") (get headers "location")))
             {:keys [body service-id] :as response} (make-request-with-debug-info
                                                      {:x-waiter-token token}

--- a/waiter/integration/waiter/authentication_test.clj
+++ b/waiter/integration/waiter/authentication_test.clj
@@ -124,8 +124,8 @@
             cookie-fn (fn [cookies name] (some #(when (= name (:name %)) %) cookies))
             auth-cookie (cookie-fn cookies "x-waiter-auth")
             _ (is (not (nil? auth-cookie)))
-            one-hour (* 60 60)
-            _ (is (> (:max-age auth-cookie) one-hour))
+            one-hour-in-secs (* 60 60)
+            _ (is (> (:max-age auth-cookie) one-hour-in-secs))
             _ (is (= (str "http://" waiter-url "/request-info") (get headers "location")))
             {:keys [body service-id] :as response} (make-request-with-debug-info
                                                      {:x-waiter-token token}

--- a/waiter/src/waiter/auth/saml.clj
+++ b/waiter/src/waiter/auth/saml.clj
@@ -14,8 +14,7 @@
 ;; limitations under the License.
 ;;
 (ns waiter.auth.saml
-  (:require [clj-time.coerce :as tc]
-            [clj-time.core :as t]
+  (:require [clj-time.core :as t]
             [clj-time.format :as f]
             [clojure.data.codec.base64 :as b64]
             [clojure.java.io :as io]
@@ -130,17 +129,16 @@
                                         (.getAttributeValues a))})
                           attributes))
         conditions (.getConditions assertion)
-        audiences (mapcat #(let [audiences (.getAudiences %)]
-                             (map (fn [a] (.getAudienceURI a)) audiences))
-                          (.getAudienceRestrictions conditions))]
+        authn-statements (.getAuthnStatements assertion)
+        min-session-not-on-or-after (when (not-empty authn-statements)
+                                      (apply t/min-date '(map (.getSessionNotOnOrAfter %) authn-statements)))]
     {:attrs attrs
-     :audiences audiences
-     :name-id {:value (when name-id (.getValue name-id))
-               :format (when name-id (.getFormat name-id))}
      :confirmation {:in-response-to (.getInResponseTo subject-confirmation-data)
-                    :not-before (tc/to-timestamp (.getNotBefore subject-confirmation-data))
-                    :not-on-or-after (tc/to-timestamp (.getNotOnOrAfter subject-confirmation-data))
-                    :recipient (.getRecipient subject-confirmation-data)}}))
+                    :not-before (.getNotBefore subject-confirmation-data)
+                    :not-on-or-after (.getNotOnOrAfter subject-confirmation-data)
+                    :recipient (.getRecipient subject-confirmation-data)}
+     :name-id-value (when name-id (.getValue name-id))
+     :min-session-not-on-or-after min-session-not-on-or-after}))
 
 (defn- validate-saml-assertion-signature
   "Checks that the SAML assertion has a valid signature."
@@ -189,13 +187,18 @@
                             {:status 400})))
         assertion (first assertions)
         _ (validate-saml-assertion-signature assertion saml-signature-validator)
-        {:keys [attrs confirmation name-id]} (parse-saml-assertion assertion)
-        not-on-or-after (clj-time.coerce/from-sql-time (:not-on-or-after confirmation))
+        {:keys [attrs confirmation name-id-value min-session-not-on-or-after]} (parse-saml-assertion assertion)
+        not-on-or-after (:not-on-or-after confirmation)
         current-time (t/now)
         _ (when-not (t/before? current-time not-on-or-after)
             (throw (ex-info "Could not authenticate user. Expired SAML assertion."
                             {:current-time current-time
                              :expiry-time not-on-or-after
+                             :status 400})))
+        _ (when (and min-session-not-on-or-after (not (t/before? current-time min-session-not-on-or-after)))
+            (throw (ex-info "Could not authenticate user. Expired SAML session."
+                            {:current-time current-time
+                             :expiry-time min-session-not-on-or-after
                              :status 400})))
         email (first (get attrs "email"))
         ; https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/technical-reference/the-role-of-claims
@@ -205,7 +208,9 @@
         {:keys [authorization/principal authorization/user]} (auth/auth-params-map saml-principal)
         saml-principal' (if (and email (= principal user)) email saml-principal)
         saml-auth-data (utils/map->base-64-string
-                         {:not-on-or-after not-on-or-after :redirect-url request-url :saml-principal saml-principal'}
+                         {:min-session-not-on-or-after min-session-not-on-or-after
+                          :redirect-url request-url
+                          :saml-principal saml-principal'}
                          password)]
     {:body (render-authenticated-redirect-template {:auth-redirect-uri (str scheme "://" host auth-redirect-endpoint)
                                                     :saml-auth-data saml-auth-data})
@@ -217,24 +222,25 @@
   [{:keys [password]} request]
   {:pre [(not-empty password)]}
   (if-let [saml-auth-data (get-in (ring-params/params-request request) [:form-params "saml-auth-data"])]
-    (let [{:keys [not-on-or-after redirect-url saml-principal] :as saml-auth-data}
+    (let [{:keys [min-session-not-on-or-after redirect-url saml-principal] :as saml-auth-data}
           (try
             (utils/base-64-string->map saml-auth-data password)
             (catch Exception e
               (throw (ex-info "Could not parse saml-auth-data." {:inner-exception e
                                                                  :saml-auth-data saml-auth-data
                                                                  :status 400} e))))
-          _ (when-not (and not-on-or-after redirect-url saml-principal)
+          _ (when-not (and redirect-url saml-principal)
               (throw (ex-info "Could not authenticate user. Invalid SAML auth data."
                               {:saml-auth-data saml-auth-data
                                :status 500})))
           current-time (t/now)
-          _ (when-not (t/before? current-time not-on-or-after)
-              (throw (ex-info "Could not authenticate user. Expired SAML assertion."
+          _ (when (and min-session-not-on-or-after (not (t/before? current-time min-session-not-on-or-after)))
+              (throw (ex-info "Could not authenticate user. Expired SAML session."
                               {:current-time current-time
-                               :expiry-time not-on-or-after
+                               :expiry-time min-session-not-on-or-after
                                :status 400})))
-          auth-cookie-expiry-date (t/min-date not-on-or-after (t/plus current-time (t/days 1)))
+          current-time-plus-1-day (t/plus current-time (t/days 1))
+          auth-cookie-expiry-date (t/min-date (or min-session-not-on-or-after current-time-plus-1-day) current-time-plus-1-day)
           auth-cookie-age-in-seconds (-> current-time
                                        (t/interval auth-cookie-expiry-date)
                                        t/in-seconds)

--- a/waiter/src/waiter/auth/saml.clj
+++ b/waiter/src/waiter/auth/saml.clj
@@ -128,10 +128,9 @@
                                    (map #(-> % (.getDOM) (.getTextContent))
                                         (.getAttributeValues a))})
                           attributes))
-        conditions (.getConditions assertion)
         authn-statements (.getAuthnStatements assertion)
         min-session-not-on-or-after (when (not-empty authn-statements)
-                                      (apply t/min-date '(map (.getSessionNotOnOrAfter %) authn-statements)))]
+                                      (apply t/min-date (map #(.getSessionNotOnOrAfter %) authn-statements)))]
     {:attrs attrs
      :confirmation {:in-response-to (.getInResponseTo subject-confirmation-data)
                     :not-before (.getNotBefore subject-confirmation-data)
@@ -203,7 +202,6 @@
         email (first (get attrs "email"))
         ; https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/technical-reference/the-role-of-claims
         upn (first (get attrs "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"))
-        name-id-value (get name-id :value)
         saml-principal (or upn name-id-value)
         {:keys [authorization/principal authorization/user]} (auth/auth-params-map saml-principal)
         saml-principal' (if (and email (= principal user)) email saml-principal)

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -276,7 +276,8 @@
   (when value
     (let [cookie-list (HttpCookie/parse value)]
       (map (fn [^HttpCookie cookie]
-             {:name (.getName cookie)
+             {:max-age (.getMaxAge cookie)
+              :name (.getName cookie)
               :value (.getValue cookie)}) cookie-list))))
 
 (defn parse-cookies

--- a/waiter/test/waiter/util/client_tools_test.clj
+++ b/waiter/test/waiter/util/client_tools_test.clj
@@ -18,10 +18,11 @@
             [waiter.util.client-tools :refer :all]))
 
 (deftest test-parse-set-cookie-string
-  (is (= (list {:name "name" :value "value"}) (parse-set-cookie-string "name=value")))
-  (is (= (list {:name "name" :value "value"}) (parse-set-cookie-string "name=value;Path=/")))
+  (is (= (list {:max-age -1 :name "name" :value "value"}) (parse-set-cookie-string "name=value")))
+  (is (= (list {:max-age -1 :name "name" :value "value"}) (parse-set-cookie-string "name=value;Path=/")))
+  (is (= (list {:max-age 12345 :name "name" :value "value"}) (parse-set-cookie-string "name=value;Path=/;Max-Age=12345")))
   (is (nil? (parse-set-cookie-string nil))))
 
 (deftest test-parse-cookies
-  (is (= [{:name "name" :value "value"}] (parse-cookies "name=value")))
-  (is (= [{:name "name" :value "value"} {:name "name2" :value "value2"}] (parse-cookies ["name=value" "name2=value2"]))))
+  (is (= [{:max-age -1 :name "name" :value "value"}] (parse-cookies "name=value")))
+  (is (= [{:max-age -1 :name "name" :value "value"} {:max-age -1 :name "name2" :value "value2"}] (parse-cookies ["name=value" "name2=value2"]))))


### PR DESCRIPTION
## Changes proposed in this PR

- change to use the correct field for SAML auth expiry

## Why are we making these changes?

Currently using the assertion's not-on-or-after, but that's only 5 minutes and intended to allow for the original redirects between the IDP and waiter. If there is a limit on the auth, then it's the optional session-not-on-or-after
