### PR TITLE
includes pods in container creating phase as unhealthy instances

### DIFF
--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -50,7 +50,7 @@
    task-count
    task-stats])
 
-(def ^:const UNKNOWN_IP "0.0.0.0")
+(def ^:const UNKNOWN-IP "0.0.0.0")
 
 (defn make-Service [value-map]
   (map->Service (merge {:task-stats {:running 0
@@ -242,7 +242,7 @@
    protocol health-check-port-index health-check-path]
   (async/go
     (try
-      (if (and port (pos? port) host (not= UNKNOWN_IP host))
+      (if (and port (pos? port) host (not= UNKNOWN-IP host))
         (let [instance-health-check-url (health-check-url service-instance protocol health-check-port-index health-check-path)
               request-timeout-ms (max (+ (.getConnectTimeout http-client) (.getIdleTimeout http-client)) 200)
               request-abort-chan (async/chan 1)

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -163,7 +163,7 @@
         common-extractor-fn (fn [instance-id marathon-task-response]
                               (let [{:keys [appId host message slaveId state]} marathon-task-response
                                     log-directory (mesos/build-sandbox-path mesos-api slaveId framework-id instance-id)]
-                                (cond-> {:host (or host scheduler/UNKNOWN_IP)
+                                (cond-> {:host (or host scheduler/UNKNOWN-IP)
                                          :service-id (remove-slash-prefix appId)}
                                   log-directory
                                   (assoc :log-directory log-directory)

--- a/waiter/src/waiter/state.clj
+++ b/waiter/src/waiter/state.clj
@@ -1175,24 +1175,19 @@
           all-instances-flagged-with? (fn [flag] (every? #(contains? % flag) failed-instance-flags))
           no-instances-flagged-with? (fn [flag] (every? #(not (contains? % flag)) failed-instance-flags))
           all-instances-exited-similarly? (and first-exit-code (every? #(= first-exit-code %) (map :exit-code failed-instances)))
-          result (cond
-                  (and has-failed-instances? all-instances-exited-similarly?) :bad-startup-command
-                  (and has-failed-instances? (all-instances-flagged-with? :memory-limit-exceeded)) :not-enough-memory
-                  (and has-failed-instances? (no-instances-flagged-with? :has-connected)) :cannot-connect
-                  (and has-failed-instances? (no-instances-flagged-with? :has-responded)) :health-check-timed-out
-                  (and has-failed-instances? (all-instances-flagged-with? :never-passed-health-checks)) :invalid-health-check-response
-                  (and has-unhealthy-instances? (= first-unhealthy-status 401)) :health-check-requires-authentication)]
-      (when result
-        (log/info "get-deployment-error"
-                  {:deployment-error result
-                   :instances {:failed failed-instances
-                               :unhealthy unhealthy-instances}
-                   :service-id (-> (or (seq failed-instances)
-                                       (seq unhealthy-instances)
-                                       (seq healthy-instances))
-                                 first
-                                 :service-id)}))
-      result)))
+          deployment-error (cond
+                             (and has-failed-instances? all-instances-exited-similarly?) :bad-startup-command
+                             (and has-failed-instances? (all-instances-flagged-with? :memory-limit-exceeded)) :not-enough-memory
+                             (and has-failed-instances? (no-instances-flagged-with? :has-connected)) :cannot-connect
+                             (and has-failed-instances? (no-instances-flagged-with? :has-responded)) :health-check-timed-out
+                             (and has-failed-instances? (all-instances-flagged-with? :never-passed-health-checks)) :invalid-health-check-response
+                             (and has-unhealthy-instances? (= first-unhealthy-status 401)) :health-check-requires-authentication)]
+      (when deployment-error
+        (log/debug "computed deployment error"
+                   {:deployment-error deployment-error
+                    :instances {:failed (map :id failed-instances)
+                                :unhealthy (map :id unhealthy-instances)}}))
+      deployment-error)))
 
 (defn get-instability-issue
   "Returns appropriate instability issue (only oom for now) for a service based on its instances, or nil if no such issues."

--- a/waiter/src/waiter/state.clj
+++ b/waiter/src/waiter/state.clj
@@ -1174,14 +1174,25 @@
           failed-instance-flags (map :flags failed-instances)
           all-instances-flagged-with? (fn [flag] (every? #(contains? % flag) failed-instance-flags))
           no-instances-flagged-with? (fn [flag] (every? #(not (contains? % flag)) failed-instance-flags))
-          all-instances-exited-similarly? (and first-exit-code (every? #(= first-exit-code %) (map :exit-code failed-instances)))]
-      (cond
-        (and has-failed-instances? all-instances-exited-similarly?) :bad-startup-command
-        (and has-failed-instances? (all-instances-flagged-with? :memory-limit-exceeded)) :not-enough-memory
-        (and has-failed-instances? (no-instances-flagged-with? :has-connected)) :cannot-connect
-        (and has-failed-instances? (no-instances-flagged-with? :has-responded)) :health-check-timed-out
-        (and has-failed-instances? (all-instances-flagged-with? :never-passed-health-checks)) :invalid-health-check-response
-        (and has-unhealthy-instances? (= first-unhealthy-status 401)) :health-check-requires-authentication))))
+          all-instances-exited-similarly? (and first-exit-code (every? #(= first-exit-code %) (map :exit-code failed-instances)))
+          result (cond
+                  (and has-failed-instances? all-instances-exited-similarly?) :bad-startup-command
+                  (and has-failed-instances? (all-instances-flagged-with? :memory-limit-exceeded)) :not-enough-memory
+                  (and has-failed-instances? (no-instances-flagged-with? :has-connected)) :cannot-connect
+                  (and has-failed-instances? (no-instances-flagged-with? :has-responded)) :health-check-timed-out
+                  (and has-failed-instances? (all-instances-flagged-with? :never-passed-health-checks)) :invalid-health-check-response
+                  (and has-unhealthy-instances? (= first-unhealthy-status 401)) :health-check-requires-authentication)]
+      (when result
+        (log/info "get-deployment-error"
+                  {:deployment-error result
+                   :instances {:failed failed-instances
+                               :unhealthy unhealthy-instances}
+                   :service-id (-> (or (seq failed-instances)
+                                       (seq unhealthy-instances)
+                                       (seq healthy-instances))
+                                 first
+                                 :service-id)}))
+      result)))
 
 (defn get-instability-issue
   "Returns appropriate instability issue (only oom for now) for a service based on its instances, or nil if no such issues."

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -395,7 +395,6 @@
                                            :waiter/service-id "test-app-1234"}}
                   :spec {:containers [{:ports [{:containerPort 8080 :protocol "TCP"}]}]}
                   :status {:phase "Pending"
-                           :podIP "1.2.3.4"
                            :startTime "2014-09-13T00:24:46Z"
                            :containerStatuses [{:name "test-app-1234"
                                                 :ready false
@@ -488,7 +487,7 @@
                    {:active-instances
                     [(scheduler/make-ServiceInstance
                        {:healthy? false
-                        :host "1.2.3.4"
+                        :host "0.0.0.0"
                         :id "test-app-1234.test-app-1234-abcd0-0"
                         :k8s/container-statuses [{:name "test-app-1234" :ready false :reason "ContainerCreating":state :waiting}]
                         :k8s/pod-phase "Pending"


### PR DESCRIPTION
## Changes proposed in this PR

- includes kubernetes pods without assigned IPs in active instances

## Why are we making these changes?

We would like to introspect the state of the instance in the underlying scheduler. We should eagerly report about any instance we hear back from the scheduler, including those in the `ContainerCreating` state.

