### PR TITLE
Ignore .test_metrics directory

### DIFF
--- a/waiter/.gitignore
+++ b/waiter/.gitignore
@@ -30,3 +30,6 @@ bin/generated-nginx.conf
 
 # Minimesos
 .minimesos
+
+# waiter test_helpers tmp dir
+.test_metrics


### PR DESCRIPTION
## Changes proposed in this PR

Ignore `.test_metrics` directory

## Why are we making these changes?

This is generated automatically when we launch out tests, and I'd like git to ignore it.