### PR TITLE
Handle missing service on k8s delete

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -551,6 +551,14 @@
                       (= 200)))
                 :interval 5 :timeout 60)))
 
+        (testing "deleted service is removed from all routers"
+          (assert-service-not-on-any-routers waiter-url service-id cookies))
+
+        (testing "delete service again (should get 404)"
+          (is (-> (make-request waiter-url (str "/apps/" service-id) :method :delete)
+                  :status
+                  (= 404))))
+
         (testing "service-deleted-from-all-routers"
           (let [router-id->service-id-deleted
                 (pc/map-from-keys

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -1056,6 +1056,13 @@
     (log/debug service-id "has" instances "instances.")
     instances))
 
+(defmacro assert-service-not-on-any-routers
+  [waiter-url service-id cookies]
+  `(let [service-id# ~service-id
+         cookies# ~cookies]
+     (doseq [[_# router-url#] (routers ~waiter-url)]
+       (is (wait-for #(not (contains? (retrieve-services-on-router router-url# :cookies cookies#) service-id#)))))))
+
 (defmacro assert-service-on-all-routers
   [waiter-url service-id cookies]
   `(let [service-id# ~service-id


### PR DESCRIPTION
## Changes proposed in this PR

Return 404 when service is nil or incomplete.

## Why are we making these changes?

Currently this fails when the HTTP DELETE request comes back with an error. We should fail before making the HTTP request.