### PR TITLE
logging and import cleanup in process_request.clj

### DIFF
--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -513,7 +513,7 @@
    {:keys [uri] :as request} reason-map reservation-status-promise confirm-live-connection-with-abort
    request-state-chan {:keys [status] :as response}]
   (when (utils/request->debug-enabled? request)
-    (log/info "backend response status:" (:status response)"and headers:" (:headers response)))
+    (log/info "backend response status:" (:status response) "and headers:" (:headers response)))
   (let [{:keys [service-description service-id]} descriptor
         {:strs [backend-proto blacklist-on-503 metric-group]} service-description
         waiter-debug-enabled? (utils/request->debug-enabled? request)


### PR DESCRIPTION
## Changes proposed in this PR

- logs backend response status and headers when debug is enabled
- cleans up unused imports
- makes logs consistently start with lower-case characters 

## Why are we making these changes?

Additional logging helps with debugging individual requests. Code cleanup is general hygiene.

