### PR TITLE
avoids races in interstitial metrics that end up affecting other unit tests

### DIFF
--- a/waiter/test/waiter/metrics_test.clj
+++ b/waiter/test/waiter/metrics_test.clj
@@ -26,10 +26,10 @@
             [plumbing.core :as pc]
             [waiter.core :as core]
             [waiter.metrics :refer :all]
-            [waiter.test-helpers :as test-helpers]
+            [waiter.test-helpers :refer :all]
             [waiter.util.async-utils :as au]
             [waiter.util.utils :as utils])
-  (:import (com.codahale.metrics MetricFilter MetricRegistry)
+  (:import (com.codahale.metrics MetricFilter)
            (org.joda.time DateTime)))
 
 (deftest test-compress-strings
@@ -55,15 +55,6 @@
   (is (= '(.concat (.concat "a." b) ".c") (metric-name ["a" 'b "c"])))
   (is (= '(.concat (.concat "a.b." c) ".d") (metric-name ["a" "b" 'c "d"])))
   (is (= '(.concat (.concat "a." b) ".c.d") (metric-name ["a" 'b "c" "d"]))))
-
-(def ^:private all-metrics-match-filter (reify MetricFilter (matches [_ _ _] true)))
-
-(defmacro with-isolated-registry
-  [& body]
-  `(with-redefs [mc/default-registry (MetricRegistry.)]
-     (.removeMatching mc/default-registry all-metrics-match-filter)
-     (do ~@body)
-     (.removeMatching mc/default-registry all-metrics-match-filter)))
 
 (deftest test-service-counter
   (with-isolated-registry
@@ -363,9 +354,9 @@
                                            {:keys [iteration]} (async/<!! response-chan)]
                                        iteration))
                 initial-iteration (retrieve-iteration)]
-            (test-helpers/wait-for #(> (retrieve-iteration) initial-iteration)
-                                   :interval metrics-gc-interval-ms
-                                   :unit-multiplier 1)))]
+            (wait-for #(> (retrieve-iteration) initial-iteration)
+                      :interval metrics-gc-interval-ms
+                      :unit-multiplier 1)))]
     (testing "Transient Data producer"
       (reset! service-id->metrics-atom {})
       (create-metrics "test-service-1")

--- a/waiter/test/waiter/reporters_test.clj
+++ b/waiter/test/waiter/reporters_test.clj
@@ -19,20 +19,12 @@
             [metrics.core :as mc]
             [metrics.counters :as counters]
             [waiter.metrics :as metrics]
+            [waiter.test-helpers :refer :all]
             [waiter.reporter :refer :all])
   (:import (clojure.lang ExceptionInfo)
-           (com.codahale.metrics MetricFilter MetricRegistry ConsoleReporter)
+           (com.codahale.metrics ConsoleReporter)
            (com.codahale.metrics.graphite GraphiteSender)
            (java.io PrintStream ByteArrayOutputStream)))
-
-(def ^:private all-metrics-match-filter (reify MetricFilter (matches [_ _ _] true)))
-
-(defmacro with-isolated-registry
-  [& body]
-  `(with-redefs [mc/default-registry (MetricRegistry.)]
-     (.removeMatching mc/default-registry all-metrics-match-filter)
-     (do ~@body)
-     (.removeMatching mc/default-registry all-metrics-match-filter)))
 
 (deftest console-reporter-bad-schema
   (is (thrown-with-msg? ExceptionInfo #"period-ms missing-required-key"


### PR DESCRIPTION

## Changes proposed in this PR

- avoids races in interstitial metrics that end up affecting other unit tests

## Why are we making these changes?

Avoid flaky tests.

Fixes https://github.com/twosigma/waiter/issues/342
Fixes https://github.com/twosigma/waiter/issues/356
Fixes https://github.com/twosigma/waiter/issues/866
