### PR TITLE
disables sending trailers to non-http/2 backends

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -27,10 +27,8 @@
             [waiter.service-description :as sd]
             [waiter.util.client-tools :refer :all]
             [waiter.util.date-utils :as du]
-            [waiter.util.http-utils :as hu]
             [waiter.util.utils :as utils])
-  (:import (java.io ByteArrayInputStream)
-           (java.net URLEncoder)))
+  (:import (java.net URLEncoder)))
 
 (deftest ^:parallel ^:integration-fast test-basic-functionality
   (testing-using-waiter-url
@@ -160,7 +158,7 @@
                                  waiter-url
                                  request-headers
                                  :path "/request-info"
-                                 :body (ByteArrayInputStream. (.getBytes long-request)))
+                                 :body (make-chunked-body long-request 4096 20))
                   chunked-body-str (str (:body chunked-resp))
                   chunked-body-json (json/read-str chunked-body-str)]
               (is (= request-length (get-in chunked-body-json ["request-length"])) chunked-body-str)

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -149,10 +149,11 @@
                                waiter-url request-headers
                                :path "/request-info"
                                :body long-request)
-                  plain-body-json (json/read-str (str (:body plain-resp)))]
-              (is (= (str request-length) (get-in plain-body-json ["headers" "content-length"])))
-              (is (= request-length (get-in plain-body-json ["request-length"])))
-              (is (nil? (get-in plain-body-json ["headers" "transfer-encoding"])))))
+                  plain-body-str (str (:body plain-resp))
+                  plain-body-json (json/read-str plain-body-str)]
+              (is (= (str request-length) (get-in plain-body-json ["headers" "content-length"])) plain-body-str)
+              (is (= request-length (get-in plain-body-json ["request-length"])) plain-body-str)
+              (is (nil? (get-in plain-body-json ["headers" "transfer-encoding"])) plain-body-str)))
 
           (testing "chunked request"
             (let [chunked-resp (make-kitchen-request
@@ -160,10 +161,11 @@
                                  request-headers
                                  :path "/request-info"
                                  :body (ByteArrayInputStream. (.getBytes long-request)))
-                  chunked-body-json (json/read-str (str (:body chunked-resp)))]
-              (is (= request-length (get-in chunked-body-json ["request-length"])))
-              (is (= "chunked" (get-in chunked-body-json ["headers" "transfer-encoding"])))
-              (is (nil? (get-in chunked-body-json ["headers" "content-length"])))))))
+                  chunked-body-str (str (:body chunked-resp))
+                  chunked-body-json (json/read-str chunked-body-str)]
+              (is (= request-length (get-in chunked-body-json ["request-length"])) chunked-body-str)
+              (is (= "chunked" (get-in chunked-body-json ["headers" "transfer-encoding"])) chunked-body-str)
+              (is (nil? (get-in chunked-body-json ["headers" "content-length"])) chunked-body-str)))))
 
       (testing "large header"
         (let [all-chars (map char (range 33 127))

--- a/waiter/integration/waiter/trailers_test.clj
+++ b/waiter/integration/waiter/trailers_test.clj
@@ -114,7 +114,9 @@
                       (str body-json))
                   (is (= "chunked" (get-in response [:headers "transfer-encoding"]))
                       (-> response :headers str)))
-                (is (= request-trailers (get body-json "trailers"))
+                ;; we do not sent trailers to http/1 backends
+                (is (= (if (hu/http2? http-version) request-trailers {})
+                       (get body-json "trailers"))
                     (-> response :headers str))
                 (is (= response-trailers (some-> response :trailers))
                     (-> response :headers str))))))))))

--- a/waiter/integration/waiter/trailers_test.clj
+++ b/waiter/integration/waiter/trailers_test.clj
@@ -18,14 +18,13 @@
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [waiter.util.client-tools :refer :all]
-            [waiter.util.http-utils :as hu])
-  (:import (java.io ByteArrayInputStream)))
+            [waiter.util.http-utils :as hu]))
 
 (defn- run-sediment-trailers-support-test
   [waiter-url backend-proto]
   (testing "request and response trailers"
     (let [request-length 100000
-          long-request (apply str (repeat request-length "a"))
+          long-request (apply str (take request-length (cycle "abcdefghijklmnopqrstuvwxyz")))
           sediment-command (sediment-server-command "${PORT0}")
           request-headers {:x-waiter-backend-proto backend-proto
                            :x-waiter-cmd sediment-command
@@ -46,7 +45,7 @@
                            waiter-url
                            (assoc request-headers
                              "x-cid" (rand-name))
-                           :body (ByteArrayInputStream. (.getBytes long-request))
+                           :body (make-chunked-body long-request 4096 20)
                            :path "/trailers"
                            :protocol backend-proto)
                 body-json (try
@@ -94,7 +93,7 @@
                                    "x-sediment-sleep-before-response-trailer-ms" response-trailer-delay-ms
                                    "x-sediment-sleep-after-chunk-send-ms" 100)
                                  (seq response-trailers))
-                               :body (ByteArrayInputStream. (.getBytes long-request))
+                               :body (make-chunked-body long-request 4096 20)
                                :path "/trailers"
                                :protocol backend-proto
                                :trailers-fn (fn []
@@ -133,7 +132,7 @@
   [waiter-url backend-proto]
   (testing "request and response trailers"
     (let [request-length 100000
-          long-request (apply str (repeat request-length "a"))
+          long-request (apply str (take request-length (cycle "abcdefghijklmnopqrstuvwxyz")))
           request-headers {:x-waiter-backend-proto backend-proto
                            :x-waiter-debug true
                            :x-waiter-name (rand-name)}
@@ -158,7 +157,7 @@
                                (assoc request-headers
                                  "x-kitchen-pre-trailer-sleep-ms" response-trailer-delay-ms)
                                (seq response-trailers))
-                             :body (ByteArrayInputStream. (.getBytes long-request))
+                             :body (make-chunked-body long-request 4096 20)
                              :path "/chunked"
                              :protocol backend-proto)]
               (log/info "response headers:" (:headers response))

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -306,20 +306,21 @@
                 (servlet-input-stream->channel service-id metric-group streaming-timeout-ms abort-ch ctrl-ch))]
     (http/request
       http-client
-      {:abort-ch abort-ch
-       :as :bytes
-       :auth auth
-       :body body'
-       :headers headers
-       :fold-chunked-response? (not (hu/http2? proto-version))
-       :fold-chunked-response-buffer-size output-buffer-size
-       :follow-redirects? false
-       :idle-timeout idle-timeout
-       :method request-method
-       :query-string query-string
-       :trailers-fn trailers-fn
-       :url endpoint
-       :version proto-version})))
+      (cond-> {:abort-ch abort-ch
+               :as :bytes
+               :auth auth
+               :body body'
+               :headers headers
+               :fold-chunked-response? (not (hu/http2? proto-version))
+               :fold-chunked-response-buffer-size output-buffer-size
+               :follow-redirects? false
+               :idle-timeout idle-timeout
+               :method request-method
+               :query-string query-string
+               :url endpoint
+               :version proto-version}
+        ;; some of our http/1 backends do not support trailers, so disable for all of them
+        (hu/http2? proto-version) (assoc :trailers-fn trailers-fn)))))
 
 (defn make-request
   "Makes an asynchronous http request to the instance endpoint and returns a channel."


### PR DESCRIPTION
## Changes proposed in this PR

- disables sending trailers to non-http/2 backends

## Why are we making these changes?

Some of our http/1 backends do not support trailers, so disable sending request trailers for all of them.
