### PR TITLE
adds authentication source to the request log

### DIFF
--- a/waiter/src/waiter/auth/authentication.clj
+++ b/waiter/src/waiter/auth/authentication.clj
@@ -151,7 +151,8 @@
   (fn auth-cookie-handler
     [{:keys [headers] :as request}]
     (let [[auth-principal _ :as decoded-auth-cookie] (get-and-decode-auth-cookie-value headers password)]
-      (handler
-        (cond-> request
-          (decoded-auth-valid? decoded-auth-cookie)
-          (merge (auth-params-map :cookie auth-principal)))))))
+      (if (decoded-auth-valid? decoded-auth-cookie)
+        (let [auth-params-map (auth-params-map :cookie auth-principal)
+              handler' (middleware/wrap-merge handler auth-params-map)]
+          (handler' request))
+        (handler request)))))

--- a/waiter/src/waiter/auth/saml.clj
+++ b/waiter/src/waiter/auth/saml.clj
@@ -26,7 +26,6 @@
             [ring.util.codec :as codec]
             [ring.util.response :as response]
             [waiter.auth.authentication :as auth]
-            [waiter.middleware :as middleware]
             [waiter.util.date-utils :as du]
             [waiter.util.utils :as utils]
             [waiter.metrics :as metrics])
@@ -203,7 +202,7 @@
         ; https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/technical-reference/the-role-of-claims
         upn (first (get attrs "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"))
         saml-principal (or upn name-id-value)
