### PR TITLE
Include pod logs in Travis logs tarball

### DIFF
--- a/waiter/bin/ci/run-integration-tests-k8s-scheduler.sh
+++ b/waiter/bin/ci/run-integration-tests-k8s-scheduler.sh
@@ -22,11 +22,9 @@ CONTAINERS_DIR=${WAITER_DIR}/../containers
 ${DIR}/minikube-setup.sh
 
 # Start S3 test server
-if [[ $TEST_SELECTOR =~ heavy$ ]]; then
-    ${DIR}/s3-server-setup.sh
-    S3SERVER_IP=$(docker inspect s3server | jq -r '.[0].NetworkSettings.Networks.bridge.IPAddress')
-    export WAITER_S3_BUCKET=http://$S3SERVER_IP:8000/waiter-service-logs
-fi
+${DIR}/s3-server-setup.sh
+S3SERVER_IP=$(docker inspect s3server | jq -r '.[0].NetworkSettings.Networks.bridge.IPAddress')
+export WAITER_S3_BUCKET=http://$S3SERVER_IP:8000/waiter-service-logs
 
 # Ensure we have the docker image for the pods
 ${CONTAINERS_DIR}/bin/build-docker-images.sh

--- a/waiter/bin/ci/s3-server-setup.sh
+++ b/waiter/bin/ci/s3-server-setup.sh
@@ -11,7 +11,7 @@ type aws || pip install awscli --upgrade --user
 # The API server endpoint is accessible via localhost:8888
 # https://hub.docker.com/r/scality/s3server
 echo Starting S3 server docker container
-docker run --name s3server --detach --rm --publish=8888:8000 scality/s3server:6018536a
+docker run --name s3server --detach --rm --env=REMOTE_MANAGEMENT_DISABLE=1 --publish=8888:8000 zenko/cloudserver:8.1.15
 echo -n Waiting for S3 server
 while ! curl localhost:8888 &>/dev/null; do
     echo -n .


### PR DESCRIPTION
## Changes proposed in this PR

- Switch to more recent s3 server docker image: zenko/cloudserver
- Copy pod logs out of s3 when building log tarball from Travis

## Why are we making these changes?

We want to preserve the back-end service logs on k8s just like we do on mesos and shell scheduler.