### PR TITLE
makes assert-ping-response less flaky

### DIFF
--- a/waiter/integration/waiter/health_check_test.clj
+++ b/waiter/integration/waiter/health_check_test.clj
@@ -34,9 +34,9 @@
                (get-in ping-response [:headers :x-kitchen-protocol-version]))
             (str ping-response))
         (is (= "get" (get-in ping-response [:headers :x-kitchen-request-method])) (str ping-response))
-        (is (or (= {:exists? true :healthy? true :service-id service-id :status "Running"} service-state)
-                (= {:exists? true :healthy? false :service-id service-id :status "Starting"} service-state))
-            (str service-state)))
+        (is (:exists? service-state) (str service-state))
+        (is (= service-id (:service-id service-state)) (str service-state))
+        (is (contains? #{"Running" "Starting"} (:status service-state)) (str service-state)))
       (do
         (is (= "timed-out" (get ping-response :result)) (str ping-response))
         (is (= {:exists? true :healthy? false :service-id service-id :status "Starting"} service-state))))))


### PR DESCRIPTION
## Changes proposed in this PR

- makes assert-ping-response less flaky

## Why are we making these changes?

The test flaked: https://travis-ci.org/twosigma/waiter/jobs/565516782

```
lein parallel-test :only waiter.health-check-test/test-basic-ping-service
FAIL in (test-basic-ping-service) (health_check_test.clj:37)
waiter.health-check-test/test-basic-ping-service
{:exists? true, :healthy? true, :service-id "waiter-service-whcttbps471221134308-5cc99ee2fb4617c542ec879b9d29cbbe", :status "Starting"}
expected: (or (= {:exists? true, :healthy? true, :service-id service-id, :status "Running"} service-state) (= {:exists? true, :healthy? false, :service-id service-id, :status "Starting"} service-state))
  actual: false
```

