### PR TITLE
limits the maximum number of work-stealing offers in-flight from a router

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -775,7 +775,7 @@
 
  :work-stealing {
                  ;; The maximum number of outstanding work-stealing offers per router:
-                 :max-work-stealing-in-flight-offers 4000
+                 :max-in-flight-offers 4000
 
                  ;; The interval (milliseconds) on which Waiter makes work-stealing offers:
                  :offer-help-interval-ms 100

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -774,6 +774,9 @@
  ; ---------- Load Balancing ----------
 
  :work-stealing {
+                 ;; The maximum number of outstanding work-stealing offers per router:
+                 :max-work-stealing-in-flight-offers 4000
+
                  ;; The interval (milliseconds) on which Waiter makes work-stealing offers:
                  :offer-help-interval-ms 100
 

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -624,8 +624,8 @@
                             (let [jwt-config (assoc jwt-config :password (first passwords))]
                               (jwt/jwt-authenticator jwt-config)))))
    :local-usage-agent (pc/fnk [] (agent {}))
-   :offers-allowed-semaphore (pc/fnk [[:settings [:work-stealing max-work-stealing-in-flight-offers]]]
-                               (semaphore/create-semaphore max-work-stealing-in-flight-offers))
+   :offers-allowed-semaphore (pc/fnk [[:settings [:work-stealing max-in-flight-offers]]]
+                               (semaphore/create-semaphore max-in-flight-offers))
    :passwords (pc/fnk [[:settings password-store-config]]
                 (let [password-provider (utils/create-component password-store-config)
                       passwords (password-store/retrieve-passwords password-provider)

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -41,6 +41,7 @@
             [waiter.util.date-utils :as du]
             [waiter.util.http-utils :as hu]
             [waiter.util.ring-utils :as ru]
+            [waiter.util.semaphore :as semaphore]
             [waiter.util.utils :as utils])
   (:import (java.io InputStream)))
 
@@ -705,11 +706,12 @@
 
 (defn get-work-stealing-state
   "Outputs the global work-stealing state."
-  [router-id request]
+  [offers-allowed-semaphore router-id request]
   (get-function-state
     (fn compute-work-stealing-state []
       (let [request-params (-> request ru/query-params-request :query-params)]
-        {:metrics (cond-> (metrics/get-metrics (metrics/conjunctive-metrics-filter
+        {:global-offers (semaphore/state offers-allowed-semaphore)
+         :metrics (cond-> (metrics/get-metrics (metrics/conjunctive-metrics-filter
                                                  (metrics/prefix-metrics-filter "waiter")
                                                  (metrics/contains-metrics-filter "work-stealing")))
                     (utils/param-contains? request-params "include" "services")

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -178,7 +178,8 @@
                                                                      (s/required-key "stale-timeout-mins") schema/non-negative-int}}
    (s/required-key :websocket-config) {(s/required-key :ws-max-binary-message-size) schema/positive-int
                                        (s/required-key :ws-max-text-message-size) schema/positive-int}
-   (s/required-key :work-stealing) {(s/required-key :offer-help-interval-ms) schema/positive-int
+   (s/required-key :work-stealing) {(s/required-key :max-work-stealing-in-flight-offers) schema/non-negative-int
+                                    (s/required-key :offer-help-interval-ms) schema/positive-int
                                     (s/required-key :reserve-timeout-ms) schema/positive-int}
    (s/required-key :zookeeper) {(s/required-key :base-path) schema/non-empty-string
                                 (s/required-key :connect-string) schema/valid-zookeeper-connect-config
@@ -457,7 +458,8 @@
                                    "stale-timeout-mins" 15}}
    :websocket-config {:ws-max-binary-message-size (* 1024 1024 40)
                       :ws-max-text-message-size (* 1024 1024 40)}
-   :work-stealing {:offer-help-interval-ms 100
+   :work-stealing {:max-work-stealing-in-flight-offers 4000
+                   :offer-help-interval-ms 100
                    :reserve-timeout-ms 1000}
    :zookeeper {:base-path "/waiter"
                :curator-retry-policy {:base-sleep-time-ms 100

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -178,7 +178,7 @@
                                                                      (s/required-key "stale-timeout-mins") schema/non-negative-int}}
    (s/required-key :websocket-config) {(s/required-key :ws-max-binary-message-size) schema/positive-int
                                        (s/required-key :ws-max-text-message-size) schema/positive-int}
-   (s/required-key :work-stealing) {(s/required-key :max-work-stealing-in-flight-offers) schema/non-negative-int
+   (s/required-key :work-stealing) {(s/required-key :max-in-flight-offers) schema/non-negative-int
                                     (s/required-key :offer-help-interval-ms) schema/positive-int
                                     (s/required-key :reserve-timeout-ms) schema/positive-int}
    (s/required-key :zookeeper) {(s/required-key :base-path) schema/non-empty-string
@@ -458,7 +458,7 @@
                                    "stale-timeout-mins" 15}}
    :websocket-config {:ws-max-binary-message-size (* 1024 1024 40)
                       :ws-max-text-message-size (* 1024 1024 40)}
-   :work-stealing {:max-work-stealing-in-flight-offers 4000
+   :work-stealing {:max-in-flight-offers 4000
                    :offer-help-interval-ms 100
                    :reserve-timeout-ms 1000}
    :zookeeper {:base-path "/waiter"

--- a/waiter/src/waiter/util/semaphore.clj
+++ b/waiter/src/waiter/util/semaphore.clj
@@ -1,0 +1,64 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns waiter.util.semaphore)
+
+(defprotocol Semaphore
+  (total-permits [this]
+    "Returns the number of total permits allowed.")
+  (available-permits [this]
+    "Returns the number of available permits.")
+  (state [this]
+    "Returns internal state of the semaphore as a map.")
+  (try-acquire! [this]
+    "Acquires a permit, if one is available and returns immediately, with the value true, reducing the number of available permits by one.
+     If no permit is available then this method will return immediately with the value false.")
+  (release! [this]
+    "Releases a permit, increasing the number of available permits by one.
+     Returns the number of acquired permits."))
+
+;; Restricts the semaphore to only non-blocking operations.
+;; Unlike java.util.concurrent.Semaphore, provides max permits allowed.
+(defrecord NonBlockingSemaphore [acquired-permits-counter max-permits]
+  Semaphore
+  (total-permits [_]
+    max-permits)
+  (available-permits [_]
+    (- max-permits @acquired-permits-counter))
+  (state [this]
+    {:allowed (total-permits this)
+     :available (available-permits this)})
+  (try-acquire! [_]
+    (let [acquired-atom (atom false)]
+      (swap! acquired-permits-counter
+             (fn acquire-permit [acquired-permits]
+               (if (< acquired-permits max-permits)
+                 (do
+                   (reset! acquired-atom true)
+                   (inc acquired-permits))
+                 acquired-permits)))
+      @acquired-atom))
+  (release! [_]
+    (swap! acquired-permits-counter
+           (fn release-permit [acquired-permits]
+             (when-not (pos? acquired-permits)
+               (throw (IllegalStateException. "No acquired permits to release!")))
+             (dec acquired-permits)))))
+
+(defn create-semaphore
+  "Creates a Semaphore with the given number of permits."
+  [max-permits]
+  {:pre [(pos? max-permits)]}
+  (->NonBlockingSemaphore (atom 0) max-permits))

--- a/waiter/test/waiter/util/semaphore_test.clj
+++ b/waiter/test/waiter/util/semaphore_test.clj
@@ -1,0 +1,47 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns waiter.util.semaphore-test
+  (:require [clojure.test :refer :all]
+            [waiter.util.semaphore :refer :all])
+  (:import (waiter.util.semaphore NonBlockingSemaphore)))
+
+(deftest test-counting-semaphore-creation
+  (is (thrown? AssertionError (create-semaphore -1)))
+  (is (thrown? AssertionError (create-semaphore 0)))
+  (is (instance? NonBlockingSemaphore (create-semaphore 1)))
+  (is (instance? NonBlockingSemaphore (create-semaphore 10))))
+
+(deftest test-counting-semaphore-operations
+  (let [max-permits 4
+        semaphore (create-semaphore max-permits)]
+    (is (= max-permits (total-permits semaphore)))
+    (is (= max-permits (available-permits semaphore)))
+    (dotimes [n max-permits]
+      (is (try-acquire! semaphore))
+      (is (= (- max-permits n 1) (available-permits semaphore))))
+    (dotimes [_ 10]
+      (is (not (try-acquire! semaphore))))
+    (is (= (- max-permits 1) (release! semaphore)))
+    (is (= 1 (available-permits semaphore)))
+    (is (try-acquire! semaphore))
+    (is (zero? (available-permits semaphore)))
+    (dotimes [n max-permits]
+      (is (= (- max-permits n 1) (release! semaphore)))
+      (is (= (inc n) (available-permits semaphore))))
+    (is (thrown? IllegalStateException (release! semaphore)))
+    (is (thrown? IllegalStateException (release! semaphore)))
+    (is (try-acquire! semaphore))
+    (is (= (dec max-permits) (available-permits semaphore)))))

--- a/waiter/test/waiter/work_stealing_test.clj
+++ b/waiter/test/waiter/work_stealing_test.clj
@@ -19,6 +19,7 @@
             [clojure.test :refer :all]
             [clojure.walk :as walk]
             [waiter.test-helpers]
+            [waiter.util.semaphore :as semaphore]
             [waiter.util.utils :as utils]
             [waiter.work-stealing :refer :all]))
 
@@ -110,6 +111,7 @@
 (let [router-id "test-router-id"
       service-id "test-service-id"
       metrics-atom (atom nil)
+      max-permits 100
       service-id->router-id->metrics (fn [in-service-id] (is (= service-id in-service-id)) @metrics-atom)]
 
   (defn- make-request-id [iteration loop-counter]
@@ -123,22 +125,25 @@
                                     :target-router-id router-id})))
 
   (deftest test-work-stealing-balancer-initialization
-    (let [initial-state {:iteration 10, :request-id->work-stealer {"req-1" {:instance {}}}}
+    (let [initial-state {:iteration 10 :request-id->work-stealer {"req-1" {:instance {}}}}
           offer-help-fn (fn [_ _] nil)
           release-instance-fn (fn [_] nil)
           reserve-instance-fn (fn [_ response-chan] (async/>!! response-chan :no-instance-found))
           _ (reset! metrics-atom nil)
           custom-timeout-chan (async/chan 1)
           timeout-chan-factory (constantly custom-timeout-chan)
+          offers-allowed-semaphore (semaphore/create-semaphore max-permits)
           {:keys [exit-chan query-chan]}
           (work-stealing-balancer initial-state timeout-chan-factory service-id->router-id->metrics reserve-instance-fn
-                                  release-instance-fn offer-help-fn router-id service-id)]
-      (reset! metrics-atom {"router-1" (make-metrics {:outstanding 10, :slots-available 20})})
-      (check-work-stealing-balancer-query-state query-chan initial-state)
+                                  release-instance-fn offer-help-fn offers-allowed-semaphore router-id service-id)]
+      (reset! metrics-atom {"router-1" (make-metrics {:outstanding 10 :slots-available 20})})
+      (check-work-stealing-balancer-query-state
+        query-chan
+        (assoc initial-state :global-offers {:allowed max-permits :available max-permits}))
       (async/>!! exit-chan :exit)))
 
   (deftest test-work-stealing-balancer-no-routers-require-help
-    (let [initial-state {:iteration 10, :request-id->work-stealer {}}
+    (let [initial-state {:iteration 10 :request-id->work-stealer {}}
           offer-help-fn (fn [_ _] nil)
           release-instance-fn (fn [_] nil)
           reserve-instance-counter (atom 0)
@@ -148,18 +153,23 @@
           _ (reset! metrics-atom nil)
           custom-timeout-chan (async/chan 1)
           timeout-chan-factory (constantly custom-timeout-chan)
+          offers-allowed-semaphore (semaphore/create-semaphore max-permits)
           {:keys [exit-chan query-chan]}
           (work-stealing-balancer initial-state timeout-chan-factory service-id->router-id->metrics reserve-instance-fn
-                                  release-instance-fn offer-help-fn router-id service-id)]
-      (reset! metrics-atom {"router-1" (make-metrics {:outstanding 10, :slots-available 20})
+                                  release-instance-fn offer-help-fn offers-allowed-semaphore router-id service-id)]
+      (reset! metrics-atom {"router-1" (make-metrics {:outstanding 10 :slots-available 20})
                             "router-2" (make-metrics {:slots-available 20})})
-      (check-work-stealing-balancer-query-state query-chan {:iteration 10, :request-id->work-stealer {},
-                                                            :slots {:offerable 0, :offered 0}})
+      (check-work-stealing-balancer-query-state
+        query-chan
+        {:global-offers {:allowed max-permits :available max-permits}
+         :iteration 10
+         :request-id->work-stealer {}
+         :slots {:offerable 0 :offered 0}})
       (is (zero? (deref reserve-instance-counter)))
       (async/>!! exit-chan :exit)))
 
   (deftest test-work-stealing-balancer-no-instance-available
-    (let [initial-state {:iteration 10, :request-id->work-stealer {}}
+    (let [initial-state {:iteration 10 :request-id->work-stealer {}}
           offer-help-fn (fn [_ _] nil)
           reserve-instance-counter (atom 0)
           reserve-instance-fn (fn [_ response-chan]
@@ -169,28 +179,31 @@
           _ (reset! metrics-atom nil)
           custom-timeout-chan (async/chan 1)
           timeout-chan-factory (constantly custom-timeout-chan)
+          offers-allowed-semaphore (semaphore/create-semaphore max-permits)
           {:keys [exit-chan query-chan]}
           (work-stealing-balancer initial-state timeout-chan-factory service-id->router-id->metrics reserve-instance-fn
-                                  release-instance-fn offer-help-fn router-id service-id)]
+                                  release-instance-fn offer-help-fn offers-allowed-semaphore router-id service-id)]
 
-      (reset! metrics-atom {router-id (make-metrics {:outstanding 10, :slots-available 15})
+      (reset! metrics-atom {router-id (make-metrics {:outstanding 10 :slots-available 15})
                             "router-1" (make-metrics {:outstanding 10})
                             "router-2" (make-metrics {:slots-available 20})})
       (async/>!! custom-timeout-chan :custom-timeout)
       (check-work-stealing-balancer-query-state
-        query-chan {:iteration 11, :request-id->work-stealer {}, :slots {:offerable 5, :offered 0}})
+        query-chan
+        {:global-offers {:allowed max-permits :available max-permits}
+         :iteration 11 :request-id->work-stealer {} :slots {:offerable 5 :offered 0}})
       (is (= 1 @reserve-instance-counter))
       (async/>!! exit-chan :exit)))
 
   (deftest test-work-stealing-balancer-single-instance-available-reservation-and-release
     (let [available-slots 1
-          initial-state {:iteration 10, :request-id->work-stealer {}}
+          initial-state {:iteration 10 :request-id->work-stealer {}}
           request-id->cleanup-chan-atom (atom {})
           offer-help-fn (fn [{:keys [request-id]} cleanup-chan]
                           (swap! request-id->cleanup-chan-atom assoc request-id cleanup-chan))
           response-callback (fn [request-id response-status]
                               (async/>!! (get @request-id->cleanup-chan-atom request-id)
-                                         {:request-id request-id, :status response-status}))
+                                         {:request-id request-id :status response-status}))
           released-instances-atom (atom #{})
           release-instance-fn (fn [reservation-result]
                                 (swap! released-instances-atom conj (get-in reservation-result [:instance :id])))
@@ -203,18 +216,21 @@
           _ (reset! metrics-atom nil)
           custom-timeout-chan (async/chan 1)
           timeout-chan-factory (constantly custom-timeout-chan)
+          offers-allowed-semaphore (semaphore/create-semaphore max-permits)
           {:keys [exit-chan query-chan]}
           (work-stealing-balancer initial-state timeout-chan-factory service-id->router-id->metrics reserve-instance-fn
-                                  release-instance-fn offer-help-fn router-id service-id)]
+                                  release-instance-fn offer-help-fn offers-allowed-semaphore router-id service-id)]
 
-      (reset! metrics-atom {router-id (make-metrics {:outstanding 10, :slots-available 15})
+      (reset! metrics-atom {router-id (make-metrics {:outstanding 10 :slots-available 15})
                             "router-1" (make-metrics {:outstanding 10})
                             "router-2" (make-metrics {:slots-available 20})})
       (async/>!! custom-timeout-chan :custom-timeout)
-      (check-work-stealing-balancer-query-state query-chan {:iteration 11
-                                                            :request-id->work-stealer
-                                                            (populate-request-id->workstealer {} 10 0 "router-1" "test-instance-id-1")
-                                                            :slots {:offerable 5, :offered 1}})
+      (check-work-stealing-balancer-query-state
+        query-chan
+        {:global-offers {:allowed max-permits :available (dec max-permits)}
+         :iteration 11
+         :request-id->work-stealer (populate-request-id->workstealer {} 10 0 "router-1" "test-instance-id-1")
+         :slots {:offerable 5 :offered 1}})
 
       (is (pos? @reserve-instance-counter))
       (is (contains? @request-id->cleanup-chan-atom "test-service-id.test-router-id.ws10.offer0"))
@@ -222,14 +238,18 @@
       (response-callback "test-service-id.test-router-id.ws10.offer0" :success)
       (async/>!! custom-timeout-chan :custom-timeout)
       (check-work-stealing-balancer-query-state
-        query-chan {:iteration 14, :request-id->work-stealer {}, :slots {:offerable 5, :offered 0}})
+        query-chan
+        {:global-offers {:allowed max-permits :available max-permits}
+         :iteration 14
+         :request-id->work-stealer {}
+         :slots {:offerable 5 :offered 0}})
       (is (contains? @released-instances-atom "test-instance-id-1"))
 
       (async/>!! exit-chan :exit)))
 
   (deftest test-work-stealing-balancer-multiple-instances-available-incremental-reservation
     (let [available-slots 7
-          initial-state {:iteration 10, :request-id->work-stealer {}}
+          initial-state {:iteration 10 :request-id->work-stealer {}}
           request-id->cleanup-chan-atom (atom {})
           offer-help-fn (fn [{:keys [request-id]} cleanup-chan]
                           (swap! request-id->cleanup-chan-atom assoc request-id cleanup-chan))
@@ -245,42 +265,45 @@
           _ (reset! metrics-atom nil)
           custom-timeout-chan (async/chan 1)
           timeout-chan-factory (constantly custom-timeout-chan)
+          offers-allowed-semaphore (semaphore/create-semaphore max-permits)
           {:keys [exit-chan query-chan]}
           (work-stealing-balancer initial-state timeout-chan-factory service-id->router-id->metrics reserve-instance-fn
-                                  release-instance-fn offer-help-fn router-id service-id)]
+                                  release-instance-fn offer-help-fn offers-allowed-semaphore router-id service-id)]
 
-      (reset! metrics-atom {router-id (make-metrics {:outstanding 10, :slots-available 15})
+      (reset! metrics-atom {router-id (make-metrics {:outstanding 10 :slots-available 15})
                             "router-1" (make-metrics {:outstanding 1})
                             "router-2" (make-metrics {:outstanding 1})})
       (async/>!! custom-timeout-chan :custom-timeout)
       (check-work-stealing-balancer-query-state
-        query-chan {:iteration 11
-                    :request-id->work-stealer
-                    (-> {}
-                        (populate-request-id->workstealer 10 0 "router-2" "test-instance-id-1")
-                        (populate-request-id->workstealer 10 1 "router-1" "test-instance-id-2"))
-                    :slots {:offerable 5, :offered 2}})
+        query-chan
+        {:global-offers {:allowed max-permits :available (- max-permits 2)}
+         :iteration 11
+         :request-id->work-stealer (-> {}
+                                     (populate-request-id->workstealer 10 0 "router-2" "test-instance-id-1")
+                                     (populate-request-id->workstealer 10 1 "router-1" "test-instance-id-2"))
+         :slots {:offerable 5 :offered 2}})
 
       (is (= 2 @reserve-instance-counter))
       (is (contains? @request-id->cleanup-chan-atom (make-request-id 10 0)))
       (is (contains? @request-id->cleanup-chan-atom (make-request-id 10 1)))
 
-      (reset! metrics-atom {router-id (make-metrics {:outstanding 10, :slots-available 13})
+      (reset! metrics-atom {router-id (make-metrics {:outstanding 10 :slots-available 13})
                             "router-1" (make-metrics {:outstanding 0})
                             "router-2" (make-metrics {:outstanding 0})
                             "router-3" (make-metrics {:outstanding 4})
                             "router-4" (make-metrics {:outstanding 3})})
       (async/>!! custom-timeout-chan :custom-timeout)
       (check-work-stealing-balancer-query-state
-        query-chan {:iteration 13
-                    :request-id->work-stealer
-                    (-> {}
-                        (populate-request-id->workstealer 10 0 "router-2" "test-instance-id-1")
-                        (populate-request-id->workstealer 10 1 "router-1" "test-instance-id-2")
-                        (populate-request-id->workstealer 12 0 "router-3" "test-instance-id-3")
-                        (populate-request-id->workstealer 12 1 "router-4" "test-instance-id-4")
-                        (populate-request-id->workstealer 12 2 "router-3" "test-instance-id-5"))
-                    :slots {:offerable 3, :offered 5}})
+        query-chan
+        {:global-offers {:allowed max-permits :available (- max-permits 5)}
+         :iteration 13
+         :request-id->work-stealer (-> {}
+                                     (populate-request-id->workstealer 10 0 "router-2" "test-instance-id-1")
+                                     (populate-request-id->workstealer 10 1 "router-1" "test-instance-id-2")
+                                     (populate-request-id->workstealer 12 0 "router-3" "test-instance-id-3")
+                                     (populate-request-id->workstealer 12 1 "router-4" "test-instance-id-4")
+                                     (populate-request-id->workstealer 12 2 "router-3" "test-instance-id-5"))
+         :slots {:offerable 3 :offered 5}})
 
       (is (= 5 @reserve-instance-counter))
       (is (contains? @request-id->cleanup-chan-atom (make-request-id 10 0)))
@@ -293,13 +316,13 @@
 
   (deftest test-work-stealing-balancer-multiple-instances-available-reservation-and-release
     (let [available-slots 7
-          initial-state {:iteration 10, :request-id->work-stealer {}}
+          initial-state {:iteration 10 :request-id->work-stealer {}}
           request-id->cleanup-chan-atom (atom {})
           offer-help-fn (fn [{:keys [request-id]} cleanup-chan]
                           (swap! request-id->cleanup-chan-atom assoc request-id cleanup-chan))
           response-callback (fn [request-id response-status]
                               (async/>!! (get @request-id->cleanup-chan-atom request-id)
-                                         {:request-id request-id, :status response-status}))
+                                         {:request-id request-id :status response-status}))
           released-instances-atom (atom #{})
           release-instance-fn (fn [reservation-result]
                                 (swap! released-instances-atom conj (get-in reservation-result [:instance :id])))
@@ -312,24 +335,26 @@
           _ (reset! metrics-atom nil)
           custom-timeout-chan (async/chan 1)
           timeout-chan-factory (constantly custom-timeout-chan)
+          offers-allowed-semaphore (semaphore/create-semaphore max-permits)
           {:keys [exit-chan query-chan]}
           (work-stealing-balancer initial-state timeout-chan-factory service-id->router-id->metrics reserve-instance-fn
-                                  release-instance-fn offer-help-fn router-id service-id)]
+                                  release-instance-fn offer-help-fn offers-allowed-semaphore router-id service-id)]
 
-      (reset! metrics-atom {router-id (make-metrics {:outstanding 10, :slots-available 15})
+      (reset! metrics-atom {router-id (make-metrics {:outstanding 10 :slots-available 15})
                             "router-1" (make-metrics {:outstanding 4})
                             "router-2" (make-metrics {:outstanding 3})})
       (async/>!! custom-timeout-chan :custom-timeout)
       (check-work-stealing-balancer-query-state
-        query-chan {:iteration 11
-                    :request-id->work-stealer
-                    (-> {}
-                        (populate-request-id->workstealer 10 0 "router-1" "test-instance-id-1")
-                        (populate-request-id->workstealer 10 1 "router-2" "test-instance-id-2")
-                        (populate-request-id->workstealer 10 2 "router-1" "test-instance-id-3")
-                        (populate-request-id->workstealer 10 3 "router-2" "test-instance-id-4")
-                        (populate-request-id->workstealer 10 4 "router-1" "test-instance-id-5"))
-                    :slots {:offerable 5, :offered 5}})
+        query-chan
+        {:global-offers {:allowed max-permits :available (- max-permits 5)}
+         :iteration 11
+         :request-id->work-stealer (-> {}
+                                     (populate-request-id->workstealer 10 0 "router-1" "test-instance-id-1")
+                                     (populate-request-id->workstealer 10 1 "router-2" "test-instance-id-2")
+                                     (populate-request-id->workstealer 10 2 "router-1" "test-instance-id-3")
+                                     (populate-request-id->workstealer 10 3 "router-2" "test-instance-id-4")
+                                     (populate-request-id->workstealer 10 4 "router-1" "test-instance-id-5"))
+         :slots {:offerable 5 :offered 5}})
 
       (is (= 5 @reserve-instance-counter))
       (is (contains? @request-id->cleanup-chan-atom (make-request-id 10 0)))
@@ -341,13 +366,14 @@
       (response-callback (make-request-id 10 0) :success)
       (response-callback (make-request-id 10 2) :success)
       (check-work-stealing-balancer-query-state
-        query-chan {:iteration 14
-                    :request-id->work-stealer
-                    (-> {}
-                        (populate-request-id->workstealer 10 1 "router-2" "test-instance-id-2")
-                        (populate-request-id->workstealer 10 3 "router-2" "test-instance-id-4")
-                        (populate-request-id->workstealer 10 4 "router-1" "test-instance-id-5"))
-                    :slots {:offerable 5, :offered 3}})
+        query-chan
+        {:global-offers {:allowed max-permits :available (- max-permits 3)}
+         :iteration 14
+         :request-id->work-stealer (-> {}
+                                     (populate-request-id->workstealer 10 1 "router-2" "test-instance-id-2")
+                                     (populate-request-id->workstealer 10 3 "router-2" "test-instance-id-4")
+                                     (populate-request-id->workstealer 10 4 "router-1" "test-instance-id-5"))
+         :slots {:offerable 5 :offered 3}})
       (is (contains? @released-instances-atom "test-instance-id-1"))
       (is (not (contains? @released-instances-atom "test-instance-id-2")))
       (is (contains? @released-instances-atom "test-instance-id-3"))
@@ -357,40 +383,43 @@
       (is (not (contains? @released-instances-atom "test-instance-id-7")))
       (is (not (contains? @released-instances-atom "test-instance-id-8")))
 
-      (reset! metrics-atom {router-id (make-metrics {:outstanding 10, :slots-available 15})
+      (reset! metrics-atom {router-id (make-metrics {:outstanding 10 :slots-available 15})
                             "router-3" (make-metrics {:outstanding 10})
                             "router-4" (make-metrics {:outstanding 30})})
       (async/>!! custom-timeout-chan :custom-timeout)
       (check-work-stealing-balancer-query-state
-        query-chan {:iteration 16
-                    :request-id->work-stealer
-                    (-> {}
-                        (populate-request-id->workstealer 10 1 "router-2" "test-instance-id-2")
-                        (populate-request-id->workstealer 10 3 "router-2" "test-instance-id-4")
-                        (populate-request-id->workstealer 10 4 "router-1" "test-instance-id-5")
-                        (populate-request-id->workstealer 15 0 "router-4" "test-instance-id-6")
-                        (populate-request-id->workstealer 15 1 "router-4" "test-instance-id-7"))
-                    :slots {:offerable 5, :offered 5}})
+        query-chan
+        {:global-offers {:allowed max-permits :available (- max-permits 5)}
+         :iteration 16
+         :request-id->work-stealer (-> {}
+                                     (populate-request-id->workstealer 10 1 "router-2" "test-instance-id-2")
+                                     (populate-request-id->workstealer 10 3 "router-2" "test-instance-id-4")
+                                     (populate-request-id->workstealer 10 4 "router-1" "test-instance-id-5")
+                                     (populate-request-id->workstealer 15 0 "router-4" "test-instance-id-6")
+                                     (populate-request-id->workstealer 15 1 "router-4" "test-instance-id-7"))
+         :slots {:offerable 5 :offered 5}})
 
       (response-callback (make-request-id 10 1) :success)
       (response-callback (make-request-id 10 3) :success)
       (response-callback (make-request-id 15 1) :success)
       (check-work-stealing-balancer-query-state
-        query-chan {:iteration 20,
-                    :request-id->work-stealer
-                    (-> {}
-                        (populate-request-id->workstealer 10 4 "router-1" "test-instance-id-5")
-                        (populate-request-id->workstealer 15 0 "router-4" "test-instance-id-6"))
-                    :slots {:offerable 5, :offered 2}})
+        query-chan
+        {:global-offers {:allowed max-permits :available (- max-permits 2)}
+         :iteration 20
+         :request-id->work-stealer (-> {}
+                                     (populate-request-id->workstealer 10 4 "router-1" "test-instance-id-5")
+                                     (populate-request-id->workstealer 15 0 "router-4" "test-instance-id-6"))
+         :slots {:offerable 5 :offered 2}})
 
       (async/>!! custom-timeout-chan :custom-timeout)
       (check-work-stealing-balancer-query-state
-        query-chan {:iteration 22,
-                    :request-id->work-stealer
-                    (-> {}
-                        (populate-request-id->workstealer 10 4 "router-1" "test-instance-id-5")
-                        (populate-request-id->workstealer 15 0 "router-4" "test-instance-id-6"))
-                    :slots {:offerable 5, :offered 2}})
+        query-chan
+        {:global-offers {:allowed max-permits :available (- max-permits 2)}
+         :iteration 22
+         :request-id->work-stealer (-> {}
+                                     (populate-request-id->workstealer 10 4 "router-1" "test-instance-id-5")
+                                     (populate-request-id->workstealer 15 0 "router-4" "test-instance-id-6"))
+         :slots {:offerable 5 :offered 2}})
       (is (contains? @released-instances-atom "test-instance-id-1"))
       (is (contains? @released-instances-atom "test-instance-id-2"))
       (is (contains? @released-instances-atom "test-instance-id-3"))
@@ -399,6 +428,119 @@
       (is (not (contains? @released-instances-atom "test-instance-id-6")))
       (is (contains? @released-instances-atom "test-instance-id-7"))
       (is (not (contains? @released-instances-atom "test-instance-id-8")))
+
+      (async/>!! exit-chan :exit)))
+
+  (deftest test-work-stealing-balancer-offers-limited-by-max-work-stealing-offers
+    (let [available-slots 7
+          max-permits 2
+          initial-state {:iteration 10 :request-id->work-stealer {}}
+          request-id->cleanup-chan-atom (atom {})
+          offer-help-fn (fn [{:keys [request-id]} cleanup-chan]
+                          (swap! request-id->cleanup-chan-atom assoc request-id cleanup-chan))
+          response-callback (fn [request-id response-status]
+                              (let [response-chan (get @request-id->cleanup-chan-atom request-id)]
+                                (async/>!! response-chan {:request-id request-id :status response-status})))
+          released-instances-atom (atom #{})
+          release-instance-fn (fn [reservation-result]
+                                (swap! released-instances-atom conj (get-in reservation-result [:instance :id])))
+          reserve-instance-counter (atom 0)
+          reserve-instance-fn (fn [_ response-chan]
+                                (swap! reserve-instance-counter inc)
+                                (if (<= @reserve-instance-counter available-slots)
+                                  (async/>!! response-chan {:id (str "test-instance-id-" @reserve-instance-counter)})
+                                  (async/>!! response-chan :no-instance-found)))
+          _ (reset! metrics-atom nil)
+          custom-timeout-chan (async/chan 1)
+          timeout-chan-factory (constantly custom-timeout-chan)
+          offers-allowed-semaphore (semaphore/create-semaphore max-permits)
+          {:keys [exit-chan query-chan]}
+          (work-stealing-balancer initial-state timeout-chan-factory service-id->router-id->metrics reserve-instance-fn
+                                  release-instance-fn offer-help-fn offers-allowed-semaphore router-id service-id)]
+
+      (reset! metrics-atom {router-id (make-metrics {:outstanding 10 :slots-available 15})
+                            "router-1" (make-metrics {:outstanding 4})
+                            "router-2" (make-metrics {:outstanding 3})})
+      (async/>!! custom-timeout-chan :custom-timeout)
+      (check-work-stealing-balancer-query-state
+        query-chan
+        {:global-offers {:allowed max-permits :available 0}
+         :iteration 11
+         :request-id->work-stealer (-> {}
+                                     (populate-request-id->workstealer 10 0 "router-1" "test-instance-id-1")
+                                     (populate-request-id->workstealer 10 1 "router-2" "test-instance-id-2"))
+         :slots {:offerable 5 :offered 2}})
+
+      (is (= 2 @reserve-instance-counter))
+      (is (contains? @request-id->cleanup-chan-atom (make-request-id 10 0)))
+      (is (contains? @request-id->cleanup-chan-atom (make-request-id 10 1)))
+      (is (not (contains? @request-id->cleanup-chan-atom (make-request-id 10 2))))
+      (is (not (contains? @request-id->cleanup-chan-atom (make-request-id 10 3))))
+      (is (not (contains? @request-id->cleanup-chan-atom (make-request-id 10 4))))
+
+      (response-callback (make-request-id 10 0) :success)
+      (check-work-stealing-balancer-query-state
+        query-chan
+        {:global-offers {:allowed max-permits :available 1}
+         :iteration 13
+         :request-id->work-stealer (-> {}
+                                     (populate-request-id->workstealer 10 1 "router-2" "test-instance-id-2"))
+         :slots {:offerable 5 :offered 1}})
+      (is (contains? @released-instances-atom "test-instance-id-1"))
+      (is (not (contains? @released-instances-atom "test-instance-id-2")))
+      (is (not (contains? @released-instances-atom "test-instance-id-3")))
+      (is (not (contains? @released-instances-atom "test-instance-id-4")))
+      (is (not (contains? @released-instances-atom "test-instance-id-5")))
+
+      (reset! metrics-atom {router-id (make-metrics {:outstanding 10 :slots-available 15})
+                            "router-3" (make-metrics {:outstanding 10})
+                            "router-4" (make-metrics {:outstanding 30})})
+      (async/>!! custom-timeout-chan :custom-timeout)
+      (check-work-stealing-balancer-query-state
+        query-chan
+        {:global-offers {:allowed max-permits :available 0}
+         :iteration 15
+         :request-id->work-stealer (-> {}
+                                     (populate-request-id->workstealer 10 1 "router-2" "test-instance-id-2")
+                                     (populate-request-id->workstealer 14 0 "router-4" "test-instance-id-3"))
+         :slots {:offerable 5 :offered 2}})
+
+      (response-callback (make-request-id 10 1) :success)
+      (check-work-stealing-balancer-query-state
+        query-chan {:iteration 17
+                    :request-id->work-stealer
+                    (-> {}
+                      (populate-request-id->workstealer 14 0 "router-4" "test-instance-id-3"))
+                    :slots {:offerable 5 :offered 1}})
+
+      (async/>!! custom-timeout-chan :custom-timeout)
+      (check-work-stealing-balancer-query-state
+        query-chan
+        {:global-offers {:allowed max-permits :available 0}
+         :iteration 19
+         :request-id->work-stealer (-> {}
+                                     (populate-request-id->workstealer 14 0 "router-4" "test-instance-id-3")
+                                     (populate-request-id->workstealer 18 0 "router-4" "test-instance-id-4"))
+         :slots {:offerable 5 :offered 2}})
+      (is (contains? @released-instances-atom "test-instance-id-1"))
+      (is (contains? @released-instances-atom "test-instance-id-2"))
+      (is (not (contains? @released-instances-atom "test-instance-id-3")))
+      (is (not (contains? @released-instances-atom "test-instance-id-4")))
+      (is (not (contains? @released-instances-atom "test-instance-id-5")))
+
+      (response-callback (make-request-id 18 0) :success)
+      (check-work-stealing-balancer-query-state
+        query-chan
+        {:global-offers {:allowed max-permits :available 1}
+         :iteration 21
+         :request-id->work-stealer (-> {}
+                                     (populate-request-id->workstealer 14 0 "router-4" "test-instance-id-3"))
+         :slots {:offerable 5 :offered 1}})
+      (is (contains? @released-instances-atom "test-instance-id-1"))
+      (is (contains? @released-instances-atom "test-instance-id-2"))
+      (is (not (contains? @released-instances-atom "test-instance-id-3")))
+      (is (contains? @released-instances-atom "test-instance-id-4"))
+      (is (not (contains? @released-instances-atom "test-instance-id-5")))
 
       (async/>!! exit-chan :exit))))
 
@@ -427,52 +569,56 @@
                                                   (let [response-chan (async/promise-chan)
                                                         body-chan (async/promise-chan)]
                                                     (async/>!! body-chan (utils/clj->json response-map))
-                                                    (async/>!! response-chan {:body body-chan, :status status})
+                                                    (async/>!! response-chan {:body body-chan :status status})
                                                     {target-router-id response-chan})))]
     (with-redefs [work-stealing-balancer
-                  (fn [_ _ _ _ _ offer-help-fn _ _]
+                  (fn [_ _ _ _ _ offer-help-fn _ _ _]
                     (reset! offer-help-fn-atom offer-help-fn))]
 
       (testing "2XX response - missing status"
-        (let [make-inter-router-requests-fn (make-inter-router-requests-fn-factory 200 {})]
-          (start-work-stealing-balancer instance-rpc-chan reserve-timeout-ms offer-help-interval-ms service-id->router-id->metrics
-                                        make-inter-router-requests-fn router-id service-id)
+        (let [offers-allowed-semaphore (semaphore/create-semaphore 10)
+              make-inter-router-requests-fn (make-inter-router-requests-fn-factory 200 {})]
+          (start-work-stealing-balancer instance-rpc-chan reserve-timeout-ms offer-help-interval-ms offers-allowed-semaphore
+                                        service-id->router-id->metrics make-inter-router-requests-fn router-id service-id)
           (is @offer-help-fn-atom)
           (let [offer-help-fn @offer-help-fn-atom
                 reservation-parameters {:request-id request-id :target-router-id target-router-id}
                 cleanup-chan (async/chan 1)]
             (offer-help-fn reservation-parameters cleanup-chan)
-            (is (= {:request-id request-id, :status :work-stealing-error} (async/<!! cleanup-chan))))))
+            (is (= {:request-id request-id :status :work-stealing-error} (async/<!! cleanup-chan))))))
 
       (testing "2XX response - success"
-        (let [make-inter-router-requests-fn (make-inter-router-requests-fn-factory 200 {:response-status "successful"})]
-          (start-work-stealing-balancer instance-rpc-chan reserve-timeout-ms offer-help-interval-ms service-id->router-id->metrics
-                                        make-inter-router-requests-fn router-id service-id)
+        (let [offers-allowed-semaphore (semaphore/create-semaphore 10)
+              make-inter-router-requests-fn (make-inter-router-requests-fn-factory 200 {:response-status "successful"})]
+          (start-work-stealing-balancer instance-rpc-chan reserve-timeout-ms offer-help-interval-ms offers-allowed-semaphore
+                                        service-id->router-id->metrics make-inter-router-requests-fn router-id service-id)
           (is @offer-help-fn-atom)
           (let [offer-help-fn @offer-help-fn-atom
                 reservation-parameters {:request-id request-id :target-router-id target-router-id}
                 cleanup-chan (async/chan 1)]
             (offer-help-fn reservation-parameters cleanup-chan)
-            (is (= {:request-id request-id, :status :successful} (async/<!! cleanup-chan))))))
+            (is (= {:request-id request-id :status :successful} (async/<!! cleanup-chan))))))
 
       (testing "2XX response - failure"
-        (let [make-inter-router-requests-fn (make-inter-router-requests-fn-factory 200 {:response-status "failure"})]
-          (start-work-stealing-balancer instance-rpc-chan reserve-timeout-ms offer-help-interval-ms service-id->router-id->metrics
-                                        make-inter-router-requests-fn router-id service-id)
+        (let [offers-allowed-semaphore (semaphore/create-semaphore 10)
+              make-inter-router-requests-fn (make-inter-router-requests-fn-factory 200 {:response-status "failure"})]
+          (start-work-stealing-balancer instance-rpc-chan reserve-timeout-ms offer-help-interval-ms offers-allowed-semaphore
+                                        service-id->router-id->metrics make-inter-router-requests-fn router-id service-id)
           (is @offer-help-fn-atom)
           (let [offer-help-fn @offer-help-fn-atom
                 reservation-parameters {:request-id request-id :target-router-id target-router-id}
                 cleanup-chan (async/chan 1)]
             (offer-help-fn reservation-parameters cleanup-chan)
-            (is (= {:request-id request-id, :status :failure} (async/<!! cleanup-chan))))))
+            (is (= {:request-id request-id :status :failure} (async/<!! cleanup-chan))))))
 
       (testing "4XX response - failure"
-        (let [make-inter-router-requests-fn (make-inter-router-requests-fn-factory 400 {:response-status "failure"})]
-          (start-work-stealing-balancer instance-rpc-chan reserve-timeout-ms offer-help-interval-ms service-id->router-id->metrics
-                                        make-inter-router-requests-fn router-id service-id)
+        (let [offers-allowed-semaphore (semaphore/create-semaphore 10)
+              make-inter-router-requests-fn (make-inter-router-requests-fn-factory 400 {:response-status "failure"})]
+          (start-work-stealing-balancer instance-rpc-chan reserve-timeout-ms offer-help-interval-ms offers-allowed-semaphore
+                                        service-id->router-id->metrics make-inter-router-requests-fn router-id service-id)
           (is @offer-help-fn-atom)
           (let [offer-help-fn @offer-help-fn-atom
                 reservation-parameters {:request-id request-id :target-router-id target-router-id}
                 cleanup-chan (async/chan 1)]
             (offer-help-fn reservation-parameters cleanup-chan)
-            (is (= {:request-id request-id, :status :work-stealing-error} (async/<!! cleanup-chan)))))))))
+            (is (= {:request-id request-id :status :work-stealing-error} (async/<!! cleanup-chan)))))))))


### PR DESCRIPTION
## Changes proposed in this PR

- limits the maximum number of work-stealing offers in-flight from a router
- introduces global codahale metrics for work-stealing

## Why are we making these changes?

Limits the total number of in-flight work-stealing requests outgoing from a router. This allows us to cap the resources used by routers for work-stealing purposes.

### Example state output:
<img width="761" alt="Screen Shot 2019-09-05 at 1 40 04 PM" src="https://user-images.githubusercontent.com/6611249/64337203-b5c9f600-d000-11e9-877d-91b47004fde0.png">

