### PR TITLE
adds blocking-timeout to server-options

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -123,7 +123,10 @@
 
  ;; The configuration for the Waiter server that will be launched.
  ;; Unless specified otherwise, all the entries below are optional:
- :server-options {;; Whether or not to  enable secure HTTP2 transport, default false
+ :server-options {;; The timeout in ms for blocking I/O operations, default 15 minutes (in millis)
+                  :blocking-timeout 900000
+
+                  ;; Whether or not to  enable secure HTTP2 transport, default false
                   :http2? false
 
                   ;; Whether or not to  enable HTTP2 cleartext transport, default true

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -41,7 +41,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20190628_191138-g11cccbc"
+                 [twosigma/jet "0.7.10-20190701_144314-ga425faa"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -392,7 +392,12 @@
                          :scheduler-gc-broken-service-interval-ms 60000
                          :scheduler-gc-interval-ms 60000}
    :scheduler-syncer-interval-secs 5
-   :server-options {:blocking-timeout 900000 ;; 15 minutes
+   :server-options {;; HttpInput.read() uses getBlockingTimeout() and does not uses zero to mean:
+                    ;; 0 for a blocking timeout equal to the idle timeout 
+                    ;; as promised by the HttpConfiguration javadoc.
+                    ;; We set it to a reasonably high 15 mins by default.
+                    ;; The idle timeout is configured per request, so we do not explicitly configure it here.
+                    :blocking-timeout 900000 ;; 15 minutes
                     :http2? false
                     :http2c? true
                     :max-threads 200

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -103,7 +103,8 @@
                                           (s/required-key :scheduler-gc-broken-service-interval-ms) schema/positive-int
                                           (s/required-key :scheduler-gc-interval-ms) schema/positive-int}
    (s/required-key :scheduler-syncer-interval-secs) schema/positive-int
-   (s/required-key :server-options) {(s/optional-key :http2?) s/Bool
+   (s/required-key :server-options) {(s/optional-key :blocking-timeout) schema/non-negative-int
+                                     (s/optional-key :http2?) s/Bool
                                      (s/optional-key :http2c?) s/Bool
                                      (s/optional-key :keystore) schema/non-empty-string
                                      (s/optional-key :keystore-type) schema/non-empty-string
@@ -391,7 +392,8 @@
                          :scheduler-gc-broken-service-interval-ms 60000
                          :scheduler-gc-interval-ms 60000}
    :scheduler-syncer-interval-secs 5
-   :server-options {:http2? false
+   :server-options {:blocking-timeout 900000 ;; 15 minutes
+                    :http2? false
                     :http2c? true
                     :max-threads 200
                     :request-header-size 32768


### PR DESCRIPTION
**Associated jet change**: https://github.com/twosigma/jet/pull/31

## Changes proposed in this PR

- adds blocking-timeout to server-options

## Why are we making these changes?

Add timeout in ms for blocking I/O operations. This is important as threads can get indeifinitely blocked on read() operations from the input stream:

```
"pool-1-thread-131" #293 prio=5 os_prio=0 tid=0x00007f60e80d8800 nid=0x33d1 in Object.wait() [0x00007f609b3e5000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(Native Method)
	at java.lang.Object.wait(Object.java:502)
	at org.eclipse.jetty.server.HttpInput.blockForContent(HttpInput.java:575)
	at org.eclipse.jetty.server.HttpInput$1.blockForContent(HttpInput.java:1100)
	at org.eclipse.jetty.server.HttpInput.read(HttpInput.java:315)
	- locked <0x00000000949df2c8> (a java.util.ArrayDeque)
	at java.io.InputStream.read(InputStream.java:101)
	at waiter.process_request$eval31985$stream_http_request__31986.invoke(process_request.clj:280)
	at waiter.process_request$eval31985$stream_http_request__31986$invoke_stream_http_request__31987.invoke(process_request.clj:263)
	at clojure.lang.AFn.run(AFn.java:22)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

