### PR TITLE
test-pod-namespace is slow

### DIFF
--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -187,7 +187,7 @@
         (is (some? pod-spec))
         (is (= expected-namespace pod-namespace))))))
 
-(deftest ^:parallel ^:integration-fast test-pod-namespace
+(deftest ^:parallel ^:integration-slow test-pod-namespace
   "Expected behavior for services with namespaces:
    Run-As-User    Namespace   Validation
    Missing        Missing     OK


### PR DESCRIPTION
## Changes proposed in this PR

Mark test-pod-namespace as slow

## Why are we making these changes?

It creates a bunch of services. It's slow.