### PR TITLE
aborts backend requests using the abort-ch - v2

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -43,7 +43,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20190725_133505-gf1a6862"
+                 [twosigma/jet "0.7.10-20190726_062116-ge1f0a7b"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -43,7 +43,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20190725_133040-g0c08fb4"
+                 [twosigma/jet "0.7.10-20190725_133505-gf1a6862"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -285,7 +285,7 @@
                                                                   correlation-id
                                                                   (log/info "request byte stream error, result of aborted request:" aborted?)
                                                                   (async/close! body-ch)))]
-                                                 (log/error throwable "unable to stream request bytes, aborting request")
+                                                 (log/info throwable "unable to stream request bytes, aborting request")
                                                  (async/>!! abort-ch [throwable callback])))
                                              (report-request-size-metrics 0 true)
                                              (if throwable

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -243,7 +243,7 @@
       (if (and (pos? port) host)
         (let [instance-health-check-url (health-check-url service-instance protocol health-check-port-index health-check-path)
               request-timeout-ms (max (+ (.getConnectTimeout http-client) (.getIdleTimeout http-client)) 200)
-              request-abort-chan (async/promise-chan)
+              request-abort-chan (async/chan 1)
               health-check-response-chan (http/get http-client instance-health-check-url {:abort-ch request-abort-chan})
               _ (meters/mark! (metrics/waiter-meter "scheduler" scheduler-name "health-check" "invocation-rate"))
               {:keys [error-flag status]}

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -262,7 +262,10 @@
 
                 (async/timeout request-timeout-ms)
                 ([_]
-                  (async/>! request-abort-chan (TimeoutException. "Health check request exceeded its allocated time"))
+                 (let [ex (TimeoutException. "Health check request exceeded its allocated time")
+                       callback (fn abort-health-check-callback [aborted?]
+                                  (log/info "health check aborted:" aborted?))]
+                   (async/>! request-abort-chan [ex callback]))
                   (meters/mark! (metrics/waiter-meter "scheduler" scheduler-name "health-check" "timeout-rate"))
                   (log/info "health check timed out before receiving response"
                             {:health-check-path health-check-path


### PR DESCRIPTION
## Jet PR:

[handles multiple abort attempts to a request](https://github.com/twosigma/jet/pull/35/files)


## Changes proposed in this PR

- aborts backend requests using the abort-ch
- handles multiple abort attempts to a request

## Why are we making these changes?

Consistently abort backend requests using the `abort-ch` mechanism. Fallback to invoking `abort` directly only when the channel mechanism fails.

