### PR TITLE
adds support for grpc client deadline

### DIFF
--- a/waiter/integration/waiter/grpc_test.clj
+++ b/waiter/integration/waiter/grpc_test.clj
@@ -14,7 +14,8 @@
 ;; limitations under the License.
 ;;
 (ns waiter.grpc-test
-  (:require [clojure.string :as str]
+  (:require [clojure.core.async :as async]
+            [clojure.string :as str]
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [clojure.walk :as walk]
@@ -22,6 +23,7 @@
             [waiter.util.client-tools :refer :all])
   (:import (com.twosigma.waiter.courier CourierReply CourierSummary GrpcClient GrpcClient$CancellationPolicy StateReply)
            (io.grpc Status)
+           (java.util.concurrent CountDownLatch)
            (java.util.function Function)))
 
 (def cancel-policy-none GrpcClient$CancellationPolicy/NONE)
@@ -116,6 +118,16 @@
      (when status#
        (is (= "CANCELLED" (-> status# .getCode str)) assertion-message#)
        (is (= message# (.getDescription status#)) assertion-message#))))
+
+(defmacro assert-grpc-deadline-exceeded-status
+  "Asserts that the status represents a grpc OK status."
+  [status assertion-message]
+  `(let [status# ~status
+         assertion-message# ~assertion-message]
+     (is status# assertion-message#)
+     (when status#
+       (is (= "DEADLINE_EXCEEDED" (-> status# .getCode str)) assertion-message#)
+       (is (str/includes? (.getDescription status#) "deadline exceeded after") assertion-message#))))
 
 (defmacro assert-grpc-server-exit-status
   "Asserts that the status represents a grpc OK status."
@@ -256,6 +268,42 @@
                 assertion-message (grpc-result->assertion-message correlation-id rpc-result)]
             (assert-grpc-status status "DEADLINE_EXCEEDED" "Request to service backend timed out" assertion-message)
             (is (nil? reply) assertion-message)))))))
+
+(deftest ^:parallel ^:integration-fast test-grpc-unary-call-deadline-exceeded
+  (testing-using-waiter-url
+    (let [{:keys [h2c-port host request-headers service-id]} (start-courier-instance waiter-url)]
+      (with-service-cleanup
+        service-id
+        (testing "deadline exceeded"
+          (let [id (rand-name "m")
+                from (rand-name "f")
+                content (rand-str 1000)
+                correlation-id (rand-name)
+                request-headers (assoc request-headers "x-cid" correlation-id)
+                grpc-client (initialize-grpc-client correlation-id host h2c-port)
+                sleep-duration-latch (CountDownLatch. 1)
+                sleep-duration-ms 5000
+                deadline-duration-ms (- sleep-duration-ms 1000)
+                _ (async/go
+                    (async/<! (async/timeout (+ sleep-duration-ms 1000)))
+                    (.countDown sleep-duration-latch))
+                rpc-result (.sendPackage grpc-client request-headers id from content sleep-duration-ms deadline-duration-ms)
+                ^CourierReply reply (.result rpc-result)
+                ^Status status (.status rpc-result)
+                assertion-message (->> (cond-> {:correlation-id correlation-id
+                                                :service-id service-id}
+                                         reply (assoc :reply {:id (.getId reply)
+                                                              :response (.getResponse reply)})
+                                         status (assoc :status {:code (-> status .getCode str)
+                                                                :description (.getDescription status)}))
+                                    (into (sorted-map))
+                                    str)]
+            (assert-grpc-deadline-exceeded-status status assertion-message)
+            (is (nil? reply) assertion-message)
+            (.await sleep-duration-latch)
+            ;; TODO undo after fix to https://github.com/haproxy/haproxy/issues/172
+            (when-not (behind-proxy? waiter-url)
+              (assert-request-state grpc-client request-headers service-id correlation-id ::deadline-exceeded))))))))
 
 (deftest ^:parallel ^:integration-fast test-grpc-unary-call-server-cancellation
   (testing-using-waiter-url
@@ -529,6 +577,54 @@
                   (is (= (count messages) (.getNumMessages summary)) assertion-message)
                   (is (= (reduce + (map count messages)) (.getTotalLength summary)) assertion-message))
                 (assert-request-state grpc-client request-headers service-id correlation-id ::success)))))))))
+
+(deftest ^:parallel ^:integration-fast test-grpc-client-streaming-deadline-exceeded
+  (testing-using-waiter-url
+    (let [{:keys [h2c-port host request-headers service-id]} (start-courier-instance waiter-url)
+          correlation-id-prefix (rand-name)]
+      (with-service-cleanup
+        service-id
+        (doseq [max-message-length [1000 50000]]
+          (let [num-messages 120
+                messages (doall (repeatedly num-messages #(rand-str (inc (rand-int max-message-length)))))]
+
+            (testing (str max-message-length " messages completion")
+              (log/info "starting streaming to and from server - independent mode test")
+              (let [cancel-threshold (inc num-messages)
+                    from (rand-name "f")
+                    correlation-id (str correlation-id-prefix "-" max-message-length)
+                    request-headers (assoc request-headers "x-cid" correlation-id)
+                    ids (map #(str "id-" %) (range num-messages))
+                    grpc-client (initialize-grpc-client correlation-id host h2c-port)
+                    sleep-duration-latch (CountDownLatch. 1)
+                    sleep-duration-ms 5000
+                    deadline-duration-ms (- sleep-duration-ms 1000)
+                    _ (async/go
+                        (async/<! (async/timeout (+ sleep-duration-ms 1000)))
+                        (.countDown sleep-duration-latch))
+                    rpc-result (.aggregatePackages grpc-client request-headers ids from messages 1000
+                                                   cancel-threshold cancel-policy-none deadline-duration-ms)
+                    ^CourierSummary summary (.result rpc-result)
+                    ^Status status (.status rpc-result)
+                    assertion-message (->> (cond-> {:correlation-id correlation-id
+                                                    :service-id service-id}
+                                             summary (assoc :summary {:num-messages (.getNumMessages summary)
+                                                                      :total-length (.getTotalLength summary)})
+                                             status (assoc :status {:code (-> status .getCode str)
+                                                                    :description (.getDescription status)}))
+                                        (into (sorted-map))
+                                        str)]
+                (log/info correlation-id "aggregated packages...")
+                ;; TODO undo after fix to https://github.com/haproxy/haproxy/issues/172
+                (if (and (behind-proxy? waiter-url)
+                         (= "UNAVAILABLE" (some-> status .getCode str)))
+                  (assert-grpc-status status "UNAVAILABLE" "Received Rst Stream" assertion-message)
+                  (assert-grpc-deadline-exceeded-status status assertion-message))
+                (is (nil? summary) assertion-message)
+                (.await sleep-duration-latch)
+                ;; TODO undo after fix to https://github.com/haproxy/haproxy/issues/172
+                (when-not (behind-proxy? waiter-url)
+                  (assert-request-state grpc-client request-headers service-id correlation-id ::deadline-exceeded))))))))))
 
 (deftest ^:parallel ^:integration-slow test-grpc-client-streaming-server-exit
   (testing-using-waiter-url

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -192,6 +192,9 @@
                                [error-cause message status])
                              (instance? IllegalStateException error)
                              [:generic-error (.getMessage error) 400]
+                             ;; cancel_stream_error is used to indicate that the stream is no longer needed
+                             (and (instance? IOException error) (= "cancel_stream_error" (.getMessage error)))
+                             [:client-error "Client action means stream is no longer needed" 400]
                              (instance? EofException error)
                              [:client-error "Connection unexpectedly closed while streaming request" 400]
                              (instance? TimeoutException error)

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -271,6 +271,7 @@
                                        (cid/with-correlation-id
                                          correlation-id
                                          (let [complete-trigger-id (utils/unique-identifier)]
+                                           (log/debug throwable "received from ctrl-chan" message)
                                            (deliver complete-triggered-promise complete-trigger-id)
                                            (when (= complete-trigger-id @complete-triggered-promise)
                                              ;; avoid decrementing the counter multiple times

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -271,7 +271,6 @@
                                        (cid/with-correlation-id
                                          correlation-id
                                          (let [complete-trigger-id (utils/unique-identifier)]
-                                           (log/debug throwable "received from ctrl-chan" message)
                                            (deliver complete-triggered-promise complete-trigger-id)
                                            (when (= complete-trigger-id @complete-triggered-promise)
                                              ;; avoid decrementing the counter multiple times

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -103,12 +103,17 @@
           (log/info "port" port "is already in use, assuming Waiter is running"))
         (str (retrieve-hostname) ":" port)))))
 
+(defn retrieve-waiter-port
+  "Retrieves the Waiter port for receiving http requests."
+  [waiter-url]
+  (or (second (str/split waiter-url #":" 2))
+      "80"))
+
 (defn retrieve-h2c-port
   "Retrieves the Waiter port for receiving h2c requests."
   [waiter-url]
   (or (System/getenv "WAITER_H2C_PORT")
-      (second (str/split waiter-url #":" 2))
-      "80"))
+      (retrieve-waiter-port waiter-url)))
 
 (defn retrieve-h2c-url
   "Retrieves the Waiter url for receiving h2c requests."
@@ -130,6 +135,12 @@
   (str (first (str/split waiter-url #":" 2))
        ":"
        (retrieve-ssl-port ssl-port)))
+
+(defn behind-proxy?
+  "Returns true if Waiter if running behind a proxy."
+  [waiter-url]
+  (not= (retrieve-waiter-port waiter-url)
+        (retrieve-h2c-port waiter-url)))
 
 (defn interval-to-str [^Period interval]
   (let [builder (doto (PeriodFormatterBuilder.)


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for grpc client deadline exceeded

## Why are we making these changes?

gRPC deadlines should not result in instance blacklisting as it is not a backend error.

### Example logs:
```
test-grpc-unary-call-deadline-exceeded:
2019-07-25 11:18:46,035 INFO  waiter.process-request [async-dispatch-45] - [CID=wgttgucde122695437161170] java.io.IOException cancel_stream_error identified as :client-error
2019-07-25 11:18:46,037 ERROR waiter.util.utils [async-dispatch-45] - [CID=wgttgucde122695437161170] #error {
2019-07-25 11:18:46,042 INFO  waiter.process-request [async-dispatch-48] - [CID=wgttgucde122695437161170] done processing request :client-error

test-grpc-client-streaming-deadline-exceeded:
2019-07-25 11:24:11,247 INFO  waiter.process-request [async-dispatch-24] - [CID=wgttgcsde123020804110521-1000] org.eclipse.jetty.io.EofException Reset cancel_stream_error identified as :client-error
2019-07-25 11:24:11,248 INFO  waiter.process-request [async-dispatch-24] - [CID=wgttgcsde123020804110521-1000] clojure.lang.ExceptionInfo error in frontend request identified as :client-error
2019-07-25 11:24:11,248 ERROR waiter.util.utils [async-dispatch-24] - [CID=wgttgcsde123020804110521-1000] #error {
2019-07-25 11:24:11,253 INFO  waiter.process-request [async-dispatch-14] - [CID=wgttgcsde123020804110521-1000] done processing request :client-error

test-grpc-unary-call-server-cancellation:
2019-07-25 11:23:03,184 INFO  waiter.process-request [async-dispatch-32] - [CID=wgttgucsc122955552164187] eagerly closing response body as grpc status is 1
2019-07-25 11:23:03,184 INFO  waiter.process-request [async-dispatch-14] - [CID=wgttgucsc122955552164187] done processing request :success
2019-07-25 11:23:03,189 INFO  waiter.process-request [async-dispatch-49] - [CID=wgttgucsc122955552164187] attaching grpc headers into trailer: {grpc-message Cancelled by server, grpc-status 1}
2019-07-25 11:23:03,189 INFO  waiter.process-request [async-dispatch-49] - [CID=wgttgucsc122955552164187] closing response trailers channel

test-grpc-client-streaming-server-cancellation
2019-07-25 11:25:52,406 INFO  waiter.process-request [async-dispatch-8] - [CID=wgttgcssc123105055651800.SEND_ERROR.0-120.50000] eagerly closing response body as grpc status is 1
2019-07-25 11:25:52,406 INFO  waiter.process-request [async-dispatch-42] - [CID=wgttgcssc123105055651800.SEND_ERROR.0-120.50000] 0 bytes streamed in response
2019-07-25 11:25:52,406 INFO  waiter.process-request [async-dispatch-35] - [CID=wgttgcssc123105055651800.SEND_ERROR.0-120.50000] attaching grpc headers into trailer: {grpc-message Cancelled by server, grpc-status 1}
2019-07-25 11:25:52,406 INFO  waiter.process-request [async-dispatch-35] - [CID=wgttgcssc123105055651800.SEND_ERROR.0-120.50000] closing response trailers channel
2019-07-25 11:25:52,406 INFO  waiter.process-request [async-dispatch-8] - [CID=wgttgcssc123105055651800.SEND_ERROR.0-120.50000] done processing request :success
```

