### PR TITLE
adds state and unknown host for marathon instances

### DIFF
--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -161,15 +161,18 @@
   (let [service-id (remove-slash-prefix (get-in marathon-response (conj service-keys :id)))
         framework-id (retrieve-framework-id-fn)
         common-extractor-fn (fn [instance-id marathon-task-response]
-                              (let [{:keys [appId host message slaveId]} marathon-task-response
+                              (let [{:keys [appId host message slaveId state]} marathon-task-response
                                     log-directory (mesos/build-sandbox-path mesos-api slaveId framework-id instance-id)]
-                                (cond-> {:host host
+                                (cond-> {:host (or host scheduler/UNKNOWN_IP)
                                          :service-id (remove-slash-prefix appId)}
                                   log-directory
                                   (assoc :log-directory log-directory)
 
                                   message
                                   (assoc :message (str/trim message))
+
+                                  state
+                                  (assoc :marathon/state state)
 
                                   (str/includes? (str message) "Memory limit exceeded:")
                                   (assoc :flags #{:memory-limit-exceeded})

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -74,6 +74,7 @@
                                           :ports [31045],
                                           :stagedAt "2014-09-12T23:28:28.594Z",
                                           :startedAt "2014-09-13T00:24:46.959Z",
+                                          :state "TASK_RUNNING",
                                           :version "2014-09-12T23:28:21.737Z"},
                                          {
                                           :appId "/test-app-1234",
@@ -108,6 +109,7 @@
                                                   :host "10.141.141.11",
                                                   :id "test-app-1234.A",
                                                   :log-directory nil,
+                                                  :marathon/state "TASK_RUNNING"
                                                   :message nil,
                                                   :port 31045,
                                                   :service-id "test-app-1234",
@@ -139,6 +141,7 @@
                                                   :host "10.141.141.10",
                                                   :id "test-app-1234.D",
                                                   :log-directory nil,
+                                                  :marathon/state "TASK_FAILED"
                                                   :message "Abnormal executor termination",
                                                   :port 0,
                                                   :service-id "test-app-1234",
@@ -370,6 +373,7 @@
                          :host "10.141.141.10"
                          :port 0
                          :started-at (du/str-to-date "2014-09-12T23:23:41.711Z" formatter-marathon)
+                         :marathon/state "TASK_FAILED"
                          :message "Abnormal executor termination"}))})
         service-id->failed-instances-transient-store (atom {})
         actual (response-data->service->service-instances


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for unknown IP address

## Why are we making these changes?

Adds more visibility into the state of the Marathon task.
