### PR TITLE
performs cleanup of request body channels when frontend request completes

### DIFF
--- a/waiter/integration/waiter/streaming_test.clj
+++ b/waiter/integration/waiter/streaming_test.clj
@@ -52,12 +52,14 @@
             _ (log/info "metrics" (get service-settings :metrics))
             aggregate-metrics (get-in service-settings [:metrics :aggregate])
             request-counts (get-in aggregate-metrics [:counters :request-counts])
+            request-counts-str (str request-counts)
             request-size-histogram (get-in aggregate-metrics [:histograms :request-size])
             response-size-histogram (get-in aggregate-metrics [:histograms :response-size])]
-        (is (zero? (:outstanding request-counts)) (-> aggregate-metrics))
-        (is (zero? (:streaming request-counts)))
-        (is (= (inc num-streaming-requests) (:successful request-counts)))
-        (is (= (inc num-streaming-requests) (:total request-counts)))
+        (is (zero? (:outstanding request-counts)) request-counts-str)
+        (is (zero? (:request-body-streaming request-counts)) request-counts-str)
+        (is (zero? (:streaming request-counts)) request-counts-str)
+        (is (= (inc num-streaming-requests) (:successful request-counts)) request-counts-str)
+        (is (= (inc num-streaming-requests) (:total request-counts)) request-counts-str)
         ;; there is no content length on the canary request
         (is (= (inc num-streaming-requests) (get request-size-histogram :count 0))
             (str "request-size-histogram: " request-size-histogram))

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -252,7 +252,7 @@
                                          (let [complete-trigger-id (utils/unique-identifier)]
                                            (deliver complete-triggered-promise complete-trigger-id)
                                            (when (= complete-trigger-id @complete-triggered-promise)
-                                             (log/info "closing request body as" message)
+                                             (log/debug "closing request body as" message)
                                              (counters/dec! request-body-streaming-counter)
                                              (when throwable
                                                (log/error throwable "unable to stream request bytes, aborting request")


### PR DESCRIPTION
## Changes proposed in this PR

- performs cleanup of request body channels when frontend request completes
- includes cause in backpressure error if available

## Why are we making these changes?

Perform cleanup and avoid memory leaks from any async blocks that are trying to read from the request body channel.

