### PR TITLE
expires kubernetes services instances stuck in non-running state

### DIFF
--- a/waiter/bin/ci/run-integration-tests-k8s-scheduler.sh
+++ b/waiter/bin/ci/run-integration-tests-k8s-scheduler.sh
@@ -37,6 +37,7 @@ ${WAITER_DIR}/bin/run-using-k8s.sh ${WAITER_PORT} &
 bash +x ${DIR}/monitor-pods.sh &
 
 # Run the integration tests
+export INTEGRATION_TEST_BAD_IMAGE="twosigma/does-not-exist"
 export INTEGRATION_TEST_CUSTOM_IMAGE="twosigma/integration"
 export INTEGRATION_TEST_CUSTOM_IMAGE_ALIAS="alias/integration"
 export INTEGRATION_TEST_KITCHEN_IMAGE="twosigma/waiter-test-apps"

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -440,6 +440,11 @@
                                  ;; String value used to annotate Kubernetes objects that are orchestrated by this Waiter instantiation:
                                  :cluster-name "waiter"
 
+                                 ;; Duration to wait before marking a pod as expired when it hasn't transitioned to running state (default is 90).
+                                 ;; Configure the value to 0 to disable expiring instances and removing the duration constraint on pods
+                                 ;; before they transition to the running state.
+                                 :container-running-grace-secs 90
+
                                  ;; Configuration for creating and querying a sidecar container in each Waiter Service Instance's Kuberentes pod
                                  ;; running a server for directory listings (in JSON) and serving file contents.
                                  ;; Waiter expects the directory listings in the format returned by nginx's autoindex module when configured for JSON.

--- a/waiter/config-k8s.edn
+++ b/waiter/config-k8s.edn
@@ -36,6 +36,7 @@
  :scheduler-config {:kind :kubernetes
                     :kubernetes {:authorizer {:kind :sanity-check
                                               :sanity-check {:factory-fn waiter.authorization/sanity-check-authorizer}}
+                                 :container-running-grace-secs 90
                                  :fileserver {:port 591}
                                  :log-bucket-sync-secs 5
                                  :log-bucket-url #config/env-default ["WAITER_S3_BUCKET" nil]

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -208,26 +208,58 @@
       (log/error e "error converting failed pod to waiter service instance" pod)
       (comment "Returning nil on failure."))))
 
