### PR TITLE
ensures response trailers are always non-empty

### DIFF
--- a/waiter/integration/waiter/trailers_test.clj
+++ b/waiter/integration/waiter/trailers_test.clj
@@ -61,7 +61,10 @@
                   (-> response :headers str)))
             (is (= {} (get body-json "trailers"))
                 (-> response :headers str))
-            (is (= {"x-waiter-trailer-reason" "ensures-non-empty-trailers"} (some-> response :trailers))
+            ;; TODO remove when https://github.com/eclipse/jetty.project/issues/3829 is fixed and empty trailer frames are not sent.
+            (is (= (when (hu/http2? http-version)
+                     {"x-waiter-trailer-reason" "ensures-non-empty-trailers"})
+                   (some-> response :trailers))
                 (-> response :headers str))))
 
         (let [request-trailer-delay-ms 100

--- a/waiter/integration/waiter/trailers_test.clj
+++ b/waiter/integration/waiter/trailers_test.clj
@@ -39,6 +39,31 @@
         (is service-id)
         (assert-response-status canary-response 200)
 
+        (testing "jet returns some trailers"
+          (let [response (make-shell-request
+                           waiter-url
+                           (assoc request-headers
+                             "x-cid" (rand-name))
+                           :body (ByteArrayInputStream. (.getBytes long-request))
+                           :path "/trailers"
+                           :protocol backend-proto)
+                body-json (try
+                            (some-> response :body str json/read-str)
+                            (catch Exception ex
+                              (log/error ex "unable to parse response as json")
+                              (is false (str "unable to parse response as json" (:body response)))))
+                http-version (hu/backend-protocol->http-version backend-proto)]
+            (is (= http-version (get body-json "protocol")))
+            (when (= "http" backend-proto)
+              (is (= "chunked" (get-in body-json ["headers" "Transfer-Encoding"]))
+                  (str body-json))
+              (is (= "chunked" (get-in response [:headers "transfer-encoding"]))
+                  (-> response :headers str)))
+            (is (= {} (get body-json "trailers"))
+                (-> response :headers str))
+            (is (= {"x-waiter-trailer-reason" "ensures-non-empty-trailers"} (some-> response :trailers))
+                (-> response :headers str))))
+
         (let [request-trailer-delay-ms 100
               response-trailer-delay-ms 100]
           (doseq [response-status [200 400 500]]

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -41,7 +41,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20190612_154727-g9cb249e"
+                 [twosigma/jet "0.7.10-20190628_061424-g729ea66"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -41,7 +41,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20190628_061424-g729ea66"
+                 [twosigma/jet "0.7.10-20190628_191138-g11cccbc"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]


### PR DESCRIPTION
**Associated jet change**: https://github.com/twosigma/jet/pull/30

## Changes proposed in this PR

- ensures response trailers are always non-empty

## Why are we making these changes?

Sending empty header frames in the response when there are no trailers is problematic since it is not clear whether empty header frames are allowed and some proxies, e.g. haproxy (suspected code block), explicitly disallow and fail http/2 connections on empty header frames.

See for details: https://github.com/eclipse/jetty.project/issues/3829

