### PR TITLE
make tests compatible with composite scheduler

### DIFF
--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -134,7 +134,7 @@
 
           ;; Test that the killed instances' logs were persisted to S3.
           ;; This portion of the test logic was modified from the active-instances tests above.
-          (let [log-bucket-url (k8s-log-bucket-url waiter-url)
+          (let [log-bucket-url (-> (default-scheduler-settings waiter-url) :log-bucket-url)
                 killed-instances (get-in (service-settings waiter-url service-id :cookies cookies)
                                          [:instances :killed-instances])
                 log-url (:log-url (first killed-instances))

--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -134,7 +134,7 @@
 
           ;; Test that the killed instances' logs were persisted to S3.
           ;; This portion of the test logic was modified from the active-instances tests above.
-          (let [log-bucket-url (-> (default-scheduler-settings waiter-url) :log-bucket-url)
+          (let [log-bucket-url (-> waiter-url get-kubernetes-scheduler-settings :log-bucket-url)
                 killed-instances (get-in (service-settings waiter-url service-id :cookies cookies)
                                          [:instances :killed-instances])
                 log-url (:log-url (first killed-instances))
@@ -205,7 +205,7 @@
   (testing-using-waiter-url
     (when (using-k8s? waiter-url)
       (let [current-user (retrieve-username)
-            default-namespace (-> waiter-url default-scheduler-settings :replicaset-spec-builder :default-namespace)
+            default-namespace (-> waiter-url get-kubernetes-scheduler-settings :replicaset-spec-builder :default-namespace)
             star-user-header {:x-waiter-run-as-user "*"}
             current-user-header {:x-waiter-run-as-user current-user}
             not-current-user "not-current-user"]

--- a/waiter/integration/waiter/request_timeout_test.clj
+++ b/waiter/integration/waiter/request_timeout_test.clj
@@ -223,7 +223,7 @@
                                                  (quot 1000000))] ; truncated nanos->millis
               (is (<= startup-delay-ms instance-acquired-delay-ms)
                   (str "Healthy instance was found in just " instance-acquired-delay-ms " ms (too short)")))
-            (when (using-marathon? waiter-url)
+            (when (can-query-for-grace-period? waiter-url)
               (is (= (t/in-seconds grace-period) (service-id->grace-period waiter-url service-id)))))
           (delete-service waiter-url service-id))
         (finally

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -563,37 +563,37 @@
       (log/info ks "=" value))
     value))
 
+(defn default-scheduler-settings
+  "Return the default 'leaf-level' scheduler's settings map"
+  [waiter-url]
+  (let [{:keys [kind] :as top-settings} (-> waiter-url waiter-settings :scheduler-config)
+        settings (get top-settings (keyword kind))]
+    (if-let [default-sub-scheduler (:default-scheduler settings)]
+      (get-in settings [:components (keyword default-sub-scheduler)])
+      settings)))
+
+(defn retrieve-default-scheduler-name
+  "Return the name of the default 'leaf-level' scheduler"
+  [waiter-url & {:keys [settings] :or {settings nil}}]
+  (let [settings (or settings (waiter-settings waiter-url))
+        kind (get-in settings [:scheduler-config :kind])
+        default-scheduler (get-in settings [:scheduler-config (keyword kind) :default-scheduler])]
+    (or default-scheduler kind)))
+
 (defn marathon-url
   "Returns the Marathon URL setting"
-  [waiter-url & {:keys [verbose] :or {verbose false}}]
-  (setting waiter-url [:scheduler-config :marathon :url] :verbose verbose))
+  [waiter-url]
+  (-> (default-scheduler-settings waiter-url) :url))
 
-(defn k8s-log-bucket-url
-  "Returns the S3 bucket url for K8s service log backups"
-  [waiter-url & {:keys [verbose] :or {verbose false}}]
-  (setting waiter-url [:scheduler-config :kubernetes :log-bucket-url] :verbose verbose))
-
-(defn num-tasks-running [waiter-url service-id & {:keys [verbose prev-tasks-running] :or {verbose false prev-tasks-running -1}}]
+(defn num-marathon-tasks-running [waiter-url service-id & {:keys [prev-tasks-running] :or {prev-tasks-running -1}}]
   (let [http-options {:conn-timeout 10000, :socket-timeout 10000, :spnego-auth use-spnego}
-        marathon-url (marathon-url waiter-url :verbose verbose)
+        marathon-url (marathon-url waiter-url)
         marathon-api (marathon/api-factory http1-client http-options marathon-url)
         info-response (marathon/get-app marathon-api service-id)
         tasks-running' (get-in info-response [:app :tasksRunning])]
     (when (not= prev-tasks-running tasks-running')
       (log/debug service-id "has" tasks-running' "task(s) running."))
     (int tasks-running')))
-
-(defn scale-service-to [waiter-url service-id target-instances]
-  (let [marathon-url (marathon-url waiter-url)]
-    (log/info service-id "being scaled to" target-instances "task(s).")
-    (let [http-options {:conn-timeout 10000, :socket-timeout 10000, :spnego-auth use-spnego}
-          marathon-api (marathon/api-factory http1-client http-options marathon-url)
-          old-descriptor (:app (marathon/get-app marathon-api service-id))
-          new-descriptor (update-in
-                           (select-keys old-descriptor [:id :cmd :mem :cpus :instances])
-                           [:instances]
-                           (fn [_] target-instances))]
-      (marathon/update-app marathon-api service-id new-descriptor))))
 
 (defn delete-service
   ([waiter-url service-id-or-waiter-headers]
@@ -615,11 +615,8 @@
              (when (and (not delete-success) (not no-such-service))
                (log/warn "Unable to delete" service-id)
                (throw (Exception. (str "Unable to delete" service-id)))))))
-       (catch Exception _
-         (try
-           (scale-service-to waiter-url service-id 0)
-           (catch Exception e
-             (log/error "Error in deleting service" service-id ":" (.getMessage e)))))))))
+       (catch Exception e
+         (log/error "Error in deleting service" service-id ":" (.getMessage e)))))))
 
 (defn await-futures
   [futures & {:keys [verbose] :or {verbose false}}]
@@ -939,23 +936,6 @@
         app-info-response (make-request marathon-url app-info-path)
         app-info-map (walk/keywordize-keys (try-parse-json (:body app-info-response)))]
     (:gracePeriodSeconds (first (:healthChecks (:app app-info-map))))))
-
-(defn default-scheduler-settings
-  "Return the default 'leaf-level' scheduler's settings map"
-  [waiter-url]
-  (let [{:keys [kind] :as top-settings} (-> waiter-url waiter-settings :scheduler-config)
-        settings (get top-settings (keyword kind))]
-    (if-let [default-sub-scheduler (:default-scheduler settings)]
-      (get-in settings [:components (keyword default-sub-scheduler)])
-      settings)))
-
-(defn retrieve-default-scheduler-name
-  "Return the name of the default 'leaf-level' scheduler"
-  [waiter-url]
-  (let [settings (waiter-settings waiter-url)
-        kind (get-in settings [:scheduler-config :kind])
-        default-scheduler (get-in settings [:scheduler-config (keyword kind) :default-scheduler])]
-    (or default-scheduler kind)))
 
 (defn using-cook?
   "Returns true if Waiter is configured to use Cook for scheduling"


### PR DESCRIPTION
## Changes proposed in this PR

- update functions that read scheduler settings to use the default-scheduler-settings function

## Why are we making these changes?

code needs to still work even if a composite scheduler is used