+(defn- check-expired
+  "Returns true when the pod instance can be classified as expired.
+   An instance can be expired for the following reasons:
+   - it has restarted too many times (reached the restart-expiry-threshold threshold)
+   - the primary container (waiter-apps) has not transitioned to running state in container-running-grace-secs seconds."
+  [{:keys [container-running-grace-secs restart-expiry-threshold]}
+   instance-id restart-count primary-container-status pod-started-at]
+  (cond
+    (>= restart-count restart-expiry-threshold)
+    (do
+      (log/info "instance expired as it reached the restart threshold"
+                {:instance-id instance-id
+                 :restart-count restart-count})
+      true)
+    (and pod-started-at
+         (pos? container-running-grace-secs)
+         (not (contains? (get primary-container-status :state) :running))
+         (-> (t/now)
+           (t/minus (t/seconds container-running-grace-secs))
+           (t/after? pod-started-at)))
+    (do
+      (log/info "instance expired as it took too long to transition to running state"
+                {:instance-id instance-id
+                 :primary-container-status primary-container-status
+                 :started-at pod-started-at})
+      true)))
+
 (defn pod->ServiceInstance
   "Convert a Kubernetes Pod JSON response into a Waiter Service Instance record."
-  [restart-expiry-threshold pod]
+  [scheduler pod]
   (try
-    (let [port0 (get-in pod [:spec :containers 0 :ports 0 :containerPort])
-          ;; waiter-app is the first container we register
+    (let [;; waiter-app is the first container we register
           restart-count (get-in pod [:status :containerStatuses 0 :restartCount] 0)
+          instance-id (pod->instance-id pod restart-count)
+          port0 (get-in pod [:spec :containers 0 :ports 0 :containerPort])
           run-as-user (or (get-in pod [:metadata :labels :waiter/user])
                           ;; falling back to namespace for legacy pods missing the waiter/user label
                           (k8s-object->namespace pod))
           ;; pod phase documentation: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
           {:keys [phase] :as pod-status} (:status pod)
-          container-statuses (get pod-status :containerStatuses)]
+          container-statuses (get pod-status :containerStatuses)
+          primary-container-status (first container-statuses)
+          pod-started-at (-> pod (get-in [:status :startTime]) timestamp-str->datetime)]
       (scheduler/make-ServiceInstance
         (cond-> {:extra-ports (->> (get-in pod [:metadata :annotations :waiter/port-count])
                                    Integer/parseInt range next (mapv #(+ port0 %)))
-                 :flags (cond-> #{} (>= restart-count restart-expiry-threshold) (conj :expired))
-                 :healthy? (get-in pod [:status :containerStatuses 0 :ready] false)
+                 :flags (cond-> #{}
+                          (check-expired scheduler instance-id restart-count primary-container-status pod-started-at)
+                          (conj :expired))
+                 :healthy? (true? (get primary-container-status :ready))
                  :host (get-in pod [:status :podIP] scheduler/UNKNOWN-IP)
-                 :id (pod->instance-id pod restart-count)
+                 :id instance-id
                  :k8s/app-name (get-in pod [:metadata :labels :app])
                  :k8s/namespace (k8s-object->namespace pod)
                  :k8s/pod-name (k8s-object->id pod)
@@ -236,9 +268,7 @@
                  :log-directory (log-dir-path run-as-user restart-count)
                  :port port0
                  :service-id (k8s-object->service-id pod)
-                 :started-at (-> pod
-                               (get-in [:status :startTime])
-                               (timestamp-str->datetime))}
+                 :started-at pod-started-at}
           phase (assoc :k8s/pod-phase phase)
           (seq container-statuses) (assoc :k8s/container-statuses
                                           (map (fn [{:keys [state] :as status}]
@@ -334,10 +364,10 @@
 (defn- get-service-instances!
   "Get all active Waiter Service Instances associated with the given Waiter Service.
    Also updates the service-id->failed-instances-transient-store as a side-effect."
-  [{:keys [restart-expiry-threshold] :as scheduler} basic-service-info]
+  [scheduler basic-service-info]
   (vec (for [pod (get-replicaset-pods scheduler basic-service-info)
              :when (live-pod? pod)]
-         (let [service-instance (pod->ServiceInstance restart-expiry-threshold pod)]
+         (let [service-instance (pod->ServiceInstance scheduler pod)]
            (track-failed-instances! service-instance scheduler pod)
            service-instance))))
 
@@ -523,6 +553,7 @@
 (defrecord KubernetesScheduler [api-server-url
                                 authorizer
                                 cluster-name
+                                container-running-grace-secs
                                 custom-options
                                 daemon-state
                                 fileserver
@@ -1035,13 +1066,14 @@
 (defn kubernetes-scheduler
   "Returns a new KubernetesScheduler with the provided configuration. Validates the
    configuration against kubernetes-scheduler-schema and throws if it's not valid."
-  [{:keys [authentication authorizer cluster-name custom-options http-options log-bucket-sync-secs
+  [{:keys [authentication authorizer cluster-name container-running-grace-secs custom-options http-options log-bucket-sync-secs
            log-bucket-url max-patch-retries max-name-length pod-base-port pod-sigkill-delay-secs
            pod-suffix-length replicaset-api-version replicaset-spec-builder restart-expiry-threshold scheduler-name
            scheduler-state-chan scheduler-syncer-interval-secs service-id->service-description-fn
            service-id->password-fn start-scheduler-syncer-fn url watch-retries]
     {fileserver-port :port fileserver-scheme :scheme :as fileserver} :fileserver :as context}]
   {:pre [(schema/contains-kind-sub-map? authorizer)
+         (or (zero? container-running-grace-secs) (pos-int? container-running-grace-secs))
          (or (nil? custom-options) (map? custom-options))
          (or (nil? fileserver-port)
              (and (integer? fileserver-port)
@@ -1093,6 +1125,7 @@
         scheduler-config {:api-server-url url
                           :http-client http-client
                           :cluster-name cluster-name
+                          :container-running-grace-secs container-running-grace-secs
                           :replicaset-api-version replicaset-api-version
                           :restart-expiry-threshold restart-expiry-threshold
                           :service-id->failed-instances-transient-store service-id->failed-instances-transient-store
@@ -1109,6 +1142,7 @@
           scheduler (->KubernetesScheduler url
                                            authorizer
                                            cluster-name
+                                           container-running-grace-secs
                                            custom-options
                                            daemon-state
                                            fileserver

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -224,10 +224,9 @@
       true)
     (and pod-started-at
          (pos? container-running-grace-secs)
-         (not (contains? (get primary-container-status :state) :running))
-         (-> (t/now)
-           (t/minus (t/seconds container-running-grace-secs))
-           (t/after? pod-started-at)))
+         (empty? (:lastState primary-container-status))
+         (not (contains? (:state primary-container-status) :running))
+         (<= container-running-grace-secs (t/in-seconds (t/interval pod-started-at (t/now)))))
     (do
       (log/info "instance expired as it took too long to transition to running state"
                 {:instance-id instance-id

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -345,6 +345,7 @@
                                    :authorizer {:kind :default
                                                 :default {:factory-fn 'waiter.authorization/noop-authorizer}}
                                    :cluster-name "waiter"
+                                   :container-running-grace-secs 90
                                    :fileserver {:cmd ["/bin/fileserver-start"]
                                                 :image "twosigma/waiter-fileserver"
                                                 :resources {:cpu 0.1 :mem 128}

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -321,10 +321,9 @@
 
 (defn make-request
   ([waiter-url path &
-    {:keys [abort-ch body client cookies content-type disable-auth form-params headers
+    {:keys [body client cookies content-type disable-auth form-params headers
             method multipart protocol query-params scheme trailers-fn verbose]
-     :or {abort-ch (async/promise-chan)
-          body nil
+     :or {body nil
           cookies []
           disable-auth false
           headers {}
@@ -354,8 +353,7 @@
              {:keys [body error error-chan headers status trailers]}
              (async/<!! (http/request
                           client
-                          (cond-> {:abort-ch abort-ch
-                                   :body body
+                          (cond-> {:body body
                                    :follow-redirects? false
                                    :headers request-headers
                                    :method method
@@ -372,8 +370,7 @@
                        (when error-chan (async/<!! error-chan)))]
          (when verbose
            (log/info (get request-headers "x-cid") "response size:" (count (str response-body))))
-         {:abort-ch abort-ch
-          :body response-body
+         {:body response-body
           :cookies (parse-cookies (get headers "set-cookie"))
           :error error
           :headers headers

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -1663,4 +1663,12 @@
             dummy-scheduler {:container-running-grace-secs 45
                              :restart-expiry-threshold restart-expiry-threshold}
             instance (pod->ServiceInstance dummy-scheduler pod)]
-        (is (= (scheduler/make-ServiceInstance (assoc instance-map :flags #{:expired})) instance))))))
+        (is (= (scheduler/make-ServiceInstance (assoc instance-map :flags #{:expired})) instance))))
+
+    (testing "previously started pod not expired despite instance exceeded running grace period"
+      (let [restart-expiry-threshold 25
+            dummy-scheduler {:container-running-grace-secs 45
+                             :restart-expiry-threshold restart-expiry-threshold}
+            pod (assoc-in pod [:status :containerStatuses 0 :lastState] {:terminated {}})
+            instance (pod->ServiceInstance dummy-scheduler pod)]
+        (is (= (scheduler/make-ServiceInstance instance-map) instance))))))


### PR DESCRIPTION
## Changes proposed in this PR

- adds the container-running-grace-secs configuration to the kubernetes scheduler

## Why are we making these changes?

We would like to replace pods that do not start but are not cleaned up by the grace period trigger (which takes effect only after the container has started) in kubernetes.
