### PR TITLE
remove usage of java.util.URLDecoder and java.util.URLEncoder

### DIFF
--- a/waiter/integration/waiter/authentication_test.clj
+++ b/waiter/integration/waiter/authentication_test.clj
@@ -4,8 +4,9 @@
             [clojure.string :as string]
             [clojure.test :refer :all]
             [reaver :as reaver]
-            [waiter.util.client-tools :refer :all])
-  (:import (java.net URL URLEncoder)))
+            [waiter.util.client-tools :refer :all]
+            [waiter.util.utils :as utils])
+  (:import (java.net URL)))
 
 (deftest ^:parallel ^:integration-fast test-default-composite-authenticator
   (testing-using-waiter-url
@@ -95,8 +96,8 @@
                 saml-redirect-location (get headers "location")
                 {:keys [relay-state saml-response waiter-saml-acs-endpoint]} (perform-saml-authentication saml-redirect-location)
                 {:keys [body] :as response} (make-request waiter-saml-acs-endpoint ""
-                                                          :body (str "SAMLResponse=" (URLEncoder/encode saml-response)
-                                                                     "&RelayState=" (URLEncoder/encode relay-state))
+                                                          :body (str "SAMLResponse=" (utils/url-encode saml-response)
+                                                                     "&RelayState=" (utils/url-encode relay-state))
                                                           :headers {"content-type" "application/x-www-form-urlencoded"}
                                                           :method :post)
                 _ (assert-response-status response 200)
@@ -106,7 +107,7 @@
                                 "form input[name=saml-auth-data]" (reaver/attr :value))
                 _ (is (= (str "http://" waiter-url "/waiter-auth/saml/auth-redirect") waiter-saml-auth-redirect-endpoint))
                 {:keys [cookies headers] :as response} (make-request waiter-url "/waiter-auth/saml/auth-redirect"
-                                                                     :body (str "saml-auth-data=" (URLEncoder/encode saml-auth-data))
+                                                                     :body (str "saml-auth-data=" (utils/url-encode saml-auth-data))
                                                                      :headers {"content-type" "application/x-www-form-urlencoded"}
                                                                      :method :post)
                 _ (assert-response-status response 303)

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -27,10 +27,8 @@
             [waiter.service-description :as sd]
             [waiter.util.client-tools :refer :all]
             [waiter.util.date-utils :as du]
-            [waiter.util.http-utils :as hu]
             [waiter.util.utils :as utils])