-        {:keys [authorization/principal authorization/user]} (auth/auth-params-map saml-principal)
+        {:keys [authorization/principal authorization/user]} (auth/auth-params-map :saml saml-principal)
         saml-principal' (if (and email (= principal user)) email saml-principal)
         saml-auth-data (utils/map->base-64-string
                          {:min-session-not-on-or-after min-session-not-on-or-after
@@ -243,7 +242,7 @@
                                        (t/interval auth-cookie-expiry-date)
                                        t/in-seconds)
           {:keys [authorization/principal authorization/user] :as auth-params-map}
-          (auth/auth-params-map saml-principal)]
+          (auth/auth-params-map :saml saml-principal)]
       (auth/handle-request-auth (constantly {:body ""
                                              :headers {"location" redirect-url}
                                              :status 303})

--- a/waiter/src/waiter/auth/spnego.clj
+++ b/waiter/src/waiter/auth/spnego.clj
@@ -152,7 +152,7 @@
               (if-not error
                 (try
                   (if principal
-                    (let [response (auth/handle-request-auth request-handler request principal password)]
+                    (let [response (auth/handle-request-auth request-handler request :spnego principal password)]
                       (log/debug "added cookies to response")
                       (if token
                         (if (map? response)

--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -49,11 +49,12 @@
 
 (defn response->context
   "Convert a response into a context suitable for logging."
-  [{:keys [authorization/principal backend-response-latency-ns descriptor latest-service-id get-instance-latency-ns
-           handle-request-latency-ns headers instance protocol status] :as response}]
+  [{:keys [authorization/method authorization/principal backend-response-latency-ns descriptor latest-service-id
+           get-instance-latency-ns handle-request-latency-ns headers instance protocol status] :as response}]
   (let [{:keys [service-id service-description]} descriptor
         {:strs [content-length content-type grpc-status server]} headers]
     (cond-> {:status (or status 200)}
+      method (assoc :authentication-method (name method))
       backend-response-latency-ns (assoc :backend-response-latency-ns backend-response-latency-ns)
       content-length (assoc :response-content-length content-length)
       content-type (assoc :response-content-type content-type)

--- a/waiter/src/waiter/websocket.clj
+++ b/waiter/src/waiter/websocket.clj
@@ -106,7 +106,7 @@
   [password process-request-fn {:keys [headers] :as request}]
   (let [auth-cookie (-> headers (get "cookie") str auth/get-auth-cookie-value) ;; auth-cookie is assumed to be valid
         [auth-principal auth-time] (auth/decode-auth-cookie auth-cookie password)
-        auth-params-map (auth/auth-params-map auth-principal)
+        auth-params-map (auth/auth-params-map :cookie auth-principal)
         handler (middleware/wrap-merge process-request-fn auth-params-map)]
     (log/info "processing websocket request" {:user auth-principal})
     (-> request

--- a/waiter/test/waiter/auth/authenticator_test.clj
+++ b/waiter/test/waiter/auth/authenticator_test.clj
@@ -71,7 +71,10 @@
     (testing "valid auth cookie"
       (with-redefs [decode-auth-cookie (constantly [auth-principal (+ (System/currentTimeMillis) 60000)])]
         (let [auth-cookie-handler (wrap-auth-cookie-handler password request-handler)]
-          (is (= {:body {:principal auth-principal :user auth-user}}
+          (is (= {:authorization/method :cookie
+                  :authorization/principal auth-principal
+                  :authorization/user auth-user
+                  :body {:principal auth-principal :user auth-user}}
                  (auth-cookie-handler {:headers {"cookie" "x-waiter-auth=test-auth-cookie"}}))))))
 
     (testing "invalid auth cookie"

--- a/waiter/test/waiter/auth/authenticator_test.clj
+++ b/waiter/test/waiter/auth/authenticator_test.clj
@@ -28,6 +28,7 @@
     (let [request-handler (wrap-auth-handler authenticator identity)
           request {}
           expected-request (assoc request
+                             :authorization/method :single-user
                              :authorization/principal username
                              :authorization/user username)
           actual-result (request-handler request)]

--- a/waiter/test/waiter/auth/saml_test.clj
+++ b/waiter/test/waiter/auth/saml_test.clj
@@ -113,7 +113,8 @@
         (let [dummy-request' (-> (merge-with merge dummy-request {:headers {"content-type" "application/x-www-form-urlencoded"}})
                                (merge {:request-method :post
                                        :body (StringBufferInputStream. "saml-auth-data=my-saml-auth-data")}))]
-          (is (= {:authorization/principal "my-user@domain"
+          (is (= {:authorization/method :saml
+                  :authorization/principal "my-user@domain"
                   :authorization/user "my-user"
                   :body ""
                   :headers {"location" "redirect-url"
@@ -132,7 +133,8 @@
         (let [dummy-request' (-> (merge-with merge dummy-request {:headers {"content-type" "application/x-www-form-urlencoded"}})
                                (merge {:request-method :post
                                        :body (StringBufferInputStream. "saml-auth-data=my-saml-auth-data")}))]
-          (is (= {:authorization/principal "my-user@domain"
+          (is (= {:authorization/method :saml
+                  :authorization/principal "my-user@domain"
                   :authorization/user "my-user"
                   :body ""
                   :headers {"location" "redirect-url"
@@ -151,7 +153,8 @@
         (let [dummy-request' (-> (merge-with merge dummy-request {:headers {"content-type" "application/x-www-form-urlencoded"}})
                                (merge {:request-method :post
                                        :body (StringBufferInputStream. "saml-auth-data=my-saml-auth-data")}))]
-          (is (= {:authorization/principal "my-user@domain"
+          (is (= {:authorization/method :saml
+                  :authorization/principal "my-user@domain"
                   :authorization/user "my-user"
                   :body ""
                   :headers {"location" "redirect-url"

--- a/waiter/test/waiter/auth/spnego_test.clj
+++ b/waiter/test/waiter/auth/spnego_test.clj
@@ -15,9 +15,7 @@
 ;;
 (ns waiter.auth.spnego-test
   (:require [clojure.core.async :as async]
-            [clojure.string :as str]
             [clojure.test :refer :all]
-            [waiter.auth.authentication :as auth]
             [waiter.auth.spnego :refer :all]
             [waiter.util.utils :as utils]))
 
@@ -95,6 +93,7 @@
                                  response
                                  (async/<!! response))]
                   (is (= (assoc ideal-response
+                           :authorization/method :spnego
                            :authorization/principal "user@test.com"
                            :authorization/user "user"
                            :headers {"www-authenticate" "test-token"})
@@ -109,6 +108,7 @@
                                  response
                                  (async/<!! response))]
                   (is (= (assoc ideal-response
+                           :authorization/method :spnego
                            :authorization/principal "user@test.com"
                            :authorization/user "user")
                          (utils/dissoc-in response [:headers "set-cookie"]))))))))))))

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -1285,7 +1285,11 @@
       (testing "cookie-authentication"
         (with-redefs [auth/get-and-decode-auth-cookie-value (constantly ["user@test.com" (System/currentTimeMillis)])
                       auth/decoded-auth-valid? (fn [[principal _]] (some? principal))]
-          (is (= {:principal "user@test.com" :source ::standard-handler}
+          (is (= {:authorization/method :cookie,
+                  :authorization/principal "user@test.com",
+                  :authorization/user "user"
+                  :principal "user@test.com"
+                  :source ::standard-handler}
                  (request-handler {:headers {"cookie" "test-cookie"}})))))
 
       (testing "require-authentication"

--- a/waiter/test/waiter/request_log_test.clj
+++ b/waiter/test/waiter/request_log_test.clj
@@ -52,7 +52,8 @@
            (request->context request)))))
 
 (deftest test-response->context
-  (let [response {:authorization/principal "principal@DOMAIN.COM"
+  (let [response {:authorization/method :cookie
+                  :authorization/principal "principal@DOMAIN.COM"
                   :backend-response-latency-ns 1000
                   :descriptor {:service-id "service-id"
                                :service-description {"metric-group" "service-metric-group"
@@ -70,7 +71,8 @@
                   :latest-service-id "latest-service-id"
                   :protocol "HTTP/2.0"
                   :status 200}]
-    (is (= {:backend-response-latency-ns 1000
+    (is (= {:authentication-method "cookie"
+            :backend-response-latency-ns 1000
             :backend-protocol "HTTP/2.0"
             :get-instance-latency-ns 500
             :grpc-status "13"

--- a/waiter/test/waiter/websocket_test.clj
+++ b/waiter/test/waiter/websocket_test.clj
@@ -186,7 +186,8 @@
             process-request-atom (atom false)
             process-request-fn (fn process-request-fn [in-request]
                                  (is (= in-request
-                                        (assoc request :authorization/principal auth-principal
+                                        (assoc request :authorization/method :cookie
+                                                       :authorization/principal auth-principal
                                                        :authorization/time auth-time
                                                        :authorization/user auth-user)))
                                  (reset! process-request-atom true)


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for the authentication method in the request log
- ensures authentication data in response when authenticated via cookies

## Why are we making these changes?

It helps debuggability to know the source of authenticating requests.

