### PR TITLE
makes test-kubernetes-pod-expiry less flaky

### DIFF
--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -267,7 +267,7 @@
             (make-request-with-debug-info
               {:x-waiter-distribution-scheme "simple"
                :x-waiter-name (rand-name)}
-              #(make-kitchen-request waiter-url % :method :get :path "/"))]
+              #(make-kitchen-request waiter-url % :method :get :path "/hello"))]
         (is service-id)
         (with-service-cleanup
           service-id
@@ -275,7 +275,7 @@
           (dotimes [_ 5]
             (let [request-headers (assoc request-headers :x-kitchen-delay-ms 1000)
                   response (make-kitchen-request waiter-url request-headers :path "/die")]
-              (assert-response-status response 502)))
+              (assert-response-status response #{502 503})))
           ;; assert that more than one pod was created
           (is (wait-for
                 (fn []

--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -267,7 +267,7 @@
             (make-request-with-debug-info
               {:x-waiter-distribution-scheme "simple"
                :x-waiter-name (rand-name)}
-              #(make-kitchen-request waiter-url % :method :get :path "/hello"))]
+              #(make-kitchen-request waiter-url % :method :get :path "/"))]
         (is service-id)
         (with-service-cleanup
           service-id

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -352,15 +352,19 @@
   `(let [response-cid# (get-in ~response [:headers "x-cid"] "unknown")
          response-server# (get-in ~response [:headers "server"] "unknown")
          actual-status# (:status ~response)
+         expected-status# ~expected-status
+         expected-status-set# (if (set? expected-status#)
+                                expected-status#
+                                #{expected-status#})
          response-body# (:body ~response)
          response-error# (:error ~response)
          assertion-message# (str "[CID=" response-cid# ", server=" response-server# "] "
                                  "Expected status: " ~expected-status
                                  ", actual: " actual-status# "\r\n Body:" response-body#
                                  (when response-error# (str "\r\n Error: " response-error#)))]
-     (when (not= ~expected-status actual-status#)
+     (when-not (contains? expected-status-set# actual-status#)
        (log/error assertion-message#))
-     (is (= ~expected-status actual-status#) assertion-message#)))
+     (is (contains? expected-status-set# actual-status#) assertion-message#)))
 
 (defn kitchen-cmd
   ([] (kitchen-cmd ""))


### PR DESCRIPTION


## Changes proposed in this PR

- makes test-kubernetes-pod-expiry less flaky when deployment error logic is triggered

## Why are we making these changes?

We don't like flaky tests.

