### PR TITLE
Change log level to warn for bad service names.

### DIFF
--- a/waiter/src/waiter/kv.clj
+++ b/waiter/src/waiter/kv.clj
@@ -95,9 +95,9 @@
   given the underlying ZooKeeper implementation."
   [key]
   (when (re-matches #".*/.*" key)
-    (throw (ex-info "Key may not contain '/'" {:key key})))
+    (throw (ex-info "Key may not contain '/'" {:key key :log-level :warn})))
   (when (re-matches #"^\..*" key)
-    (throw (ex-info "Key may not begin with '.'" {:key key}))))
+    (throw (ex-info "Key may not begin with '.'" {:key key :log-level :warn}))))
 
 (defn zk-keys
   "Create a lazy sequence of keys."


### PR DESCRIPTION
We should probably be rejecting these service names at injection, instead
of at the zookeeper level. Oh well.

## Changes proposed in this PR

-

## Why are we making these changes?


