### PR TITLE
includes unhealthy instances while computing expired instances

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -623,6 +623,10 @@
            ;; Throttles the rate at which kill requests are sent to the scheduler:
            :inter-kill-request-wait-time-ms 1000
 
+           ;; The autoscaler accounts for expired (both healthy and unhealthy) instances while scaling.
+           ;; Limits the number of unhealthy expired instances taken into account by the scaling algorithm:
+           :max-expired-unhealthy-instances-to-consider 2
+
            ;; Individual scale-up operations are throttled so that we can minimize overshoot of instances.
            ;; The number of new instances started per scale-up is the maximum of 1 and the resource consumed
            ;; limit calculated based on the cpus and mem specified in the quanta-constraints.

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -973,7 +973,7 @@
   {:autoscaler (pc/fnk [[:curator leader?-fn]
                         [:routines router-metrics-helpers service-id->service-description-fn]
                         [:scheduler scheduler]
-                        [:settings [:scaling autoscaler-interval-ms]]
+                        [:settings [:scaling autoscaler-interval-ms max-expired-unhealthy-instances-to-consider]]
                         [:state scheduler-interactions-thread-pool]
                         autoscaling-multiplexer router-state-maintainer]
                  (let [service-id->metrics-fn (:service-id->metrics-fn router-metrics-helpers)
@@ -982,7 +982,7 @@
                    (scaling/autoscaler-goroutine
                      {} leader?-fn service-id->metrics-fn executor-multiplexer-chan scheduler autoscaler-interval-ms
                      scaling/scale-service service-id->service-description-fn router-state-push-mult
-                     scheduler-interactions-thread-pool)))
+                     scheduler-interactions-thread-pool max-expired-unhealthy-instances-to-consider)))
    :autoscaling-multiplexer (pc/fnk [[:routines delegate-instance-kill-request-fn peers-acknowledged-blacklist-requests-fn
                                       service-id->service-description-fn]
                                      [:scheduler scheduler]

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -92,6 +92,7 @@
                                     (s/required-key :interval-ms) schema/positive-int}
    (s/required-key :scaling) {(s/required-key :autoscaler-interval-ms) schema/positive-int
                               (s/required-key :inter-kill-request-wait-time-ms) schema/positive-int
+                              (s/required-key :max-expired-unhealthy-instances-to-consider) schema/non-negative-int
                               (s/required-key :quanta-constraints) {(s/required-key :cpus) schema/positive-int
                                                                     (s/required-key :mem) schema/positive-int}}
    (s/required-key :scheduler-config) (s/constrained
@@ -320,6 +321,7 @@
    :scaling {:autoscaler-interval-ms 1000
              ; throttles the rate at which kill requests are sent to the scheduler
              :inter-kill-request-wait-time-ms 1000
+             :max-expired-unhealthy-instances-to-consider 2
              :quanta-constraints {:cpus 64
                                   :mem (* 512 1024)}}
    :scheduler-config {:kind :marathon

--- a/waiter/src/waiter/state.clj
+++ b/waiter/src/waiter/state.clj
@@ -1296,7 +1296,7 @@
                                               expired-instances (filter #(or (contains? (:flags %) :expired)
                                                                              (and (pos? expiry-mins-int)
                                                                                   (du/older-than? scheduler-sync-time expiry-mins %)))
-                                                                        healthy-instances)
+                                                                        (concat healthy-instances unhealthy-instances))
                                               starting-instances (filter #(not (du/older-than? scheduler-sync-time grace-period-secs %)) unhealthy-instances)
                                               service-id->expired-instances' (assoc service-id->expired-instances service-id expired-instances)
                                               service-id->starting-instances' (assoc service-id->starting-instances service-id starting-instances)
@@ -1320,6 +1320,7 @@
                                                   rem-instance-ids (filterv (complement curr-instance-ids) prev-instance-ids)
                                                   unhealthy-instance-ids (mapv :id (get service-id->unhealthy-instances' service-id))]
                                               (log/info "update-healthy-instances:" service-id "has"
+                                                        (count expired-instances) "expired instance(s),"
                                                         (count healthy-instances) "healthy instance(s) and"
                                                         (count unhealthy-instance-ids) "unhealthy instance(s)."
                                                         (if (seq new-instance-ids) (str "New healthy instances: " new-instance-ids ".") "")

--- a/waiter/src/waiter/state.clj
+++ b/waiter/src/waiter/state.clj
@@ -1293,10 +1293,13 @@
                                         (let [grace-period-secs (t/seconds (int (get service-description "grace-period-secs")))
                                               expiry-mins-int (int (get service-description "instance-expiry-mins"))
                                               expiry-mins (t/minutes expiry-mins-int)
-                                              expired-instances (filter #(or (contains? (:flags %) :expired)
-                                                                             (and (pos? expiry-mins-int)
-                                                                                  (du/older-than? scheduler-sync-time expiry-mins %)))
-                                                                        (concat healthy-instances unhealthy-instances))
+                                              instance-expired? (fn instance-expired? [instance]
+                                                                  (or (contains? (:flags instance) :expired)
+                                                                      (and (pos? expiry-mins-int)
+                                                                           (du/older-than? scheduler-sync-time expiry-mins instance))))
+                                              expired-healthy-instances (filter instance-expired? healthy-instances)
+                                              expired-unhealthy-instances (filter instance-expired? unhealthy-instances)
+                                              expired-instances (concat expired-healthy-instances expired-unhealthy-instances)
                                               starting-instances (filter #(not (du/older-than? scheduler-sync-time grace-period-secs %)) unhealthy-instances)
                                               service-id->expired-instances' (assoc service-id->expired-instances service-id expired-instances)
                                               service-id->starting-instances' (assoc service-id->starting-instances service-id starting-instances)
@@ -1320,9 +1323,11 @@
                                                   rem-instance-ids (filterv (complement curr-instance-ids) prev-instance-ids)
                                                   unhealthy-instance-ids (mapv :id (get service-id->unhealthy-instances' service-id))]
                                               (log/info "update-healthy-instances:" service-id "has"
-                                                        (count expired-instances) "expired instance(s),"
-                                                        (count healthy-instances) "healthy instance(s) and"
-                                                        (count unhealthy-instance-ids) "unhealthy instance(s)."
+                                                        {:num-expired-healthy-instances (count expired-healthy-instances)
+                                                         :num-expired-unhealthy-instances (count expired-unhealthy-instances)
+                                                         :num-healthy-instances (count healthy-instances)
+                                                         :num-unhealthy-instance-ids (count unhealthy-instance-ids)
+                                                         :service-d service-id}
                                                         (if (seq new-instance-ids) (str "New healthy instances: " new-instance-ids ".") "")
                                                         (if (seq rem-instance-ids) (str "Removed healthy instances: " rem-instance-ids ".") "")
                                                         (if (seq unhealthy-instance-ids) (str "Unhealthy instances: " unhealthy-instance-ids ".") ""))))

--- a/waiter/test/waiter/scaling_test.clj
+++ b/waiter/test/waiter/scaling_test.clj
@@ -670,7 +670,7 @@
                                    10)
                           ; max instances is 20
                           "app5" (do
-                                   (is (= 11 scale-amount))
+                                   (is (= 7 scale-amount))
                                    (is (= 21 scale-to-instances))
                                    18)))
         ; simple scaling function that targets outstanding-requests
@@ -689,7 +689,7 @@
                                   "app2" (merge config {})
                                   "app3" (merge config {"min-instances" 5})
                                   "app4" (merge config {"max-instances" 10})
-                                  "app5" (merge config {"max-instances" 20})
+                                  "app5" (merge config {"max-instances" 20}) ;; scale past max instances to replace expired
                                   "app6" (merge config {})}
                                  ;; service-id->outstanding-requests
                                  {"app1" 10
@@ -713,22 +713,22 @@
                                   "app2" {:healthy-instances 5 :task-count 5 :expired-healthy-instances 0 :expired-unhealthy-instances 0}
                                   "app3" {:healthy-instances 0 :task-count 0 :expired-healthy-instances 0 :expired-unhealthy-instances 0}
                                   "app4" {:healthy-instances 15 :task-count 15 :expired-healthy-instances 0 :expired-unhealthy-instances 0}
-                                  "app5" {:healthy-instances 10 :task-count 10 :expired-healthy-instances 7 :expired-unhealthy-instances 4}
+                                  ;; scale past the max instances of 20 to replace 9 (7 + 2) of the expired instances
+                                  "app5" {:healthy-instances 10 :task-count 14 :expired-healthy-instances 7 :expired-unhealthy-instances 4}
                                   "app6" {:healthy-instances 5 :task-count 5 :expired-healthy-instances 0 :expired-unhealthy-instances 0}}
                                  ;; service-id->scheduler-state
                                  {"app1" {:instances 5 :task-count 5}
                                   "app2" {:instances 5 :task-count 5}
                                   "app3" {:instances 0 :task-count 0}
                                   "app4" {:instances 15 :task-count 15}
-                                  "app5" {:instances 10 :task-count 10}
+                                  "app5" {:instances 14 :task-count 14}
                                   "app6" {:instances 5 :task-count 5}}
                                  max-expired-unhealthy-instances-to-consider)]
-      (clojure.pprint/pprint result)
       (is (= {:target-instances 10, :scale-to-instances 10, :scale-amount 5} (get result "app1")))
       (is (= {:target-instances 5, :scale-to-instances 5, :scale-amount 0} (get result "app2")))
       (is (= {:target-instances 5, :scale-to-instances 5, :scale-amount 5} (get result "app3")))
       (is (= {:target-instances 10, :scale-to-instances 10, :scale-amount -5} (get result "app4")))
-      (is (= {:target-instances 12, :scale-to-instances 21, :scale-amount 11} (get result "app5")))
+      (is (= {:target-instances 12, :scale-to-instances 21, :scale-amount 7} (get result "app5")))
       (is (nil? (get result "app6"))))))
 
 (deftest normalize-factor-test

--- a/waiter/test/waiter/state_test.clj
+++ b/waiter/test/waiter/state_test.clj
@@ -1222,14 +1222,14 @@
             healthy-instances-fn (fn [service-id index n]
                                    (vec (map #(assoc
                                                 {:started-at start-time}
-                                                :id (str service-id "." % "1"))
+                                                :id (str service-id "." % ".h"))
                                              (range (if (zero? (mod index 2)) 1 (max 1 n))))))
             unhealthy-instances-fn (fn [service-id index]
-                                     (vec (map (fn [x] {:id (str service-id "." x "1")
+                                     (vec (map (fn [x] {:id (str service-id "." x ".u")
                                                         :started-at start-time})
                                                (range (if (zero? (mod index 2)) 1 0)))))
             failed-instances-fn (fn [service-id index]
-                                  (vec (map (fn [x] {:id (str service-id "." x "1")
+                                  (vec (map (fn [x] {:id (str service-id "." x ".f")
                                                      :started-at start-time})
                                             (range (if (zero? (mod index 2)) 1 0)))))]
         (dotimes [n num-message-iterations]
@@ -1267,11 +1267,12 @@
                                     (pc/map-from-keys
                                       (fn [service]
                                         (let [healthy-instances (healthy-instances-fn service (index-fn service) n)
+                                              unhealthy-instances (unhealthy-instances-fn service (index-fn service))
                                               expiry-mins-int (Integer/parseInt (str/replace service "service-" ""))
                                               expiry-mins (t/minutes expiry-mins-int)]
                                           (filter #(and (pos? expiry-mins-int)
                                                         (du/older-than? current-time expiry-mins %1))
-                                                  healthy-instances)))
+                                                  (concat healthy-instances unhealthy-instances))))
                                       expected-service-ids)
                                     :service-id->starting-instances
                                     (pc/map-from-keys


### PR DESCRIPTION
## Changes proposed in this PR

- verifies scaling algorithm works when there are no healthy instances but expired instances are present
- includes unhealthy instances while computing expired instances
- limits the number of unhealthy expired instances considered by the scaling algorithm

## Why are we making these changes?

Expired instances can be healthy or unhealthy. We should consider both classes of instances while accounting for expired instances.

