### PR TITLE
More time for log files to appear in S3 for test

### DIFF
--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -145,10 +145,8 @@
                                (string/includes? body log-bucket-url))
                             :interval 5 :timeout 300)
                           (str "Log URL never pointed to S3 bucket " log-bucket-url)))
-                  _ (log/debug "Log Url Killed:" log-url)
                   {:keys [body] :as logs-response} (make-request-fn log-url)
                   _ (assert-response-status logs-response 200)
-                  _ (log/debug "Response body:" body)
                   log-files-list (walk/keywordize-keys (json/read-str body))
                   stdout-file-link (:url (first (filter #(= (:name %) "stdout") log-files-list)))
                   stderr-file-link (:url (first (filter #(= (:name %) "stderr") log-files-list)))]

--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -143,7 +143,7 @@
                       (is (wait-for
                             #(let [{:keys [body] :as logs-response} (make-request-fn log-url)]
                                (string/includes? body log-bucket-url))
-                            :interval 1 :timeout 60)
+                            :interval 5 :timeout 300)
                           (str "Log URL never pointed to S3 bucket " log-bucket-url)))
                   _ (log/debug "Log Url Killed:" log-url)
                   {:keys [body] :as logs-response} (make-request-fn log-url)


### PR DESCRIPTION
## Changes proposed in this PR

Allow more time for files to appear in S3 bucket when running the `test-s3-logs` k8s integration test.

## Why are we making these changes?

There can be a delay between `PUT`ing a file via the S3 Rest API and when the file is visible in the bucket. This test appears to be failing sometimes because the time limit was too short.