### PR TITLE
adds integration test for clients that cancel via process exit

### DIFF
--- a/containers/test-apps/courier/pom.xml
+++ b/containers/test-apps/courier/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>twosigma</groupId>
     <artifactId>courier</artifactId>
-    <version>1.5.9</version>
+    <version>1.5.14</version>
 
     <name>courier</name>
     <url>https://github.com/twosigma/waiter/tree/master/test-apps/courier</url>

--- a/containers/test-apps/courier/src/main/java/com/twosigma/waiter/courier/GrpcClient.java
+++ b/containers/test-apps/courier/src/main/java/com/twosigma/waiter/courier/GrpcClient.java
@@ -92,6 +92,14 @@ public class GrpcClient {
                 throw new CancellationException(message);
             }
         },
+        EXIT() {
+            @Override
+            public void apply(final Context.CancellableContext cancellableContext,
+                              final ClientCallStreamObserver<?> observer,
+                              final String message) {
+                System.exit(1);
+            }
+        },
         NONE() {
             @Override
             public void apply(final Context.CancellableContext cancellableContext,

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -34,7 +34,7 @@
                   :exclusions [prismatic/schema ring/ring-core]]
                  [clj-jgit "0.8.10"
                   :scope "test"]
-                 [twosigma/courier "1.5.9"
+                 [twosigma/courier "1.5.14"
                   :exclusions [com.google.guava/guava io.grpc/grpc-core]
                   :scope "test"]
                  ;; avoids the following:
@@ -114,8 +114,9 @@
 
   :resource-paths ["resources"]
   :main waiter.main
-  :plugins [[test2junit "1.2.2"]
-            [com.holychao/parallel-test "0.3.2"]]
+  :plugins [[com.holychao/parallel-test "0.3.2"]
+            [lein-exec "0.3.7"]
+            [test2junit "1.2.2"]]
   ; In case of kerberos problems, export KRB5_KTNAME=/var/spool/keytabs/$(id -un)
   :jvm-opts ["-server"
              "-Dsun.security.jgss.lib=/opt/mitkrb5/lib/libgssapi_krb5.so"

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -274,6 +274,7 @@
                                        (cid/with-correlation-id
                                          correlation-id
                                          (let [complete-trigger-id (utils/unique-identifier)]
+                                           (log/debug throwable "received from ctrl-chan" message)
                                            (deliver complete-triggered-promise complete-trigger-id)
                                            (when (= complete-trigger-id @complete-triggered-promise)
                                              ;; avoid decrementing the counter multiple times

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -274,7 +274,6 @@
                                        (cid/with-correlation-id
                                          correlation-id
                                          (let [complete-trigger-id (utils/unique-identifier)]
-                                           (log/debug throwable "received from ctrl-chan" message)
                                            (deliver complete-triggered-promise complete-trigger-id)
                                            (when (= complete-trigger-id @complete-triggered-promise)
                                              ;; avoid decrementing the counter multiple times

--- a/waiter/test-files/grpc/grpc_client_exit.clj
+++ b/waiter/test-files/grpc/grpc_client_exit.clj
@@ -1,0 +1,64 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns grpc.grpc-client-exit
+  (:require [clj-time.core :as t]
+            [clj-time.format :as f]
+            [clojure.test :refer :all]
+            [waiter.util.client-tools :refer :all]
+            [waiter.util.date-utils :as du]
+            [waiter.util.utils :as utils])
+  (:import (com.twosigma.waiter.courier GrpcClient GrpcClient$CancellationPolicy)
+           (java.util.function Function)))
+
+(defn- initialize-grpc-client
+  "Initializes grpc client logging to specific correlation id"
+  [correlation-id host port]
+  (let [date-formatter (:date-hour-minute-second-fraction f/formatters)
+        log-function (reify Function
+                       (apply [_ message]
+                         (println (du/date-to-str (t/now) date-formatter) correlation-id message)))]
+    (GrpcClient. host port log-function)))
+
+(try
+  (println "num command line arguments:" (count *command-line-args*))
+  (let [[_ host h2c-port service-id correlation-id cookie] *command-line-args*
+        token (str "^SERVICE-ID#" service-id)
+        port (Integer/parseInt h2c-port)
+        grpc-client (initialize-grpc-client correlation-id host port)
+        request-headers {"cookie" cookie
+                         "x-cid" correlation-id
+                         "x-waiter-token" token}
+        num-messages 100
+        ids (map #(str "id-" %) (range num-messages))
+        from "from"
+        messages (map #(str "message-" %) (range num-messages))
+        inter-message-sleep-ms 100
+        lock-step-mode true
+        cancel-threshold (/ num-messages 2)
+        cancellation-policy GrpcClient$CancellationPolicy/EXIT
+        deadline-duration-ms 60000]
+    (println "host:" host)
+    (println "port:" port)
+    (println "request-headers:" (update request-headers "cookie" utils/truncate 20))
+    (println "num-messages:" num-messages)
+    (println "cancel-threshold:" cancel-threshold)
+    (println "invoking GrpcClient method...")
+    (.collectPackages grpc-client request-headers ids from messages inter-message-sleep-ms lock-step-mode
+                      cancel-threshold cancellation-policy deadline-duration-ms))
+  (catch Throwable throwable
+    (.printStackTrace throwable System/out))
+  (finally
+    (System/exit 0)))


### PR DESCRIPTION
## Changes proposed in this PR

- adds integration test for clients that cancel via process exit

## Why are we making these changes?

A gRPC client exiting abruptly should also be treated as a client cancellation.

### waiter logs: request identified as client error
```
2019-07-25 17:05:23,482 INFO  waiter.core [qtp709883348-181] - [CID=wgttgbsce143478578297273] request received: {:internal-protocol HTTP/2.0, :request-id 8282a4881311-f0370db67dd9ecd-http, :remote-addr 127.0.0.1, :client-protocol HTTP/2.0, :headers {te trailers, grpc-accept-encoding gzip, host 127.0.0.1:9091, x-cid wgttgbsce143478578297273, content-type application/grpc, x-waiter-token ^SERVICE-ID#w9091-wgttgbsce143476858830466-29bb9aee2ea50f08cdc2044458bbba19, user-agent grpc-java-netty/1.20.0, grpc-timeout 59716136u}, :content-length nil, :content-type application/grpc, :character-encoding nil, :uri /courier.Courier/CollectPackages, :query-string nil, :router-id r9091-7f0c6731ef91-92848c202af0dda, :scheme :http, :request-method :post}
2019-07-25 17:05:23,489 INFO  waiter.process-request [async-dispatch-29] - [CID=wgttgbsce143478578297273] suggested instance: w9091-wgttgbsce143476858830466-29bb9aee2ea50f08cdc2044458bbba19.827dd65a2e7d-6455d7bb45bb0638 127.0.0.4 10500
2019-07-25 17:05:29,164 ERROR waiter.process-request [qtp709883348-181] - [CID=wgttgbsce143478578297273] unable to stream request bytes, aborting request
2019-07-25 17:05:29,170 INFO  waiter.process-request [qtp709883348-181] - [CID=wgttgbsce143478578297273] streamed 1480 bytes from request input stream
2019-07-25 17:05:29,171 INFO  waiter.process-request [async-dispatch-37] - [CID=wgttgbsce143478578297273] exception occurred while streaming response for w9091-wgttgbsce143476858830466-29bb9aee2ea50f08cdc2044458bbba19
2019-07-25 17:05:29,172 INFO  waiter.process-request [async-dispatch-37] - [CID=wgttgbsce143478578297273] java.nio.channels.ClosedChannelException nil identified as :instance-error
2019-07-25 17:05:29,172 INFO  waiter.process-request [async-dispatch-37] - [CID=wgttgbsce143478578297273] clojure.lang.ExceptionInfo error in frontend request identified as :client-error
2019-07-25 17:05:29,172 INFO  waiter.process-request [async-dispatch-37] - [CID=wgttgbsce143478578297273] clojure.lang.ExceptionInfo error occurred after streaming 487 bytes in response identified as :client-error
2019-07-25 17:05:29,172 INFO  waiter.process-request [async-dispatch-37] - [CID=wgttgbsce143478578297273] sending poison pill to response channel
2019-07-25 17:05:29,172 INFO  waiter.process-request [async-dispatch-37] - [CID=wgttgbsce143478578297273] done processing request :client-error
```

### Test state output: cancel and cancel_handler present
```
2019-07-25 17:05:31,205 INFO  waiter.grpc-test [main] - [CID=wgttgbsce143478578297273] received response StateReply{cid=wgttgbsce143478578297273, response=[INIT, READY, RECEIVE_MESSAGE, SEND_HEADERS, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, RECEIVE_MESSAGE, SEND_MESSAGE, CANCEL, CANCEL_HANDLER, CLOSE]}
```

### Script output: script exiting during cancellation
```
wgttgbsce143478578297273 initializing plaintext client at 127.0.0.1:9091
wgttgbsce143478578297273 will try to send package from from ...
wgttgbsce143478578297273 acquiring semaphore before sending request id-0
wgttgbsce143478578297273 sending message CourierRequest{id=id-0, from=from, message.length=9}
wgttgbsce143478578297273 acquiring semaphore before sending request id-1
wgttgbsce143478578297273 headers received from server:Metadata(content-type=application/grpc,x-cid=wgttgbsce143478578297273,grpc-encoding=identity,grpc-accept-encoding=gzip,set-cookie=x-waiter-auth=TlBZAvYN3wc%2FxRya1Zf%2BK2aiUrdZEM6M3r8lUQv2tN8bpZTLI96fUGnSqkDuIow%2BZ
F2jBg%3D%3D;Max-Age=86400;Path=/;HttpOnly=true)
wgttgbsce143478578297273 received response CourierSummary{count=1, length=9}
wgttgbsce143478578297273 releasing semaphore after receiving response
wgttgbsce143478578297273 sending message CourierRequest{id=id-1, from=from, message.length=9}
...
wgttgbsce143478578297273 sending message CourierRequest{id=id-49, from=from, message.length=10}
wgttgbsce143478578297273 received response CourierSummary{count=50, length=490}
wgttgbsce143478578297273 releasing semaphore after receiving response
wgttgbsce143478578297273 cancelling sending messages
```
