### PR TITLE
uses status code of 503 for request streaming timeout

### DIFF
--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -276,6 +276,7 @@
                     (statsd/inc! metric-group "request_bytes" unreported-bytes-to-statsd))
                   (let [description-map {:bytes-pending bytes-read
                                          :bytes-streamed bytes-streamed
+                                         :status 503
                                          :streaming-timeout-ms streaming-timeout-ms}]
                     (log/error "unable to stream request bytes" description-map)
                     (stream-error-handler (ex-info "unable to stream request bytes" description-map)))))


### PR DESCRIPTION
## Changes proposed in this PR

- uses status code of 503 for request streaming timeout

## Why are we making these changes?

Applying back pressure is one effective technique for notifying clients of busy backends, e.g. by sending a meaningful server is busy message via the [HTTP `503` status code](https://httpstatuses.com/503).


