### PR TITLE
Handle case when suggested instance is nil

### DIFF
--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -681,6 +681,8 @@
                         instance (:out timed-instance)
                         instance-elapsed (:elapsed timed-instance)
                         proto-version (hu/backend-protocol->http-version backend-proto)]
+                    (when-not instance
+                      (throw (ex-info "Suggested instance was nil" reason-map)))
                     (statsd/histo! metric-group "get_instance" instance-elapsed)
                     (-> (try
                           (log/info "suggested instance:" (:id instance) (:host instance) (:port instance))


### PR DESCRIPTION
## Changes proposed in this PR

Handle case when suggested instance is nil

## Why are we making these changes?

This doesn't look like it should happen, but we've seen it in the logs.
Handling this error more proactively with an exception here will help
avoid a more confusing failure later in the control flow.
