### PR TITLE
adds endpoint to visualize work-stealing metrics

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -119,6 +119,7 @@
                               ["/scheduler" :state-scheduler-handler-fn]
                               ["/service-description-builder" :state-service-description-builder-handler-fn]
                               ["/statsd" :state-statsd-handler-fn]
+                              ["/work-stealing" :state-work-stealing-handler-fn]
                               [["/" :service-id] :state-service-handler-fn]]
                      "status" :status-handler-fn
                      "token" :token-handler-fn
@@ -1581,6 +1582,11 @@
                               (wrap-secure-request-fn
                                 (fn state-statsd-handler-fn [request]
                                   (handler/get-statsd-state router-id request))))
+   :state-work-stealing-handler-fn (pc/fnk [[:state router-id]
+                                            wrap-secure-request-fn]
+                                     (wrap-secure-request-fn
+                                       (fn state-work-stealing-handler-fn [request]
+                                         (handler/get-work-stealing-state router-id request))))
    :status-handler-fn (pc/fnk [] handler/status-handler)
    :token-handler-fn (pc/fnk [[:curator kv-store]
                               [:routines make-inter-router-requests-sync-fn synchronize-fn validate-service-description-fn]

--- a/waiter/src/waiter/metrics.clj
+++ b/waiter/src/waiter/metrics.clj
@@ -214,6 +214,14 @@
     (matches [_ name _]
       (str/includes? name candidate-substring))))
 
+(defn conjunctive-metrics-filter
+  "Creates a MetricFilter that filters by the provided substring on metric names."
+  [^MetricFilter metrics-filter-left ^MetricFilter metrics-filter-right]
+  (reify MetricFilter
+    (matches [_ name metric]
+      (and (.matches metrics-filter-left name metric)
+           (.matches metrics-filter-right name metric)))))
+
 (defn get-service-metrics
   "Retrieves the metrics for a sepcific service-id available at this router."
   [service-id]


### PR DESCRIPTION
## Changes proposed in this PR

- adds global work-stealing metrics per router
- adds endpoint to visualize work-stealing metrics

## Why are we making these changes?

Get a feel of the work-stealing behavior globally for all requests.

