### PR TITLE
Use lein parallel-test v0.3.2

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -115,7 +115,7 @@
   :resource-paths ["resources"]
   :main waiter.main
   :plugins [[test2junit "1.2.2"]
-            [com.holychao/parallel-test "0.3.1"]]
+            [com.holychao/parallel-test "0.3.2"]]
   ; In case of kerberos problems, export KRB5_KTNAME=/var/spool/keytabs/$(id -un)
   :jvm-opts ["-server"
              "-Dsun.security.jgss.lib=/opt/mitkrb5/lib/libgssapi_krb5.so"


### PR DESCRIPTION
## Changes proposed in this PR

- Upgrade lein parallel-test 0.3.1 to 0.3.2

## Why are we making these changes?

Hoping the parallel-test driver will hang less often after upgrading.