### PR TITLE
upgrades jetty version to 9.4.20.v20190813

### DIFF
--- a/waiter/integration/waiter/grpc_test.clj
+++ b/waiter/integration/waiter/grpc_test.clj
@@ -145,7 +145,7 @@
          assertion-message# ~assertion-message]
      (is status# assertion-message#)
      (when status#
-       (is (contains? #{"UNAVAILABLE" "INTERNAL"} (-> status# .getCode str)) assertion-message#))))
+       (is (contains? #{"CANCELLED" "INTERNAL" "UNAVAILABLE"} (-> status# .getCode str)) assertion-message#))))
 
 (defmacro assert-grpc-unknown-status
   "Asserts that the status represents a grpc OK status."

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -41,7 +41,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20190726_062116-ge1f0a7b"
+                 [twosigma/jet "0.7.10-20190820_214226-g0c908dc"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]


### PR DESCRIPTION
[**Jet PR**](https://github.com/twosigma/jet/pull/36).

## Changes proposed in this PR

- upgrades jetty version to 9.4.20.v20190813

## Why are we making these changes?

Use latest version of jet/jetty that has trailer fixes.
