### PR TITLE
truncates authorization and cookie values in kitchen request-info response

### DIFF
--- a/containers/test-apps/kitchen/bin/kitchen
+++ b/containers/test-apps/kitchen/bin/kitchen
@@ -123,7 +123,10 @@ def gzip_compress(in_data):
 
 def truncate(in_string, truncate_length):
     "Collapse and truncate the given text to the given length."
-    return in_string[:truncate_length] + (in_string[truncate_length:] and '...')
+    if len(in_string) > truncate_length:
+        return in_string[:truncate_length] + '...'
+    else:
+        return in_string
 
 
 class LoggerMixin():
@@ -952,14 +955,13 @@ class Kitchen(HTTPWebSocketsHandler):
         if len(self.headers) > 0:
             info['headers'] = { k.lower(): v for k, v in self.headers.items() }
 
-            cookie_value = info['headers'].get('authorization', None)
-            if cookie_value is not None:
-                info['headers']['authorization'] = truncate(cookie_value, 15)
+            authorization_value = info['headers'].get('authorization')
+            if authorization_value is not None:
+                info['headers']['authorization'] = truncate(authorization_value, 15)
 
-            cookie_value = info['headers'].get('cookie', None)
+            cookie_value = info['headers'].get('cookie')
             if cookie_value is not None:
-                cookie_entries = [e for e in cookie_value.split(';') if e]
-                info['headers']['cookie'] = [truncate(v, 25) for v in cookie_entries]
+                info['headers']['cookie'] = [truncate(v, 25) for v in cookie_value.split(';') if v]
 
         if self.__query is not None:
             info['query-string'] = self.__query

--- a/containers/test-apps/kitchen/bin/kitchen
+++ b/containers/test-apps/kitchen/bin/kitchen
@@ -121,6 +121,11 @@ def gzip_compress(in_data):
     return out_data
 
 
+def truncate(in_string, truncate_length):
+    "Collapse and truncate the given text to the given length."
+    return in_string[:truncate_length] + (in_string[truncate_length:] and '...')
+
+
 class LoggerMixin():
     def logger(self):
         return logging.getLogger()
@@ -943,10 +948,22 @@ class Kitchen(HTTPWebSocketsHandler):
                  'request-length': self.__request_body_length,
                  'request-method': self.__method,
                  'uri': self.__path }
+
         if len(self.headers) > 0:
             info['headers'] = { k.lower(): v for k, v in self.headers.items() }
+
+            cookie_value = info['headers'].get('authorization', None)
+            if cookie_value is not None:
+                info['headers']['authorization'] = truncate(cookie_value, 15)
+
+            cookie_value = info['headers'].get('cookie', None)
+            if cookie_value is not None:
+                cookie_entries = [e for e in cookie_value.split(';') if e]
+                info['headers']['cookie'] = [truncate(v, 25) for v in cookie_entries]
+
         if self.__query is not None:
             info['query-string'] = self.__query
+
         return json.dumps(info, sort_keys=True)
 
     def __set_response(self, response_bytes, response_length=None):

--- a/waiter/integration/waiter/cookie_support_integration_test.clj
+++ b/waiter/integration/waiter/cookie_support_integration_test.clj
@@ -50,11 +50,11 @@
                                                                                               :discard false
                                                                                               :path "/"})))
               body-json (json/read-str (str body))]
-          (is (= "test=cookie" (get-in body-json ["headers" "cookie"])))))
+          (is (= ["test=cookie"] (get-in body-json ["headers" "cookie"])))))
       (testing "no cookies sent to backend (x-waiter-auth removed)"
         (let [{:keys [service-id cookies]} (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))
               {:keys [body]} (make-request-with-debug-info headers #(make-kitchen-request waiter-url % :path "/request-info"
                                                                                           :cookies cookies))
               {:strs [headers]} (json/read-str (str body))]
-          (is (str/blank? (get headers "cookie")))
+          (is (empty? (get headers "cookie")))
           (delete-service waiter-url service-id))))))


### PR DESCRIPTION
## Changes proposed in this PR

- truncates authorization and cookie values in kitchen request-info response

## Why are we making these changes?

We should not display back sensitive information in the response.

Fixes https://github.com/twosigma/waiter/issues/737

