### PR TITLE
updates jet version for fix for response trailers and body streaming race

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -43,7 +43,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20190723_182557-gfa75f4c"
+                 [twosigma/jet "0.7.10-20190725_133040-g0c08fb4"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -43,7 +43,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20190709_215542-ge7c9dbb"
+                 [twosigma/jet "0.7.10-20190723_182557-gfa75f4c"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]


### PR DESCRIPTION
## Jet PR

[Avoids closing actively streaming body channel after trailers have been received](https://github.com/twosigma/jet/pull/34)

## Changes proposed in this PR

- updates jet version for fix for response trailers and body streaming race

## Why are we making these changes?

We wish to stream the entire response body sent from the server when possible.
