### PR TITLE
fixes websocket connection for authentication disabled

### DIFF
--- a/waiter/integration/waiter/websocket_integration_test.clj
+++ b/waiter/integration/waiter/websocket_integration_test.clj
@@ -122,35 +122,36 @@
                               :token token)
           waiter-headers {"x-waiter-token" token}]
       (try
-        (let [token-response (post-token waiter-url token-description)
-              _ (assert-response-status token-response 200)
-              response-promise (promise)
-              connection (ws-client/connect!
-                           (websocket-client-factory)
-                           (ws-url waiter-url "/websocket-auth")
-                           (fn [{:keys [in out]}]
-                             (async/go
-                               (async/>! out "request-info")
-                               (swap! ws-response-atom conj (async/<! in))
-                               (swap! ws-response-atom conj (async/<! in))
-                               (deliver response-promise :done)
-                               (async/close! out)))
-                           {:middleware (fn [_ ^UpgradeRequest request]
-                                          (websocket/add-headers-to-upgrade-request! request waiter-headers))})
-              [close-code error] (connection->ctrl-data connection)]
-          (is (= :qbits.jet.websocket/close close-code))
-          (is (= StatusCode/NORMAL error))
-          (is (= :done (deref response-promise default-timeout-period :timed-out))))
-        (log/info "websocket responses:" @ws-response-atom)
-        (is (= "Connected to kitchen" (first @ws-response-atom)) (str @ws-response-atom))
-        (let [{:keys [headers]} (-> @ws-response-atom second str json/read-str walk/keywordize-keys)
-              {:keys [upgrade x-cid x-waiter-auth-principal]} headers]
-          (println headers)
-          (is x-cid)
-          (is (= upgrade "websocket"))
-          (is (nil? x-waiter-auth-principal)))
+        (let [token-response (post-token waiter-url token-description)]
+          (assert-response-status token-response 200)
+          (try
+            (let [response-promise (promise)
+                  connection (ws-client/connect!
+                               (websocket-client-factory)
+                               (ws-url waiter-url "/websocket-auth")
+                               (fn [{:keys [in out]}]
+                                 (async/go
+                                   (async/>! out "request-info")
+                                   (swap! ws-response-atom conj (async/<! in))
+                                   (swap! ws-response-atom conj (async/<! in))
+                                   (deliver response-promise :done)
+                                   (async/close! out)))
+                               {:middleware (fn [_ ^UpgradeRequest request]
+                                              (websocket/add-headers-to-upgrade-request! request waiter-headers))})
+                  [close-code error] (connection->ctrl-data connection)]
+              (is (= :qbits.jet.websocket/close close-code))
+              (is (= StatusCode/NORMAL error))
+              (is (= :done (deref response-promise default-timeout-period :timed-out))))
+            (log/info "websocket responses:" @ws-response-atom)
+            (is (= "Connected to kitchen" (first @ws-response-atom)) (str @ws-response-atom))
+            (let [{:keys [headers]} (-> @ws-response-atom second str json/read-str walk/keywordize-keys)
+                  {:keys [upgrade x-cid x-waiter-auth-principal]} headers]
+              (is x-cid)
+              (is (= upgrade "websocket"))
+              (is (nil? x-waiter-auth-principal)))
+            (finally
+              (delete-service waiter-url waiter-headers))))
         (finally
-          (delete-service waiter-url waiter-headers)
           (delete-token-and-assert waiter-url token))))))
 
 (deftest ^:parallel ^:integration-fast test-request-auth-success-single-subprotocol

--- a/waiter/integration/waiter/websocket_integration_test.clj
+++ b/waiter/integration/waiter/websocket_integration_test.clj
@@ -163,8 +163,7 @@
                               :name (rand-name)
                               :permitted-user "*"
                               :run-as-user (retrieve-username)
-                              :token token)
-          ]
+                              :token token)]
       (try
         (let [token-response (post-token waiter-url token-description)]
           (assert-response-status token-response 200)

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1192,21 +1192,20 @@
                                           [:settings instance-request-properties]
                                           [:state instance-rpc-chan local-usage-agent passwords websocket-client]
                                           wrap-descriptor-fn]
-                                   (fn default-websocket-handler-fn [request]
-                                     (let [password (first passwords)
-                                           make-request-fn (fn make-ws-request
-                                                             [instance request request-properties passthrough-headers end-route metric-group
-                                                              backend-proto proto-version]
-                                                             (ws/make-request websocket-client service-id->password-fn instance request request-properties
-                                                                              passthrough-headers end-route metric-group backend-proto proto-version))
-                                           process-request-fn (fn process-request-fn [request]
-                                                                (pr/process make-request-fn instance-rpc-chan start-new-service-fn
-                                                                            instance-request-properties determine-priority-fn ws/process-response!
-                                                                            ws/abort-request-callback-factory local-usage-agent request))
-                                           handler (-> process-request-fn
-                                                     (ws/wrap-ws-close-on-error)
-                                                     wrap-descriptor-fn)]
-                                       (ws/request-handler password handler request))))
+                                   (let [password (first passwords)
+                                         make-request-fn (fn make-ws-request
+                                                           [instance request request-properties passthrough-headers end-route metric-group
+                                                            backend-proto proto-version]
+                                                           (ws/make-request websocket-client service-id->password-fn instance request request-properties
+                                                                            passthrough-headers end-route metric-group backend-proto proto-version))
+                                         process-request-fn (fn process-request-fn [request]
+                                                              (pr/process make-request-fn instance-rpc-chan start-new-service-fn
+                                                                          instance-request-properties determine-priority-fn ws/process-response!
+                                                                          ws/abort-request-callback-factory local-usage-agent request))]
+                                     (->> process-request-fn
+                                       ws/wrap-ws-close-on-error
+                                       wrap-descriptor-fn
+                                       (ws/make-request-handler password))))
    :display-settings-handler-fn (pc/fnk [wrap-secure-request-fn settings]
                                   (wrap-secure-request-fn
                                     (fn display-settings-handler-fn [_]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -987,9 +987,11 @@
                                                   :uri (some-> request .getRequestURI .getPath)})
                                        (.setHeader response "server" server-name)
                                        (.setHeader response "x-cid" correlation-id)
-                                       (let [{:keys [service-parameter-template]}
+                                       (let [{:keys [service-parameter-template waiter-headers]}
                                              (sd/discover-service-parameters kv-store token-defaults waiter-hostnames request-headers)]
-                                         (and (or (= "disabled" (get service-parameter-template "authentication"))
+                                         ;; authentication can be skipped if it is disabled and there are no on-the-fly headers
+                                         (and (or (and (= "disabled" (get service-parameter-template "authentication"))
+                                                       (not-any? sd/service-parameter-keys (-> waiter-headers headers/drop-waiter-header-prefix keys)))
                                                   (ws/request-authenticator password request response))
                                               (ws/request-subprotocol-acceptor request response)))))))})
 

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -978,7 +978,7 @@
                                          password (first passwords)]
                                      (cid/with-correlation-id
                                        correlation-id
-                                       (log/info "request received websocket upgrade"
+                                       (log/info "request received (websocket upgrade)"
                                                  {:headers (headers/truncate-header-values request-headers)
                                                   :http-version (.getHttpVersion request)
                                                   :method (some-> request .getMethod str/lower-case)

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -987,15 +987,11 @@
                                                   :uri (some-> request .getRequestURI .getPath)})
                                        (.setHeader response "server" server-name)
                                        (.setHeader response "x-cid" correlation-id)
-                                       (let [{:keys [service-parameter-template token]}
+                                       (let [{:keys [service-parameter-template]}
                                              (sd/discover-service-parameters kv-store token-defaults waiter-hostnames request-headers)]
-                                         (if (= "disabled" (get service-parameter-template "authentication"))
-                                           (do
-                                             (log/info "authentication is disabled for websocket request using token" token)
-                                             true)
-                                           (if (ws/request-authenticator password request response)
-                                             (ws/request-subprotocol-acceptor request response)
-                                             false)))))))})
+                                         (and (or (= "disabled" (get service-parameter-template "authentication"))
+                                                  (ws/request-authenticator password request response))
+                                              (ws/request-subprotocol-acceptor request response)))))))})
 
 (def daemons
   {:autoscaler (pc/fnk [[:curator leader?-fn]

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -72,7 +72,8 @@
     (str/trim (:out shell-output))))
 
 (defn retrieve-username []
-  (execute-command "id" "-un"))
+  (or (System/getProperty "user.name")
+      (execute-command "id" "-un")))
 
 (defn retrieve-hostname []
   (if use-spnego

--- a/waiter/src/waiter/websocket.clj
+++ b/waiter/src/waiter/websocket.clj
@@ -76,7 +76,9 @@
   (try
     (let [sec-websocket-protocols (vec (.getHeaders request "sec-websocket-protocol"))]
       (condp = (count sec-websocket-protocols)
-        0 true
+        0 (do
+            (log/info "no subprotocols provided, accepting upgrade request")
+            true)
         1 (let [accepted-subprotocol (first sec-websocket-protocols)]
             (log/info "accepting websocket subprotocol" accepted-subprotocol)
             (.setAcceptedSubProtocol response accepted-subprotocol)

--- a/waiter/test/waiter/websocket_test.clj
+++ b/waiter/test/waiter/websocket_test.clj
@@ -188,8 +188,8 @@
                                  (is (= in-request
                                         (assoc request :authorization/method :cookie
                                                        :authorization/principal auth-principal
-                                                       :authorization/time auth-time
-                                                       :authorization/user auth-user)))
+                                                       :authorization/user auth-user
+                                                       :waiter/auth-expiry-time auth-time)))
                                  (reset! process-request-atom true)
                                  {})]
         (with-redefs [auth/get-auth-cookie-value identity
@@ -197,6 +197,18 @@
                                                 (is (= cookie-value in-cookie))
                                                 (is (= password in-password))
                                                 [auth-principal auth-time])]
+          (request-handler password process-request-fn request))
+        (is @process-request-atom)))
+
+    (testing "auth cookie missing"
+      (let [output-channel (async/promise-chan)
+            request {:headers headers, :out output-channel}
+            process-request-atom (atom false)
+            process-request-fn (fn process-request-fn [in-request]
+                                 (is (= in-request request))
+                                 (reset! process-request-atom true)
+                                 {})]
+        (with-redefs [auth/get-auth-cookie-value (constantly nil)]
           (request-handler password process-request-fn request))
         (is @process-request-atom)))))
 


### PR DESCRIPTION
## Changes proposed in this PR

- refactors websocket integration tests
- skips authentication check in the upgrade request check (`websocket-request-acceptor`)
- avoids the expectation that `waiter-auth` cookie will be present while handling websocket requests

## Why are we making these changes?

Websocket requests should not require authentication if the token is configured to use `authentication: disabled`.


