### PR TITLE
Eagerly upload completed container logs to S3

### DIFF
--- a/containers/fileserver/Dockerfile
+++ b/containers/fileserver/Dockerfile
@@ -1,6 +1,9 @@
-FROM nginx:1.15-alpine
+FROM nginx:1.16-alpine
 
+RUN apk add --no-cache bash curl
 COPY fileserver-start /bin/
+COPY s3-log-backup /bin/
 COPY nginx.conf /root/nginx.conf.template
+WORKDIR /root
 RUN mkdir -p /srv/www && echo 'Hello!' > /srv/www/hello.txt
 CMD ["fileserver-start"]

--- a/containers/fileserver/fileserver-start
+++ b/containers/fileserver/fileserver-start
@@ -1,11 +1,32 @@
-#!/bin/sh
+#!/bin/bash
 
 # Set default server port
 : ${WAITER_FILESERVER_PORT:=9090}
 export WAITER_FILESERVER_PORT
 
 # Generate server config from template
-envsubst </root/nginx.conf.template >/root/nginx.conf
+envsubst <./nginx.conf.template >./nginx.conf
 
-# Start server in non-daemon mode, replacing current process
-exec nginx -c /root/nginx.conf
+# Start server in non-daemon mode
+nginx -c $PWD/nginx.conf &
+nginx_pid=$!
+
+# Start s3 upload daemon
+s3-log-backup &
+s3_daemon_pid=$!
+
+# On SIGTERM, upload logs to S3 before exiting
+handle_sigterm() {
+    echo GOT SIGTERM
+    if kill -0 $s3_daemon_pid &>/dev/null; then
+        kill $s3_daemon_pid  # propagate sigterm to s3 upload daemon
+        wait $s3_daemon_pid  # wait for s3 upload daemon to exit
+    fi
+    kill $nginx_pid  # propagate sigterm to nginx
+}
+trap handle_sigterm SIGTERM
+
+# Wait for nginx to terminate
+while kill -0 $nginx_pid &>/dev/null; do
+    wait $nginx_pid || sleep 0.1
+done

