### PR TITLE
enables proto tests

### DIFF
--- a/waiter/integration/waiter/proto_test.clj
+++ b/waiter/integration/waiter/proto_test.clj
@@ -112,27 +112,23 @@
 
 (deftest ^:parallel ^:integration-slow ^:resource-heavy test-http-backend-proto-service
   (testing-using-waiter-url
-    (when-not (using-k8s? waiter-url) ; temporarily disable on kubernetes until failing test issue resolved
-      (run-backend-proto-service-test waiter-url "http" "http" "HTTP/1.1")
-      (is "test completed marker"))))
+    (run-backend-proto-service-test waiter-url "http" "http" "HTTP/1.1")
+    (is "test completed marker")))
 
 (deftest ^:parallel ^:integration-slow ^:resource-heavy test-https-backend-proto-service
   (testing-using-waiter-url
-    (when-not (using-k8s? waiter-url) ; temporarily disable on kubernetes until failing test issue resolved
-      (run-backend-proto-service-test waiter-url "https" "https" "HTTP/1.1")
-      (is "test completed marker"))))
+    (run-backend-proto-service-test waiter-url "https" "https" "HTTP/1.1")
+    (is "test completed marker")))
 
 (deftest ^:parallel ^:integration-slow ^:resource-heavy test-h2c-backend-proto-service
   (testing-using-waiter-url
-    (when-not (using-k8s? waiter-url) ; temporarily disable on kubernetes until failing test issue resolved
-      (run-backend-proto-service-test waiter-url "h2c" "http" "HTTP/2.0")
-      (is "test completed marker"))))
+    (run-backend-proto-service-test waiter-url "h2c" "http" "HTTP/2.0")
+    (is "test completed marker")))
 
 (deftest ^:parallel ^:integration-slow ^:resource-heavy test-h2-backend-proto-service
   (testing-using-waiter-url
-    (when-not (using-k8s? waiter-url) ; temporarily disable on kubernetes until failing test issue resolved
-      (run-backend-proto-service-test waiter-url "h2" "https" "HTTP/2.0")
-      (is "test completed marker"))))
+    (run-backend-proto-service-test waiter-url "h2" "https" "HTTP/2.0")
+    (is "test completed marker")))
 
 (deftest ^:parallel ^:integration-fast test-internal-protocol
   (testing-using-waiter-url

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -319,9 +319,11 @@
           headers {}
           method :get
           query-params {}
-          scheme "http"
           verbose false}}]
-   (let [client (or client
+   (let [scheme (or scheme
+                    (some-> protocol http-utils/backend-proto->scheme)
+                    "http")
+         client (or client
                     (when protocol
                       (http-utils/select-http-client
                         protocol {:http1-client http1-client :http2-client http2-client}))


### PR DESCRIPTION
## Changes proposed in this PR

- corrects scheme for https requests from proto tests
- enables proto tests for all schedulers

## Why are we making these changes?

We would like to test the full complement of our proto support while streaming data.
