### PR TITLE
Revert "shortens integration test CIDs"

### DIFF
--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -217,9 +217,7 @@
 (defn current-test-name
   "Get the name of the currently-running test."
   []
-  (str (-> *testing-vars* first meta :ns str)
-       "/"
-       (-> *testing-vars* first meta :name)))
+  (-> *testing-vars* first meta :name (or "test-unknown-name") str))
 
 (defmacro testing-using-waiter-url
   [& body]
@@ -255,27 +253,16 @@
       :instance-id instance-id
       :service-id service-id)))
 
-(defn extract-acronym
-  "Shortens the name taking only the leading characters across the delimiters.
-   E.g. `(extract-acronym \"aaa.bbb-ccc/ddd#eee-fff.ggg\") -> \"abcdfg\"`"
-  [name-with-dashes]
-  (->> (str/split (str name-with-dashes) #"-|\.|/")
-    (remove str/blank?)
-    (map first)
-    (str/join "")
-    str/lower-case))
-
 (defn ensure-cid-in-headers
   [request-headers & {:keys [verbose] :or {verbose false}}]
   (let [cid (or (get request-headers "x-cid")
                 (get request-headers :x-cid))]
     (if cid
       request-headers
-      (let [correlation-id (cid/get-correlation-id)
-            new-cid (str "test-" (extract-acronym (current-test-name)) "-" (utils/unique-identifier))]
+      (let [new-cid (str (cid/get-correlation-id) "-" (utils/unique-identifier))]
         (when verbose
           (log/info "Using cid" new-cid))
-        (when (str/includes? correlation-id "UNKNOWN")
+        (when (str/includes? new-cid "UNKNOWN")
           (log/info "Correlation id context unspecified")
           (when verbose
             (log/warn (RuntimeException.))))
@@ -724,11 +711,12 @@
 
 (defn rand-name
   ([]
-   (let [service-name (current-test-name)]
+   (let [service-name (str (or (:name (meta (first *testing-vars*))) "test-unknown-name"))]
      (rand-name service-name)))
   ([service-name]
-   (let [test-prefix (System/getenv "WAITER_TEST_PREFIX")]
-     (str/replace (str test-prefix (extract-acronym service-name) (System/nanoTime)) #"-" ""))))
+   (let [username (System/getProperty "user.name")
+         test-prefix (System/getenv "WAITER_TEST_PREFIX")]
+     (str/replace (str test-prefix service-name username (rand-int 3000000)) #"-" ""))))
 
 (defn- token->etag
   "Returns the current etag of a token"


### PR DESCRIPTION
## Changes proposed in this PR

- Reverts twosigma/waiter#811
- Restores integration test service-ids to legible values

## Why are we making these changes?

While the logs are more terse now, they're also much harder to understand. I don't think this was a good tradeoff at all. Here's some sample output from our parallel k8s tests in Travis:

```
***** Kubernetes pod state at 00:13:16 *****
NAMESPACE     NAME                                                                 READY     STATUS             RESTARTS   AGE
waiter        wbittmql828471528002-3478e67d67bc71f8d41da21543dfd24b-r6nlm          2/2       Running            0          12m
waiter        wbttds1448675777777-c73126c6fcf87d6c3b87bc021cb9ea6b-5jwv2           0/2       Pending            0          2m
waiter        wcettsfgr1550582535125-9fac0229d8ad2e26cf60b3457c0a2998-p2lxd        0/2       Pending            0          50s
waiter        wcetttcr1513451491889-8cfd39a113af91c5e2665e23b3da4771-hc7jb         0/2       Terminating        0          1m
waiter        wnattnag1328230068096-cb63abd881b6fd600978c613856ad486-8tq6b         0/2       Pending            0          4m
waiter        wsttlr1579164555661-ccf0775dc71627561b49403e8f1aff2a-ldhxq           0/2       Pending            0          22s
waiter        wsttsswcs1514357568862-eb894ba66d95435305e79123dbbfb47e-nsw4j        0/2       Terminating        0          1m
```

How do we map those service names (embedded in the pod names) back to the corresponding tests? With the old naming scheme, it was trivial. Now it's not.