### PR TITLE
introduces x-waiter-auth headers in /waiter-auth

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1543,9 +1543,13 @@
                                         (auth/process-callback authenticator request)))
    :waiter-auth-handler-fn (pc/fnk [wrap-secure-request-fn]
                              (wrap-secure-request-fn
-                               (fn waiter-auth-handler-fn [request]
+                               (fn waiter-auth-handler-fn
+                                 [{:keys [authorization/method authorization/principal authorization/user]}]
                                  (utils/attach-waiter-source
-                                   {:body (str (:authorization/user request))
+                                   {:body (str user)
+                                    :headers {"x-waiter-auth-method" (some-> method name)
+                                              "x-waiter-auth-principal" (str principal)
+                                              "x-waiter-auth-user" (str user)}
                                     :status 200}))))
    :waiter-request-consent-handler-fn (pc/fnk [[:routines service-description->service-id token->service-description-template]
                                                [:settings consent-expiry-days]


### PR DESCRIPTION
## Changes proposed in this PR

- introduces x-waiter-auth headers in /waiter-auth

## Why are we making these changes?

Adds additional information in the `/waiter-auth` output that is backward compatible (doesn't change the response body) and helps with debugging and testing.

