### PR TITLE
adds instance backend-proto to the request log

### DIFF
--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -785,6 +785,7 @@
                         (update :headers headers/dissoc-hop-by-hop-headers proto-version)
                         (assoc :get-instance-latency-ns instance-elapsed
                                :instance instance
+                               :instance-proto backend-proto
                                :protocol proto-version)
                         (assoc-debug-header "x-waiter-get-available-instance-ns" (str instance-elapsed))))))
               (catch Exception e ; Handle case where we couldn't get an instance

--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -50,7 +50,7 @@
 (defn response->context
   "Convert a response into a context suitable for logging."
   [{:keys [authorization/method authorization/principal backend-response-latency-ns descriptor latest-service-id
-           get-instance-latency-ns handle-request-latency-ns headers instance protocol status] :as response}]
+           get-instance-latency-ns handle-request-latency-ns headers instance instance-proto protocol status] :as response}]
   (let [{:keys [service-id service-description]} descriptor
         {:strs [content-length content-type grpc-status server]} headers]
     (cond-> {:status (or status 200)}
@@ -67,6 +67,7 @@
                       :instance-id (:id instance)
                       :instance-port (:port instance)
                       :get-instance-latency-ns get-instance-latency-ns)
+      instance-proto (assoc :instance-proto instance-proto)
       latest-service-id (assoc :latest-service-id latest-service-id)
       principal (assoc :principal principal)
       protocol (assoc :backend-protocol protocol)

--- a/waiter/test/waiter/request_log_test.clj
+++ b/waiter/test/waiter/request_log_test.clj
@@ -68,6 +68,7 @@
                   :instance {:host "instance-host"
                              :id "instance-id"
                              :port 123}
+                  :instance-proto "instance-proto"
                   :latest-service-id "latest-service-id"
                   :protocol "HTTP/2.0"
                   :status 200}]
@@ -80,6 +81,7 @@
             :instance-host "instance-host"
             :instance-id "instance-id"
             :instance-port 123
+            :instance-proto "instance-proto"
             :latest-service-id "latest-service-id"
             :metric-group "service-metric-group"
             :principal "principal@DOMAIN.COM"


### PR DESCRIPTION
## Changes proposed in this PR

- adds instance backend-proto to the request log

## Why are we making these changes?

Easier debuggability.

