### PR TITLE
adds kubernetes pod name to the request log

### DIFF
--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -52,7 +52,8 @@
   [{:keys [authorization/method authorization/principal backend-response-latency-ns descriptor latest-service-id
            get-instance-latency-ns handle-request-latency-ns headers instance instance-proto protocol status] :as response}]
   (let [{:keys [service-id service-description]} descriptor
-        {:strs [content-length content-type grpc-status server]} headers]
+        {:strs [content-length content-type grpc-status server]} headers
+        {:keys [k8s/pod-name]} instance]
     (cond-> {:status (or status 200)}
       method (assoc :authentication-method (name method))
       backend-response-latency-ns (assoc :backend-response-latency-ns backend-response-latency-ns)
@@ -69,6 +70,7 @@
                       :get-instance-latency-ns get-instance-latency-ns)
       instance-proto (assoc :instance-proto instance-proto)
       latest-service-id (assoc :latest-service-id latest-service-id)
+      pod-name (assoc :k8s-pod-name pod-name)
       principal (assoc :principal principal)
       protocol (assoc :backend-protocol protocol)
       server (assoc :server server)

--- a/waiter/test/waiter/request_log_test.clj
+++ b/waiter/test/waiter/request_log_test.clj
@@ -67,6 +67,7 @@
                             "server" "foo-bar"}
                   :instance {:host "instance-host"
                              :id "instance-id"
+                             :k8s/pod-name "test-pod-name"
                              :port 123}
                   :instance-proto "instance-proto"
                   :latest-service-id "latest-service-id"
@@ -82,6 +83,7 @@
             :instance-id "instance-id"
             :instance-port 123
             :instance-proto "instance-proto"
+            :k8s-pod-name "test-pod-name"
             :latest-service-id "latest-service-id"
             :metric-group "service-metric-group"
             :principal "principal@DOMAIN.COM"


### PR DESCRIPTION
## Changes proposed in this PR

- adds kubernetes pod name to the request log

## Why are we making these changes?

Easier debuggability.
