### PR TITLE
adds request and response content-length header to request log

### DIFF
--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -30,7 +30,7 @@
 (defn request->context
   "Convert a request into a context suitable for logging."
   [{:keys [client-protocol headers internal-protocol query-string remote-addr request-id request-method request-time uri] :as request}]
-  (let [{:strs [content-type host origin user-agent x-cid x-forwarded-for]} headers]
+  (let [{:strs [content-length content-type host origin user-agent x-cid x-forwarded-for]} headers]
     (cond-> {:cid x-cid
              :host host
              :path uri
@@ -42,6 +42,7 @@
       client-protocol (assoc :client-protocol client-protocol)
       internal-protocol (assoc :internal-protocol internal-protocol)
       query-string (assoc :query-string query-string)
+      content-length (assoc :request-content-length content-length)
       content-type (assoc :request-content-type content-type)
       request-time (assoc :request-time (du/date-to-str request-time))
       user-agent (assoc :user-agent user-agent))))
@@ -51,9 +52,10 @@
   [{:keys [authorization/principal backend-response-latency-ns descriptor latest-service-id get-instance-latency-ns
            handle-request-latency-ns headers instance protocol status] :as response}]
   (let [{:keys [service-id service-description]} descriptor
-        {:strs [content-type grpc-status server]} headers]
+        {:strs [content-length content-type grpc-status server]} headers]
     (cond-> {:status (or status 200)}
       backend-response-latency-ns (assoc :backend-response-latency-ns backend-response-latency-ns)
+      content-length (assoc :response-content-length content-length)
       content-type (assoc :response-content-type content-type)
       descriptor (assoc :metric-group (get service-description "metric-group")
                         :service-id service-id

--- a/waiter/test/waiter/request_log_test.clj
+++ b/waiter/test/waiter/request_log_test.clj
@@ -20,7 +20,9 @@
 
 (deftest test-request->context
   (let [request {:client-protocol "HTTP/2.0"
-                 :headers {"host" "host"
+                 :headers {"content-length" "20"
+                           "content-type" "application/json"
+                           "host" "host"
                            "origin" "www.origin.org"
                            "user-agent" "test-user-agent"
                            "x-cid" "123"}
@@ -41,6 +43,8 @@
             :path "/"
             :query-string "a=1"
             :remote-addr "127.0.0.1"
+            :request-content-length "20"
+            :request-content-type "application/json"
             :request-id "abc"
             :request-time "2018-04-11T00:00:00.000Z"
             :scheme "http"
@@ -56,7 +60,8 @@
                                                      "version" "service-version"}}
                   :get-instance-latency-ns 500
                   :handle-request-latency-ns 2000
-                  :headers {"content-type" "application/xml"
+                  :headers {"content-length" "40"
+                            "content-type" "application/xml"
                             "grpc-status" "13"
                             "server" "foo-bar"}
                   :instance {:host "instance-host"
@@ -76,6 +81,7 @@
             :latest-service-id "latest-service-id"
             :metric-group "service-metric-group"
             :principal "principal@DOMAIN.COM"
+            :response-content-length "40"
             :response-content-type "application/xml"
             :server "foo-bar"
             :service-id "service-id"


### PR DESCRIPTION
## Changes proposed in this PR

- adds request and response content-length header to request log

## Why are we making these changes?

When available, we would like to be able to report these values.