--- a/containers/fileserver/s3-log-backup
+++ b/containers/fileserver/s3-log-backup
@@ -8,8 +8,10 @@ fi
 
 # Detect graceful shutdown of main container in pod
 await_graceful_shutdown() {
-    grace_millis=$(( ${WAITER_GRACE_SECS:-3} * 1000 ))
-    for (( t=0; t<=grace_millis; t+=100 )); do
+    # We wait an extra 500ms after the grace period to ensure that
+    # the waiter-k8s-init script has had sufficient time to finish.
+    grace_millis=$(( ${WAITER_GRACE_SECS:-3} * 1000 + 500 ))
+    for (( t=0; t<grace_millis; t+=100 )); do
         [ -f './latest/.waiter_cmd_exited' ] && break
         sleep 0.1
     done
@@ -41,12 +43,19 @@ sandbox_backup() {
     echo "Finished S3 backups for $sandbox_dir"
 }
 
+run_completed() {
+    local run_number=$1
+    # Either the presence of the sentinal file or the next run's directory
+    # are each sufficient to determine that the current run was completed.
+    [[ -f "./r${run_number}/.waiter_cmd_exited" || -d "./r$((run_number+1))" ]]
+}
+
 cd "${1:-/srv/www}"
 # For each ./r* directory created by a container restart,
 # we upload the stdout and stderr to the target directory in the S3 bucket.
 i=0
 while ! $graceful_shutdown_complete || (( i <= last_run )); do
-    while ! [ -f "./r$i/.waiter_cmd_exited" ] && ! $graceful_shutdown_complete; do
+    while ! run_completed $i && ! $graceful_shutdown_complete; do
         sleep 0.1
     done
     sandbox_backup "./r$i"

--- a/containers/fileserver/s3-log-backup
+++ b/containers/fileserver/s3-log-backup
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# send logs to S3 (if enabled)
+if [ -z "$WAITER_LOG_BUCKET_URL" ]; then
+    echo 'S3 log backups disabled'
+    exit 0
+fi
+
+# Detect graceful shutdown of main container in pod
+await_graceful_shutdown() {
+    grace_millis=$(( ${WAITER_GRACE_SECS:-3} * 1000 ))
+    for (( t=0; t<=grace_millis; t+=100 )); do
+        [ -f './latest/.waiter_cmd_exited' ] && break
+        sleep 0.1
+    done
+    graceful_shutdown_complete=true
+    last_run=$(( $(readlink ./latest | sed 's|^.*/r||') ))
+}
+graceful_shutdown_complete=false
+trap await_graceful_shutdown SIGTERM
+
+# Extract this pod's name from the (short) hostname
+# this is used to create a unique path in S3
+pod_name=$(hostname -s)
+base_url="$WAITER_LOG_BUCKET_URL/$pod_name"
+
+waiter_log_files='stdout stderr'
+
+sandbox_backup() {
+    local sandbox_dir=$1
+    [ -d $sandbox_dir ] || return
+    echo "Starting S3 backups for $sandbox_dir"
+    for f in $waiter_log_files; do
+        logfile="$sandbox_dir/$f"
+        # Using the -T option with curl PUTs the target file to the given URL,
+        # and avoids loading the full file into memory when sending the payload.
+        # Enabling Kerberos/SPNEGO when the bucket is not kerberized does not
+        # cause an error, and the extra flags are ignored on non-kerberized systems.
+        curl -s --anyauth -u: -T "$logfile" "$base_url/$logfile"
+    done
+    echo "Finished S3 backups for $sandbox_dir"
+}
+
+cd "${1:-/srv/www}"
+# For each ./r* directory created by a container restart,
+# we upload the stdout and stderr to the target directory in the S3 bucket.
+i=0
+while ! $graceful_shutdown_complete || (( i <= last_run )); do
+    while ! [ -f "./r$i/.waiter_cmd_exited" ] && ! $graceful_shutdown_complete; do
+        sleep 0.1
+    done
+    sandbox_backup "./r$i"
+    (( i++ ))
+done

--- a/containers/test-apps/waiter-init/bin/test-waiter-k8s-init
+++ b/containers/test-apps/waiter-init/bin/test-waiter-k8s-init
@@ -148,22 +148,4 @@ assert $working_dir != $old_working_dir
 assert -f $working_dir/$fresh_file_name
 assert $(cat $working_dir/$fresh_file_name) == hello
 
-#
-# Ensure that the stdout file captured by the wrapper script
-# is uploaded to S3 when the script is terminated.
-# This test runs iff WAITER_LOG_BUCKET_URL is non-null.
-#
-start_guarded_test 'stdout uploaded to s3 bucket' "$WAITER_LOG_BUCKET_URL" <<EOF
-echo TestString && sleep 10
-EOF
-if $test_started; then
-    send_sigterm
-    send_sigterm
-    await_exit_and_assert_code 143
-    pod_name=$(hostname --short)
-    target_bucket_dir=$WAITER_LOG_BUCKET_URL/$pod_name/$working_dir
-    assert "$(curl -s $target_bucket_dir/stdout)" == TestString
-    assert "$(curl -s $target_bucket_dir/stdout | wc -c)" == 11
-fi
-
 printf '\n\nAll tests passed\n'

--- a/containers/test-apps/waiter-init/bin/waiter-k8s-init
+++ b/containers/test-apps/waiter-init/bin/waiter-k8s-init
@@ -72,30 +72,6 @@ pod_shutdown() {
 
     waiter_init_log 'User process terminated.'
 
-    # send logs to S3 (if enabled)
-    if [ "$WAITER_LOG_BUCKET_URL" ]; then
-        # Extract this pod's name from the hostname
-        # (this is used to create a unique path in S3)
-        pod_name=$(hostname --short)
-        base_url="$WAITER_LOG_BUCKET_URL/$pod_name"
-        # For each ./r* directory created by a container restart,
-        # we upload the stdout and stderr to the target directory in the S3 bucket.
-        # We work backwards from the most recent run down to 0 to increase the odds
-        # that our most recent runs' logs are successfully persisted before a SIGKILL.
-        cd "$waiter_sandbox_base_dir"
-        for i in $(seq $waiter_restart_count -1 0); do
-            waiter_log_files='stdout stderr'
-            for f in $waiter_log_files; do
-                logfile="r$i/$f"
-                # Using the -T option with curl PUTs the target file to the given URL,
-                # and avoids loading the full file into memory when sending the payload.
-                # Enabling Kerberos/SPNEGO when the bucket is not kerberized does not
-                # cause an error, and the extra flags are ignored on non-kerberized systems.
-                curl -s --negotiate -u: -T "$logfile" "$base_url/$logfile"
-            done
-        done
-    fi
-
     # wait for second sigterm to arrive
     while [ $waiter_2nd_sigterm != received ]; do
         sleep 0.1
@@ -116,6 +92,11 @@ handle_2nd_k8s_terminate() {
 
 waiter_2nd_sigterm=skip
 trap handle_k8s_terminate SIGTERM
+
+pre_exit_hook() {
+    touch $HOME/.waiter_cmd_exited  # create sentinel file
+}
+trap pre_exit_hook EXIT
 
 # Track container restart count
 waiter_restart_count=$(( $([ -f .waiter-container-runs ] && cat .waiter-container-runs) ))

--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -73,7 +73,7 @@
         (validate-kubernetes-custom-image waiter-url custom-image)))))
 
 ;; Fails on (is (> (count instance-ids) 1) (str instance-ids)) as there is only one instance
-(deftest ^:parallel ^:integration-slow ^:resource-heavy ^:explicit test-s3-logs
+(deftest ^:parallel ^:integration-slow ^:resource-heavy test-s3-logs
   (testing-using-waiter-url
     (when (using-k8s? waiter-url)
       (let [headers {:x-waiter-name (rand-name)

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -255,6 +255,12 @@
       :instance-id instance-id
       :service-id service-id)))
 
+(defn response->location
+  "Get the Location header from an HTTP response.
+   Handles both HTTP v1 and v2 styles of capitalization."
+  [{:keys [headers]}]
+  (or (get headers "Location") (get headers "location")))
+
 (defn extract-acronym
   "Shortens the name taking only the leading characters across the delimiters.
    E.g. `(extract-acronym \"aaa.bbb-ccc/ddd#eee-fff.ggg\") -> \"abcdfg\"`"


### PR DESCRIPTION
## Changes proposed in this PR

* Move S3 log backup logic into the fileserver sidecar.
* Re-enable integration test for logs backed up to S3.

## Why are we making these changes?

Rather than waiting until the pod is being deleted before uploading,
the sidecar uploads the logs for each run of the main container as soon
as it detects that container's exit (via a sentinel file).

This also addresses a bug where log files are not uploaded to S3 if the
main app container is in a CrashBackOffLoop when the pod is deleted.