### PR TITLE
removes clojurescript dependencies

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -55,7 +55,7 @@
                  [digest "1.4.8"
                   :exclusions [org.clojure/clojure]]
                  [fullcontact/full.async "1.0.0"
-                  :exclusions [org.clojure/clojure org.clojure/core.async]]
+                  :exclusions [org.clojure/clojure org.clojure/clojurescript org.clojure/core.async]]
                  [io.dropwizard.metrics/metrics-graphite "3.1.1"
                   :exclusions [org.slf4j/slf4j-api]]
                  [joda-time "2.10.1"]


### PR DESCRIPTION
## Changes proposed in this PR

- removes clojurescript dependencies

## Why are we making these changes?

Removes unneeded classes from our list of dependencies and uberjar.

Output of `lein deps`:

Before:
```
[fullcontact/full.async "1.0.0" :exclusions [[org.clojure/clojure] [org.clojure/core.async]]]
   [org.clojure/clojurescript "1.9.293"]
     [com.google.javascript/closure-compiler-unshaded "v20160911"]
       [args4j "2.0.26"]
       [com.google.javascript/closure-compiler-externs "v20160911"]
       [com.google.jsinterop/jsinterop-annotations "1.0.0"]
     [org.clojure/google-closure-library "0.0-20160609-f42b4a24"]
       [org.clojure/google-closure-library-third-party "0.0-20160609-f42b4a24"]
     [org.mozilla/rhino "1.7R5"]
```

After:
```
[fullcontact/full.async "1.0.0" :exclusions [[org.clojure/clojure] [org.clojure/clojurescript] [org.clojure/core.async]]]
```