### PR TITLE
wip: limits the maximum number of work-stealing offers in-flight

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -753,7 +753,7 @@
 
  :work-stealing {
                  ;; The maximum number of outstanding work-stealing offers per service per router:
-                 :max-work-stealing-offers-per-service 50
+                 :max-work-stealing-offers-per-service 20
 
                  ;; The interval (milliseconds) on which Waiter makes work-stealing offers:
                  :offer-help-interval-ms 100

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -752,6 +752,9 @@
  ; ---------- Load Balancing ----------
 
  :work-stealing {
+                 ;; The maximum number of outstanding work-stealing offers per service per router:
+                 :max-work-stealing-offers-per-service 50
+
                  ;; The interval (milliseconds) on which Waiter makes work-stealing offers:
                  :offer-help-interval-ms 100
 

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -941,14 +941,16 @@
                              (scheduler/validate-service scheduler service-id)
                              (service/start-new-service
                                scheduler descriptor start-service-cache scheduler-interactions-thread-pool)))
-   :start-work-stealing-balancer-fn (pc/fnk [[:settings [:work-stealing offer-help-interval-ms reserve-timeout-ms]]
+   :start-work-stealing-balancer-fn (pc/fnk [[:settings [:work-stealing max-work-stealing-offers-per-service
+                                                         offer-help-interval-ms reserve-timeout-ms]]
                                              [:state instance-rpc-chan router-id]
                                              make-inter-router-requests-async-fn router-metrics-helpers]
                                       (fn start-work-stealing-balancer [service-id]
                                         (let [{:keys [service-id->router-id->metrics]} router-metrics-helpers]
                                           (work-stealing/start-work-stealing-balancer
-                                            instance-rpc-chan reserve-timeout-ms offer-help-interval-ms service-id->router-id->metrics
-                                            make-inter-router-requests-async-fn router-id service-id))))
+                                            instance-rpc-chan reserve-timeout-ms offer-help-interval-ms max-work-stealing-offers-per-service
+                                            service-id->router-id->metrics make-inter-router-requests-async-fn
+                                            router-id service-id))))
    :stop-work-stealing-balancer-fn (pc/fnk []
                                      (fn stop-work-stealing-balancer [service-id work-stealing-chan-map]
                                        (log/info "stopping work-stealing balancer for" service-id)

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -175,7 +175,8 @@
                                                                      (s/required-key "stale-timeout-mins") schema/non-negative-int}}
    (s/required-key :websocket-config) {(s/required-key :ws-max-binary-message-size) schema/positive-int
                                        (s/required-key :ws-max-text-message-size) schema/positive-int}
-   (s/required-key :work-stealing) {(s/required-key :offer-help-interval-ms) schema/positive-int
+   (s/required-key :work-stealing) {(s/required-key :max-work-stealing-offers-per-service) schema/non-negative-int
+                                    (s/required-key :offer-help-interval-ms) schema/positive-int
                                     (s/required-key :reserve-timeout-ms) schema/positive-int}
    (s/required-key :zookeeper) {(s/required-key :base-path) schema/non-empty-string
                                 (s/required-key :connect-string) schema/valid-zookeeper-connect-config
@@ -452,7 +453,8 @@
                                    "stale-timeout-mins" 15}}
    :websocket-config {:ws-max-binary-message-size (* 1024 1024 40)
                       :ws-max-text-message-size (* 1024 1024 40)}
-   :work-stealing {:offer-help-interval-ms 100
+   :work-stealing {:max-work-stealing-offers-per-service 20
+                   :offer-help-interval-ms 100
                    :reserve-timeout-ms 1000}
    :zookeeper {:base-path "/waiter"
                :curator-retry-policy {:base-sleep-time-ms 100


### PR DESCRIPTION

## Changes proposed in this PR

- limits the maximum number of work-stealing offers in-flight per service per router

## Why are we making these changes?

The number of work-stealing offers can grow to become quite large and affect the number of ports available on the hosts. By restricting the number of outstanding work-stealing offers per service per router, we can bound the number of ports assigned to these offers as a function of the number of live services.

