### PR TITLE
Adds metrics collection to integration tests

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -32,6 +32,8 @@
 
   :dependencies [[bidi "2.1.5"
                   :exclusions [prismatic/schema ring/ring-core]]
+                 [clj-jgit "0.8.10"
+                  :scope "test"]
                  [twosigma/courier "1.4.6"
                   :exclusions [com.google.guava/guava io.grpc/grpc-core]
                   :scope "test"]
@@ -141,7 +143,8 @@
   :profiles {:debug {:jvm-opts
                      ;; enable remote debugger to connect on port 5005
                      ["-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"]}
-             :test {:jvm-opts
+             :test {:injections [(require 'waiter.test-helpers)]
+                    :jvm-opts
                     [~(str "-Dwaiter.test.courier.cmd="
                         (or (System/getenv "WAITER_TEST_COURIER_CMD")
                           (.getCanonicalPath (clojure.java.io/file "../containers/test-apps/courier/bin/run-courier-server.sh"))))

--- a/waiter/test/waiter/test_helpers.clj
+++ b/waiter/test/waiter/test_helpers.clj
@@ -91,14 +91,13 @@
      :namespace namespace}))
 
 (defn- full-test-name
-  ([]
-   (:full-name (test-name-info (first *testing-vars*))))
-  ([m]
-   (:full-name (test-name-info (:var m)))))
+  [m]
+  (:full-name (test-name-info (:var m))))
 
 (defn- inc-test-counter
   [test-name->counter-atom]
-  (swap! test-name->counter-atom (fn [map] (update-in map [(full-test-name)] #(inc (or % 0))))))
+  (if-let [testing-var (first *testing-vars*)]
+    (swap! test-name->counter-atom (fn [map] (update-in map [(:full-name (test-name-info testing-var))] #(inc (or % 0)))))))
 
 (defonce ^:private username
          (ct/retrieve-username))

--- a/waiter/test/waiter/test_helpers.clj
+++ b/waiter/test/waiter/test_helpers.clj
@@ -177,8 +177,7 @@
                                                     :run-id (System/getenv "")
                                                     :build-id (System/getenv "")
                                                     :result result
-                                                    :runtime-ms elapsed-millis
-                                                    })
+                                                    :runtime-ms elapsed-millis})
                              :client http-client
                              :headers {"content-type" "application/json"}
                              :method :post))))
@@ -195,7 +194,7 @@
       (println "\nRan" (:test m) "tests containing"
                (+ (:pass m) (:fail m) (:error m)) "assertions.")
       (println (:fail m) "failures," (:error m) "errors.")
-      (http/stop-client! http-client))))
+      (when http-client (http/stop-client! http-client)))))
 
 ;; Overrides the default reporter for :error so that the ex-data of
 ;; an exception is printed.  The default report doesn't print the ex-data.

--- a/waiter/test/waiter/test_helpers.clj
+++ b/waiter/test/waiter/test_helpers.clj
@@ -185,8 +185,8 @@
                                         :git-commit-hash-under-test (System/getenv "TEST_METRICS_COMMIT_HASH_UNDER_TEST")
                                         :host hostname
                                         :user username
-                                        :run-id (System/getenv "")
-                                        :build-id (System/getenv "")
+                                        :run-id (System/getenv "TEST_METRICS_RUN_ID")
+                                        :build-id (System/getenv "TEST_METRICS_BUILD_ID")
                                         :result result
                                         :runtime-milliseconds elapsed-millis
                                         :expected-to-fail (-> (System/getenv "TEST_METRICS_EXPECTED_TO_FAIL") str Boolean/parseBoolean)})))))

--- a/waiter/test/waiter/test_metrics_test.clj
+++ b/waiter/test/waiter/test_metrics_test.clj
@@ -1,0 +1,45 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns waiter.test-metrics-test
+  (:require [clojure.test :refer :all]))
+
+(deftest test-2-assertions
+  (testing "assertion 1"
+    (is (= 2 (+ 1 1))))
+  (testing "assertion 2"
+    (is (= 4 (+ 2 2)))))
+
+(deftest test-2-assertions-fail
+  (dotimes [_ 2]
+    (testing "assertion 1"
+      (is (= 3 (+ 1 1))))
+    (testing "assertion 2"
+      (is (= 5 (+ 2 2))))))
+
+(deftest test-2-slow-assertions
+  (testing "assertion 1"
+    (Thread/sleep 300)
+    (is (= 2 (+ 1 1))))
+  (testing "assertion 2"
+    (Thread/sleep 300)
+    (is (= 4 (+ 2 2)))))
+
+(deftest test-2-assertions-skip
+  (dotimes [_ 0]
+    (testing "assertion 1"
+      (is (= 3 (+ 1 1))))
+    (testing "assertion 2"
+      (is (= 5 (+ 2 2))))))

--- a/waiter/test/waiter/test_metrics_test.clj
+++ b/waiter/test/waiter/test_metrics_test.clj
@@ -22,8 +22,16 @@
   (testing "assertion 2"
     (is (= 4 (+ 2 2)))))
 
-(deftest test-2-assertions-fail
-  (dotimes [_ 2]
+; failing test needs to be commented out when actually committed
+;(deftest test-2-assertions-fail
+;  (dotimes [_ 2]
+;    (testing "assertion 1"
+;      (is (= 3 (+ 1 1))))
+;    (testing "assertion 2"
+;      (is (= 5 (+ 2 2))))))
+
+(deftest test-2-assertions-skip
+  (dotimes [_ 0]
     (testing "assertion 1"
       (is (= 3 (+ 1 1))))
     (testing "assertion 2"
@@ -36,10 +44,3 @@
   (testing "assertion 2"
     (Thread/sleep 300)
     (is (= 4 (+ 2 2)))))
-
-(deftest test-2-assertions-skip
-  (dotimes [_ 0]
-    (testing "assertion 1"
-      (is (= 3 (+ 1 1))))
-    (testing "assertion 2"
-      (is (= 5 (+ 2 2))))))

--- a/waiter/test/waiter/test_metrics_test.clj
+++ b/waiter/test/waiter/test_metrics_test.clj
@@ -14,7 +14,8 @@
 ;; limitations under the License.
 ;;
 (ns waiter.test-metrics-test
-  (:require [clojure.test :refer :all]))
+  (:require [clojure.test :refer :all])
+  (:import (java.util.concurrent Executors)))
 
 (deftest test-2-assertions
   (testing "assertion 1"
@@ -44,3 +45,13 @@
   (testing "assertion 2"
     (Thread/sleep 300)
     (is (= 4 (+ 2 2)))))
+
+(deftest test-assertion-in-thread-pool
+  (let [thread-pool (Executors/newFixedThreadPool 1)]
+    (testing "assertion-in-thread-pool"
+      (waiter.util.async-utils/execute
+        #(is (= 2 (+ 1 1)))
+        thread-pool)
+      (Thread/sleep 1000)
+      (is (= 4 (+ 2 2)))
+      (.shutdown thread-pool))))


### PR DESCRIPTION
## Changes proposed in this PR

- add test clj-jgit dependency to get git info
- modify test hooks to call out to elastic search with test metrics

## Why are we making these changes?

To support collecting metrics over time about test pass/fail rates and run times.
