### PR TITLE
adds support for rate limiting the number of spnego auth responses by requesting host

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -232,6 +232,9 @@
                                    :concurrency-level 20
                                    ;; the idle time before cached threads from the invocation throttler are terminated
                                    :keep-alive-mins 5
+                                   ;; the maximum rate of requests per host that can trigger Kerberos authentication
+                                   ;; before server responds with a 503 temporarily unavailable
+                                   :max-one-minute-rate-per-host 100
                                    ;; the maximum number of request waiting for Kerberos auth before server responds
                                    ;; with a 503 temporarily unavailable
                                    :max-queue-length 1000}

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -247,6 +247,7 @@
                           :kerberos {:factory-fn 'waiter.auth.kerberos/kerberos-authenticator
                                      :concurrency-level 20
                                      :keep-alive-mins 5
+                                     :max-one-minute-rate-per-host 100
                                      :max-queue-length 1000}
                           :one-user {:factory-fn 'waiter.auth.authentication/one-user-authenticator}}
    :cors-config {:kind :patterns

--- a/waiter/test/waiter/auth/kerberos_test.clj
+++ b/waiter/test/waiter/auth/kerberos_test.clj
@@ -112,6 +112,7 @@
   (with-redefs [start-prestash-cache-maintainer (constantly nil)]
     (let [config {:concurrency-level 20
                   :keep-alive-mins 5
+                  :max-one-minute-rate-per-host 100
                   :max-queue-length 100
                   :password "test-password"
                   :prestash-cache-refresh-ms 100


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for rate-limiting the number of spnego auth responses by requesting host

## Why are we making these changes?

Avoids a misbehaving client (cookies disabled) from affecting other services by overloading the Kerberos auth mechanism. 

