### PR TITLE
adds support for grpc-status on waiter generated responses

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -295,10 +295,8 @@
                                 (= status 500) ["13" "Internal Server Error"]
                                 (= status 503) ["14" "Service Unavailable"]
                                 (= status 504) ["4" "Gateway Timeout"])]
-      (let [[grpc-status grpc-message] grpc-status-data
-            grpc-message (if (string? body)
-                           (utils/truncate body 128)
-                           grpc-message)
+      (let [[grpc-status standard-message] grpc-status-data
+            grpc-message (if (string? body) body standard-message)
             trailers-ch (async/promise-chan)
             new-headers (assoc headers
                           "content-type" "application/grpc"

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -595,10 +595,10 @@
    :server-name (pc/fnk [[:settings git-version]] (str "waiter/" (str/join (take 7 git-version))))
    :service-description-builder (pc/fnk [[:settings service-description-builder-config service-description-constraints]]
                                   (when-let [unknown-keys (-> service-description-constraints
-                                                              keys
-                                                              set
-                                                              (set/difference sd/service-parameter-keys)
-                                                              seq)]
+                                                            keys
+                                                            set
+                                                            (set/difference sd/service-parameter-keys)
+                                                            seq)]
                                     (throw (ex-info "Unsupported keys present in the service description constraints"
                                                     {:service-description-constraints service-description-constraints
                                                      :unsupported-keys (-> unknown-keys vec sort)})))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -311,6 +311,8 @@
                                     "grpc-message" grpc-message
                                     "grpc-status" grpc-status)]
             (async/>! trailers-ch new-trailers-data)))
