### PR TITLE
Handle nil start timestamps for failed Kubernetes instances

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -58,7 +58,7 @@
 (defn timestamp-str->datetime
   "Parse a Kubernetes API timestamp string."
   [k8s-timestamp-str]
-  (du/str-to-date k8s-timestamp-str k8s-timestamp-format))
+  (du/str-to-date-safe k8s-timestamp-str k8s-timestamp-format))
 
 (defn- use-short-service-hash? [k8s-max-name-length]
   ;; This is fairly arbitrary, but if we have at least 48 characters for the app name,

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -757,19 +757,13 @@
                :running-pids running-pids})
     (run! kill-process-group! orphaned-pids)))
 
-(defn- str-to-date-safe
-  "nil-safe str-to-date call"
-  [date-str]
-  (when date-str
-    (du/str-to-date date-str)))
-
 (defn- mark-lost-processes
   "Detects and marks lost processes."
   [running-pids id->instance]
   (pc/map-vals
     (fn [{:strs [killed?] pid "shell-scheduler/pid" :as instance}]
       (cond-> (-> (pc/map-keys keyword instance)
-                  (update :started-at str-to-date-safe))
+                  (update :started-at du/str-to-date-safe))
         (and (not killed?) (not (contains? running-pids pid)))
         (assoc :killed? true
                :message "Process lost after restart")))
@@ -811,7 +805,7 @@
                                          (pc/map-vals
                                            (fn [reservation]
                                              (-> (pc/map-keys keyword reservation)
-                                                 (update :expiry-time str-to-date-safe)
+                                                 (update :expiry-time du/str-to-date-safe)
                                                  (update :state keyword)))))]
               (log/info "restoring" (count port->reservation) "entries into port->reservation-atom")
               (reset! port->reservation-atom port->reservation))

--- a/waiter/src/waiter/util/date_utils.clj
+++ b/waiter/src/waiter/util/date_utils.clj
@@ -44,6 +44,13 @@
        (log/error "unable to parse" date-str "with formatter" formatter)
        (throw ex)))))
 
+(defn str-to-date-safe
+  "nil-safe str-to-date call"
+  (^DateTime [date-str]
+   (str-to-date-safe date-str formatter-iso8601))
+  (^DateTime [date-str formatter]
+    (when date-str (str-to-date date-str formatter))))
+
 (defn time-seq
   "Returns a sequence of date-time values growing over specific period.
   Takes as input the starting value and the growing value, returning a


### PR DESCRIPTION
## Changes proposed in this PR

- Move `str-to-date-safe` into `date-utils` namespace
- Use `str-to-date-safe` to parse instance timestamps for Kubernetes scheduler

## Why are we making these changes?

Waiter-Kubernetes can sometimes lose track of failed instance timestamps, in which case they come back `nil`.