### PR TITLE
aborts backend requests using the abort-ch

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -43,7 +43,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20190709_215542-ge7c9dbb"
+                 [twosigma/jet "0.7.10-20190715_034008-g8925e4c"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -264,7 +264,7 @@
                                                                   correlation-id
                                                                   (log/info "request byte stream error, result of aborted request:" aborted?)
                                                                   (async/close! body-ch)))]
-                                                 (log/error throwable "unable to stream request bytes, aborting request")
+                                                 (log/info throwable "unable to stream request bytes, aborting request")
                                                  (async/>!! abort-ch [throwable callback])))
                                              (report-request-size-metrics 0 true)
                                              (if throwable

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -250,15 +250,29 @@
                                        (cid/with-correlation-id
                                          correlation-id
                                          (let [complete-trigger-id (utils/unique-identifier)]
+                                           (log/debug throwable "received from ctrl-chan" message)
                                            (deliver complete-triggered-promise complete-trigger-id)
                                            (when (= complete-trigger-id @complete-triggered-promise)
                                              (log/debug "closing request body as" message)
                                              (counters/dec! request-body-streaming-counter)
+                                             ;; the callback is necessary as there is a data race between aborting the
+                                             ;; request and closing of the body channel triggering a normal complete before
+                                             ;; the abort request gets processed.
                                              (when throwable
-                                               (log/error throwable "unable to stream request bytes, aborting request")
-                                               (async/>!! abort-ch throwable))
+                                               (let [callback (fn complete-request-streaming-abort-result-callback [aborted?]
+                                                                (cid/with-correlation-id
+                                                                  correlation-id
+                                                                  (log/info "request byte stream error, result of aborted request:" aborted?)
+                                                                  (async/close! body-ch)))]
+                                                 (log/error throwable "unable to stream request bytes, aborting request")
+                                                 (async/>!! abort-ch [throwable callback])))
                                              (report-request-size-metrics 0 true)
-                                             (async/close! body-ch))))))]
+                                             (if throwable
+                                               ;; TODO avoid the need for the timeout while sending to abort channel
+                                               (async/go
+                                                 (async/<! (async/timeout 1000))
+                                                 (async/close! body-ch))
+                                               (async/close! body-ch)))))))]
     (counters/inc! request-body-streaming-counter)
     (when ctrl-ch
       (async/go
@@ -485,13 +499,19 @@
 
 (defn abort-http-request-callback-factory
   "Creates a callback to abort the http request."
-  [response]
-  (fn abort-http-request-callback [^Exception e]
-    (let [ex (if (instance? IOException e) e (IOException. e))
-          aborted (if-let [request (:request response)]
-                    (.abort request ex)
-                    (log/warn "unable to abort as request not found inside response!"))]
-      (log/info "aborted backend request:" aborted))))
+  [{:keys [abort-ch] :as response}]
+  (fn abort-backend-request-callback [^Exception ex]
+    (let [correlation-id (cid/get-correlation-id)
+          callback (fn abort-http-request-result-callback [aborted?]
+                     (cid/with-correlation-id
+                       correlation-id
+                       (log/debug ex "aborted backend request:" aborted? "due to" (.getClass ex))))]
+      (when abort-ch
+        (log/debug "requesting backend to be aborted via abort-ch"))
+      (when-not (and abort-ch (async/>!! abort-ch [ex callback]))
+        (log/debug "aborting backend request directly")
+        (let [aborted? (some-> response :request (.abort ex))]
+          (log/info "result of aborting backend request directly:" aborted?))))))
 
 (defn- introspect-trailers
   "Introspects and logs trailers received in the response"

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -262,7 +262,10 @@
 
                 (async/timeout request-timeout-ms)
                 ([_]
-                  (async/>! request-abort-chan (TimeoutException. "Health check request exceeded its allocated time"))
+                 (let [ex (TimeoutException. "Health check request exceeded its allocated time")
+                       callback (fn abort-health-check-callback [aborted?]
+                                  (log/info "health check aborted:" aborted?))]
+                   (async/>! request-abort-chan [ex callback]))
                   (meters/mark! (metrics/waiter-meter "scheduler" scheduler-name "health-check" "timeout-rate"))
                   (log/info "health check timed out before receiving response"
                             {:health-check-path health-check-path


### PR DESCRIPTION
## Changes proposed in this PR

- aborts backend requests using the abort-ch

## Why are we making these changes?

Consistently abort backend requests using the `abort-ch` mechanism. Fallback to invoking `abort` directly only when the channel mechanism fails.


