### PR TITLE
Report GSS Exceptions as 403 errors (not 500)

### DIFF
--- a/waiter/src/waiter/auth/spnego.clj
+++ b/waiter/src/waiter/auth/spnego.clj
@@ -31,7 +31,7 @@
   (:import (org.apache.commons.codec.binary Base64)
            (org.eclipse.jetty.client.api Authentication$Result Request)
            (org.eclipse.jetty.http HttpHeader)
-           (org.ietf.jgss GSSManager GSSCredential GSSContext GSSName Oid)
+           (org.ietf.jgss GSSManager GSSCredential GSSContext GSSException GSSName Oid)
            (java.net URI)
            (java.util.concurrent ThreadPoolExecutor)))
 
@@ -120,6 +120,13 @@
                               (gss-get-principal gss-context))]
               (async/>!! response-chan {:principal principal
                                         :token token}))
+            (catch GSSException ex
+              (log/error ex "gss exception during kerberos auth")
+              (async/>!! response-chan
+                         {:error (ex-info "Error during Kerberos authentication"
+                                          {:details (.getMessage ex)
+                                           :status 403}
+                                          ex)}))
             (catch Throwable th
               (log/error th "error while performing kerberos auth")
               (async/>!! response-chan {:error th}))


### PR DESCRIPTION
## Changes proposed in this PR

Return HTTP 403 rather than 500 when catching `GSSExeption` during Kerberos authentication.

## Why are we making these changes?

Reporting GSS Kerberos errors as _HTTP 500 Internal Server Error_ makes clients think that Waiter is having a problem, whereas every time I've seen this it's actually an issue with the client sending invalid credentials. Returning _HTTP 403 Forbidden_ will make it more obvious that this is an issue validating the client's credentials.