### PR TITLE
refactors descriptor to allow retrieving previous-descriptor from multiple sources

### DIFF
--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -1001,6 +1001,18 @@
        (apply max-key (fn [[_ {:strs [last-update-time]}]] (or last-update-time 0)))
        first))
 
+(defn retrieve-most-recently-modified-token-update-time
+  "Computes the last-update-time of the most recently modified token from the descriptor."
+  [descriptor]
+  (or
+    (some->> descriptor
+      :sources
+      :token->token-data
+      (pc/map-vals (fn [[_ {:strs [last-update-time]}]] (or last-update-time 0)))
+      vals
+      (apply max))
+    0))
+
 (defn service-id->service-description
   "Loads the service description for the specified service-id including any overrides."
   [kv-store service-id service-description-defaults metric-group-mappings & {:keys [effective?] :or {effective? true}}]


### PR DESCRIPTION

## Changes proposed in this PR

- refactors descriptor to allow retrieving previous-descriptor from multiple sources

## Why are we making these changes?

Make it easier to plug in multiple contributors to fallback descriptors.
