### PR TITLE
disable flaky tests only on kubernetes

### DIFF
--- a/waiter/integration/waiter/proto_test.clj
+++ b/waiter/integration/waiter/proto_test.clj
@@ -110,25 +110,29 @@
                           :verbose true)]
                   (assert-streaming-response waiter-url correlation-id protocol expected-response-size response))))))))))
 
-(deftest ^:parallel ^:integration-slow ^:resource-heavy ^:explicit test-http-backend-proto-service
+(deftest ^:parallel ^:integration-slow ^:resource-heavy test-http-backend-proto-service
   (testing-using-waiter-url
-    (run-backend-proto-service-test waiter-url "http" "http" "HTTP/1.1")
-    (is "test completed marker")))
+    (when-not (using-k8s? waiter-url) ; temporarily disable on kubernetes until failing test issue resolved
+      (run-backend-proto-service-test waiter-url "http" "http" "HTTP/1.1")
+      (is "test completed marker"))))
 
-(deftest ^:parallel ^:integration-slow ^:resource-heavy ^:explicit test-https-backend-proto-service
+(deftest ^:parallel ^:integration-slow ^:resource-heavy test-https-backend-proto-service
   (testing-using-waiter-url
-    (run-backend-proto-service-test waiter-url "https" "https" "HTTP/1.1")
-    (is "test completed marker")))
+    (when-not (using-k8s? waiter-url) ; temporarily disable on kubernetes until failing test issue resolved
+      (run-backend-proto-service-test waiter-url "https" "https" "HTTP/1.1")
+      (is "test completed marker"))))
 
-(deftest ^:parallel ^:integration-slow ^:resource-heavy ^:explicit test-h2c-backend-proto-service
+(deftest ^:parallel ^:integration-slow ^:resource-heavy test-h2c-backend-proto-service
   (testing-using-waiter-url
-    (run-backend-proto-service-test waiter-url "h2c" "http" "HTTP/2.0")
-    (is "test completed marker")))
+    (when-not (using-k8s? waiter-url) ; temporarily disable on kubernetes until failing test issue resolved
+      (run-backend-proto-service-test waiter-url "h2c" "http" "HTTP/2.0")
+      (is "test completed marker"))))
 
-(deftest ^:parallel ^:integration-slow ^:resource-heavy ^:explicit test-h2-backend-proto-service
+(deftest ^:parallel ^:integration-slow ^:resource-heavy test-h2-backend-proto-service
   (testing-using-waiter-url
-    (run-backend-proto-service-test waiter-url "h2" "https" "HTTP/2.0")
-    (is "test completed marker")))
+    (when-not (using-k8s? waiter-url) ; temporarily disable on kubernetes until failing test issue resolved
+      (run-backend-proto-service-test waiter-url "h2" "https" "HTTP/2.0")
+      (is "test completed marker"))))
 
 (deftest ^:parallel ^:integration-fast test-internal-protocol
   (testing-using-waiter-url


### PR DESCRIPTION
## Changes proposed in this PR

-disable flaky proto backend tests only on kubernetes

## Why are we making these changes?


