### PR TITLE
Marks two integration tests ^:explicit

### DIFF
--- a/waiter/integration/waiter/grpc_test.clj
+++ b/waiter/integration/waiter/grpc_test.clj
@@ -572,7 +572,7 @@
                     (Thread/sleep 1500) ;; sleep to allow cancellation propagation to backend
                     (assert-request-state grpc-client request-headers service-id correlation-id ::client-cancel)))))))))))
 
-(deftest ^:parallel ^:integration-slow test-grpc-bidi-streaming-server-exit
+(deftest ^:parallel ^:integration-slow ^:explicit test-grpc-bidi-streaming-server-exit
   (testing-using-waiter-url
     (let [num-messages 120
           num-iterations 3

--- a/waiter/integration/waiter/proto_test.clj
+++ b/waiter/integration/waiter/proto_test.clj
@@ -123,7 +123,7 @@
     (run-backend-proto-service-test waiter-url "https" "https" "HTTP/1.1")
     (is "test completed marker")))
 
-(deftest ^:parallel ^:integration-slow ^:resource-heavy test-h2c-backend-proto-service
+(deftest ^:parallel ^:integration-slow ^:resource-heavy ^:explicit test-h2c-backend-proto-service
   (testing-using-waiter-url
     (run-backend-proto-service-test waiter-url "h2c" "http" "HTTP/2.0")
     (is "test completed marker")))


### PR DESCRIPTION
## Changes proposed in this PR

- marking `^:explicit test-grpc-bidi-streaming-server-exit`
- marking `^:explicit test-h2c-backend-proto-service`

## Why are we making these changes?

The tests are failing and taking longer than 15 minutes to fail.
