### PR TITLE
cleanup trailer support after jetty upgrade

### DIFF
--- a/waiter/integration/waiter/trailers_test.clj
+++ b/waiter/integration/waiter/trailers_test.clj
@@ -63,10 +63,7 @@
                   (-> response :headers str)))
             (is (= {} (get body-json "trailers"))
                 (-> response :headers str))
-            ;; TODO remove when https://github.com/eclipse/jetty.project/issues/3829 is fixed and empty trailer frames are not sent.
-            (is (= (when (hu/http2? http-version)
-                     {"x-waiter-trailer-reason" "ensures-non-empty-trailers"})
-                   (some-> response :trailers))
+            (is (nil? (some-> response :trailers))
                 (-> response :headers str))))
 
         (let [request-trailer-delay-ms 100

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -41,7 +41,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20190831_042058-gd668ab7"
+                 [twosigma/jet "0.7.10-20190831_055713-gf193d34"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -41,7 +41,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20190820_214226-g0c908dc"
+                 [twosigma/jet "0.7.10-20190831_042058-gd668ab7"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -574,9 +574,8 @@
 
 (defn- forward-grpc-status-headers-in-trailers
   "Adds logging for tracking response trailers for requests.
-   Since we always send some trailers, we need to repeat the grpc status headers in the trailers
-   to ensure client evaluates the request to the same grpc error.
-   Please see https://github.com/eclipse/jetty.project/issues/3829 for details."
+   When only headers are provided jetty terminates the request with an empty data frame,
+   we work around that limitation by sending trailers that carry the same grpc error message."
   [{:keys [headers trailers] :as response}]
   (if trailers
     (let [correlation-id (cid/get-correlation-id)


### PR DESCRIPTION

## Jet PR

[Removes workarounds for empty trailers](https://github.com/twosigma/jet/pull/37).

## Changes proposed in this PR

- uses jet that avoids the need to perform special handling for empty trailers in http/2 requests

## Why are we making these changes?

Reduce tech debt.

