### PR TITLE
marks and disables flaky tests

### DIFF
--- a/waiter/integration/waiter/busy_instance_test.clj
+++ b/waiter/integration/waiter/busy_instance_test.clj
@@ -20,7 +20,9 @@
             [waiter.util.client-tools :refer :all]
             [waiter.util.utils :as utils]))
 
-(deftest ^:parallel ^:integration-slow ^:resource-heavy test-busy-instance-not-reserved
+;; the following assertion is flaky: (is (every? #(not %) results))
+;; every now and then at least one of the values in that array will be true.
+(deftest ^:explicit ^:parallel ^:integration-slow ^:resource-heavy test-busy-instance-not-reserved
   (testing-using-waiter-url
     (let [extra-headers {:x-waiter-name (rand-name)
                          :x-waiter-scale-up-factor 0.99}

--- a/waiter/integration/waiter/metrics_output_test.clj
+++ b/waiter/integration/waiter/metrics_output_test.clj
@@ -196,7 +196,9 @@
       (get-in ["state" "service-id->launch-tracker" service-id])
       some?))
 
-(deftest ^:parallel ^:integration-slow test-launch-metrics-output
+;; assertion fails: reasonable values for current service's startup-time metrics
+;; (not (<= 10 99.793 60))
+(deftest ^:explicit ^:parallel ^:integration-slow test-launch-metrics-output
   (testing-using-waiter-url
     (let [router->endpoint (routers waiter-url)
           service-name (rand-name)


### PR DESCRIPTION
## Changes proposed in this PR

- marks and disables flaky tests

## Why are we making these changes?

We prefer green builds when there is no fault in the change being made.

