### PR TITLE
Use lein parallel-test v0.3.2

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -115,7 +115,7 @@
   :resource-paths ["resources"]
   :main waiter.main
   :plugins [[test2junit "1.2.2"]
-            [com.holychao/parallel-test "0.3.1"]]
+            [com.holychao/parallel-test "0.3.2"]]
   ; In case of kerberos problems, export KRB5_KTNAME=/var/spool/keytabs/$(id -un)
   :jvm-opts ["-server"
              "-Dsun.security.jgss.lib=/opt/mitkrb5/lib/libgssapi_krb5.so"

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -79,7 +79,7 @@
                  [org.apache.curator/curator-x-discovery "2.11.0"
                   :exclusions [io.netty/netty org.slf4j/slf4j-api]]
                  [org.clojure/clojure "1.10.0"]
-                 [org.clojure/core.async "0.4.490"
+                 [org.clojure/core.async "0.4.474"
                   :exclusions [org.clojure/clojure org.clojure/tools.reader]]
                  [org.clojure/core.memoize "0.7.1"
                   :exclusions [org.clojure/clojure]]

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -78,7 +78,7 @@
                                io.netty/netty]]
                  [org.apache.curator/curator-x-discovery "2.11.0"
                   :exclusions [io.netty/netty org.slf4j/slf4j-api]]
-                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/clojure "1.7.0"]
                  [org.clojure/core.async "0.4.474"
                   :exclusions [org.clojure/clojure org.clojure/tools.reader]]
                  [org.clojure/core.memoize "0.7.1"


### PR DESCRIPTION
## Changes proposed in this PR

- Upgrade lein parallel-test 0.3.1 to 0.3.2

## Why are we making these changes?

Hoping the parallel-test driver will hang less often after upgrading.