+        ;; when only headers are provided jetty terminates the request with an empty data frame,
+        ;; we work around that limitation by sending trailers that carry the same grpc error message.
         (assoc response
           :headers new-headers
           :trailers trailers-ch))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -292,7 +292,10 @@
     (if-let [grpc-status-data (cond
                                 (= status 400) ["3" "Bad Request"]
                                 (= status 401) ["16" "Unauthorized"]
+                                (= status 403) ["7" "Permission Denied"]
+                                (= status 429) ["14" "Too Many Requests"]
                                 (= status 500) ["13" "Internal Server Error"]
+                                (= status 502) ["14" "Bad Gateway"]
                                 (= status 503) ["14" "Service Unavailable"]
                                 (= status 504) ["4" "Gateway Timeout"])]
       (let [[grpc-status standard-message] grpc-status-data

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -85,6 +85,7 @@
                                        {:ring-handler (-> (core/ring-handler-factory waiter-request?-fn handlers)
                                                           (cors/wrap-cors-preflight cors-validator (:max-age cors-config))
                                                           core/wrap-error-handling
+                                                          (core/wrap-grpc-status server-name)
                                                           (core/wrap-debug generate-log-url-fn)
                                                           rlog/wrap-log
                                                           core/correlation-id-middleware

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -85,7 +85,7 @@
                                        {:ring-handler (-> (core/ring-handler-factory waiter-request?-fn handlers)
                                                           (cors/wrap-cors-preflight cors-validator (:max-age cors-config))
                                                           core/wrap-error-handling
-                                                          (core/wrap-grpc-status server-name)
+                                                          core/wrap-grpc-status
                                                           (core/wrap-debug generate-log-url-fn)
                                                           rlog/wrap-log
                                                           core/correlation-id-middleware

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -252,9 +252,8 @@
     (attach-waiter-source
       {:body (case content-type
                "application/grpc"
-               (-> (or (-> data-map :details :friendly-error-message)
-                       (:message error-context))
-                 (str/replace #"\n" "; "))
+               ;; grpc error responses should not have a body as the client will try to parse it into a proto object
+               nil
                "application/json"
                (json/write-str {:waiter-error error-context}
                                :escape-slash false
@@ -275,6 +274,9 @@
                  (str/replace #"\n  $" "\n")))
        :headers (-> headers
                   (assoc-if-absent "content-type" content-type))
+       :waiter/message (-> (or (-> data-map :details :friendly-error-message)
+                               (:message error-context))
+                         (str/replace #"\n" "; "))
        :status status})))
 
 (defn- wrap-unhandled-exception

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -274,8 +274,9 @@
                  (str/replace #"\n  $" "\n")))
        :headers (-> headers
                   (assoc-if-absent "content-type" content-type))
-       :waiter/message (-> (or (-> data-map :details :friendly-error-message)
-                               (:message error-context))
+       :waiter/message (-> error-context
+                         :message
+                         str
                          (str/replace #"\n" "; "))
        :status status})))
 

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -1494,13 +1494,16 @@
       (is (= (attach-grpc-errors response 16 "Unauthorized")
              (->> response add-grpc-headers-and-trailers load-trailers))))
     (let [response (make-response 403 {"foo" "bar"})]
-      (is (= (load-trailers response)
+      (is (= (attach-grpc-errors response 7 "Permission Denied")
+             (->> response add-grpc-headers-and-trailers load-trailers))))
+    (let [response (make-response 429 nil)]
+      (is (= (attach-grpc-errors response 14 "Too Many Requests")
              (->> response add-grpc-headers-and-trailers load-trailers))))
     (let [response (make-response 500 nil)]
       (is (= (attach-grpc-errors response 13 "Internal Server Error")
              (->> response add-grpc-headers-and-trailers load-trailers))))
     (let [response (make-response 502 {"foo" "bar"})]
-      (is (= (load-trailers response)
+      (is (= (attach-grpc-errors response 14 "Bad Gateway")
              (->> response add-grpc-headers-and-trailers load-trailers))))
     (let [response (make-response 503 nil)]
       (is (= (attach-grpc-errors response 14 "Service Unavailable")

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -1455,3 +1455,75 @@
   (is (= "WS" (request->protocol {:scheme :ws})))
   (is (= "WS" (request->protocol {:headers {} :scheme :ws})))
   (is (= "WS/13" (request->protocol {:headers {"sec-websocket-version" "13"} :scheme :ws}))))
+
+(deftest test-add-grpc-headers-and-trailers
+  (let [server-name "test-server-name"
+        make-response (fn make-response
+                        [status trailers]
+                        (let [trailers-ch (async/promise-chan)]
+                          (when trailers
+                            (async/>!! trailers-ch trailers)
+                            (async/close! trailers-ch))
+                          (cond-> {:headers {"server" server-name}
+                                   :status status}
+                            trailers (assoc :trailers trailers-ch))))
+        load-trailers (fn load-trailers [{:keys [trailers] :as response}]
+                        (cond-> response
+                          trailers (update :trailers async/<!!)))
+        attach-grpc-errors (fn attach-grpc-errors [response grpc-status grpc-message]
+                             (-> response
+                               load-trailers
+                               (update :headers assoc
+                                       "content-type" "application/grpc"
+                                       "grpc-message" grpc-message
+                                       "grpc-status" (str grpc-status))
+                               (update :trailers assoc
+                                       "grpc-message" grpc-message
+                                       "grpc-status" (str grpc-status))))]
+    (let [response (make-response 200 nil)]
+      (is (= response (->> response (add-grpc-headers-and-trailers server-name) load-trailers))))
+    (let [response (make-response 200 {"foo" "bar"})]
+      (is (= (load-trailers response)
+             (->> response (add-grpc-headers-and-trailers server-name) load-trailers))))
+    (let [response (make-response 301 {"foo" "bar"})]
+      (is (= (load-trailers response)
+             (->> response (add-grpc-headers-and-trailers server-name) load-trailers))))
+    (let [response (make-response 400 nil)]
+      (is (= (attach-grpc-errors response 3 "Bad Request")
+             (->> response (add-grpc-headers-and-trailers server-name) load-trailers))))
+    (let [response (make-response 401 nil)]
+      (is (= (attach-grpc-errors response 16 "Unauthorized")
+             (->> response (add-grpc-headers-and-trailers server-name) load-trailers))))
+    (let [response (make-response 403 {"foo" "bar"})]
+      (is (= (load-trailers response)
+             (->> response (add-grpc-headers-and-trailers server-name) load-trailers))))
+    (let [response (make-response 500 nil)]
+      (is (= (attach-grpc-errors response 13 "Internal Server Error")
+             (->> response (add-grpc-headers-and-trailers server-name) load-trailers))))
+    (let [response (make-response 502 {"foo" "bar"})]
+      (is (= (load-trailers response)
+             (->> response (add-grpc-headers-and-trailers server-name) load-trailers))))
+    (let [response (make-response 503 nil)]
+      (is (= (attach-grpc-errors response 14 "Service Unavailable")
+             (->> response (add-grpc-headers-and-trailers server-name) load-trailers))))
+    (let [response (make-response 504 nil)]
+      (is (= (attach-grpc-errors response 4 "Gateway Timeout")
+             (->> response (add-grpc-headers-and-trailers server-name) load-trailers))))))
+
+(deftest test-wrap-grpc-status
+  (let [server-name "test-server-name"
+        standard-response {:body "hello" :status 200}
+        handler (constantly standard-response)
+        test-handler (wrap-grpc-status handler server-name)]
+    (with-redefs [add-grpc-headers-and-trailers (fn [_ response]
+                                                  (assoc response :add-grpc-headers-and-trailers true))]
+      (testing "non-grpc request"
+        (is (= standard-response (test-handler {:headers {}})))
+        (is (= standard-response (test-handler {:headers {"content-type" "application/xml"}})))
+        (is (= standard-response (test-handler {:client-protocol "HTTP/1.1"
+                                                :headers {"content-type" "application/grpc"}}))))
+
+      (testing "grpc request"
+        (is (= (assoc standard-response :add-grpc-headers-and-trailers true)
+               (test-handler {:client-protocol "HTTP/2.0"
+                              :headers {"content-type" "application/grpc"}})))))))


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for grpc-status on waiter generated responses

## Why are we making these changes?

Provide additional information to the GRPC clients when available on Waiter responses.

