### PR TITLE
courier: adds support for client-side cancellations and deadlines

### DIFF
--- a/containers/test-apps/courier/pom.xml
+++ b/containers/test-apps/courier/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>twosigma</groupId>
     <artifactId>courier</artifactId>
-    <version>1.4.6</version>
+    <version>1.5.9</version>
 
     <name>courier</name>
     <url>https://github.com/twosigma/waiter/tree/master/test-apps/courier</url>

--- a/containers/test-apps/courier/src/main/java/com/twosigma/waiter/courier/GrpcClient.java
+++ b/containers/test-apps/courier/src/main/java/com/twosigma/waiter/courier/GrpcClient.java
@@ -20,6 +20,7 @@ import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
+import io.grpc.Context;
 import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
 import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
 import io.grpc.ManagedChannel;
@@ -28,6 +29,8 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
 import io.grpc.stub.MetadataUtils;
 import io.grpc.stub.StreamObserver;
 
@@ -68,6 +71,54 @@ public class GrpcClient {
         public Status status() {
             return status;
         }
+    }
+
+    public enum CancellationPolicy {
+
+        CONTEXT() {
+            @Override
+            public void apply(
+                final Context.CancellableContext cancellableContext,
+                final ClientCallStreamObserver<?> observer,
+                final String message) {
+                cancellableContext.cancel(new RuntimeException(message));
+            }
+        },
+        EXCEPTION() {
+            @Override
+            public void apply(final Context.CancellableContext cancellableContext,
+                              final ClientCallStreamObserver<?> observer,
+                              final String message) {
+                throw new CancellationException(message);
+            }
+        },
+        NONE() {
+            @Override
+            public void apply(final Context.CancellableContext cancellableContext,
+                              final ClientCallStreamObserver<?> observer,
+                              final String message) {
+                // do nothing
+            }
+        },
+        OBSERVER() {
+            @Override
+            public void apply(final Context.CancellableContext cancellableContext,
+                              final ClientCallStreamObserver<?> observer,
+                              final String message) {
+                if (observer == null) {
+                    throw new IllegalStateException("Cannot cancel when stream observer is missing!");
+                } else {
+                    final StatusRuntimeException error = Status.CANCELLED
+                        .withDescription("Observer: " + message)
+                        .asRuntimeException();
+                    observer.cancel(message, error);
+                }
+            }
+        };
+
+        public abstract void apply(final Context.CancellableContext cancellableContext,
+                                   final ClientCallStreamObserver<?> observer,
+                                   final String message);
     }
 
     private static Variant retrieveVariant(final String id) {
@@ -165,10 +216,8 @@ public class GrpcClient {
         });
     }
 
