### PR TITLE
Add service description builder state

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -115,6 +115,7 @@
                               ["/maintainer" :state-maintainer-handler-fn]
                               ["/router-metrics" :state-router-metrics-handler-fn]
                               ["/scheduler" :state-scheduler-handler-fn]
+                              ["/service-description-builder" :state-service-description-builder-handler-fn]
                               ["/statsd" :state-statsd-handler-fn]
                               [["/" :service-id] :state-service-handler-fn]]
                      "status" :status-handler-fn
@@ -1448,6 +1449,12 @@
                                  (wrap-secure-request-fn
                                    (fn scheduler-state-handler-fn [request]
                                      (handler/get-scheduler-state router-id scheduler request))))
+   :state-service-description-builder-handler-fn (pc/fnk [[:state router-id service-description-builder]]
+                                                   (fn service-description-builder-state-handler-fn [request]
+                                                     (handler/get-query-fn-state
+                                                       router-id
+                                                       #(sd/state service-description-builder)
+                                                       request)))
    :state-service-handler-fn (pc/fnk [[:daemons state-sources]
                                       [:state instance-rpc-chan local-usage-agent router-id]
                                       wrap-secure-request-fn]

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -606,7 +606,7 @@
       (utils/clj->streaming-json-response {:details (->> ["autoscaler" "autoscaling-multiplexer" "codahale-reporters" "fallback"
                                                           "gc-broken-services" "gc-services" "gc-transient-metrics" "interstitial"
                                                           "kv-store" "launch-metrics" "leader" "local-usage" "maintainer"
-                                                          "router-metrics" "scheduler"
+                                                          "router-metrics" "scheduler" "service-description-builder"
                                                           "statsd"]
                                                          (pc/map-from-keys make-url))
                                            :router-id router-id

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -537,7 +537,7 @@
   [service-description username]
   (assoc service-description "run-as-user" username "permitted-user" username))
 
-(defrecord DefaultServiceDescriptionBuilder [max-constraints-schema state-atom]
+(defrecord DefaultServiceDescriptionBuilder [max-constraints-schema]
   ServiceDescriptionBuilder
 
   (build [_ user-service-description
@@ -559,7 +559,7 @@
        :service-id service-id}))
 
   (state [_]
-    @state-atom)
+    {})
 
   (validate [_ service-description args-map]
     (->> (merge-with set/union args-map {:valid-cmd-types #{"docker" "shell"}})
@@ -574,7 +574,7 @@
 
 (defn create-default-service-description-builder
   "Returns a new DefaultServiceDescriptionBuilder which uses the specified resource limits."
-  [{:keys [constraints state-atom]}]
+  [{:keys [constraints]}]
   (let [max-constraints-schema (->> constraints
                                     extract-max-constraints
                                     (map (fn [[k v]]
@@ -582,9 +582,8 @@
                                              [(s/optional-key k)
                                               (s/pred #(<= (if string-param? (count %) %) v)
                                                       (symbol (str "limit-" v)))])))
-                                    (into {s/Str s/Any}))
-        state-atom (or state-atom (atom {}))]
-    (->DefaultServiceDescriptionBuilder max-constraints-schema state-atom)))
+                                    (into {s/Str s/Any}))]
+    (->DefaultServiceDescriptionBuilder max-constraints-schema)))
 
 (defn service-description->health-check-url
   "Returns the configured health check Url or a default value (available in `default-health-check-path`)"

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -525,6 +525,9 @@
   (build [this core-service-description args-map]
     "Returns a map of {:service-id ..., :service-description ..., :core-service-description...}")
 
+  (state [this]
+    "Returns the global (i.e. non-service-specific) state the service description builder is maintaining")
+
   (validate [this service-description args-map]
     "Throws if the provided service-description is not valid"))
 

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -2375,3 +2375,6 @@
     (store-source-tokens! synchronize-fn kv-store service-id source-tokens-4)
     (is (= #{source-tokens-1 source-tokens-3 source-tokens-4}
            (service-id->source-tokens-entries kv-store service-id)))))
+
+(deftest test-service-description-builder-state
+  (is {} (state (create-default-service-description-builder {}))))


### PR DESCRIPTION
## Changes proposed in this PR

- expose service description builder state

## Why are we making these changes?

stateful custom service description builder needs to expose state for health monitoring
