### PR TITLE
Refactor usage of java.util.URLDecoder

### DIFF
--- a/waiter/src/waiter/cookie_support.clj
+++ b/waiter/src/waiter/cookie_support.clj
@@ -24,6 +24,7 @@
   (:import clojure.lang.ExceptionInfo
            org.eclipse.jetty.util.UrlEncoded))
 
+; TODO: make a url-encode method, move these methods to utils, and refactor usages of java.util.URLDecoder java.util.URLEncoder
 (defn url-decode
   "Decode a URL-encoded string.  java.util.URLDecoder is super slow."
   [^String string]


### PR DESCRIPTION
## Changes proposed in this PR

- make a url-encode method, move these methods to utils, and refactor usages of java.util.URLDecoder java.util.URLEncoder

## Why are we making these changes?

org.eclipse.jetty.util.UrlEncoded is supposed to be faster, unify usage

