### PR TITLE
handle gRPC client and server cancellations

### DIFF
--- a/containers/test-apps/courier/pom.xml
+++ b/containers/test-apps/courier/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>twosigma</groupId>
     <artifactId>courier</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.5-SNAPSHOT</version>
 
     <name>courier</name>
     <url>https://github.com/twosigma/waiter/tree/master/test-apps/courier</url>

--- a/containers/test-apps/courier/pom.xml
+++ b/containers/test-apps/courier/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>twosigma</groupId>
     <artifactId>courier</artifactId>
-    <version>1.2.5</version>
+    <version>1.2.6-SNAPSHOT</version>
 
     <name>courier</name>
     <url>https://github.com/twosigma/waiter/tree/master/test-apps/courier</url>

--- a/containers/test-apps/courier/pom.xml
+++ b/containers/test-apps/courier/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>twosigma</groupId>
     <artifactId>courier</artifactId>
-    <version>1.2.6-SNAPSHOT</version>
+    <version>1.2.6</version>
 
     <name>courier</name>
     <url>https://github.com/twosigma/waiter/tree/master/test-apps/courier</url>

--- a/containers/test-apps/courier/pom.xml
+++ b/containers/test-apps/courier/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>twosigma</groupId>
     <artifactId>courier</artifactId>
-    <version>1.2.5-SNAPSHOT</version>
+    <version>1.2.5</version>
 
     <name>courier</name>
     <url>https://github.com/twosigma/waiter/tree/master/test-apps/courier</url>

