### PR TITLE
Add current-for-tokens

### DIFF
--- a/waiter/bin/run-using-marathon.sh
+++ b/waiter/bin/run-using-marathon.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Usage: run-using-marathon.sh [PORT]
+#
+# Examples:
+#   run-using-marathon.sh 9091
+#   run-using-marathon.sh
+#
+# Runs Waiter, configured to use a local marathon
+
+export WAITER_PORT=${1:-9091}
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+export WAITER_MARATHON=http://localhost:8080
+export WAITER_ZOOKEEPER_CONNECT_STRING=localhost:2181
+export GRAPHITE_SERVER_PORT=5555
+
+echo "Starting waiter..."
+cd ${DIR}/..
+WAITER_AUTH_RUN_AS_USER=$(id -un) WAITER_LOG_FILE_PREFIX=${WAITER_PORT}- lein do clean, compile, run config-minimesos.edn

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1388,6 +1388,41 @@
         (finally
           (delete-token-and-assert waiter-url token))))))
 
+(deftest ^:parallel ^:integration-fast test-current-for-tokens-multiple-source-tokens
+  (testing-using-waiter-url
+    (let [service-name (rand-name)
+          token-name-a (create-token-name waiter-url (str service-name "-A"))
+          token-name-b (create-token-name waiter-url (str service-name "-B"))
+          first-service-description (assoc (kitchen-request-headers :prefix "")
+                                      :name service-name)
+          combined-token-header (str token-name-a "," token-name-b)]
+      (try
+        (let [response (post-token waiter-url (assoc first-service-description :token token-name-a))]
+            (assert-response-status response 200))
+          (let [response (post-token waiter-url (assoc first-service-description :token token-name-b))]
+            (assert-response-status response 200))
+
+        (let [service-id-a (retrieve-service-id waiter-url {:x-waiter-token combined-token-header})
+              new-service-description (update first-service-description :cpus #(+ % 0.1))]
+          (let [response (post-token waiter-url (assoc new-service-description :token token-name-a))]
+            (assert-response-status response 200))
+
+          (let [service-id-b (retrieve-service-id waiter-url {:x-waiter-token combined-token-header})]
+            (let [response (post-token waiter-url (assoc new-service-description :token token-name-b))]
+              (assert-response-status response 200))
+
+            (let [service-id-c (retrieve-service-id waiter-url {:x-waiter-token combined-token-header})
+                  service-a-details (service-settings waiter-url service-id-a)
+                  service-b-details (service-settings waiter-url service-id-b)
+                  service-c-details (service-settings waiter-url service-id-c)]
+              (is (nil? (:current-for-tokens service-a-details)))
+              (is (nil? (:current-for-tokens service-b-details)))
+              (is (= [token-name-a token-name-b]
+                     (:current-for-tokens service-c-details))))))
+        (finally
+          (delete-token-and-assert waiter-url token-name-a)
+          (delete-token-and-assert waiter-url token-name-b))))))
+
 (deftest ^:parallel ^:integration-slow ^:resource-heavy test-service-fallback-support
   (testing-using-waiter-url
     (let [service-name (rand-name)

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1272,7 +1272,8 @@
    :service-handler-fn (pc/fnk [[:curator kv-store]
                                 [:daemons router-state-maintainer]
                                 [:routines allowed-to-manage-service?-fn generate-log-url-fn make-inter-router-requests-sync-fn
-                                 router-metrics-helpers service-id->service-description-fn service-id->source-tokens-entries-fn]
+                                 router-metrics-helpers service-id->service-description-fn service-id->source-tokens-entries-fn
+                                 token->token-hash]
                                 [:scheduler scheduler]
                                 [:state router-id scheduler-interactions-thread-pool]
                                 wrap-secure-request-fn]
@@ -1284,7 +1285,7 @@
                                                         generate-log-url-fn make-inter-router-requests-sync-fn
                                                         service-id->service-description-fn service-id->source-tokens-entries-fn
                                                         query-state-fn service-id->metrics-fn scheduler-interactions-thread-pool
-                                                        request)))))
+                                                        token->token-hash request)))))
    :service-id-handler-fn (pc/fnk [[:curator kv-store]
                                    [:routines store-service-description-fn]
                                    wrap-descriptor-fn wrap-secure-request-fn]

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -354,13 +354,16 @@
 
 (defn- get-current-for-tokens
   [source-token-entries token->token-hash]
-  (->> source-token-entries
-       (reduce (fn [acc tokens] (into acc tokens)) [])
-       (filter (fn [{:strs [token version]}]
-                 (let [current-version (token->token-hash token)]
-                   (log/info "checking token" token ". Current version" current-version "source version" version)
-                   (= version current-version))))
-       (map (fn [m] (get m "token")))))
+  (reduce (fn [acc source-tokens]
+            (let [current-for-tokens (map (fn [{:strs [token version]}]
+                                            (let [current-version (token->token-hash token)]
+                                              (= version current-version)))
+                                          source-tokens)]
+              (if (every? true? current-for-tokens)
+                (into acc (map (fn [t] (get t "token")) source-tokens))
+                acc)))
+          []
+          source-token-entries))
 
 (defn- get-service-handler
   "Returns details about the service such as the service description, metrics, instances, etc."

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -417,7 +417,8 @@
                                   :make-inter-router-requests-sync-fn nil
                                   :router-metrics-helpers {:service-id->metrics-fn (constantly {})}
                                   :service-id->service-description-fn (constantly {})
-                                  :service-id->source-tokens-entries-fn (constantly #{})}
+                                  :service-id->source-tokens-entries-fn (constantly #{})
+                                  :token->token-hash identity}
                        :scheduler {:scheduler (reify scheduler/ServiceScheduler
                                                 (delete-service [_ _]
                                                   (let [result @delete-service-result-atom]
@@ -511,7 +512,8 @@
                                   :make-inter-router-requests-sync-fn nil
                                   :router-metrics-helpers {:service-id->metrics-fn (constantly service-id->metrics)}
                                   :service-id->service-description-fn (constantly {})
-                                  :service-id->source-tokens-entries-fn (constantly #{})}
+                                  :service-id->source-tokens-entries-fn (constantly #{})
+                                  :token->token-hash identity}
                        :scheduler {:scheduler (Object.)}
                        :state {:router-id "router-id"
                                :scheduler-interactions-thread-pool scheduler-interactions-thread-pool}


### PR DESCRIPTION
## Changes proposed in this PR
- Add `current-for-tokens` to service details
- Add `run-using-marathon.sh`

## Why are we making these changes?
Allows users to determine if a service is the current version for a token.