-    public RpcResult<CourierReply> sendPackage(final Map<String, Object> headers,
-                                               final String id,
-                                               final String from,
-                                               final String message) {
+    public RpcResult<StateReply> retrieveState(final Map<String, Object> headers,
+                                               final String correlationId) {
         final ManagedChannel channel = initializeChannel();
 
         try {
@@ -178,6 +227,60 @@ public class GrpcClient {
             final CourierGrpc.CourierFutureStub rawStub = CourierGrpc.newFutureStub(wrappedChannel);
             final CourierGrpc.CourierFutureStub futureStub = MetadataUtils.attachHeaders(rawStub, headerMetadata);
 
+            logFunction.apply("will try to retrieve state for " + correlationId + " ...");
+            final StateRequest request = StateRequest
+                .newBuilder()
+                .setCid(correlationId)
+                .build();
+
+            final AtomicReference<Status> status = new AtomicReference<>();
+            final AtomicReference<StateReply> response = new AtomicReference<>();
+            try {
+                final StateReply reply = futureStub.retrieveState(request).get();
+                status.set(Status.OK);
+                response.set(reply);
+            } catch (final StatusRuntimeException ex) {
+                final Status errorStatus = ex.getStatus();
+                logFunction.apply("RPC failed, status: " + errorStatus);
+                status.set(errorStatus);
+            } catch (final ExecutionException ex) {
+                final Status errorStatus = Status.fromThrowable(ex.getCause());
+                logFunction.apply("RPC execution failed: " + errorStatus);
+                status.set(errorStatus);
+            } catch (final Throwable th) {
+                logFunction.apply("RPC failed, message: " + th.getMessage());
+                status.set(Status.UNKNOWN.withDescription(th.getMessage()));
+            }
+
+            if (response.get() != null) {
+                final StateReply reply = response.get();
+                logFunction.apply("received response StateReply{" +
+                    "cid=" + reply.getCid() + ", " +
+                    "response=" + reply.getStateList() + "}");
+            }
+            return new RpcResult<>(response.get(), status.get());
+
+        } finally {
+            shutdownChannel(channel);
+        }
+    }
+
+    public RpcResult<CourierReply> sendPackage(final Map<String, Object> headers,
+                                               final String id,
+                                               final String from,
+                                               final String message,
+                                               final long sleepDurationMillis,
+                                               final long deadlineDurationMillis) {
+        final ManagedChannel channel = initializeChannel();
+
+        try {
+            final Channel wrappedChannel = wrapResponseLogger(channel);
+            final Metadata headerMetadata = createRequestHeadersMetadata(headers);
+
+            final CourierGrpc.CourierFutureStub rawStub =
+                CourierGrpc.newFutureStub(wrappedChannel).withDeadlineAfter(deadlineDurationMillis, TimeUnit.MILLISECONDS);
+            final CourierGrpc.CourierFutureStub futureStub = MetadataUtils.attachHeaders(rawStub, headerMetadata);
+
             logFunction.apply("will try to send package from " + from + " ...");
             final CourierRequest request = CourierRequest
                 .newBuilder()
@@ -185,6 +288,7 @@ public class GrpcClient {
                 .setFrom(from)
                 .setMessage(message)
                 .setVariant(retrieveVariant(id))
+                .setSleepDurationMillis(sleepDurationMillis)
                 .build();
 
             final AtomicReference<Status> status = new AtomicReference<>();
@@ -206,15 +310,15 @@ public class GrpcClient {
                 status.set(Status.UNKNOWN.withDescription(th.getMessage()));
             }
 
-            if (response.get() != null) {
-                final CourierReply reply = response.get();
+            final CourierReply reply = response.get();
+            if (reply != null) {
                 logFunction.apply("received response CourierReply{" +
                     "id=" + reply.getId() + ", " +
                     "response=" + reply.getResponse() + ", " +
                     "message.length=" + reply.getMessage().length() + "}");
                 logFunction.apply("messages equal = " + message.equals(reply.getMessage()));
             }
-            return new RpcResult<>(response.get(), status.get());
+            return new RpcResult<>(reply, status.get());
 
         } finally {
             shutdownChannel(channel);
@@ -227,10 +331,13 @@ public class GrpcClient {
                                                            final List<String> messages,
                                                            final int interMessageSleepMs,
                                                            final boolean lockStepMode,
-                                                           final int cancelThreshold) {
+                                                           final int cancelThreshold,
+                                                           final CancellationPolicy cancellationPolicy,
+                                                           final long deadlineDurationMillis) {
         final ManagedChannel channel = initializeChannel();
         final AtomicBoolean awaitChannelTermination = new AtomicBoolean(true);
 
+        final Context.CancellableContext cancellableContext = Context.current().withCancellation();
         try {
             final Semaphore lockStep = new Semaphore(1);
             final AtomicBoolean errorSignal = new AtomicBoolean(false);
@@ -238,112 +345,130 @@ public class GrpcClient {
             final Channel wrappedChannel = wrapResponseLogger(channel);
             final Metadata headerMetadata = createRequestHeadersMetadata(headers);
 
-            final CourierGrpc.CourierStub rawStub = CourierGrpc.newStub(wrappedChannel);
+            final CourierGrpc.CourierStub rawStub =
+                CourierGrpc.newStub(wrappedChannel).withDeadlineAfter(deadlineDurationMillis, TimeUnit.MILLISECONDS);
             final CourierGrpc.CourierStub futureStub = MetadataUtils.attachHeaders(rawStub, headerMetadata);
 
             logFunction.apply("will try to send package from " + from + " ...");
 
+            final AtomicReference<ClientCallStreamObserver> observer = new AtomicReference<>();
             final AtomicReference<Status> status = new AtomicReference<>();
             final AtomicReference<List<CourierSummary>> response = new AtomicReference<>();
 
-            final CompletableFuture<List<CourierSummary>> responsePromise = new CompletableFuture<>();
-            try {
-                final StreamObserver<CourierRequest> collector =
-                    futureStub.collectPackages(new StreamObserver<CourierSummary>() {
+            cancellableContext.run(() -> {
+                final CompletableFuture<List<CourierSummary>> responsePromise = new CompletableFuture<>();
+                try {
+                    final List<CourierSummary> resultList = new ArrayList<>();
 
-                        final List<CourierSummary> resultList = new ArrayList<>();
+                    final StreamObserver<CourierRequest> collector =
+                        futureStub.collectPackages(new ClientResponseObserver<CourierRequest, CourierSummary>() {
 
-                        @Override
-                        public void onNext(final CourierSummary response) {
-                            logFunction.apply("received response CourierSummary{" +
-                                "count=" + response.getNumMessages() + ", " +
-                                "length=" + response.getTotalLength() + "}");
-                            resultList.add(response);
+                            @Override
+                            public void beforeStart(final ClientCallStreamObserver<CourierRequest> requestStream) {
+                                observer.set(requestStream);
+                            }
+
+                            @Override
+                            public void onNext(final CourierSummary response) {
+                                logFunction.apply("received response CourierSummary{" +
+                                    "count=" + response.getNumMessages() + ", " +
+                                    "length=" + response.getTotalLength() + "}");
+                                resultList.add(response);
+                                if (lockStepMode) {
+                                    logFunction.apply("releasing semaphore after receiving response");
+                                    lockStep.release();
+                                }
+                            }
+
+                            @Override
+                            public void onError(final Throwable th) {
+                                logFunction.apply("error in collecting summaries " + th);
+                                errorSignal.compareAndSet(false, true);
+                                if (lockStepMode) {
+                                    logFunction.apply("releasing semaphore after receiving error");
+                                    lockStep.release();
+                                }
+                                if (th instanceof StatusRuntimeException) {
+                                    final StatusRuntimeException exception = (StatusRuntimeException) th;
+                                    status.set(exception.getStatus());
+                                } else {
+                                    status.set(Status.UNKNOWN.withDescription(th.getMessage()));
+                                }
+                                resolveResponsePromise();
+                            }
+
+                            @Override
+                            public void onCompleted() {
+                                logFunction.apply("completed collecting summaries");
+                                status.set(Status.OK);
+                                resolveResponsePromise();
+                            }
+
+                            private void resolveResponsePromise() {
+                                logFunction.apply("client result has " + resultList.size() + " entries");
+                                responsePromise.complete(resultList);
+                            }
+                        });
+
+                    try {
+                        for (int i = 0; i < messages.size(); i++) {
+                            if (i >= cancelThreshold) {
+                                logFunction.apply("cancelling sending messages");
+                                awaitChannelTermination.set(false);
+
+                                final String cancellationMessage = "Cancel threshold reached: " + cancelThreshold + " -> " + cancellationPolicy;
+                                cancellationPolicy.apply(cancellableContext, observer.get(), cancellationMessage);
+                            }
+                            if (errorSignal.get()) {
+                                logFunction.apply("aborting sending messages as error was discovered");
+                                break;
+                            }
+                            final String requestId = ids.get(i);
                             if (lockStepMode) {
-                                logFunction.apply("releasing semaphore after receiving response");
-                                lockStep.release();
+                                logFunction.apply("acquiring semaphore before sending request " + requestId);
+                                lockStep.acquire();
                             }
+                            final CourierRequest request = CourierRequest
+                                .newBuilder()
+                                .setId(requestId)
+                                .setFrom(from)
+                                .setMessage(messages.get(i))
+                                .setVariant(retrieveVariant(requestId))
+                                .build();
+                            logFunction.apply("sending message CourierRequest{" +
+                                "id=" + request.getId() + ", " +
+                                "from=" + request.getFrom() + ", " +
+                                "message.length=" + request.getMessage().length() + "}");
+                            collector.onNext(request);
+                            Thread.sleep(interMessageSleepMs);
                         }
-
-                        @Override
-                        public void onError(final Throwable th) {
-                            logFunction.apply("error in collecting summaries " + th);
-                            errorSignal.compareAndSet(false, true);
-                            if (lockStepMode) {
-                                logFunction.apply("releasing semaphore after receiving error");
-                                lockStep.release();
-                            }
-                            if (th instanceof StatusRuntimeException) {
-                                final StatusRuntimeException exception = (StatusRuntimeException) th;
-                                status.set(exception.getStatus());
-                            } else {
-                                status.set(Status.UNKNOWN.withDescription(th.getMessage()));
-                            }
-                            resolveResponsePromise();
-                        }
-
-                        @Override
-                        public void onCompleted() {
-                            logFunction.apply("completed collecting summaries");
-                            status.set(Status.OK);
-                            resolveResponsePromise();
-                        }
-
-                        private void resolveResponsePromise() {
-                            logFunction.apply("client result has " + resultList.size() + " entries");
-                            responsePromise.complete(resultList);
-                        }
-                    });
-
-                for (int i = 0; i < messages.size(); i++) {
-                    if (i >= cancelThreshold) {
-                        logFunction.apply("cancelling sending messages");
-                        awaitChannelTermination.set(false);
-                        throw new CancellationException("Cancel threshold reached: " + cancelThreshold);
+                        logFunction.apply("completed sending packages");
+                        collector.onCompleted();
+                    } catch (final Throwable th) {
+                        logFunction.apply("client threw exception, result has " + resultList.size() + " entries");
+                        Thread.sleep(interMessageSleepMs);
+                        responsePromise.complete(resultList);
+                        throw th;
+                    } finally {
+                        response.set(responsePromise.get());
                     }
-                    if (errorSignal.get()) {
-                        logFunction.apply("aborting sending messages as error was discovered");
-                        break;
-                    }
-                    final String requestId = ids.get(i);
-                    if (lockStepMode) {
-                        logFunction.apply("acquiring semaphore before sending request " + requestId);
-                        lockStep.acquire();
-                    }
-                    final CourierRequest request = CourierRequest
-                        .newBuilder()
-                        .setId(requestId)
-                        .setFrom(from)
-                        .setMessage(messages.get(i))
-                        .setVariant(retrieveVariant(requestId))
-                        .build();
-                    logFunction.apply("sending message CourierRequest{" +
-                        "id=" + request.getId() + ", " +
-                        "from=" + request.getFrom() + ", " +
-                        "message.length=" + request.getMessage().length() + "}");
-                    collector.onNext(request);
-                    Thread.sleep(interMessageSleepMs);
+                } catch (final StatusRuntimeException ex) {
+                    logFunction.apply("RPC failed, status: " + ex.getStatus());
+                    status.set(ex.getStatus());
+                } catch (final Exception ex) {
+                    logFunction.apply("RPC failed, message: " + ex.getMessage());
+                    status.set(Status.UNKNOWN.withDescription(ex.getMessage()));
                 }
-                logFunction.apply("completed sending packages");
-                collector.onCompleted();
-
-                response.set(responsePromise.get());
-            } catch (final StatusRuntimeException ex) {
-                logFunction.apply("RPC failed, status: " + ex.getStatus());
-                status.set(ex.getStatus());
-            } catch (final Exception ex) {
-                logFunction.apply("RPC failed, message: " + ex.getMessage());
-                status.set(Status.UNKNOWN.withDescription(ex.getMessage()));
-            }
+            });
 
             return new RpcResult<>(response.get(), status.get());
-
         } finally {
             if (awaitChannelTermination.get()) {
                 shutdownChannel(channel);
             } else {
                 channel.shutdownNow();
             }
+            cancellableContext.cancel(null);
         }
     }
 
@@ -352,100 +477,113 @@ public class GrpcClient {
                                                        final String from,
                                                        final List<String> messages,
                                                        final int interMessageSleepMs,
-                                                       final int cancelThreshold) {
+                                                       final int cancelThreshold,
+                                                       final CancellationPolicy cancellationPolicy,
+                                                       final long deadlineDurationMillis) {
         final ManagedChannel channel = initializeChannel();
         final AtomicBoolean awaitChannelTermination = new AtomicBoolean(true);
 
+        final Context.CancellableContext cancellableContext = Context.current().withCancellation();
         try {
             final AtomicBoolean errorSignal = new AtomicBoolean(false);
 
             final Channel wrappedChannel = wrapResponseLogger(channel);
             final Metadata headerMetadata = createRequestHeadersMetadata(headers);
 
-            final CourierGrpc.CourierStub rawStub = CourierGrpc.newStub(wrappedChannel);
+            final CourierGrpc.CourierStub rawStub =
+                CourierGrpc.newStub(wrappedChannel).withDeadlineAfter(deadlineDurationMillis, TimeUnit.MILLISECONDS);
             final CourierGrpc.CourierStub futureStub = MetadataUtils.attachHeaders(rawStub, headerMetadata);
 
-            logFunction.apply("will try to agggreate package from " + from + " ...");
+            logFunction.apply("will try to aggregate package from " + from + " ...");
 
+            final AtomicReference<ClientCallStreamObserver> observer = new AtomicReference<>();
             final AtomicReference<Status> status = new AtomicReference<>();
             final AtomicReference<CourierSummary> response = new AtomicReference<>();
 
-            final CompletableFuture<CourierSummary> responsePromise = new CompletableFuture<>();
-            try {
-                final StreamObserver<CourierRequest> collector =
-                    futureStub.aggregatePackages(new StreamObserver<CourierSummary>() {
+            cancellableContext.run(() -> {
+                final CompletableFuture<CourierSummary> responsePromise = new CompletableFuture<>();
+                try {
+                    final StreamObserver<CourierRequest> collector =
+                        futureStub.aggregatePackages(new ClientResponseObserver<CourierRequest, CourierSummary>() {
 
-                        @Override
-                        public void onNext(final CourierSummary summary) {
-                            logFunction.apply("received response CourierSummary{" +
-                                "count=" + summary.getNumMessages() + ", " +
-                                "length=" + summary.getTotalLength() + "}");
-                            response.set(summary);
-                        }
-
-                        @Override
-                        public void onError(final Throwable th) {
-                            logFunction.apply("error in aggregating summaries " + th);
-                            errorSignal.compareAndSet(false, true);
-                            if (th instanceof StatusRuntimeException) {
-                                final StatusRuntimeException exception = (StatusRuntimeException) th;
-                                status.set(exception.getStatus());
-                            } else {
-                                status.set(Status.UNKNOWN.withDescription(th.getMessage()));
+                            @Override
+                            public void beforeStart(final ClientCallStreamObserver<CourierRequest> requestStream) {
+                                observer.set(requestStream);
                             }
-                            resolveResponsePromise();
-                        }
 
-                        @Override
-                        public void onCompleted() {
-                            logFunction.apply("completed aggregating summaries");
-                            status.set(Status.OK);
-                            resolveResponsePromise();
-                        }
+                            @Override
+                            public void onNext(final CourierSummary summary) {
+                                logFunction.apply("received response CourierSummary{" +
+                                    "count=" + summary.getNumMessages() + ", " +
+                                    "length=" + summary.getTotalLength() + "}");
+                                response.set(summary);
+                            }
 
-                        private void resolveResponsePromise() {
-                            final CourierSummary courierSummary = response.get();
-                            logFunction.apply("client result: " + courierSummary);
-                            responsePromise.complete(courierSummary);
-                        }
-                    });
+                            @Override
+                            public void onError(final Throwable th) {
+                                logFunction.apply("error in aggregating summaries " + th);
+                                errorSignal.compareAndSet(false, true);
+                                if (th instanceof StatusRuntimeException) {
+                                    final StatusRuntimeException exception = (StatusRuntimeException) th;
+                                    status.set(exception.getStatus());
+                                } else {
+                                    status.set(Status.UNKNOWN.withDescription(th.getMessage()));
+                                }
+                                resolveResponsePromise();
+                            }
 
-                for (int i = 0; i < messages.size(); i++) {
-                    if (i >= cancelThreshold) {
-                        logFunction.apply("cancelling sending messages");
-                        awaitChannelTermination.set(false);
-                        throw new CancellationException("Cancel threshold reached: " + cancelThreshold);
+                            @Override
+                            public void onCompleted() {
+                                logFunction.apply("completed aggregating summaries");
+                                status.set(Status.OK);
+                                resolveResponsePromise();
+                            }
+
+                            private void resolveResponsePromise() {
+                                final CourierSummary courierSummary = response.get();
+                                logFunction.apply("client result: " + courierSummary);
+                                responsePromise.complete(courierSummary);
+                            }
+                        });
+
+                    for (int i = 0; i < messages.size(); i++) {
+                        if (i >= cancelThreshold) {
+                            logFunction.apply("cancelling sending messages");
+                            awaitChannelTermination.set(false);
+                            final String cancellationMessage = "Cancel threshold reached: " + cancelThreshold + " -> " + cancellationPolicy;
+                            cancellationPolicy.apply(cancellableContext, observer.get(), cancellationMessage);
+                        }
+                        if (errorSignal.get()) {
+                            logFunction.apply("aborting sending messages as error was discovered");
+                            break;
+                        }
+                        final String requestId = ids.get(i);
+                        final CourierRequest request = CourierRequest
+                            .newBuilder()
+                            .setId(requestId)
+                            .setFrom(from)
+                            .setMessage(messages.get(i))
+                            .setVariant(retrieveVariant(requestId))
+                            .build();
+                        logFunction.apply("sending message CourierRequest{" +
+                            "id=" + request.getId() + ", " +
+                            "from=" + request.getFrom() + ", " +
+                            "message.length=" + request.getMessage().length() + "}");
+                        collector.onNext(request);
+                        Thread.sleep(interMessageSleepMs);
                     }
-                    if (errorSignal.get()) {
-                        logFunction.apply("aborting sending messages as error was discovered");
-                        break;
-                    }
-                    final String requestId = ids.get(i);
-                    final CourierRequest request = CourierRequest
-                        .newBuilder()
-                        .setId(requestId)
-                        .setFrom(from)
-                        .setMessage(messages.get(i))
-                        .setVariant(retrieveVariant(requestId))
-                        .build();
-                    logFunction.apply("sending message CourierRequest{" +
-                        "id=" + request.getId() + ", " +
-                        "from=" + request.getFrom() + ", " +
-                        "message.length=" + request.getMessage().length() + "}");
-                    collector.onNext(request);
-                    Thread.sleep(interMessageSleepMs);
+                    logFunction.apply("completed sending packages");
+                    collector.onCompleted();
+
+                    responsePromise.get();
+                } catch (final StatusRuntimeException ex) {
+                    logFunction.apply("RPC failed, status: " + ex.getStatus());
+                    status.set(ex.getStatus());
+                } catch (final Exception ex) {
+                    logFunction.apply("RPC failed, message: " + ex.getMessage());
+                    status.set(Status.UNKNOWN.withDescription(ex.getMessage()));
                 }
-                logFunction.apply("completed sending packages");
-                collector.onCompleted();
-
-                responsePromise.get();
-            } catch (final StatusRuntimeException ex) {
-                logFunction.apply("RPC failed, status: " + ex.getStatus());
-                status.set(ex.getStatus());
-            } catch (final Exception ex) {
-                logFunction.apply("RPC failed, message: " + ex.getMessage());
-                status.set(Status.UNKNOWN.withDescription(ex.getMessage()));
-            }
+            });
 
             return new RpcResult<>(response.get(), status.get());
 
@@ -455,6 +593,8 @@ public class GrpcClient {
             } else {
                 channel.shutdownNow();
             }
+            logFunction.apply("close the context and trigger notification of listeners");
+            cancellableContext.cancel(null);
         }
     }
 
@@ -464,22 +604,85 @@ public class GrpcClient {
      */
     public static void main(final String... args) throws Exception {
         /* Access a service running on the local machine on port 8080 */
-        final String host = "localhost";
-        final int port = 8080;
+        final String host = args.length > 0 ? args[0] : "localhost";
+        final int port = args.length > 1 ? Integer.parseInt(args[1]) : 8080;
+        final String methodName = args.length > 2 ? args[2] : "runCollectPackagesClientCancelObserver";
+        final String correlationId = args.length > 3 ? args[3] : ("courier-request-" + System.nanoTime());
+
+        System.out.println("host = " + host);
+        System.out.println("port = " + port);
+        System.out.println("correlationId = " + correlationId);
+        System.out.println("methodName = " + methodName);
+
+        LoggingConfig.initializeLogging();
+
         final GrpcClient client = new GrpcClient(host, port);
 
-        // runSendPackageSuccess(client);
-        // runSendPackageSendError(client);
-        // runCollectPackagesSuccess(client);
-        // runCollectPackagesSendError(client);
-        // runCollectPackagesExitPreResponse(client);
-        // runCollectPackagesExitPostResponse(client);
-        // runAggregatePackagesSuccess(client);
-        // runAggregatePackagesSendError(client);
-        // runAggregatePackagesExitPreResponse(client);
+        // avoid reflection, and explicitly reference method names to keep unused tracker happy
+        switch (methodName) {
+            case "runAggregatePackagesClientContext":
+                runAggregatePackagesClientContext(client, correlationId);
+                break;
+            case "runAggregatePackagesClientCancelException":
+                runAggregatePackagesClientCancelException(client, correlationId);
+                break;
+            case "runAggregatePackagesClientCancelObserver":
+                runAggregatePackagesClientCancelObserver(client, correlationId);
+                break;
+            case "runAggregatePackagesExitPreResponse":
+                runAggregatePackagesExitPreResponse(client, correlationId);
+                break;
+            case "runAggregatePackagesSendError":
+                runAggregatePackagesSendError(client, correlationId);
+                break;
+            case "runAggregatePackagesSuccess":
+                runAggregatePackagesSuccess(client, correlationId);
+                break;
+            case "runCollectPackagesClientCancelContext":
+                runCollectPackagesClientCancelContext(client, correlationId);
+                break;
+            case "runCollectPackagesClientCancelException":
+                runCollectPackagesClientCancelException(client, correlationId);
+                break;
+            case "runCollectPackagesClientCancelObserver":
+                runCollectPackagesClientCancelObserver(client, correlationId);
+                break;
+            case "runCollectPackagesExitPostResponse":
+                runCollectPackagesExitPostResponse(client, correlationId);
+                break;
+            case "runCollectPackagesExitPreResponse":
+                runCollectPackagesExitPreResponse(client, correlationId);
+                break;
+            case "runCollectPackagesSendError":
+                runCollectPackagesSendError(client, correlationId);
+                break;
+            case "runCollectPackagesSuccess":
+                runCollectPackagesSuccess(client, correlationId);
+                break;
+            case "runSendPackageSendError":
+                runSendPackageSendError(client, correlationId);
+                break;
+            case "runSendPackageSuccess":
+                runSendPackageSuccess(client, correlationId);
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported method: " + methodName);
+        }
     }
 
-    private static void runSendPackageSuccess(final GrpcClient client) {
+    private static void retrieveStateForCid(final GrpcClient client,
+                                            final Map<String, Object> headers,
+                                            final String correlationId) {
+        final String retrieveCid = "cid-retrieve-state." + System.currentTimeMillis();
+        headers.put("x-cid", retrieveCid);
+        final RpcResult<StateReply> rpcStateResult = client.retrieveState(headers, correlationId);
+        final StateReply stateReply = rpcStateResult.result();
+        client.logFunction.apply("retrieveState response = " + stateReply);
+        final Status retrieveStatus = rpcStateResult.status();
+        client.logFunction.apply("retrieveState status = " + retrieveStatus);
+    }
+
+    private static void runSendPackageSuccess(final GrpcClient client, final String correlationId) {
         final String id = UUID.randomUUID().toString();
         final String user = "Jim";
         final StringBuilder sb = new StringBuilder();
@@ -491,15 +694,16 @@ public class GrpcClient {
         }
 
         final HashMap<String, Object> headers = new HashMap<>();
-        headers.put("x-cid", "cid-send-package." + System.currentTimeMillis());
-        final RpcResult<CourierReply> rpcResult = client.sendPackage(headers, id, user, sb.toString());
+        headers.put("x-cid", correlationId);
+        final RpcResult<CourierReply> rpcResult = client.sendPackage(headers, id, user, sb.toString(), 10, 1000);
         final CourierReply courierReply = rpcResult.result();
         client.logFunction.apply("sendPackage response = " + courierReply);
         final Status status = rpcResult.status();
         client.logFunction.apply("sendPackage status = " + status);
+        retrieveStateForCid(client, headers, correlationId);
     }
 
-    private static void runSendPackageSendError(final GrpcClient client) {
+    private static void runSendPackageSendError(final GrpcClient client, final String correlationId) {
         final String id = UUID.randomUUID().toString() + ".SEND_ERROR";
         final String user = "Jim";
         final StringBuilder sb = new StringBuilder();
@@ -511,104 +715,205 @@ public class GrpcClient {
         }
 
         final HashMap<String, Object> headers = new HashMap<>();
-        headers.put("x-cid", "cid-send-package." + System.currentTimeMillis());
-        final RpcResult<CourierReply> rpcResult = client.sendPackage(headers, id, user, sb.toString());
+        headers.put("x-cid", correlationId);
+        final RpcResult<CourierReply> rpcResult = client.sendPackage(headers, id, user, sb.toString(), 10, 1000);
         final CourierReply courierReply = rpcResult.result();
         client.logFunction.apply("sendPackage response = " + courierReply);
         final Status status = rpcResult.status();
         client.logFunction.apply("sendPackage status = " + status);
+        retrieveStateForCid(client, headers, correlationId);
     }
 
-    private static void runCollectPackagesSuccess(final GrpcClient client) {
+    private static void runCollectPackagesSuccess(final GrpcClient client, final String correlationId) {
         final HashMap<String, Object> headers = new HashMap<>();
-        headers.put("x-cid", "cid-collect-packages-success." + System.currentTimeMillis());
+        headers.put("x-cid", correlationId);
         final List<String> ids = IntStream.range(0, 10).mapToObj(i -> "id-" + i).collect(Collectors.toList());
         final List<String> messages = IntStream.range(0, 10).mapToObj(i -> "message-" + i).collect(Collectors.toList());
         final RpcResult<List<CourierSummary>> rpcResult =
-            client.collectPackages(headers, ids, "User", messages, 100, true, messages.size() + 1);
+            client.collectPackages(headers, ids, "User", messages, 100, true,
+                messages.size() + 1, CancellationPolicy.NONE, 10000);
         final List<CourierSummary> courierSummaries = rpcResult.result();
         client.logFunction.apply("collectPackages[success] summary = " + courierSummaries);
         final Status status = rpcResult.status();
         client.logFunction.apply("collectPackages[success] status = " + status);
     }
 
-    private static void runCollectPackagesSendError(final GrpcClient client) {
+    private static void runCollectPackagesClientCancelContext(final GrpcClient client, final String correlationId) {
         final HashMap<String, Object> headers = new HashMap<>();
-        headers.put("x-cid", "cid-collect-packages-server-error." + System.currentTimeMillis());
+        headers.put("x-cid", correlationId);
         final List<String> ids = IntStream.range(0, 10).mapToObj(i -> "id-" + i).collect(Collectors.toList());
         ids.set(5, ids.get(5) + ".SEND_ERROR");
         final List<String> messages = IntStream.range(0, 10).mapToObj(i -> "message-" + i).collect(Collectors.toList());
         final RpcResult<List<CourierSummary>> rpcResult =
-            client.collectPackages(headers, ids, "User", messages, 100, true, messages.size() + 1);
+            client.collectPackages(headers, ids, "User", messages, 100, true,
+                messages.size() / 2, CancellationPolicy.CONTEXT, 10000);
+        final List<CourierSummary> courierSummaries = rpcResult.result();
+        client.logFunction.apply("collectPackages[cancel] summary = " + courierSummaries);
+        final Status status = rpcResult.status();
+        client.logFunction.apply("collectPackages[cancel] status = " + status);
+        retrieveStateForCid(client, headers, correlationId);
+    }
+
+    private static void runCollectPackagesClientCancelException(final GrpcClient client, final String correlationId) {
+        final HashMap<String, Object> headers = new HashMap<>();
+        headers.put("x-cid", correlationId);
+        final List<String> ids = IntStream.range(0, 10).mapToObj(i -> "id-" + i).collect(Collectors.toList());
+        ids.set(5, ids.get(5) + ".SEND_ERROR");
+        final List<String> messages = IntStream.range(0, 10).mapToObj(i -> "message-" + i).collect(Collectors.toList());
+        final RpcResult<List<CourierSummary>> rpcResult =
+            client.collectPackages(headers, ids, "User", messages, 100, true,
+                messages.size() / 2, CancellationPolicy.EXCEPTION, 10000);
+        final List<CourierSummary> courierSummaries = rpcResult.result();
+        client.logFunction.apply("collectPackages[cancel] summary = " + courierSummaries);
+        final Status status = rpcResult.status();
+        client.logFunction.apply("collectPackages[cancel] status = " + status);
+        retrieveStateForCid(client, headers, correlationId);
+    }
+
+    private static void runCollectPackagesClientCancelObserver(final GrpcClient client, final String correlationId) {
+        final HashMap<String, Object> headers = new HashMap<>();
+        headers.put("x-cid", correlationId);
+        final List<String> ids = IntStream.range(0, 10).mapToObj(i -> "id-" + i).collect(Collectors.toList());
+        ids.set(5, ids.get(5) + ".SEND_ERROR");
+        final List<String> messages = IntStream.range(0, 10).mapToObj(i -> "message-" + i).collect(Collectors.toList());
+        final RpcResult<List<CourierSummary>> rpcResult =
+            client.collectPackages(headers, ids, "User", messages, 100, true,
+                messages.size() / 2, CancellationPolicy.OBSERVER, 10000);
+        final List<CourierSummary> courierSummaries = rpcResult.result();
+        client.logFunction.apply("collectPackages[cancel] summary = " + courierSummaries);
+        final Status status = rpcResult.status();
+        client.logFunction.apply("collectPackages[cancel] status = " + status);
+        retrieveStateForCid(client, headers, correlationId);
+    }
+
+    private static void runCollectPackagesSendError(final GrpcClient client, final String correlationId) {
+        final HashMap<String, Object> headers = new HashMap<>();
+        headers.put("x-cid", correlationId);
+        final List<String> ids = IntStream.range(0, 10).mapToObj(i -> "id-" + i).collect(Collectors.toList());
+        ids.set(5, ids.get(5) + ".SEND_ERROR");
+        final List<String> messages = IntStream.range(0, 10).mapToObj(i -> "message-" + i).collect(Collectors.toList());
+        final RpcResult<List<CourierSummary>> rpcResult =
+            client.collectPackages(headers, ids, "User", messages, 100, true,
+                messages.size() + 1, CancellationPolicy.EXCEPTION, 10000);
         final List<CourierSummary> courierSummaries = rpcResult.result();
         client.logFunction.apply("collectPackages[cancel] summary = " + courierSummaries);
         final Status status = rpcResult.status();
         client.logFunction.apply("collectPackages[cancel] status = " + status);
     }
 
-    private static void runCollectPackagesExitPreResponse(final GrpcClient client) {
+    private static void runCollectPackagesExitPreResponse(final GrpcClient client, final String correlationId) {
         final HashMap<String, Object> headers = new HashMap<>();
-        headers.put("x-cid", "cid-collect-packages-server-pre-cancel." + System.currentTimeMillis());
+        headers.put("x-cid", correlationId);
         final List<String> ids = IntStream.range(0, 10).mapToObj(i -> "id-" + i).collect(Collectors.toList());
         ids.set(5, ids.get(5) + ".EXIT_PRE_RESPONSE");
         final List<String> messages = IntStream.range(0, 10).mapToObj(i -> "message-" + i).collect(Collectors.toList());
         final RpcResult<List<CourierSummary>> rpcResult =
-            client.collectPackages(headers, ids, "User", messages, 100, true, messages.size() + 1);
+            client.collectPackages(headers, ids, "User", messages, 100, true,
+                messages.size() + 1, CancellationPolicy.EXCEPTION, 10000);
         final List<CourierSummary> courierSummaries = rpcResult.result();
         client.logFunction.apply("collectPackages[cancel] summary = " + courierSummaries);
         final Status status = rpcResult.status();
         client.logFunction.apply("collectPackages[cancel] status = " + status);
     }
 
-    private static void runCollectPackagesExitPostResponse(final GrpcClient client) {
+    private static void runCollectPackagesExitPostResponse(final GrpcClient client, final String correlationId) {
         final HashMap<String, Object> headers = new HashMap<>();
-        headers.put("x-cid", "cid-collect-packages-server-post-cancel." + System.currentTimeMillis());
+        headers.put("x-cid", correlationId);
         final List<String> ids = IntStream.range(0, 10).mapToObj(i -> "id-" + i).collect(Collectors.toList());
         ids.set(5, ids.get(5) + ".EXIT_POST_RESPONSE");
         final List<String> messages = IntStream.range(0, 10).mapToObj(i -> "message-" + i).collect(Collectors.toList());
         final RpcResult<List<CourierSummary>> rpcResult =
-            client.collectPackages(headers, ids, "User", messages, 100, true, messages.size() + 1);
+            client.collectPackages(headers, ids, "User", messages, 100, true,
+                messages.size() + 1, CancellationPolicy.EXCEPTION, 10000);
         final List<CourierSummary> courierSummaries = rpcResult.result();
         client.logFunction.apply("collectPackages[cancel] summary = " + courierSummaries);
         final Status status = rpcResult.status();
         client.logFunction.apply("collectPackages[cancel] status = " + status);
     }
 
-    private static void runAggregatePackagesSuccess(final GrpcClient client) {
+    private static void runAggregatePackagesSuccess(final GrpcClient client, final String correlationId) {
         final HashMap<String, Object> headers = new HashMap<>();
-        headers.put("x-cid", "cid-aggregate-packages-success." + System.currentTimeMillis());
+        headers.put("x-cid", correlationId);
         final List<String> ids = IntStream.range(0, 10).mapToObj(i -> "id-" + i).collect(Collectors.toList());
         final List<String> messages = IntStream.range(0, 10).mapToObj(i -> "message-" + i).collect(Collectors.toList());
         final RpcResult<CourierSummary> rpcResult =
-            client.aggregatePackages(headers, ids, "User", messages, 100, messages.size() + 1);
+            client.aggregatePackages(headers, ids, "User", messages, 100,
+                messages.size() + 1, CancellationPolicy.EXCEPTION, 10000);
         final CourierSummary courierSummary = rpcResult.result();
         client.logFunction.apply("aggregatePackages[success] summary = " + courierSummary);
         final Status status = rpcResult.status();
         client.logFunction.apply("aggregatePackages[success] status = " + status);
     }
 
-    private static void runAggregatePackagesSendError(final GrpcClient client) {
+    private static void runAggregatePackagesClientContext(final GrpcClient client, final String correlationId) {
         final HashMap<String, Object> headers = new HashMap<>();
-        headers.put("x-cid", "cid-aggregate-packages-server-error." + System.currentTimeMillis());
+        headers.put("x-cid", correlationId);
+        final List<String> ids = IntStream.range(0, 10).mapToObj(i -> "id-" + i).collect(Collectors.toList());
+        final List<String> messages = IntStream.range(0, 10).mapToObj(i -> "message-" + i).collect(Collectors.toList());
+        final RpcResult<CourierSummary> rpcResult =
+            client.aggregatePackages(headers, ids, "User", messages, 100,
+                messages.size() / 2, CancellationPolicy.CONTEXT, 10000);
+        final CourierSummary courierSummary = rpcResult.result();
+        client.logFunction.apply("aggregatePackages[success] summary = " + courierSummary);
+        final Status status = rpcResult.status();
+        client.logFunction.apply("aggregatePackages[success] status = " + status);
+        retrieveStateForCid(client, headers, correlationId);
+    }
+
+    private static void runAggregatePackagesClientCancelException(final GrpcClient client, final String correlationId) {
+        final HashMap<String, Object> headers = new HashMap<>();
+        headers.put("x-cid", correlationId);
+        final List<String> ids = IntStream.range(0, 10).mapToObj(i -> "id-" + i).collect(Collectors.toList());
+        final List<String> messages = IntStream.range(0, 10).mapToObj(i -> "message-" + i).collect(Collectors.toList());
+        final RpcResult<CourierSummary> rpcResult =
+            client.aggregatePackages(headers, ids, "User", messages, 100,
+                messages.size() / 2, CancellationPolicy.EXCEPTION, 10000);
+        final CourierSummary courierSummary = rpcResult.result();
+        client.logFunction.apply("aggregatePackages[success] summary = " + courierSummary);
+        final Status status = rpcResult.status();
+        client.logFunction.apply("aggregatePackages[success] status = " + status);
+        retrieveStateForCid(client, headers, correlationId);
+    }
+
+    private static void runAggregatePackagesClientCancelObserver(final GrpcClient client, final String correlationId) {
+        final HashMap<String, Object> headers = new HashMap<>();
+        headers.put("x-cid", correlationId);
+        final List<String> ids = IntStream.range(0, 10).mapToObj(i -> "id-" + i).collect(Collectors.toList());
+        final List<String> messages = IntStream.range(0, 10).mapToObj(i -> "message-" + i).collect(Collectors.toList());
+        final RpcResult<CourierSummary> rpcResult =
+            client.aggregatePackages(headers, ids, "User", messages, 100,
+                messages.size() / 2, CancellationPolicy.OBSERVER, 10000);
+        final CourierSummary courierSummary = rpcResult.result();
+        client.logFunction.apply("aggregatePackages[success] summary = " + courierSummary);
+        final Status status = rpcResult.status();
+        client.logFunction.apply("aggregatePackages[success] status = " + status);
+        retrieveStateForCid(client, headers, correlationId);
+    }
+
+    private static void runAggregatePackagesSendError(final GrpcClient client, final String correlationId) {
+        final HashMap<String, Object> headers = new HashMap<>();
+        headers.put("x-cid", correlationId);
         final List<String> ids = IntStream.range(0, 10).mapToObj(i -> "id-" + i).collect(Collectors.toList());
         ids.set(5, ids.get(5) + ".SEND_ERROR");
         final List<String> messages = IntStream.range(0, 10).mapToObj(i -> "message-" + i).collect(Collectors.toList());
         final RpcResult<CourierSummary> rpcResult =
-            client.aggregatePackages(headers, ids, "User", messages, 100, messages.size() + 1);
+            client.aggregatePackages(headers, ids, "User", messages, 100,
+                messages.size() + 1, CancellationPolicy.EXCEPTION, 10000);
         final CourierSummary courierSummary = rpcResult.result();
         client.logFunction.apply("aggregatePackages[cancel] summary = " + courierSummary);
         final Status status = rpcResult.status();
         client.logFunction.apply("aggregatePackages[cancel] status = " + status);
     }
 
-    private static void runAggregatePackagesExitPreResponse(final GrpcClient client) {
+    private static void runAggregatePackagesExitPreResponse(final GrpcClient client, final String correlationId) {
         final HashMap<String, Object> headers = new HashMap<>();
-        headers.put("x-cid", "cid-aggregate-packages-server-pre-cancel." + System.currentTimeMillis());
+        headers.put("x-cid", correlationId);
         final List<String> ids = IntStream.range(0, 10).mapToObj(i -> "id-" + i).collect(Collectors.toList());
         ids.set(5, ids.get(5) + ".EXIT_PRE_RESPONSE");
         final List<String> messages = IntStream.range(0, 10).mapToObj(i -> "message-" + i).collect(Collectors.toList());
         final RpcResult<CourierSummary> rpcResult =
-            client.aggregatePackages(headers, ids, "User", messages, 100, messages.size() + 1);
+            client.aggregatePackages(headers, ids, "User", messages, 100,
+                messages.size() + 1, CancellationPolicy.EXCEPTION, 10000);
         final CourierSummary courierSummary = rpcResult.result();
         client.logFunction.apply("aggregatePackages[cancel] summary = " + courierSummary);
         final Status status = rpcResult.status();

--- a/containers/test-apps/courier/src/main/java/com/twosigma/waiter/courier/LoggingConfig.java
+++ b/containers/test-apps/courier/src/main/java/com/twosigma/waiter/courier/LoggingConfig.java
@@ -1,0 +1,37 @@
+package com.twosigma.waiter.courier;
+
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+
+public class LoggingConfig {
+
+    protected static void initializeLogging() {
+        try {
+            // Programmatic configuration
+            System.setProperty(
+                "java.util.logging.SimpleFormatter.format",
+                "%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$-7s (%2$s) %5$s %6$s%n");
+
+            final ConsoleHandler consoleHandler = new ConsoleHandler();
+            consoleHandler.setLevel(Level.FINEST);
+            consoleHandler.setFormatter(new SimpleFormatter());
+
+            final Logger rootLogger = Logger.getLogger("");
+            rootLogger.setLevel(Level.FINEST);
+            rootLogger.addHandler(consoleHandler);
+
+            final Logger opencensusLogger = Logger.getLogger("io.opencensus");
+            opencensusLogger.setLevel(Level.INFO);
+            opencensusLogger.addHandler(consoleHandler);
+
+            final Logger grpcContextLogger = Logger.getLogger("io.grpc.Context");
+            grpcContextLogger.setLevel(Level.INFO);
+            grpcContextLogger.addHandler(consoleHandler);
+        } catch (Exception e) {
+            // The runtime won't show stack traces if the exception is thrown
+            e.printStackTrace();
+        }
+    }
+}

--- a/containers/test-apps/courier/src/main/java/com/twosigma/waiter/courier/Main.java
+++ b/containers/test-apps/courier/src/main/java/com/twosigma/waiter/courier/Main.java
@@ -25,6 +25,9 @@ public class Main {
     public static void main(final String... args) throws Exception {
         final int port0 = args.length > 0 ? Integer.parseInt(args[0]) : 8080;
         final int port1 = args.length > 1 ? Integer.parseInt(args[1]) : 8081;
+
+        LoggingConfig.initializeLogging();
+
         LOGGER.info("gRPC server configured to run on port " + port0);
         LOGGER.info("health-check (http) server configured to run on port " + port1);
 

--- a/containers/test-apps/courier/src/main/proto/courier.proto
+++ b/containers/test-apps/courier/src/main/proto/courier.proto
@@ -29,6 +29,8 @@ service Courier {
     rpc CollectPackages (stream CourierRequest) returns (stream CourierSummary);
     // Processes a stream of messages, returns a unary message
     rpc AggregatePackages (stream CourierRequest) returns (CourierSummary);
+    // Sends summary about a request (identified by a correlation id).
+    rpc RetrieveState (StateRequest) returns (StateReply);
 }
 
 enum Variant {
@@ -43,6 +45,7 @@ message CourierRequest {
     string from = 2;
     string message = 3;
     Variant variant = 4;
+    int64 sleep_duration_millis = 5;
 }
 
 message CourierReply {
@@ -54,4 +57,13 @@ message CourierReply {
 message CourierSummary {
     int64 num_messages = 1;
     int64 total_length = 2;
+}
+
+message StateRequest {
+    string cid = 1;
+}
+
+message StateReply {
+    string cid = 1;
+    repeated string state = 2;
 }


### PR DESCRIPTION

## Changes proposed in this PR

- adds support for grpc request state tracking
- adds support for various client-side cancellations
- adds support for client-side deadlines

## Why are we making these changes?

Adds various grpc capabilities to courier to allow testing for various features while proxying through Waiter.