-  (:import (java.io ByteArrayInputStream)
-           (java.net URLEncoder)))
+  (:import (java.io ByteArrayInputStream)))
 
 (deftest ^:parallel ^:integration-fast test-basic-functionality
   (testing-using-waiter-url
@@ -117,7 +115,7 @@
           (is (= bad-query-string (get (json/read-str body) "query-string"))))
 
         (log/info "Basic test for query-string with encoded characters")
-        (let [bad-query-string (str "q=" (URLEncoder/encode "~`!@$%^&*()_-+={}[]|:;'<>,.?&foo=%12jhsdf"))
+        (let [bad-query-string (str "q=" (utils/url-encode "~`!@$%^&*()_-+={}[]|:;'<>,.?&foo=%12jhsdf"))
               {:keys [body] :as response} (make-kitchen-request
                                             waiter-url
                                             (assoc request-headers :accept "application/json")

--- a/waiter/src/waiter/async_request.clj
+++ b/waiter/src/waiter/async_request.clj
@@ -22,8 +22,9 @@
             [waiter.metrics :as metrics]
             [waiter.scheduler :as scheduler]
             [waiter.service :as service]
-            [waiter.statsd :as statsd])
-  (:import [java.net ConnectException SocketTimeoutException URI URLEncoder]
+            [waiter.statsd :as statsd]
+            [waiter.util.utils :as utils])
+  (:import [java.net ConnectException SocketTimeoutException URI]
            java.util.concurrent.TimeoutException))
 
 (defn normalize-location-header
@@ -137,7 +138,7 @@
    The function expects prefix to end with a slash and location to begin with a slash.
    Returns a formatted url: prefix/{request-id}/{router-id}/{service-id}/{host}/{port}{location}"
   [prefix {:keys [host location port request-id router-id service-id]}]
-  (let [encode #(if %1 (URLEncoder/encode %1 "UTF-8") (str %1))]
+  (let [encode #(if %1 (utils/url-encode %1 "UTF-8") (str %1))]
     (str prefix (encode request-id) "/" (encode router-id) "/" service-id "/" (str host) "/" (str port) location)))
 
 (defn post-process-async-request-response

--- a/waiter/src/waiter/cookie_support.clj
+++ b/waiter/src/waiter/cookie_support.clj
@@ -20,15 +20,9 @@
             [clojure.tools.logging :as log]
             [taoensso.nippy :as nippy]
             [waiter.util.cache-utils :as cu]
-            [waiter.util.ring-utils :as ru])
-  (:import clojure.lang.ExceptionInfo
-           org.eclipse.jetty.util.UrlEncoded))
-
-(defn url-decode
-  "Decode a URL-encoded string.  java.util.URLDecoder is super slow."
-  [^String string]
-  (when string
-    (UrlEncoded/decodeString string)))
+            [waiter.util.ring-utils :as ru]
+            [waiter.util.utils :as utils])
+  (:import clojure.lang.ExceptionInfo))
 
 (defn- strip-double-quotes
   [value]
@@ -43,7 +37,7 @@
   (when cookie-string
     (let [name-regex (re-pattern (str "(?i)" cookie-name "=([^;]+)"))]
       (when-let [^String value (second (re-find name-regex cookie-string))]
-        (-> value url-decode strip-double-quotes)))))
+        (-> value utils/url-decode strip-double-quotes)))))
 
 (defn remove-cookie
   "Removes the specified cookie"
@@ -61,7 +55,7 @@
   "Inserts the provided name-value pair as a Set-Cookie header in the response"
   [response password name value age-in-seconds]
   (letfn [(add-cookie-into-response [response]
-            (let [encoded-cookie (UrlEncoded/encodeString (encode-cookie value password))
+            (let [encoded-cookie (utils/url-encode (encode-cookie value password))
                   path "/"
                   set-cookie-header (str name "=" encoded-cookie ";Max-Age=" age-in-seconds ";Path=" path ";HttpOnly=true")
                   existing-header (get-in response [:headers "set-cookie"])

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -23,7 +23,6 @@
             [clojure.walk :as walk]
             [comb.template :as template]
             [digest]
-            [plumbing.core :as pc]
             [taoensso.nippy :as nippy]
             [taoensso.nippy.compression :as compression]
             [waiter.util.date-utils :as du])
@@ -33,10 +32,12 @@
            java.lang.Process
            java.net.ServerSocket
            java.nio.ByteBuffer
+           java.nio.charset.Charset
            java.util.UUID
            java.util.concurrent.ThreadLocalRandom
            java.util.regex.Pattern
            javax.servlet.ServletResponse
+           org.eclipse.jetty.util.UrlEncoded
            (org.joda.time DateTime)
            (schema.utils ValidationError)))
 
@@ -544,3 +545,21 @@
   (if (instance? ExceptionInfo e)
     (ex-info (.getMessage e) (update-fn (ex-data e)) (or (.getCause e) e))
     (ex-info (.getMessage e) (update-fn {}) e)))
+
+(defn url-decode
+  "Decode a URL-encoded string.  java.util.URLDecoder is super slow."
+  ([^String string]
+   (when string
+     (UrlEncoded/decodeString string)))
+  ([^String string charset-name]
+   (when string
+     (UrlEncoded/decodeString string 0 (.length string) (Charset/forName charset-name)))))
+
+(defn url-encode
+  "URL-encode a string.  java.util.URLEncoder is super slow."
+  ([^String string]
+   (when string
+     (UrlEncoded/encodeString string)))
+  ([^String string charset-name]
+   (when string
+     (UrlEncoded/encodeString string (Charset/forName charset-name)))))

--- a/waiter/src/waiter/websocket.clj
+++ b/waiter/src/waiter/websocket.clj
@@ -34,8 +34,9 @@
             [waiter.statsd :as statsd]
             [waiter.util.async-utils :as au]
             [waiter.util.http-utils :as hu]
-            [waiter.util.ring-utils :as ru])
-  (:import (java.net HttpCookie SocketTimeoutException URLDecoder URLEncoder)
+            [waiter.util.ring-utils :as ru]
+            [waiter.util.utils :as utils])
+  (:import (java.net HttpCookie SocketTimeoutException)
            (java.nio ByteBuffer)
            (org.eclipse.jetty.websocket.api MessageTooLargeException StatusCode UpgradeRequest)
            (org.eclipse.jetty.websocket.common WebSocketSession)
@@ -56,7 +57,7 @@
                             (seq (.getCookies request)))
           auth-cookie-valid? (and auth-cookie
                                   (-> auth-cookie
-                                      (URLDecoder/decode "UTF-8")
+                                      (utils/url-decode "UTF-8")
                                       (auth/decode-auth-cookie password)
                                       auth/decoded-auth-valid?))]
       (when-not auth-cookie-valid?
@@ -94,7 +95,7 @@
   "Attaches a dummy x-waiter-auth cookie into the request to enable mimic-ing auth in inter-router websocket requests."
   [router-id password ^UpgradeRequest request]
   (let [cookie-value [(str router-id "@waiter-peer-router") (System/currentTimeMillis)]
-        auth-cookie-value (URLEncoder/encode (cookie-support/encode-cookie cookie-value password) "UTF-8")]
+        auth-cookie-value (utils/url-encode (cookie-support/encode-cookie cookie-value password) "UTF-8")]
     (log/info "attaching" auth-cookie-value "to websocket request")
     (-> request
         (.getCookies)

--- a/waiter/test/waiter/async_request_test.clj
+++ b/waiter/test/waiter/async_request_test.clj
@@ -19,8 +19,8 @@
             [clojure.test :refer :all]
             [plumbing.core :as pc]
             [waiter.async-request :refer :all]
-            [waiter.service :as service])
-  (:import java.net.URLDecoder))
+            [waiter.service :as service]
+            [waiter.util.utils :as utils]))
 
 (deftest test-monitor-async-request
   (let [check-interval-ms 10
@@ -331,7 +331,7 @@
                             (when (str/starts-with? (str uri) prefix)
                               (let [route-uri (subs (str uri) (count prefix))
                                     [request-id router-id service-id host port & remaining] (str/split (str route-uri) #"/")
-                                    decode #(URLDecoder/decode %1 "UTF-8")]
+                                    decode #(utils/url-decode %1 "UTF-8")]
                                 {:host (when-not (str/blank? host) host)
                                  :location (when (seq remaining) (str "/" (str/join "/" remaining)))
                                  :port (when-not (str/blank? port) port)

--- a/waiter/test/waiter/cookie_support_test.clj
+++ b/waiter/test/waiter/cookie_support_test.clj
@@ -19,14 +19,9 @@
             [clojure.data.codec.base64 :as b64]
             [clojure.test :refer :all]
             [taoensso.nippy :as nippy]
-            [waiter.cookie-support :refer :all])
-  (:import (clojure.lang ExceptionInfo)
-           org.eclipse.jetty.util.UrlEncoded))
-
-(deftest test-url-decode
-  (is (= "testtest" (url-decode "testtest")))
-  (is (= "test test" (url-decode "test%20test")))
-  (is (nil? (url-decode nil))))
+            [waiter.cookie-support :refer :all]
+            [waiter.util.utils :as utils])
+  (:import (clojure.lang ExceptionInfo)))
 
 (deftest test-cookie-value
   (let [cookie-string "user=john; mode=test; product-name=waiter; special=\"quotes\"abound\""]
@@ -49,7 +44,7 @@
 (deftest test-add-encoded-cookie
   (let [cookie-attrs ";Max-Age=864000;Path=/;HttpOnly=true"
         max-age-sec (-> 10 t/days t/in-seconds)
-        user-cookie (str "user=" (UrlEncoded/encodeString "data:john") cookie-attrs)]
+        user-cookie (str "user=" (utils/url-encode "data:john") cookie-attrs)]
     (with-redefs [b64/encode (fn [^String data-string] (.getBytes data-string))
                   nippy/freeze (fn [input _] (str "data:" input))]
       (is (= {:headers {"set-cookie" user-cookie}}

--- a/waiter/test/waiter/util/utils_test.clj
+++ b/waiter/test/waiter/util/utils_test.clj
@@ -623,3 +623,13 @@
 (deftest test-update-exception
   (is (= {:a 1 :b 2} (ex-data (update-exception (ex-info "test" {:a 1}) #(assoc % :b 2)))))
   (is (= {:b 2} (ex-data (update-exception (RuntimeException. "test") #(assoc % :b 2))))))
+
+(deftest test-url-decode
+  (is (= "testtest" (url-decode "testtest")))
+  (is (= "test test" (url-decode "test%20test")))
+  (is (nil? (url-decode nil))))
+
+(deftest test-url-encode
+  (is (= "testtest" (url-encode "testtest")))
+  (is (= "test%20test" (url-encode "test test")))
+  (is (nil? (url-encode nil))))

--- a/waiter/test/waiter/websocket_test.clj
+++ b/waiter/test/waiter/websocket_test.clj
@@ -21,8 +21,9 @@
             [waiter.cookie-support :as cs]
             [waiter.correlation-id :as cid]
             [waiter.test-helpers]
+            [waiter.util.utils :as utils]
             [waiter.websocket :refer :all])
-  (:import (java.net HttpCookie SocketTimeoutException URLDecoder)
+  (:import (java.net HttpCookie SocketTimeoutException)
            (java.util ArrayList Collection)
            (org.eclipse.jetty.websocket.api MessageTooLargeException UpgradeRequest)
            (org.eclipse.jetty.websocket.client ClientUpgradeRequest)
@@ -166,7 +167,7 @@
                                     (when (= auth/AUTH-COOKIE-NAME (.getName cookie))
                                       (.getValue cookie)))
                                   cookie-list)
-          decoded-auth-value (cs/decode-cookie (URLDecoder/decode auth-cookie-value) password)]
+          decoded-auth-value (cs/decode-cookie (utils/url-decode auth-cookie-value) password)]
       (is (= 1 (count cookie-list)))
       (is auth-cookie-value)
       (is (= 2 (count decoded-auth-value)))


### PR DESCRIPTION
## Changes proposed in this PR

- remove usage of java.util.URLDecoder and java.util.URLEncoder
- refactor url de/encoding to utils

## Why are we making these changes?

We have two ways to url de/encode: java.util.URLDecoder and org.eclipse.jetty.util.UrlEncoded

Just use the jetty one, since it should be faster

see: https://github.com/twosigma/waiter/issues/842