--- a/containers/test-apps/courier/src/main/proto/courier.proto
+++ b/containers/test-apps/courier/src/main/proto/courier.proto
@@ -46,6 +46,8 @@ message CourierReply {
 message CourierSummary {
     int64 num_messages = 1;
     int64 total_length = 2;
+    string status_code = 3;
+    string status_description = 4;
 }
 
 message StateRequest {

--- a/containers/test-apps/courier/src/main/proto/courier.proto
+++ b/containers/test-apps/courier/src/main/proto/courier.proto
@@ -22,30 +22,37 @@ option objc_class_prefix = "TSCP";
 
 package courier;
 
-// The greeting service definition.
 service Courier {
     // Sends a package.
     rpc SendPackage (CourierRequest) returns (CourierReply);
     // Processes a stream of messages
     rpc CollectPackages (stream CourierRequest) returns (stream CourierSummary);
+    // Sends summary about a request (identified by a correlation id).
+    rpc RetrieveState (StateRequest) returns (StateResponse);
 }
 
-// The request message containing the package's name.
 message CourierRequest {
     string id = 1;
     string from = 2;
     string message = 3;
 }
 
-// The response message containing the package response.
 message CourierReply {
     string id = 1;
     string message = 2;
     string response = 3;
 }
 
-// The response message containing the package response.
 message CourierSummary {
     int64 num_messages = 1;
     int64 total_length = 2;
+}
+
+message StateRequest {
+    string cid = 1;
+}
+
+message StateResponse {
+    string cid = 1;
+    repeated string state = 2;
 }

--- a/waiter/bin/test.sh
+++ b/waiter/bin/test.sh
@@ -45,7 +45,7 @@ WAITER_DIR=${DIR}/..
 
 # Wait for waiter to be listening
 timeout 180s bash -c "wait_for_waiter ${WAITER_URI}"
-if [ $? -ne 0 ]; then
+if [[ $? -ne 0 ]]; then
   echo "$(date +%H:%M:%S) timed out waiting for waiter to start listening, displaying waiter log"
   cat ${WAITER_DIR}/log/*waiter.log
   exit 1
@@ -53,15 +53,15 @@ fi
 curl -s ${WAITER_URI}/state | jq .routers
 curl -s ${WAITER_URI}/settings | jq .port
 
-# TODO shams remove this thread-dump snippet
-mkdir -p ${WAITER_DIR}/log
+THREAD_DUMP_DIR=${WAITER_DIR}/log/thread-dump
+mkdir -p ${THREAD_DUMP_DIR}
 WAITER_PID=$(lsof -Pi :9091 -sTCP:LISTEN -t)
 echo "$(date +%H:%M:%S) waiter pid is ${WAITER_PID}"
 while true; do
   sleep 15
-  file_name="thread-dump-$(date +%Y%m%d-%H%M%S).log"
-  echo "$(date +%H:%M:%S) writing thread dump to ${WAITER_DIR}/log/${file_name}"
-  jstack ${WAITER_PID} > "${WAITER_DIR}/log/${file_name}"
+  file_name="$(date +%Y%m%d-%H%M%S).log"
+  echo "$(date +%H:%M:%S) writing thread dump to ${THREAD_DUMP_DIR}/${file_name}"
+  jstack ${WAITER_PID} > "${THREAD_DUMP_DIR}/${file_name}"
 done &
 
 # Run the integration tests

--- a/waiter/integration/waiter/grpc_test.clj
+++ b/waiter/integration/waiter/grpc_test.clj
@@ -22,6 +22,11 @@
   (:import (com.twosigma.waiter.courier GrpcClient)
            (java.util.function Function)))
 
+;; initialize logging on the grpc client
+(GrpcClient/setLogFunction (reify Function
+                             (apply [_ message]
+                               (log/info message))))
+
 (defn- basic-grpc-service-parameters
   []
   (let [courier-command (courier-server-command "${PORT0} ${PORT1}")]
@@ -29,12 +34,15 @@
       {:x-waiter-backend-proto "h2c"
        :x-waiter-cmd courier-command
        :x-waiter-cmd-type "shell"
+       :x-waiter-concurrency-level 32
        :x-waiter-cpus 0.2
        :x-waiter-debug true
        :x-waiter-grace-period-secs 120
        :x-waiter-health-check-port-index 1
        :x-waiter-health-check-proto "http"
        :x-waiter-idle-timeout-mins 10
+       :x-waiter-max-instances 1
+       :x-waiter-min-instances 1
        :x-waiter-mem 512
        :x-waiter-name (rand-name)
        :x-waiter-ports 2
@@ -45,65 +53,238 @@
   [length]
   (apply str (take length (repeatedly #(char (+ (rand 26) 65))))))
 
-(deftest ^:parallel ^:integration-fast test-basic-grpc-server
+(defn ping-courier-service
+  [waiter-url request-headers]
+  (make-request waiter-url "/waiter-ping" :headers request-headers))
+
+(defn start-courier-instance
+  [waiter-url]
+  (let [[host _] (str/split waiter-url #":")
+        h2c-port (Integer/parseInt (retrieve-h2c-port waiter-url))
+        request-headers (basic-grpc-service-parameters)
+        {:keys [cookies headers] :as response} (ping-courier-service waiter-url request-headers)
+        cookie-header (str/join "; " (map #(str (:name %) "=" (:value %)) cookies))
+        service-id (get headers "x-waiter-service-id")
+        request-headers (assoc request-headers
+                          "cookie" cookie-header
+                          "x-waiter-timeout" "60000")]
+    (assert-response-status response 200)
+    (is service-id)
+    (log/info "service-id:" service-id)
+    (let [{:keys [ping-response service-state]} (some-> response :body try-parse-json walk/keywordize-keys)]
+      (is (= "received-response" (:result ping-response)) (str ping-response))
+      (is (str/starts-with? (str (some-> ping-response :headers :server)) "courier-health-check"))
+      (assert-response-status ping-response 200)
+      (is (or (= {:exists? true :healthy? true :service-id service-id :status "Running"} service-state)
+              (= {:exists? true :healthy? false :service-id service-id :status "Starting"} service-state))
+          (str service-state)))
+    (assert-service-on-all-routers waiter-url service-id cookies)
+
+    {:cookies cookies
+     :h2c-port h2c-port
+     :host host
+     :request-headers request-headers
+     :service-id service-id}))
+
+(defn- retrieve-states
+  "Retrieves the states corresponding to a cid in the gRPC service defined by the request headers."
+  [host h2c-port request-headers service-id correlation-id expect-cancel?]
+  (let [retrieve-state-cid (rand-name)
+        request-headers (assoc request-headers "x-cid" retrieve-state-cid)
+        response (GrpcClient/retrieveState host h2c-port request-headers correlation-id)
+        state-count (or (some-> response (.getStateCount)) 0)
+        states (vec (doall (map #(.getState response %) (range state-count))))
+        assertion-message (str {:retrieve-cid retrieve-state-cid
+                                :result {:correlation-id correlation-id
+                                         :states states}
+                                :service-id service-id})]
+    (log/info correlation-id "states:" states)
+    (cond
+      ;; request executed without sending any data to the backend should be in non-lock-step mode
+      (zero? (count states))
+      (is (str/includes? correlation-id "independent") assertion-message)
+
+      ;; request executed without sending any data to the backend should be in non-lock-step mode
+      (= 2 (count states))
+      (do
+        (is (str/includes? correlation-id "independent") assertion-message)
+        (is (= ["INIT" "READY"] states) assertion-message))
+
+      ;; request executed without sending any data to the backend should be in non-lock-step mode
+      (= 3 (count states))
+      (do
+        (is (str/includes? correlation-id "independent") assertion-message)
+        (is (= ["INIT" "CANCEL" "CLOSE"] states) assertion-message))
+
+      ;; request executed without sending any data to the backend should be in non-lock-step mode
+      (and (= 5 (count states))
+           (not-any? #(= "RECEIVE_MESSAGE" %) states))
+      (do
+        (is (str/includes? correlation-id "independent") assertion-message)
+        (is (= ["INIT" "READY" "HALF_CLOSE" "CLOSE" "COMPLETE"] states) assertion-message))
+
+      ;; request connected to the backend and transmitted some data
+      ;; we must see a cancellation state for such requests
+      :else
+      (do
+        (when-not (= ["INIT" "READY"] (take 2 states))
+          (println assertion-message)
+          (log/info "FAIL:" assertion-message))
+        (if (> (count states) 6)
+          (is (= ["INIT" "READY" "RECEIVE_MESSAGE" "SEND_HEADERS"] (take 4 states)) assertion-message)
+          (is (= ["INIT" "READY"] (take 2 states)) assertion-message))
+        (when-not (every? #{"RECEIVE_MESSAGE" "SEND_MESSAGE"} (->> states (drop 4) (drop-last 4)))
+          (println assertion-message)
+          (log/info "FAIL:" assertion-message))
+        (is (every? #{"RECEIVE_MESSAGE" "SEND_MESSAGE"} (->> states (drop 4) (drop-last 4))) assertion-message)
+        (if expect-cancel?
+          ;; abnormal / cancellation path
+          (let [expected-last-two-state-members #{"CLOSE" "CANCEL" "COMPLETE"}
+                actual-last-two-states (take-last 2 states)]
+            (is (every? expected-last-two-state-members actual-last-two-states) assertion-message)
+            (when-not (some #{"CANCEL"} actual-last-two-states)
+              (println assertion-message)
+              (log/info "FAIL:" assertion-message))
+            (is (some #{"CANCEL"} actual-last-two-states) assertion-message)
+            (is (= 2 (count (set actual-last-two-states))) assertion-message))
+          ;; normal path
+          (is (= ["SEND_MESSAGE" "HALF_CLOSE" "CLOSE" "COMPLETE"] (take-last 4 states)) assertion-message))))
+    states))
+
+(deftest ^:parallel ^:integration-fast test-grpc-unary-call
   (testing-using-waiter-url
-    (GrpcClient/setLogFunction (reify Function
-                                 (apply [_ message]
-                                   (log/info message))))
-    (let [[host _] (str/split waiter-url #":")
-          h2c-port (Integer/parseInt (retrieve-h2c-port waiter-url))
-          request-headers (basic-grpc-service-parameters)
-          {:keys [cookies headers] :as response} (make-request waiter-url "/waiter-ping" :headers request-headers)
-          cookie-header (str/join "; " (map #(str (:name %) "=" (:value %)) cookies))
-          service-id (get headers "x-waiter-service-id")]
-
-      (assert-response-status response 200)
-      (is service-id)
-
+    (let [{:keys [h2c-port host request-headers service-id]} (start-courier-instance waiter-url)]
       (with-service-cleanup
         service-id
-
-        (let [{:keys [ping-response service-state]} (some-> response :body try-parse-json walk/keywordize-keys)]
-          (is (= "received-response" (:result ping-response)) (str ping-response))
-          (is (str/starts-with? (str (some-> ping-response :headers :server)) "courier-health-check"))
-          (assert-response-status ping-response 200)
-          (is (or (= {:exists? true :healthy? true :service-id service-id :status "Running"} service-state)
-                  (= {:exists? true :healthy? false :service-id service-id :status "Starting"} service-state))
-              (str service-state)))
-
         (testing "small request and reply"
           (log/info "starting small request and reply test")
           (let [id (rand-name "m")
                 from (rand-name "f")
                 content (rand-str 1000)
-                request-headers (assoc request-headers "cookie" cookie-header "x-cid" (rand-name))
+                request-headers (assoc request-headers "x-cid" (rand-name))
                 reply (GrpcClient/sendPackage host h2c-port request-headers id from content)]
             (is reply)
             (when reply
               (is (= id (.getId reply)))
               (is (= content (.getMessage reply)))
-              (is (= "received" (.getResponse reply))))))
+              (is (= "received" (.getResponse reply))))))))))
 
-        (testing "streaming to and from server"
-          (doseq [max-message-length [100 1000 10000 100000]]
-            (let [messages (doall (repeatedly 200 #(rand-str (inc (rand-int max-message-length)))))]
+(deftest ^:parallel ^:integration-fast test-grpc-streaming-successful
+  (testing-using-waiter-url
+    (let [{:keys [h2c-port host request-headers service-id]} (start-courier-instance waiter-url)]
+      (with-service-cleanup
+        service-id
+        (doseq [max-message-length [1000 10000 100000]]
+          (let [num-messages 100
+                messages (doall (repeatedly num-messages #(rand-str (inc (rand-int max-message-length)))))]
 
-              (testing (str "independent mode " max-message-length " messages")
+            (testing (str "independent mode " max-message-length " messages completion")
+              (log/info "starting streaming to and from server - independent mode test")
+              (let [cancel-threshold (inc num-messages)
+                    from (rand-name "f")
+                    collect-cid (str (rand-name) "-independent-complete")
+                    request-headers (assoc request-headers "x-cid" collect-cid)
+                    summaries (GrpcClient/collectPackages
+                                host h2c-port request-headers "m-" from messages 10 false cancel-threshold)]
+                (log/info collect-cid "collecting independent packages...")
+                (is (= (count messages) (count summaries)))
+                (when (seq summaries)
+                  (is (= (range 1 (inc (count messages))) (map #(.getNumMessages %) summaries)))
+                  (is (= (reductions + (map count messages)) (map #(.getTotalLength %) summaries))))
+                (Thread/sleep 1000) ;; allow server-side error processing to complete
+                (let [states (retrieve-states host h2c-port request-headers service-id collect-cid false)]
+                  (is (= (+ 6 (* 2 num-messages)) (count states)) (str collect-cid " -> " states)))))
+
+            (testing (str "lock-step mode " max-message-length " messages completion")
+              (log/info "starting streaming to and from server - lock-step mode test")
+              (let [cancel-threshold (inc num-messages)
+                    from (rand-name "f")
+                    collect-cid (str (rand-name) "-lock-step-complete")
+                    request-headers (assoc request-headers "x-cid" collect-cid)
+                    summaries (GrpcClient/collectPackages
+                                host h2c-port request-headers "m-" from messages 1 true cancel-threshold)]
+                (log/info collect-cid "collecting lock-step packages...")
+                (is (= (count messages) (count summaries)))
+                (when (seq summaries)
+                  (is (= (range 1 (inc (count messages))) (map #(.getNumMessages %) summaries)))
+                  (is (= (reductions + (map count messages)) (map #(.getTotalLength %) summaries))))
+                (Thread/sleep 1000) ;; allow server-side error processing to complete
+                (let [states (retrieve-states host h2c-port request-headers service-id collect-cid false)]
+                  (is (= (+ 6 (* 2 num-messages)) (count states)) (str collect-cid " -> " states)))))))))))
+
+(deftest ^:parallel ^:integration-slow test-grpc-streaming-client-cancellation
+  (testing-using-waiter-url
+    (let [{:keys [h2c-port host request-headers service-id]} (start-courier-instance waiter-url)]
+      (with-service-cleanup
+        service-id
+        (doseq [max-message-length [1000 10000 100000]]
+          (let [num-messages 100
+                messages (doall (repeatedly num-messages #(rand-str (inc (rand-int max-message-length)))))]
+
+            (dotimes [_ 10]
+              (testing (str "independent mode " max-message-length " messages cancellations")
                 (log/info "starting streaming to and from server - independent mode test")
-                (let [from (rand-name "f")
-                      request-headers (assoc request-headers "cookie" cookie-header "x-cid" (rand-name))
-                      summaries (GrpcClient/collectPackages host h2c-port request-headers "m-" from messages 1 false)]
-                  (is (= (count messages) (count summaries)))
-                  (when (seq summaries)
-                    (is (= (range 1 (inc (count messages))) (map #(.getNumMessages %) summaries)))
-                    (is (= (reductions + (map count messages)) (map #(.getTotalLength %) summaries))))))
+                (let [cancel-threshold (+ 5 (rand-int (- num-messages 5)))
+                      from (rand-name "f")
+                      collect-cid (str (rand-name) "-independent-cancel." cancel-threshold "." max-message-length)
+                      request-headers (assoc request-headers "x-cid" collect-cid)
+                      summaries (GrpcClient/collectPackages
+                                  host h2c-port request-headers "m-" from messages 1 false cancel-threshold)]
+                  (log/info collect-cid "collecting independent packages...")
+                  (is (nil? summaries))
+                  (Thread/sleep 1000) ;; allow server-side error processing to complete
+                  (let [states (retrieve-states host h2c-port request-headers service-id collect-cid true)]
+                    (is (>= (+ 6 (* 2 cancel-threshold)) (count states)) (str collect-cid " -> " states)))))
 
-              (testing (str "lock-step mode " max-message-length " messages")
+              (testing (str "lock-step mode " max-message-length " messages cancellations")
                 (log/info "starting streaming to and from server - lock-step mode test")
-                (let [from (rand-name "f")
-                      request-headers (assoc request-headers "cookie" cookie-header "x-cid" (rand-name))
-                      summaries (GrpcClient/collectPackages host h2c-port request-headers "m-" from messages 1 true)]
-                  (is (= (count messages) (count summaries)))
-                  (when (seq summaries)
-                    (is (= (range 1 (inc (count messages))) (map #(.getNumMessages %) summaries)))
-                    (is (= (reductions + (map count messages)) (map #(.getTotalLength %) summaries)))))))))))))
+                (let [cancel-threshold (+ 5 (rand-int (- num-messages 5)))
+                      from (rand-name "f")
+                      collect-cid (str (rand-name) "-lock-step-cancel." cancel-threshold "." max-message-length)
+                      request-headers (assoc request-headers "x-cid" collect-cid)
+                      summaries (GrpcClient/collectPackages
+                                  host h2c-port request-headers "m-" from messages 1 true cancel-threshold)]
+                  (log/info collect-cid "collecting lock-step packages...")
+                  (is (nil? summaries))
+                  (Thread/sleep 1000) ;; allow server-side error processing to complete
+                  (let [states (retrieve-states host h2c-port request-headers service-id collect-cid true)]
+                    (is (>= (+ 6 (* 2 cancel-threshold)) (count states)) (str collect-cid " -> " states))))))))))))
+
+(deftest ^:parallel ^:integration-slow test-grpc-streaming-server-cancellation
+  (testing-using-waiter-url
+    (let [num-messages 100
+          num-iterations 5]
+      (dotimes [iteration num-iterations]
+        (doseq [max-message-length [1000 10000 100000]]
+          (doseq [mode ["EXIT_PRE_RESPONSE" "EXIT_POST_RESPONSE"]]
+            (testing (str "lock-step mode " max-message-length " messages cancellations pre-response")
+              (let [{:keys [h2c-port host request-headers service-id]} (start-courier-instance waiter-url)]
+                (with-service-cleanup
+                  service-id
+                  (let [cancellation-index (* iteration (/ num-messages num-iterations))
+                        collect-cid (str (rand-name) "." mode "." cancellation-index "-" num-messages "." max-message-length)
+                        from (rand-name "f")
+                        ids (map #(str "id-" (cond-> % (= % cancellation-index) (str "." mode))) (range num-messages))
+                        messages (doall (repeatedly num-messages #(rand-str (inc (rand-int max-message-length)))))
+                        request-headers (assoc request-headers "x-cid" collect-cid)
+                        summaries (GrpcClient/collectPackages
+                                    host h2c-port request-headers ids from messages 1 true (inc num-messages))
+                        assertion-message (str {:cancellation-index cancellation-index
+                                                :collect-cid collect-cid
+                                                :iteration iteration
+                                                :service-id service-id
+                                                :summaries (map (fn [s]
+                                                                  {:num-messages (.getNumMessages s)
+                                                                   :total-length (.getTotalLength s)})
+                                                                summaries)})
+                        expected-summary-count (cond-> cancellation-index
+                                                 (= "EXIT_POST_RESPONSE" mode) inc)]
+                    (log/info "result" assertion-message) ;; TODO shams convert to log
+                    (is (= expected-summary-count (count summaries)) assertion-message)
+                    (when (seq summaries)
+                      (is (= (range 1 (inc expected-summary-count))
+                             (map #(.getNumMessages %) summaries))
+                          assertion-message)
+                      (is (= (reductions + (map count (take expected-summary-count messages)))
+                             (map #(.getTotalLength %) summaries))
+                          assertion-message))))))))))))

--- a/waiter/integration/waiter/grpc_test.clj
+++ b/waiter/integration/waiter/grpc_test.clj
@@ -221,7 +221,7 @@
           (let [num-messages 100
                 messages (doall (repeatedly num-messages #(rand-str (inc (rand-int max-message-length)))))]
 
-            (dotimes [_ 10]
+            (dotimes [_ 20]
               (testing (str "independent mode " max-message-length " messages cancellations")
                 (log/info "starting streaming to and from server - independent mode test")
                 (let [cancel-threshold (+ 5 (rand-int (- num-messages 5)))
@@ -253,7 +253,7 @@
 (deftest ^:parallel ^:integration-slow test-grpc-streaming-server-cancellation
   (testing-using-waiter-url
     (let [num-messages 100
-          num-iterations 5]
+          num-iterations 10]
       (dotimes [iteration num-iterations]
         (doseq [max-message-length [1000 10000 100000]]
           (doseq [mode ["EXIT_PRE_RESPONSE" "EXIT_POST_RESPONSE"]]

--- a/waiter/integration/waiter/grpc_test.clj
+++ b/waiter/integration/waiter/grpc_test.clj
@@ -271,7 +271,7 @@
 (deftest ^:parallel ^:integration-slow test-grpc-streaming-server-exit
   (testing-using-waiter-url
     (let [num-messages 100
-          num-iterations 20]
+          num-iterations 5]
       (dotimes [iteration num-iterations]
         (doseq [max-message-length [1000 10000 100000]]
           (doseq [mode ["EXIT_PRE_RESPONSE" "EXIT_POST_RESPONSE"]]
@@ -320,7 +320,7 @@
 (deftest ^:parallel ^:integration-slow test-grpc-streaming-server-cancellation
   (testing-using-waiter-url
     (let [num-messages 100
-          num-iterations 20]
+          num-iterations 5]
       (dotimes [iteration num-iterations]
         (doseq [max-message-length [1000 10000 100000]]
           (testing (str "lock-step mode " max-message-length " messages server error")

--- a/waiter/integration/waiter/grpc_test.clj
+++ b/waiter/integration/waiter/grpc_test.clj
@@ -271,7 +271,7 @@
 (deftest ^:parallel ^:integration-slow test-grpc-streaming-server-exit
   (testing-using-waiter-url
     (let [num-messages 100
-          num-iterations 10]
+          num-iterations 20]
       (dotimes [iteration num-iterations]
         (doseq [max-message-length [1000 10000 100000]]
           (doseq [mode ["EXIT_PRE_RESPONSE" "EXIT_POST_RESPONSE"]]
@@ -320,7 +320,7 @@
 (deftest ^:parallel ^:integration-slow test-grpc-streaming-server-cancellation
   (testing-using-waiter-url
     (let [num-messages 100
-          num-iterations 10]
+          num-iterations 20]
       (dotimes [iteration num-iterations]
         (doseq [max-message-length [1000 10000 100000]]
           (testing (str "lock-step mode " max-message-length " messages server error")

--- a/waiter/integration/waiter/grpc_test.clj
+++ b/waiter/integration/waiter/grpc_test.clj
@@ -314,9 +314,7 @@
                     (is status-summary)
                     (when status-summary
                       (log/info "server exit summary" status-summary)
-                      (is (= (if (= "EXIT_PRE_RESPONSE" mode) "UNAVAILABLE" "INTERNAL")
-                             (.getStatusCode status-summary))
-                          assertion-message)
+                      (is (contains? #{"UNAVAILABLE" "INTERNAL"} (.getStatusCode status-summary)) assertion-message)
                       (is (zero? (.getNumMessages status-summary)) assertion-message))))))))))))
 
 (deftest ^:parallel ^:integration-slow test-grpc-streaming-server-cancellation

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -32,7 +32,7 @@
 
   :dependencies [[bidi "2.1.5"
                   :exclusions [prismatic/schema ring/ring-core]]
-                 [twosigma/courier "1.2.5-SNAPSHOT"
+                 [twosigma/courier "1.2.5"
                   :exclusions [com.google.guava/guava io.grpc/grpc-core]
                   :scope "test"]
                  ;; avoids the following:

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -32,7 +32,7 @@
 
   :dependencies [[bidi "2.1.5"
                   :exclusions [prismatic/schema ring/ring-core]]
-                 [twosigma/courier "1.2.5"
+                 [twosigma/courier "1.2.6-SNAPSHOT"
                   :exclusions [com.google.guava/guava io.grpc/grpc-core]
                   :scope "test"]
                  ;; avoids the following:
@@ -41,7 +41,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20190701_193134-g62e7954"
+                 [twosigma/jet "0.7.10-20190702_064908-gd96ad15"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -32,7 +32,7 @@
 
   :dependencies [[bidi "2.1.5"
                   :exclusions [prismatic/schema ring/ring-core]]
-                 [twosigma/courier "1.2.3-SNAPSHOT"
+                 [twosigma/courier "1.2.5-SNAPSHOT"
                   :exclusions [com.google.guava/guava io.grpc/grpc-core]
                   :scope "test"]
                  ;; avoids the following:

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -41,7 +41,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20190702_064908-gd96ad15"
+                 [twosigma/jet "0.7.10-20190702_170512-ga50cbb9"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -32,7 +32,7 @@
 
   :dependencies [[bidi "2.1.5"
                   :exclusions [prismatic/schema ring/ring-core]]
-                 [twosigma/courier "1.2.6-SNAPSHOT"
+                 [twosigma/courier "1.2.6"
                   :exclusions [com.google.guava/guava io.grpc/grpc-core]
                   :scope "test"]
                  ;; avoids the following:

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -32,7 +32,7 @@
 
   :dependencies [[bidi "2.1.5"
                   :exclusions [prismatic/schema ring/ring-core]]
-                 [twosigma/courier "1.2.1"
+                 [twosigma/courier "1.2.3-SNAPSHOT"
                   :exclusions [com.google.guava/guava io.grpc/grpc-core]
                   :scope "test"]
                  ;; avoids the following:
@@ -41,7 +41,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20190701_144314-ga425faa"
+                 [twosigma/jet "0.7.10-20190701_193134-g62e7954"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]

--- a/waiter/src/waiter/async_request.clj
+++ b/waiter/src/waiter/async_request.clj
@@ -159,8 +159,9 @@
     ;; trigger execution of monitoring system
     (letfn [(make-get-request-fn []
               (counters/inc! (metrics/service-counter service-id "request-counts" "async-monitor"))
-              (let [request-stub {:body nil :headers {} :query-string query-string :request-method :get}]
-                (make-http-request-fn instance request-stub location metric-group backend-proto)))
+              (let [request-stub {:body nil :headers {} :query-string query-string :request-method :get}
+                    request-control-chan (async/promise-chan)]
+                (make-http-request-fn instance request-stub location metric-group backend-proto request-control-chan)))
             (release-instance-fn [status]
               (log/info "decrementing outstanding requests as an async request has completed:" status)
               (counters/dec! (metrics/service-counter service-id "request-counts" "async"))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1176,9 +1176,10 @@
                                      (let [password (first passwords)
                                            make-request-fn (fn make-ws-request
                                                              [instance request request-properties passthrough-headers end-route metric-group
-                                                              backend-proto proto-version]
+                                                              backend-proto proto-version request-control-chan]
                                                              (ws/make-request websocket-client service-id->password-fn instance request request-properties
-                                                                              passthrough-headers end-route metric-group backend-proto proto-version))
+                                                                              passthrough-headers end-route metric-group backend-proto proto-version
+                                                                              request-control-chan))
                                            process-request-fn (fn process-request-fn [request]
                                                                 (pr/process make-request-fn instance-rpc-chan start-new-service-fn
                                                                             instance-request-properties determine-priority-fn ws/process-response!
@@ -1238,11 +1239,11 @@
                                         [:settings instance-request-properties]
                                         [:state http-clients instance-rpc-chan local-usage-agent stream-reader-executor]]
                                  (let [make-request-fn (fn [instance request request-properties passthrough-headers end-route metric-group
-                                                            backend-proto proto-version]
+                                                            backend-proto proto-version request-control-chan]
                                                          (pr/make-request
                                                            stream-reader-executor http-clients make-basic-auth-fn service-id->password-fn
                                                            instance request request-properties passthrough-headers end-route metric-group
-                                                           backend-proto proto-version))
+                                                           backend-proto proto-version request-control-chan))
                                        process-response-fn (partial pr/process-http-response post-process-async-request-response-fn)]
                                    (fn inner-process-request [request]
                                      (pr/process make-request-fn instance-rpc-chan start-new-service-fn

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -373,10 +373,10 @@
         ;; client request needs to be closed, trigger early EOF to
         ;; - unblock any calls to input-stream.read()
         ;; - trigger clean up of request processing
-        (when (instance? HttpInput input-stream)
+        (comment when (instance? HttpInput input-stream)
           (when-not (.isFinished ^HttpInput input-stream)
-            (log/info "triggering early eof on client request")
-            (.earlyEOF ^HttpInput input-stream)))))
+            (log/info "releasing blocked client request")
+            (.unblock ^HttpInput input-stream)))))
     (try
       (submit-request-streaming-task executor stream-http-request-fn)
       (catch Throwable throwable

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -187,6 +187,8 @@
         (let [[error-cause message status] (classify-error (ex-cause error))
               error-cause (or (-> error ex-data :error-cause) error-cause)]
           [error-cause message status])
+        (instance? IllegalStateException error)
+        [:generic-error (.getMessage error) 400]
         (instance? EofException error)
         [:client-error "Connection unexpectedly closed while streaming request" 400]
         (instance? TimeoutException error)

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -544,7 +544,7 @@
           (meters/mark! stream-exception-meter)
           ;; assign instance-error or client-error correctly
           (let [[error-cause message _] (classify-error e)]
-            (log/error (.getMessage e) "identified as" error-cause "with message" message)
+            (log/error (-> e .getClass .getCanonicalName) (.getMessage e) "identified as" error-cause message)
             (deliver reservation-status-promise error-cause))
           (log/info "sending poison pill to response channel")
           (let [poison-pill-function (poison-pill-fn (cid/get-correlation-id))]

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -242,7 +242,7 @@
       (if (and (pos? port) host)
         (let [instance-health-check-url (health-check-url service-instance protocol health-check-port-index health-check-path)
               request-timeout-ms (max (+ (.getConnectTimeout http-client) (.getIdleTimeout http-client)) 200)
-              request-abort-chan (async/promise-chan)
+              request-abort-chan (async/chan 10)
               health-check-response-chan (http/get http-client instance-health-check-url {:abort-ch request-abort-chan})
               _ (meters/mark! (metrics/waiter-meter "scheduler" scheduler-name "health-check" "invocation-rate"))
               {:keys [error-flag status]}

--- a/waiter/src/waiter/websocket.clj
+++ b/waiter/src/waiter/websocket.clj
@@ -140,7 +140,8 @@
 
 (defn make-request
   "Makes an asynchronous websocket request to the instance endpoint and returns a channel."
-  [websocket-client service-id->password-fn {:keys [host port] :as instance} ws-request request-properties passthrough-headers end-route _ backend-proto proto-version]
+  [websocket-client service-id->password-fn {:keys [host port] :as instance} ws-request request-properties
+   passthrough-headers end-route _ backend-proto proto-version _]
   (let [ws-middleware (fn ws-middleware [_ ^UpgradeRequest request]
                         (let [service-password (-> instance scheduler/instance->service-id service-id->password-fn)
                               headers

--- a/waiter/test/waiter/async_request_test.clj
+++ b/waiter/test/waiter/async_request_test.clj
@@ -19,7 +19,8 @@
             [clojure.test :refer :all]
             [plumbing.core :as pc]
             [waiter.async-request :refer :all]
-            [waiter.service :as service])
+            [waiter.service :as service]
+            [waiter.util.async-utils :as au])
   (:import java.net.URLDecoder))
 
 (deftest test-monitor-async-request
@@ -294,12 +295,13 @@
         request-properties {:async-check-interval-ms 100, :async-request-timeout-ms 200}
         location (str "/location/" request-id)
         query-string "a=b&c=d|e"
-        make-http-request-fn (fn [in-instance in-request end-route metric-group backend-proto]
+        make-http-request-fn (fn [in-instance in-request end-route metric-group backend-proto request-control-chan]
                                (is (= instance in-instance))
                                (is (= {:body nil :headers {} :query-string "a=b&c=d|e" :request-method :get} in-request))
                                (is (= "/location/request-2394613984619" end-route))
                                (is (= "test-metric-group" metric-group))
-                               (is (= "http" backend-proto)))
+                               (is (= "http" backend-proto))
+                               (is (au/chan? request-control-chan)))
         instance-rpc-chan (async/chan 1)
         complete-async-request-atom (atom nil)
         response {}]

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -310,7 +310,7 @@
                                   (let [result-array (byte-array (.remaining byte-buffer))]
                                     (.get byte-buffer result-array 0 (count result-array))
                                     result-array))
-        request-control-chan (async/promise-chan)
+        streaming-complete-fn (constantly true)
         streaming-timeout-ms 3000]
 
     (testing "successful read - single task"
@@ -327,7 +327,7 @@
             exception-atom (atom nil)
             error-handler-fn (make-error-handler-fn body-ch exception-atom)]
 
-        (stream-http-request executor service-id metric-group error-handler-fn request-control-chan
+        (stream-http-request executor service-id metric-group error-handler-fn streaming-complete-fn
                              streaming-timeout-ms input-stream body-ch 0)
 
         (let [num-fragments-read-atom (atom 0)]
@@ -358,7 +358,7 @@
             exception-atom (atom nil)
             error-handler-fn (make-error-handler-fn body-ch exception-atom)]
 
-        (stream-http-request executor service-id metric-group error-handler-fn request-control-chan
+        (stream-http-request executor service-id metric-group error-handler-fn streaming-complete-fn
                              streaming-timeout-ms input-stream body-ch 0)
 
         (let [num-fragments-read-atom (atom 0)]
@@ -389,7 +389,7 @@
             exception-atom (atom nil)
             error-handler-fn (make-error-handler-fn body-ch exception-atom)]
 
-        (stream-http-request executor service-id metric-group error-handler-fn request-control-chan
+        (stream-http-request executor service-id metric-group error-handler-fn streaming-complete-fn
                              streaming-timeout-ms input-stream body-ch 0)
 
         (let [num-fragments-read-atom (atom 0)]
@@ -422,7 +422,7 @@
             exception-atom (atom nil)
             error-handler-fn (make-error-handler-fn body-ch exception-atom)]
 
-        (stream-http-request executor service-id metric-group error-handler-fn request-control-chan
+        (stream-http-request executor service-id metric-group error-handler-fn streaming-complete-fn
                              streaming-timeout-ms input-stream body-ch 0)
 
         (let [num-fragments-read-atom (atom 0)]
@@ -455,7 +455,7 @@
             exception-atom (atom nil)
             error-handler-fn (make-error-handler-fn body-ch exception-atom)]
 
-        (stream-http-request executor service-id metric-group error-handler-fn request-control-chan
+        (stream-http-request executor service-id metric-group error-handler-fn streaming-complete-fn
                              streaming-timeout-ms input-stream body-ch 0)
 
         (is (wait-for #(async-protocols/closed? body-ch)))
@@ -499,7 +499,7 @@
           (dotimes [_ queue-capacity]
             (.execute executor (constantly true))))
 
-        (stream-http-request executor service-id metric-group error-handler-fn request-control-chan
+        (stream-http-request executor service-id metric-group error-handler-fn streaming-complete-fn
                              streaming-timeout-ms input-stream body-ch 0)
 
         (let [num-fragments-read-atom (atom 0)]

--- a/waiter/test/waiter/websocket_test.clj
+++ b/waiter/test/waiter/websocket_test.clj
@@ -269,7 +269,8 @@
         assert-request-headers (fn assert-request-headers [upgrade-request]
                                  (doseq [[header-name header-value] assertion-headers]
                                    (is (= header-value (.getHeader upgrade-request header-name)) header-name)))
-        proto-version "HTTP/1.1"]
+        proto-version "HTTP/1.1"
+        request-control-chan (async/promise-chan)]
 
     (testing "successful-connect-ws"
       (with-redefs [ws-client/connect! (fn [_ instance-endpoint request-callback {:keys [middleware] :as request-properties}]
@@ -285,7 +286,7 @@
           test-cid
           (let [websocket-client nil
                 response (make-request websocket-client service-id->password-fn instance request request-properties
-                                       passthrough-headers end-route nil "http" proto-version)
+                                       passthrough-headers end-route nil "http" proto-version request-control-chan)
                 response-map (async/<!! response)]
             (is (= #{:ctrl-mult :request} (-> response-map keys set)))
             (is (= connect-request (:request response-map)))))))
@@ -304,7 +305,7 @@
           test-cid
           (let [websocket-client nil
                 response (make-request websocket-client service-id->password-fn instance request request-properties
-                                       passthrough-headers end-route nil "https" proto-version)
+                                       passthrough-headers end-route nil "https" proto-version request-control-chan)
                 response-map (async/<!! response)]
             (is (= #{:ctrl-mult :request} (-> response-map keys set)))
             (is (= connect-request (:request response-map)))))))
@@ -320,7 +321,7 @@
                                            (throw test-exception))]
           (let [websocket-client nil
                 response (make-request websocket-client service-id->password-fn instance request request-properties
-                                       passthrough-headers end-route nil "http" proto-version)]
+                                       passthrough-headers end-route nil "http" proto-version request-control-chan)]
             (is (= {:error test-exception} (async/<!! response)))))))))
 
 (deftest test-watch-ctrl-chan


### PR DESCRIPTION
**Associated jet change**: https://github.com/twosigma/jet/pull/29

## Changes proposed in this PR

- adds state tracking for individual requests in courier
- adds integration test for grpc cancellations

## Why are we making these changes?

For grpc requests, the server should be notified on client cancellations to allow performing any cleanup and vice versa.

