### PR TITLE
Clean up redundant error messages.

### DIFF
--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -417,9 +417,9 @@
                               [bytes-streamed false])))
                         (catch Exception e
                           (histograms/update! (metrics/service-histogram service-id "response-size") bytes-streamed)
-                          (log/error "error occurred after streaming" bytes-streamed "bytes in response.")
                           ; Handle lower down
-                          (throw e)))]
+                          (throw (Exception.
+                                   (str "error occurred after streaming" bytes-streamed "bytes in response.") e))))]
                   (let [bytes-reported-to-statsd'
                         (let [unreported-bytes (- bytes-streamed' bytes-reported-to-statsd)]
                           (if (or (and (not more-bytes-possibly-available?) (pos? unreported-bytes))

--- a/waiter/src/waiter/service.clj
+++ b/waiter/src/waiter/service.clj
@@ -89,7 +89,6 @@
            (throw (ex-info "Unable to put instance on work-stealing-chan."
                            {:offer-params ~offer-params, :service-id ~service-id}))))
        (do
-         (log/error "Unable to find work-stealing-chan for service" ~service-id)
          (throw (ex-info "Unable to find work-stealing-chan."
                          {:offer-params ~offer-params, :service-id ~service-id}))))))
 
@@ -165,9 +164,8 @@
          (throw (ex-info "Unable to put instance on release-chan."
                          {:instance ~instance})))
        (do
-         (log/error "Unable to find release-chan for service" service-id#)
          (throw (ex-info "Unable to find release-chan."
-                         {:instance ~instance}))))))
+                         {:instance ~instance :service service-id#}))))))
 
 (defn release-instance-go
   "Sends a rpc to the router state to release the lock on the given instance."

--- a/waiter/src/waiter/service.clj
+++ b/waiter/src/waiter/service.clj
@@ -165,7 +165,7 @@
                          {:instance ~instance})))
        (do
          (throw (ex-info "Unable to find release-chan."
-                         {:instance ~instance :service service-id#}))))))
+                         {:instance ~instance :service-id service-id#}))))))
 
 (defn release-instance-go
   "Sends a rpc to the router state to release the lock on the given instance."


### PR DESCRIPTION
We log both the thrown error as well as the log/error.

## Changes proposed in this PR

-

## Why are we making these changes?


