### PR TITLE
Deflake s3-logs test by targeting a router

### DIFF
--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -1072,6 +1072,12 @@
   (get-in (service-settings waiter-url service-id :cookies cookies)
           [:instances :active-instances]))
 
+(defn killed-instances
+  "Returns the killed instances for the given service-id"
+  [waiter-url service-id & {:keys [cookies] :or {cookies {}}}]
+  (get-in (service-settings waiter-url service-id :cookies cookies)
+          [:instances :killed-instances]))
+
 (defn num-instances
   "Returns the number of active instances for the given service-id"
   [waiter-url service-id & {:keys [cookies] :or {cookies {}}}]


### PR DESCRIPTION
## Changes proposed in this PR

- Avoid cross-router state problems (e.g., which instances are healthy or killed on which router) by sending queries to just one router.
- Override default async-request-timeout value to ensure it's more than the async request delay used in this test.

## Why are we making these changes?

This should significantly decrease the flakiness of `test-s3-logs`.