### PR TITLE
moves x-waiter-auth cookie validation into a single handler

### DIFF
--- a/waiter/test/waiter/auth/saml_test.clj
+++ b/waiter/test/waiter/auth/saml_test.clj
@@ -62,12 +62,6 @@
 (deftest test-wrap-handler
   (let [saml-authenticator (dummy-saml-authenticator)
         wrapped-handler (auth/wrap-auth-handler saml-authenticator identity)]
-    (testing "has auth cookie"
-      (with-redefs [auth/decode-auth-cookie (fn [waiter-cookie _] (if (= "my-auth-cookie" waiter-cookie) ["my-user@domain"] nil))
-                    auth/decoded-auth-valid? (fn [_] true)]
-        (is (= (merge dummy-request {:authorization/principal "my-user@domain"
-                                     :authorization/user "my-user"})
-               (wrapped-handler dummy-request)))))
     (testing "can't use POST"
       (is (thrown-with-msg? Exception #"Invalid request method for use with SAML authentication"
                             (wrapped-handler (assoc dummy-request :request-method :post)))))


### PR DESCRIPTION
## Changes proposed in this PR

- moves x-waiter-auth cookie validation into a single handler

## Why are we making these changes?

Move the common logic of cookie-based authentication to a single handler.

