### PR TITLE
Rethrow all Throwables in async get-available-instance thread

### DIFF
--- a/waiter/src/waiter/service.clj
+++ b/waiter/src/waiter/service.clj
@@ -261,7 +261,7 @@
                     (cid/with-correlation-id cid (service-not-found-fn))
                     (async/<! (async/timeout 1500))
                     (recur (inc iterations)))))))))
-      (catch Exception e
+      (catch Throwable e
         (cid/cerror cid e "Error in get-available-instance")
         e)
       (finally


### PR DESCRIPTION
## Changes proposed in this PR

Rethrow all Throwables in async get-available-instance thread

## Why are we making these changes?

full.async/go-try catches Throwable, and so should we if we don't want
to lose the errors thrown by our async tasks
