### PR TITLE
handles blacklist on 503 for grpc responses

### DIFF
--- a/waiter/src/waiter/headers.clj
+++ b/waiter/src/waiter/headers.clj
@@ -18,6 +18,7 @@
             [clojure.tools.logging :as log]
             [clojure.string :as str]
             [plumbing.core :as pc]
+            [waiter.util.http-utils :as hu]
             [waiter.util.utils :as utils]))
 
 (def ^:const waiter-header-prefix "x-waiter-")
@@ -89,8 +90,8 @@
 
 (defn- retrieve-proto-specific-hop-by-hop-headers
   "Determines the protocol version specific hop-by-hop headers."
-  [{:strs [content-type]} proto-version]
-  (when-not (and (= "HTTP/2.0" proto-version) (= content-type "application/grpc"))
+  [request-headers proto-version]
+  (when-not (hu/grpc? request-headers proto-version)
     ["te"]))
 
 (defn dissoc-hop-by-hop-headers

--- a/waiter/src/waiter/util/http_utils.clj
+++ b/waiter/src/waiter/util/http_utils.clj
@@ -133,3 +133,16 @@
   "Returns true if the http versions represents a http2 request"
   [version]
   (= "HTTP/2.0" version))
+
+(defn grpc?
+  "Returns true if the request represents a grpc request"
+  [{:strs [content-type]} proto-version]
+  (and (= "HTTP/2.0" proto-version) (= content-type "application/grpc")))
+
+(defn service-unavailable?
+  "Returns true if the response represents the service is unavailable.
+   This means either the response status is 503 or the grpc response status is UNAVAILABLE, i.e. 14."
+  [request response]
+  (or (= 503 (:status response))
+      (and (grpc? (:headers request) (:client-protocol request))
+           (= "14" (get-in response [:headers "grpc-status"])))))


### PR DESCRIPTION
## Changes proposed in this PR

- handles blacklist on 503 for grpc responses
- introduces helper methids in `http-utisl`

## Why are we making these changes?

Waiter avoids instances that are returning a 503 error code in responses, which typically indicates the server is too busy. We wish to extend this support for gRPC requests too.

As per [gRPC status codes and their closest HTTP Mapping](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md):

| Code | Number | Description | Closest HTTP Mapping |
| --- | --- | --- | --- |
| UNAVAILABLE | 14 | The service is currently unavailable. | 503 Service Unavailable |
