### PR TITLE
adds support for references in the descriptor

### DIFF
--- a/waiter/docs/service-references.md
+++ b/waiter/docs/service-references.md
@@ -15,14 +15,17 @@ By default, Waiter relies on the service idle timeout to GC services after perio
 However, service reachable only via references, e.g. tokens, can be GC-ed eagerly if the reference has been updated.
 
 When a service description is constructed from a request, the service references are also updated.
-These references are available as the `:references` key in the descriptor and are annotated by a `:type` parameter.
-The service GC process checks these references by type and marks a service as a candidate for eager GC
+These references are available as the `:reference` key in the descriptor.
+The :refrence enrty is a map where the keys represent a `:type` parameter.
+The service GC process checks individual references by type and marks a service as a candidate for eager GC
   if _all_ references used to access the service are stale.
-This staleness check is performed using the functions returned from `retrieve-reference-type->stale-fn` of the builder.
+An individual reference is stale if any of its value entries is stale.
+This staleness check on the value is performed using the functions returned from
+  `retrieve-reference-type->stale-fn` of the builder and invoking the corresponding 'type' function on the value.
 
 The default implementation of the `ServiceDescriptionBuilder` returns
   the following functions for the different reference types:
-  1. all services that can be directly accessed never go stale;
+  1. any services that can be directly accessed never goes stale;
   1. services accessed via tokens go stale if all tokens used to access the service have been updated.
 
 Custom builder implementations can add additional references to services and

--- a/waiter/docs/service-references.md
+++ b/waiter/docs/service-references.md
@@ -1,10 +1,10 @@
 # Service References
 
-To process a http request, Waiter needs to resolve a request to a service description.
+To process an HTTP request, Waiter needs to resolve a request to a service description.
 This service description tells Waiter how to locate the service instance to use to process the current request.
 
 Waiter uses request headers to construct the service description using the `ServiceDescriptionBuilder`.
-It is possible for the service to be reachable from various combinations of headers:
+It is possible for the _same_ service to be reachable from various combinations of headers:
   1. token - single or multiple
   1. on-the-fly services without tokens
   1. on-the-fly services that extend tokens, e.g. run-as-requester
@@ -14,14 +14,21 @@ It is possible for the service to be reachable from various combinations of head
 By default, Waiter relies on the service idle timeout to GC services after periods of inactivity (not receiving requests).
 However, services reachable only via references, e.g. tokens, can be GC-ed eagerly if the reference has been updated.
 
-When a service description is constructed from a request, the service references are also updated.
-These references are available as the `:reference-type->entry` key in the descriptor.
-The `reference-type->entry` is a map where the keys represent a `:type` parameter.
+**Note**: A service known to be referenced only via on-the-fly headers never goes stale.
+
+When a service description is constructed from a request, the set of references for a service are also updated.
+Individual references are available in the `:reference-type->entry` key in the descriptor,
+  the descriptor being built per request.
+It is possible to reference the same service using different combinations of on-the-fly headers and tokens.
+As such, there is a set of references (the union of all `:reference-type->entry` from the descriptor) that
+  can be used to reference a service.
 
 ### Reference (`:reference-type->entry` in the descriptor) examples
 
-- A service created with on-the-fly header without tokens will have an empty map
-  as the following value for `:reference-type->entry` in the descriptor:
+The `reference-type->entry` is a map where the keys represent a `:type` parameter used during staleness checks.
+
+- A service created with on-the-fly header without tokens never goes stale.
+  It has an empty map as the value for `:reference-type->entry` in the descriptor:
 ```
   {}
 ```
@@ -39,10 +46,10 @@ The `reference-type->entry` is a map where the keys represent a `:type` paramete
                      {:token "baz" :version "v2"}]}}
 ```
 
-If the same service can be accessed by another token, we end up building multiple
-  `reference-type->entry` maps as references that refer to the service.
-E.g. if all the above requests mapped to the same service, that service would have
-  the following references:
+As mentioned previously, as the same service can be accessed by another token, we end up
+  building a set of `reference-type->entry` maps as references that refer to the service.
+E.g. if all the example requests above mapped to the same service, that service would have
+  the following references set:
 ```
   #{{}
     {:token {:sources [{:token "foo" :version "v0"}]}}
@@ -50,7 +57,7 @@ E.g. if all the above requests mapped to the same service, that service would ha
                        {:token "baz" :version "v2"}]}}}
 ```
 
-### Staleness checks
+## Staleness checks
 
 The service GC processes all known references for a service and marks the service as a candidate for eager GC
   if _all_ references used to access the service are stale.
@@ -59,7 +66,7 @@ An individual reference, i.e. the `reference-type->entry` map computed in a requ
 This staleness check on the value is performed using the functions returned from
   `retrieve-reference-type->stale-fn` of the builder and invoking the corresponding 'type' function on the value.
 
-**Note**: a service that has an empty map among its references never goes stale as it is known to be directly referenced.
+**Note**: A service known to be directly referenced (i.e. has an empty map among its references) never goes stale.
 
 The default implementation of the `ServiceDescriptionBuilder` returns a map with a single entry for `:token`
   from the `retrieve-reference-type->stale-fn`.
@@ -76,3 +83,28 @@ E.g. a hypothetical implementation which treats the image parameter as docker im
 ```
 The `retrieve-reference-type->stale-fn` must then provide an implementation for a function that
   can check staleness of `:image` reference types.
+E.g. if `retrieve-reference-type->stale-fn` returns:
+```
+  {:image check-image-for-staleness-fn
+   :token check-token-for-staleness-fn}
+```
+and we have a service with the following set of references:
+```
+  #{{:image {:name "twosigma/courier" :build "20191002"}}
+    {:image {:name "twosigma/kitchen" :build "20191001"}
+     :token {:sources [{:token "foo" :version "v0"}]}}
+    {:token {:sources [{:token "bar" :version "v1"}
+                       {:token "baz" :version "v2"}]}}}
+```
+then the service goes stale when the following condition is true:
+```
+  (and
+    # single image expression in the or since there was only one entry in the map
+    (or (check-image-for-staleness-fn {:name "twosigma/courier" :build "20191002"}))
+    # two expressions in the or, one for image and one for token
+    (or (check-image-for-staleness-fn {:name "twosigma/kitchen" :build "20191001"})
+        (check-token-for-staleness-fn {:sources [{:token "foo" :version "v0"}]}))
+    # single token expression in the or since there was only one entry in the map
+    (or (check-token-for-staleness-fn
+          {:sources [{:token "bar" :version "v1"} {:token "baz" :version "v2"}]})))
+```

--- a/waiter/docs/service-references.md
+++ b/waiter/docs/service-references.md
@@ -1,0 +1,29 @@
+# Service References
+
+To process a http request, Waiter needs to resolve a request to a service description.
+This service description tells Waiter how to locate the service instance to use to process the current request.
+
+Waiter uses request headers to construct the service description using the `ServiceDescriptionBuilder`.
+It is possible for the service to be reachable from various combinations of headers:
+  1. token - single or multiple
+  1. on-the-fly services without tokens
+  1. on-the-fly services that extend tokens, e.g. run-as-requester
+
+## Service GC
+
+By default, Waiter relies on the service idle timeout to GC services after periods of inactivity (not receiving requests).
+However, service reachable only via references, e.g. tokens, can be GC-ed eagerly if the reference has been updated.
+
+When a service description is constructed from a request, the service references are also updated.
+These references are available as the `:references` key in the descriptor and are annotated by a `:type` parameter.
+The service GC process checks these references by type and marks a service as a candidate for eager GC
+  if _all_ references used to access the service are stale.
+This staleness check is performed using the functions returned from `retrieve-reference-type->stale-fn` of the builder.
+
+The default implementation of the `ServiceDescriptionBuilder` returns
+  the following functions for the different reference types:
+  1. all services that can be directly accessed never go stale;
+  1. services accessed via tokens go stale if all tokens used to access the service have been updated.
+
+Custom builder implementations can add additional references to services and
+  need to provide appropriate staleness check functions for each reference type.

--- a/waiter/docs/service-references.md
+++ b/waiter/docs/service-references.md
@@ -16,21 +16,53 @@ However, services reachable only via references, e.g. tokens, can be GC-ed eager
 
 When a service description is constructed from a request, the service references are also updated.
 These references are available as the `:reference-type->entry` key in the descriptor.
-The `reference-type->entry` is a map where the keys represent a `:type` parameter, e.g.
-a service created with `x-waiter-token: foo` header on a request will have the value:
+The `reference-type->entry` is a map where the keys represent a `:type` parameter.
+
+### Reference (`:reference-type->entry` in the descriptor) examples
+
+- A service created with on-the-fly header without tokens will have an empty map
+  as the following value for `:reference-type->entry` in the descriptor:
 ```
-  {:token {:sources [{"token" "foo" "version" "v1"}]}}
+  {}
+```
+
+- A service created with `x-waiter-token: foo` header on a request will have the
+  following value for `:reference-type->entry` in the descriptor:
+```
+  {:token {:sources [{:token "foo" :version "v0"}]}}
+```
+
+- A service created with `x-waiter-token: bar,baz` header on a request will have the
+  following value for `:reference-type->entry` in the descriptor:
+```
+  {:token {:sources [{:token "bar" :version "v1"}
+                     {:token "baz" :version "v2"}]}}
 ```
 
 If the same service can be accessed by another token, we end up building multiple
   `reference-type->entry` maps as references that refer to the service.
-The service GC process checks individual references by type and marks a service as a candidate for eager GC
+E.g. if all the above requests mapped to the same service, that service would have
+  the following references:
+```
+  #{{}
+    {:token {:sources [{:token "foo" :version "v0"}]}}
+    {:token {:sources [{:token "bar" :version "v1"}
+                       {:token "baz" :version "v2"}]}}}
+```
+
+### Staleness checks
+
+The service GC processes all known references for a service and marks the service as a candidate for eager GC
   if _all_ references used to access the service are stale.
-An individual reference, i.e. the `reference-type->entry` map, is stale if any of its value entries is stale.
+An individual reference, i.e. the `reference-type->entry` map computed in a request descriptor,
+  is stale if any of its value entries is stale.
 This staleness check on the value is performed using the functions returned from
   `retrieve-reference-type->stale-fn` of the builder and invoking the corresponding 'type' function on the value.
 
-The default implementation of the `ServiceDescriptionBuilder` returns a map with a single entry for `:token`.
+**Note**: a service that has an empty map among its references never goes stale as it is known to be directly referenced.
+
+The default implementation of the `ServiceDescriptionBuilder` returns a map with a single entry for `:token`
+  from the `retrieve-reference-type->stale-fn`.
 The provided `:token` staleness function deems services accessed via tokens to be stale if all tokens
   used to access the service have been updated.
 

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -317,7 +317,7 @@
 
       (let [service-settings (service-settings waiter-url service-id
                                                :query-params {"include" "references"})]
-        (is (= [{:type "direct"}] (get service-settings :references)) (str service-settings)))
+        (is (= [{}] (get service-settings :references)) (str service-settings)))
 
       (testing "metric group should be other"
         (is (= "other" (service-id->metric-group waiter-url service-id))

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -315,6 +315,10 @@
         (is (= (:x-waiter-cmd headers) (get-in service-settings [:effective-parameters :cmd])))
         (is (= "other" (get-in service-settings [:effective-parameters :metric-group])) service-id))
 
+      (let [service-settings (service-settings waiter-url service-id
+                                               :query-params {"include" "references"})]
+        (is (= [{:type "direct-access"}] (get service-settings :references)) (str service-settings)))
+
       (testing "metric group should be other"
         (is (= "other" (service-id->metric-group waiter-url service-id))
             (str "Invalid metric group for " service-id)))

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -317,7 +317,7 @@
 
       (let [service-settings (service-settings waiter-url service-id
                                                :query-params {"include" "references"})]
-        (is (= [{:type "direct-access"}] (get service-settings :references)) (str service-settings)))
+        (is (= [{:type "direct"}] (get service-settings :references)) (str service-settings)))
 
       (testing "metric group should be other"
         (is (= "other" (service-id->metric-group waiter-url service-id))

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -844,6 +844,10 @@
         (is (str/includes? service-id-1 name-string) (str "ERROR: App-name is missing " name-string))
         (assert-service-on-all-routers waiter-url service-id-1 cookies)
         (is (nil? (service-id->source-tokens-entries waiter-url service-id-1)))
+
+        (let [service-settings (service-settings waiter-url service-id-1 :query-params {"include" "references"})]
+          (is (= [{:type "direct-access"}] (get service-settings :references)) (str service-settings)))
+
         (let [token (str "^SERVICE-ID#" service-id-1)
               response (make-request-with-debug-info {:x-waiter-token token} #(make-request waiter-url "" :headers %))
               service-id-2 (:service-id response)]
@@ -854,7 +858,12 @@
             (is (= service-id-1 service-id-2) "The on-the-fly and token-based service ids do not match")
             (assert-service-on-all-routers waiter-url service-id-1 cookies)
             (is (= #{(make-source-tokens-entries waiter-url token)}
-                   (service-id->source-tokens-entries waiter-url service-id-2)))))))))
+                   (service-id->source-tokens-entries waiter-url service-id-2)))
+            (let [service-settings (service-settings waiter-url service-id-2 :query-params {"include" "references"})
+                  references (set (get service-settings :references))]
+              (is (contains? references {:type "direct-access"}) (str service-settings))
+              (is (contains? references {:sources [{:token token :version (token->etag waiter-url token)}] :type "token"})
+                  (str service-settings)))))))))
 
 (deftest ^:parallel ^:integration-fast test-namespace-token
   (testing-using-waiter-url
@@ -1406,21 +1415,45 @@
 
         (let [service-id-a (retrieve-service-id waiter-url {:x-waiter-token combined-token-header})
               new-service-description (update first-service-description :cpus #(+ % 0.1))]
+
+          (let [service-settings (service-settings waiter-url service-id-a :query-params {"include" "references"})
+                references (set (get service-settings :references))]
+            (is (not (contains? references {:type "direct-access"})) (str service-settings))
+            (is (contains? references {:sources [{:token token-name-a :version (token->etag waiter-url token-name-a)}
+                                                 {:token token-name-b :version (token->etag waiter-url token-name-b)}]
+                                       :type "token"})))
+
           (let [response (post-token waiter-url (assoc new-service-description :token token-name-a))]
             (assert-response-status response 200))
 
           (let [service-id-b (retrieve-service-id waiter-url {:x-waiter-token combined-token-header})]
+
+            (let [service-settings (service-settings waiter-url service-id-b :query-params {"include" "references"})
+                  references (set (get service-settings :references))]
+              (is (not (contains? references {:type "direct-access"})) (str service-settings))
+              (is (contains? references {:sources [{:token token-name-a :version (token->etag waiter-url token-name-a)}
+                                                   {:token token-name-b :version (token->etag waiter-url token-name-b)}]
+                                         :type "token"})))
+
             (let [response (post-token waiter-url (assoc new-service-description :token token-name-b))]
               (assert-response-status response 200))
 
-            (let [service-id-c (retrieve-service-id waiter-url {:x-waiter-token combined-token-header})
-                  service-a-details (service-settings waiter-url service-id-a)
-                  service-b-details (service-settings waiter-url service-id-b)
-                  service-c-details (service-settings waiter-url service-id-c)]
-              (is (nil? (:current-for-tokens service-a-details)))
-              (is (nil? (:current-for-tokens service-b-details)))
-              (is (= [token-name-a token-name-b]
-                     (:current-for-tokens service-c-details))))))
+            (let [service-id-c (retrieve-service-id waiter-url {:x-waiter-token combined-token-header})]
+
+              (let [service-settings (service-settings waiter-url service-id-c :query-params {"include" "references"})
+                    references (set (get service-settings :references))]
+                (is (not (contains? references {:type "direct-access"})) (str service-settings))
+                (is (contains? references {:sources [{:token token-name-a :version (token->etag waiter-url token-name-a)}
+                                                     {:token token-name-b :version (token->etag waiter-url token-name-b)}]
+                                           :type "token"})))
+
+              (let [service-a-details (service-settings waiter-url service-id-a)
+                    service-b-details (service-settings waiter-url service-id-b)
+                    service-c-details (service-settings waiter-url service-id-c)]
+                (is (nil? (:current-for-tokens service-a-details)))
+                (is (nil? (:current-for-tokens service-b-details)))
+                (is (= [token-name-a token-name-b]
+                       (:current-for-tokens service-c-details)))))))
         (finally
           (delete-token-and-assert waiter-url token-name-a)
           (delete-token-and-assert waiter-url token-name-b))))))

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -846,7 +846,7 @@
         (is (nil? (service-id->source-tokens-entries waiter-url service-id-1)))
 
         (let [service-settings (service-settings waiter-url service-id-1 :query-params {"include" "references"})]
-          (is (= [{:type "direct"}] (get service-settings :references)) (str service-settings)))
+          (is (= [{}] (get service-settings :references)) (str service-settings)))
 
         (let [token (str "^SERVICE-ID#" service-id-1)
               response (make-request-with-debug-info {:x-waiter-token token} #(make-request waiter-url "" :headers %))
@@ -861,8 +861,8 @@
                    (service-id->source-tokens-entries waiter-url service-id-2)))
             (let [service-settings (service-settings waiter-url service-id-2 :query-params {"include" "references"})
                   references (set (get service-settings :references))]
-              (is (contains? references {:type "direct"}) (str service-settings))
-              (is (contains? references {:sources [{:token token :version (token->etag waiter-url token)}] :type "token"})
+              (is (contains? references {}) (str service-settings))
+              (is (contains? references {:token {:sources [{:token token :version (token->etag waiter-url token)}]}})
                   (str service-settings)))))))))
 
 (deftest ^:parallel ^:integration-fast test-namespace-token
@@ -1418,10 +1418,9 @@
 
           (let [service-settings (service-settings waiter-url service-id-a :query-params {"include" "references"})
                 references (set (get service-settings :references))]
-            (is (not (contains? references {:type "direct"})) (str service-settings))
-            (is (contains? references {:sources [{:token token-name-a :version (token->etag waiter-url token-name-a)}
-                                                 {:token token-name-b :version (token->etag waiter-url token-name-b)}]
-                                       :type "token"})))
+            (is (not (contains? references {})) (str service-settings))
+            (is (contains? references {:token {:sources [{:token token-name-a :version (token->etag waiter-url token-name-a)}
+                                                         {:token token-name-b :version (token->etag waiter-url token-name-b)}]}})))
 
           (let [response (post-token waiter-url (assoc new-service-description :token token-name-a))]
             (assert-response-status response 200))
@@ -1430,10 +1429,9 @@
 
             (let [service-settings (service-settings waiter-url service-id-b :query-params {"include" "references"})
                   references (set (get service-settings :references))]
-              (is (not (contains? references {:type "direct"})) (str service-settings))
-              (is (contains? references {:sources [{:token token-name-a :version (token->etag waiter-url token-name-a)}
-                                                   {:token token-name-b :version (token->etag waiter-url token-name-b)}]
-                                         :type "token"})))
+              (is (not (contains? references {})) (str service-settings))
+              (is (contains? references {:token {:sources [{:token token-name-a :version (token->etag waiter-url token-name-a)}
+                                                           {:token token-name-b :version (token->etag waiter-url token-name-b)}]}})))
 
             (let [response (post-token waiter-url (assoc new-service-description :token token-name-b))]
               (assert-response-status response 200))
@@ -1442,10 +1440,9 @@
 
               (let [service-settings (service-settings waiter-url service-id-c :query-params {"include" "references"})
                     references (set (get service-settings :references))]
-                (is (not (contains? references {:type "direct"})) (str service-settings))
-                (is (contains? references {:sources [{:token token-name-a :version (token->etag waiter-url token-name-a)}
-                                                     {:token token-name-b :version (token->etag waiter-url token-name-b)}]
-                                           :type "token"})))
+                (is (not (contains? references {})) (str service-settings))
+                (is (contains? references {:token {:sources [{:token token-name-a :version (token->etag waiter-url token-name-a)}
+                                                             {:token token-name-b :version (token->etag waiter-url token-name-b)}]}})))
 
               (let [service-a-details (service-settings waiter-url service-id-a)
                     service-b-details (service-settings waiter-url service-id-b)

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -846,7 +846,7 @@
         (is (nil? (service-id->source-tokens-entries waiter-url service-id-1)))
 
         (let [service-settings (service-settings waiter-url service-id-1 :query-params {"include" "references"})]
-          (is (= [{:type "direct-access"}] (get service-settings :references)) (str service-settings)))
+          (is (= [{:type "direct"}] (get service-settings :references)) (str service-settings)))
 
         (let [token (str "^SERVICE-ID#" service-id-1)
               response (make-request-with-debug-info {:x-waiter-token token} #(make-request waiter-url "" :headers %))
@@ -861,7 +861,7 @@
                    (service-id->source-tokens-entries waiter-url service-id-2)))
             (let [service-settings (service-settings waiter-url service-id-2 :query-params {"include" "references"})
                   references (set (get service-settings :references))]
-              (is (contains? references {:type "direct-access"}) (str service-settings))
+              (is (contains? references {:type "direct"}) (str service-settings))
               (is (contains? references {:sources [{:token token :version (token->etag waiter-url token)}] :type "token"})
                   (str service-settings)))))))))
 
@@ -1418,7 +1418,7 @@
 
           (let [service-settings (service-settings waiter-url service-id-a :query-params {"include" "references"})
                 references (set (get service-settings :references))]
-            (is (not (contains? references {:type "direct-access"})) (str service-settings))
+            (is (not (contains? references {:type "direct"})) (str service-settings))
             (is (contains? references {:sources [{:token token-name-a :version (token->etag waiter-url token-name-a)}
                                                  {:token token-name-b :version (token->etag waiter-url token-name-b)}]
                                        :type "token"})))
@@ -1430,7 +1430,7 @@
 
             (let [service-settings (service-settings waiter-url service-id-b :query-params {"include" "references"})
                   references (set (get service-settings :references))]
-              (is (not (contains? references {:type "direct-access"})) (str service-settings))
+              (is (not (contains? references {:type "direct"})) (str service-settings))
               (is (contains? references {:sources [{:token token-name-a :version (token->etag waiter-url token-name-a)}
                                                    {:token token-name-b :version (token->etag waiter-url token-name-b)}]
                                          :type "token"})))
@@ -1442,7 +1442,7 @@
 
               (let [service-settings (service-settings waiter-url service-id-c :query-params {"include" "references"})
                     references (set (get service-settings :references))]
-                (is (not (contains? references {:type "direct-access"})) (str service-settings))
+                (is (not (contains? references {:type "direct"})) (str service-settings))
                 (is (contains? references {:sources [{:token token-name-a :version (token->etag waiter-url token-name-a)}
                                                      {:token token-name-b :version (token->etag waiter-url token-name-b)}]
                                            :type "token"})))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -747,12 +747,11 @@
    :synchronize-fn (pc/fnk [[:settings [:zookeeper base-path mutex-timeout-ms]]
                             curator]
                      (fn synchronize-fn [path f]
-                       (let [lock-path (str base-path "/" path)
-                             lock-name (apply str (filter #(Character/isLetterOrDigit ^char %) (str path)))]
+                       (let [lock-path (str base-path "/" path)]
                          (timers/start-stop-time!
                            (metrics/waiter-timer "core" "synchronize" "all")
                            (timers/start-stop-time!
-                             (metrics/waiter-timer "core" "synchronize" (str "cs-" lock-name))
+                             (metrics/waiter-timer "core" "synchronize" (str "cs-" path))
                              (curator/synchronize curator lock-path mutex-timeout-ms f))))))})
 
 (def scheduler
@@ -939,10 +938,10 @@
                                        assoc-run-as-user-approved? can-run-as?-fn fallback-state-atom kv-store metric-group-mappings
                                        history-length service-description-builder service-description-defaults service-id-prefix
                                        token-defaults waiter-hostnames request)
-                                     {:keys [reference service-id source-tokens]} latest-descriptor]
+                                     {:keys [reference-type->entry service-id source-tokens]} latest-descriptor]
                                  (when (seq source-tokens)
                                    (store-source-tokens-fn service-id source-tokens))
-                                 (store-reference-fn service-id reference)
+                                 (store-reference-fn service-id reference-type->entry)
                                  result)))
    :router-metrics-helpers (pc/fnk [[:state passwords router-metrics-agent]]
                              (let [password (first passwords)]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -932,17 +932,17 @@
                                         (sd/refresh-service-descriptions kv-store service-ids)))
    :request->descriptor-fn (pc/fnk [[:settings [:token-config history-length token-defaults] metric-group-mappings service-description-defaults]
                                     [:state fallback-state-atom kv-store service-description-builder service-id-prefix waiter-hostnames]
-                                    assoc-run-as-user-approved? can-run-as?-fn store-references-fn store-source-tokens-fn]
+                                    assoc-run-as-user-approved? can-run-as?-fn store-reference-fn store-source-tokens-fn]
                              (fn request->descriptor-fn [request]
                                (let [{:keys [latest-descriptor] :as result}
                                      (descriptor/request->descriptor
                                        assoc-run-as-user-approved? can-run-as?-fn fallback-state-atom kv-store metric-group-mappings
                                        history-length service-description-builder service-description-defaults service-id-prefix
                                        token-defaults waiter-hostnames request)
-                                     {:keys [references service-id source-tokens]} latest-descriptor]
+                                     {:keys [reference service-id source-tokens]} latest-descriptor]
                                  (when (seq source-tokens)
                                    (store-source-tokens-fn service-id source-tokens))
-                                 (store-references-fn service-id references)
+                                 (store-reference-fn service-id reference)
                                  result)))
    :router-metrics-helpers (pc/fnk [[:state passwords router-metrics-agent]]
                              (let [password (first passwords)]
@@ -998,10 +998,10 @@
                                        (async/go
                                          (when-let [exit-chan (get work-stealing-chan-map [:exit-chan])]
                                            (async/>! exit-chan :exit)))))
-   :store-references-fn (pc/fnk [[:curator synchronize-fn]
-                                 [:state kv-store]]
-                          (fn store-references-fn [service-id references]
-                            (sd/store-references! synchronize-fn kv-store service-id references)))
+   :store-reference-fn (pc/fnk [[:curator synchronize-fn]
+                                [:state kv-store]]
+                         (fn store-reference-fn [service-id reference]
+                           (sd/store-reference! synchronize-fn kv-store service-id reference)))
    :store-service-description-fn (pc/fnk [[:state kv-store]
                                           validate-service-description-fn]
                                    (fn store-service-description [{:keys [core-service-description service-id]}]

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -583,7 +583,7 @@
           references (cond-> references
                        (seq source-tokens) (conj {:sources source-tokens :type :token})
                        ;; if no references were used to create the service, it is directly accessible
-                       (and (empty? references) (empty? source-tokens)) (conj {:type :direct-access}))]
+                       (and (empty? references) (empty? source-tokens)) (conj {:type :direct}))]
       {:component->previous-descriptor-fns component->previous-descriptor-fns
        :core-service-description core-service-description
        :references references
@@ -591,7 +591,7 @@
        :service-id service-id}))
 
   (retrieve-reference-type->stale-fn [_ {:keys [token->token-hash]}]
-    {:direct-access (constantly false)
+    {:direct (constantly false)
      :token (fn [token] (service-token-references-stale? token->token-hash token))})
 
   (state [_]

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -417,6 +417,7 @@
                                   :generate-log-url-fn nil
                                   :make-inter-router-requests-sync-fn nil
                                   :router-metrics-helpers {:service-id->metrics-fn (constantly {})}
+                                  :service-id->references-fn (constantly {})
                                   :service-id->service-description-fn (constantly {})
                                   :service-id->source-tokens-entries-fn (constantly #{})
                                   :token->token-hash identity}
@@ -513,6 +514,7 @@
                                   :generate-log-url-fn (partial handler/generate-log-url #(str "http://www.example.com" %))
                                   :make-inter-router-requests-sync-fn nil
                                   :router-metrics-helpers {:service-id->metrics-fn (constantly service-id->metrics)}
+                                  :service-id->references-fn (constantly {})
                                   :service-id->service-description-fn (constantly {})
                                   :service-id->source-tokens-entries-fn (constantly #{})
                                   :token->token-hash identity}

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -417,7 +417,7 @@
                                   :generate-log-url-fn nil
                                   :make-inter-router-requests-sync-fn nil
                                   :router-metrics-helpers {:service-id->metrics-fn (constantly {})}
-                                  :service-id->references-fn (constantly {})
+                                  :service-id->references-fn (constantly [])
                                   :service-id->service-description-fn (constantly {})
                                   :service-id->source-tokens-entries-fn (constantly #{})
                                   :token->token-hash identity}
@@ -514,7 +514,7 @@
                                   :generate-log-url-fn (partial handler/generate-log-url #(str "http://www.example.com" %))
                                   :make-inter-router-requests-sync-fn nil
                                   :router-metrics-helpers {:service-id->metrics-fn (constantly service-id->metrics)}
-                                  :service-id->references-fn (constantly {})
+                                  :service-id->references-fn (constantly [])
                                   :service-id->service-description-fn (constantly {})
                                   :service-id->source-tokens-entries-fn (constantly #{})
                                   :token->token-hash identity}

--- a/waiter/test/waiter/descriptor_test.clj
+++ b/waiter/test/waiter/descriptor_test.clj
@@ -519,10 +519,11 @@
                                                     (let [template-basic (dissoc template "last-update-time" "previous")]
                                                       (-> descriptor
                                                         (update :core-service-description merge template-basic)
-                                                        (update :reference (fn [reference]
-                                                                             (cond-> (dissoc reference component)
-                                                                               (get-in template ["previous" "last-update-time"])
-                                                                               (assoc component {:version (str "v" (get-in template ["previous" "last-update-time"]))}))))
+                                                        (update :reference-type->entry
+                                                                (fn [reference]
+                                                                  (cond-> (dissoc reference component)
+                                                                    (get-in template ["previous" "last-update-time"])
+                                                                    (assoc component {:version (str "v" (get-in template ["previous" "last-update-time"]))}))))
                                                         (update :service-description merge template-basic)
                                                         (assoc-in [:sources component] (get template "previous")))))))
           sources {:cmd-source {"cmd" "ls2"
@@ -542,7 +543,7 @@
                                                                  [:cmd-source :cpu-source])
                            :core-service-description service-description-1
                            :passthrough-headers passthrough-headers
-                           :reference {:cmd-source {:version "v8"} :cpu-source {:version "v10"}}
+                           :reference-type->entry {:cmd-source {:version "v8"} :cpu-source {:version "v10"}}
                            :service-description service-description-1
                            :sources sources
                            :waiter-headers waiter-headers}]
@@ -551,7 +552,7 @@
             template-basic-1 (dissoc template-1 "last-update-time" "previous")]
         (is (= (-> curr-descriptor
                  (update :core-service-description merge template-basic-1)
-                 (assoc :reference {:cmd-source {:version "v8"} :cpu-source {:version "v4"}})
+                 (assoc :reference-type->entry {:cmd-source {:version "v8"} :cpu-source {:version "v4"}})
                  (update :service-description merge template-basic-1)
                  (assoc-in [:sources :cpu-source] (get template-1 "previous")))
                prev-descriptor-1))
@@ -561,7 +562,7 @@
               template-basic-2 (dissoc template-2 "last-update-time" "previous")]
           (is (= (-> prev-descriptor-1
                    (update :core-service-description merge template-basic-2)
-                   (assoc :reference {:cmd-source {:version "v6"} :cpu-source {:version "v4"}})
+                   (assoc :reference-type->entry {:cmd-source {:version "v6"} :cpu-source {:version "v4"}})
                    (update :service-description merge template-basic-2)
                    (assoc-in [:sources :cmd-source] (get template-2 "previous")))
                  prev-descriptor-2))
@@ -571,7 +572,7 @@
                 template-basic-3 (dissoc template-3 "last-update-time" "previous")]
             (is (= (-> prev-descriptor-3
                      (update :core-service-description merge template-basic-3)
-                     (assoc-in [:reference :cpu-source :version] "v4")
+                     (assoc-in [:reference-type->entry :cpu-source :version] "v4")
                      (update :service-description merge template-basic-3)
                      (assoc-in [:sources :cmd-source] (get template-3 "previous")))
                    prev-descriptor-3))
@@ -581,7 +582,7 @@
                   template-basic-4 (dissoc template-4 "last-update-time" "previous")]
               (is (= (-> prev-descriptor-3
                        (update :core-service-description merge template-basic-4)
-                       (assoc :reference {})
+                       (assoc :reference-type->entry {})
                        (update :service-description merge template-basic-4)
                        (assoc-in [:sources :cpu-source] (get template-4 "previous")))
                      prev-descriptor-4))
@@ -649,7 +650,7 @@
           passthrough-headers {}
           waiter-headers {}
           current-descriptor (-> {:passthrough-headers passthrough-headers
-                                  :reference {:token {:sources [(sd/source-tokens-entry test-token token-data-2)]}}
+                                  :reference-type->entry {:token {:sources [(sd/source-tokens-entry test-token token-data-2)]}}
                                   :sources sources
                                   :waiter-headers waiter-headers}
                                (attach-token-fallback-source token-defaults build-service-description-and-id-helper))
@@ -658,7 +659,7 @@
               :core-service-description service-description-1
               :on-the-fly? nil
               :passthrough-headers passthrough-headers
-              :reference {:token {:sources [(sd/source-tokens-entry test-token token-data-1)]}}
+              :reference-type->entry {:token {:sources [(sd/source-tokens-entry test-token token-data-1)]}}
               :service-authentication-disabled false
               :service-description (merge (:defaults sources) service-description-1)
               :service-id (sd/service-description->service-id service-id-prefix service-description-1)
@@ -690,7 +691,7 @@
           passthrough-headers {}
           waiter-headers {}
           current-descriptor (-> {:passthrough-headers passthrough-headers
-                                  :reference {:token {:sources [(sd/source-tokens-entry test-token token-data-3)]}}
+                                  :reference-type->entry {:token {:sources [(sd/source-tokens-entry test-token token-data-3)]}}
                                   :sources sources
                                   :waiter-headers waiter-headers}
                                (attach-token-fallback-source token-defaults build-service-description-and-id-helper))
@@ -699,7 +700,7 @@
               :core-service-description service-description-1
               :on-the-fly? nil
               :passthrough-headers passthrough-headers
-              :reference {:token {:sources [(sd/source-tokens-entry test-token token-data-1)]}}
+              :reference-type->entry {:token {:sources [(sd/source-tokens-entry test-token token-data-1)]}}
               :service-authentication-disabled false
               :service-description (merge (:defaults sources) service-description-1)
               :service-id (sd/service-description->service-id service-id-prefix service-description-1)
@@ -731,7 +732,7 @@
           passthrough-headers {}
           waiter-headers {"x-waiter-cpus" 20}
           current-descriptor (-> {:passthrough-headers passthrough-headers
-                                  :reference {:token {:sources [(sd/source-tokens-entry test-token token-data-2)]}}
+                                  :reference-type->entry {:token {:sources [(sd/source-tokens-entry test-token token-data-2)]}}
                                   :sources sources
                                   :waiter-headers waiter-headers}
                                (attach-token-fallback-source token-defaults build-service-description-and-id-helper))
@@ -741,7 +742,7 @@
                 :core-service-description expected-core-service-description
                 :on-the-fly? true
                 :passthrough-headers passthrough-headers
-                :reference {:token {:sources [(sd/source-tokens-entry test-token token-data-1)]}}
+                :reference-type->entry {:token {:sources [(sd/source-tokens-entry test-token token-data-1)]}}
                 :service-authentication-disabled false
                 :service-description (merge (:defaults sources) expected-core-service-description)
                 :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)
@@ -798,7 +799,7 @@
           passthrough-headers {}
           waiter-headers {}
           current-descriptor (-> {:passthrough-headers passthrough-headers
-                                  :reference {:token {:sources (:source-tokens sources)}}
+                                  :reference-type->entry {:token {:sources (:source-tokens sources)}}
                                   :sources sources
                                   :waiter-headers waiter-headers}
                                (attach-token-fallback-source token-defaults build-service-description-and-id-helper))
@@ -809,8 +810,8 @@
                 :core-service-description expected-core-service-description
                 :on-the-fly? nil
                 :passthrough-headers passthrough-headers
-                :reference {:token {:sources [(sd/source-tokens-entry test-token-1 token-data-1)
-                                              (sd/source-tokens-entry test-token-2 token-data-2p)]}}
+                :reference-type->entry {:token {:sources [(sd/source-tokens-entry test-token-1 token-data-1)
+                                                          (sd/source-tokens-entry test-token-2 token-data-2p)]}}
                 :service-authentication-disabled false
                 :service-description (merge (:defaults sources) expected-core-service-description)
                 :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)
@@ -835,8 +836,8 @@
                   :core-service-description expected-core-service-description
                   :on-the-fly? nil
                   :passthrough-headers passthrough-headers
-                  :reference {:token {:sources [(sd/source-tokens-entry test-token-1 token-data-1p)
-                                                (sd/source-tokens-entry test-token-2 token-data-2p)]}}
+                  :reference-type->entry {:token {:sources [(sd/source-tokens-entry test-token-1 token-data-1p)
+                                                            (sd/source-tokens-entry test-token-2 token-data-2p)]}}
                   :service-authentication-disabled false
                   :service-description (merge (:defaults sources) expected-core-service-description)
                   :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)

--- a/waiter/test/waiter/descriptor_test.clj
+++ b/waiter/test/waiter/descriptor_test.clj
@@ -519,11 +519,10 @@
                                                     (let [template-basic (dissoc template "last-update-time" "previous")]
                                                       (-> descriptor
                                                         (update :core-service-description merge template-basic)
-                                                        (update :references (fn [references]
-                                                                              (cond-> (vec (remove #(= component (:type %)) references))
-                                                                                (get-in template ["previous" "last-update-time"])
-                                                                                (conj {:type component
-                                                                                       :version (str "v" (get-in template ["previous" "last-update-time"]))}))))
+                                                        (update :reference (fn [reference]
+                                                                             (cond-> (dissoc reference component)
+                                                                               (get-in template ["previous" "last-update-time"])
+                                                                               (assoc component {:version (str "v" (get-in template ["previous" "last-update-time"]))}))))
                                                         (update :service-description merge template-basic)
                                                         (assoc-in [:sources component] (get template "previous")))))))
           sources {:cmd-source {"cmd" "ls2"
@@ -543,8 +542,7 @@
                                                                  [:cmd-source :cpu-source])
                            :core-service-description service-description-1
                            :passthrough-headers passthrough-headers
-                           :references [{:type :cmd-source :version "v8"}
-                                        {:type :cpu-source :version "v10"}]
+                           :reference {:cmd-source {:version "v8"} :cpu-source {:version "v10"}}
                            :service-description service-description-1
                            :sources sources
                            :waiter-headers waiter-headers}]
@@ -553,8 +551,7 @@
             template-basic-1 (dissoc template-1 "last-update-time" "previous")]
         (is (= (-> curr-descriptor
                  (update :core-service-description merge template-basic-1)
-                 (assoc :references [{:type :cmd-source :version "v8"}
-                                     {:type :cpu-source :version "v4"}])
+                 (assoc :reference {:cmd-source {:version "v8"} :cpu-source {:version "v4"}})
                  (update :service-description merge template-basic-1)
                  (assoc-in [:sources :cpu-source] (get template-1 "previous")))
                prev-descriptor-1))
@@ -564,8 +561,7 @@
               template-basic-2 (dissoc template-2 "last-update-time" "previous")]
           (is (= (-> prev-descriptor-1
                    (update :core-service-description merge template-basic-2)
-                   (assoc :references [{:type :cpu-source, :version "v4"}
-                                       {:type :cmd-source, :version "v6"}])
+                   (assoc :reference {:cmd-source {:version "v6"} :cpu-source {:version "v4"}})
                    (update :service-description merge template-basic-2)
                    (assoc-in [:sources :cmd-source] (get template-2 "previous")))
                  prev-descriptor-2))
@@ -575,7 +571,7 @@
                 template-basic-3 (dissoc template-3 "last-update-time" "previous")]
             (is (= (-> prev-descriptor-3
                      (update :core-service-description merge template-basic-3)
-                     (assoc :references [{:type :cpu-source, :version "v4"}])
+                     (assoc-in [:reference :cpu-source :version] "v4")
                      (update :service-description merge template-basic-3)
                      (assoc-in [:sources :cmd-source] (get template-3 "previous")))
                    prev-descriptor-3))
@@ -585,7 +581,7 @@
                   template-basic-4 (dissoc template-4 "last-update-time" "previous")]
               (is (= (-> prev-descriptor-3
                        (update :core-service-description merge template-basic-4)
-                       (assoc :references [])
+                       (assoc :reference {})
                        (update :service-description merge template-basic-4)
                        (assoc-in [:sources :cpu-source] (get template-4 "previous")))
                      prev-descriptor-4))
@@ -653,8 +649,7 @@
           passthrough-headers {}
           waiter-headers {}
           current-descriptor (-> {:passthrough-headers passthrough-headers
-                                  :references [{:sources [(sd/source-tokens-entry test-token token-data-2)]
-                                                :type :token}]
+                                  :reference {:token {:sources [(sd/source-tokens-entry test-token token-data-2)]}}
                                   :sources sources
                                   :waiter-headers waiter-headers}
                                (attach-token-fallback-source token-defaults build-service-description-and-id-helper))
@@ -663,8 +658,7 @@
               :core-service-description service-description-1
               :on-the-fly? nil
               :passthrough-headers passthrough-headers
-              :references [{:sources [(sd/source-tokens-entry test-token token-data-1)]
-                            :type :token}]
+              :reference {:token {:sources [(sd/source-tokens-entry test-token token-data-1)]}}
               :service-authentication-disabled false
               :service-description (merge (:defaults sources) service-description-1)
               :service-id (sd/service-description->service-id service-id-prefix service-description-1)
@@ -696,8 +690,7 @@
           passthrough-headers {}
           waiter-headers {}
           current-descriptor (-> {:passthrough-headers passthrough-headers
-                                  :references [{:sources [(sd/source-tokens-entry test-token token-data-3)]
-                                                :type :token}]
+                                  :reference {:token {:sources [(sd/source-tokens-entry test-token token-data-3)]}}
                                   :sources sources
                                   :waiter-headers waiter-headers}
                                (attach-token-fallback-source token-defaults build-service-description-and-id-helper))
@@ -706,8 +699,7 @@
               :core-service-description service-description-1
               :on-the-fly? nil
               :passthrough-headers passthrough-headers
-              :references [{:sources [(sd/source-tokens-entry test-token token-data-1)]
-                            :type :token}]
+              :reference {:token {:sources [(sd/source-tokens-entry test-token token-data-1)]}}
               :service-authentication-disabled false
               :service-description (merge (:defaults sources) service-description-1)
               :service-id (sd/service-description->service-id service-id-prefix service-description-1)
@@ -739,8 +731,7 @@
           passthrough-headers {}
           waiter-headers {"x-waiter-cpus" 20}
           current-descriptor (-> {:passthrough-headers passthrough-headers
-                                  :references [{:sources [(sd/source-tokens-entry test-token token-data-2)]
-                                                :type :token}]
+                                  :reference {:token {:sources [(sd/source-tokens-entry test-token token-data-2)]}}
                                   :sources sources
                                   :waiter-headers waiter-headers}
                                (attach-token-fallback-source token-defaults build-service-description-and-id-helper))
@@ -750,8 +741,7 @@
                 :core-service-description expected-core-service-description
                 :on-the-fly? true
                 :passthrough-headers passthrough-headers
-                :references [{:sources [(sd/source-tokens-entry test-token token-data-1)]
-                              :type :token}]
+                :reference {:token {:sources [(sd/source-tokens-entry test-token token-data-1)]}}
                 :service-authentication-disabled false
                 :service-description (merge (:defaults sources) expected-core-service-description)
                 :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)
@@ -808,7 +798,7 @@
           passthrough-headers {}
           waiter-headers {}
           current-descriptor (-> {:passthrough-headers passthrough-headers
-                                  :references [{:sources (:source-tokens sources) :type :token}]
+                                  :reference {:token {:sources (:source-tokens sources)}}
                                   :sources sources
                                   :waiter-headers waiter-headers}
                                (attach-token-fallback-source token-defaults build-service-description-and-id-helper))
@@ -819,9 +809,8 @@
                 :core-service-description expected-core-service-description
                 :on-the-fly? nil
                 :passthrough-headers passthrough-headers
-                :references [{:sources [(sd/source-tokens-entry test-token-1 token-data-1)
-                                         (sd/source-tokens-entry test-token-2 token-data-2p)]
-                              :type :token}]
+                :reference {:token {:sources [(sd/source-tokens-entry test-token-1 token-data-1)
+                                              (sd/source-tokens-entry test-token-2 token-data-2p)]}}
                 :service-authentication-disabled false
                 :service-description (merge (:defaults sources) expected-core-service-description)
                 :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)
@@ -846,9 +835,8 @@
                   :core-service-description expected-core-service-description
                   :on-the-fly? nil
                   :passthrough-headers passthrough-headers
-                  :references [{:sources [(sd/source-tokens-entry test-token-1 token-data-1p)
-                                           (sd/source-tokens-entry test-token-2 token-data-2p)]
-                                :type :token}]
+                  :reference {:token {:sources [(sd/source-tokens-entry test-token-1 token-data-1p)
+                                                (sd/source-tokens-entry test-token-2 token-data-2p)]}}
                   :service-authentication-disabled false
                   :service-description (merge (:defaults sources) expected-core-service-description)
                   :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)

--- a/waiter/test/waiter/descriptor_test.clj
+++ b/waiter/test/waiter/descriptor_test.clj
@@ -18,6 +18,7 @@
             [clojure.core.async :as async]
             [clojure.set :as set]
             [clojure.test :refer :all]
+            [clojure.walk :as walk]
             [plumbing.core :as pc]
             [waiter.descriptor :refer :all]
             [waiter.kv :as kv]
@@ -634,6 +635,12 @@
                prev-descriptor))
         (is (nil? (descriptor->previous-descriptor kv-store builder prev-descriptor))))))
 
+  (defn reference-tokens-entry
+    "Creates an entry for the source-tokens field"
+    [token token-data]
+    (walk/keywordize-keys
+      (sd/source-tokens-entry token token-data)))
+
   (deftest test-descriptor->previous-descriptor-single-token-with-previous
     (let [test-token "test-token"
           token-data-1 {"cmd" "ls" "cpus" 1 "mem" 32 "run-as-user" "ru" "version" "foo1"}
@@ -650,7 +657,7 @@
           passthrough-headers {}
           waiter-headers {}
           current-descriptor (-> {:passthrough-headers passthrough-headers
-                                  :reference-type->entry {:token {:sources [(sd/source-tokens-entry test-token token-data-2)]}}
+                                  :reference-type->entry {:token {:sources [(reference-tokens-entry test-token token-data-2)]}}
                                   :sources sources
                                   :waiter-headers waiter-headers}
                                (attach-token-fallback-source token-defaults build-service-description-and-id-helper))
@@ -659,7 +666,7 @@
               :core-service-description service-description-1
               :on-the-fly? nil
               :passthrough-headers passthrough-headers
-              :reference-type->entry {:token {:sources [(sd/source-tokens-entry test-token token-data-1)]}}
+              :reference-type->entry {:token {:sources [(reference-tokens-entry test-token token-data-1)]}}
               :service-authentication-disabled false
               :service-description (merge (:defaults sources) service-description-1)
               :service-id (sd/service-description->service-id service-id-prefix service-description-1)
@@ -691,7 +698,7 @@
           passthrough-headers {}
           waiter-headers {}
           current-descriptor (-> {:passthrough-headers passthrough-headers
-                                  :reference-type->entry {:token {:sources [(sd/source-tokens-entry test-token token-data-3)]}}
+                                  :reference-type->entry {:token {:sources [(reference-tokens-entry test-token token-data-3)]}}
                                   :sources sources
                                   :waiter-headers waiter-headers}
                                (attach-token-fallback-source token-defaults build-service-description-and-id-helper))
@@ -700,7 +707,7 @@
               :core-service-description service-description-1
               :on-the-fly? nil
               :passthrough-headers passthrough-headers
-              :reference-type->entry {:token {:sources [(sd/source-tokens-entry test-token token-data-1)]}}
+              :reference-type->entry {:token {:sources [(reference-tokens-entry test-token token-data-1)]}}
               :service-authentication-disabled false
               :service-description (merge (:defaults sources) service-description-1)
               :service-id (sd/service-description->service-id service-id-prefix service-description-1)
@@ -732,7 +739,7 @@
           passthrough-headers {}
           waiter-headers {"x-waiter-cpus" 20}
           current-descriptor (-> {:passthrough-headers passthrough-headers
-                                  :reference-type->entry {:token {:sources [(sd/source-tokens-entry test-token token-data-2)]}}
+                                  :reference-type->entry {:token {:sources [(reference-tokens-entry test-token token-data-2)]}}
                                   :sources sources
                                   :waiter-headers waiter-headers}
                                (attach-token-fallback-source token-defaults build-service-description-and-id-helper))
@@ -742,7 +749,7 @@
                 :core-service-description expected-core-service-description
                 :on-the-fly? true
                 :passthrough-headers passthrough-headers
-                :reference-type->entry {:token {:sources [(sd/source-tokens-entry test-token token-data-1)]}}
+                :reference-type->entry {:token {:sources [(reference-tokens-entry test-token token-data-1)]}}
                 :service-authentication-disabled false
                 :service-description (merge (:defaults sources) expected-core-service-description)
                 :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)
@@ -810,8 +817,8 @@
                 :core-service-description expected-core-service-description
                 :on-the-fly? nil
                 :passthrough-headers passthrough-headers
-                :reference-type->entry {:token {:sources [(sd/source-tokens-entry test-token-1 token-data-1)
-                                                          (sd/source-tokens-entry test-token-2 token-data-2p)]}}
+                :reference-type->entry {:token {:sources [(reference-tokens-entry test-token-1 token-data-1)
+                                                          (reference-tokens-entry test-token-2 token-data-2p)]}}
                 :service-authentication-disabled false
                 :service-description (merge (:defaults sources) expected-core-service-description)
                 :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)
@@ -836,8 +843,8 @@
                   :core-service-description expected-core-service-description
                   :on-the-fly? nil
                   :passthrough-headers passthrough-headers
-                  :reference-type->entry {:token {:sources [(sd/source-tokens-entry test-token-1 token-data-1p)
-                                                            (sd/source-tokens-entry test-token-2 token-data-2p)]}}
+                  :reference-type->entry {:token {:sources [(reference-tokens-entry test-token-1 token-data-1p)
+                                                            (reference-tokens-entry test-token-2 token-data-2p)]}}
                   :service-authentication-disabled false
                   :service-description (merge (:defaults sources) expected-core-service-description)
                   :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -2160,13 +2160,12 @@
         token-defaults {"fallback-period-secs" fallback-period-secs
                         "stale-timeout-mins" stale-timeout-mins}
         idle-timeout-mins 25
-        service-id "test-service-id"
+        service-id "test-service-id-"
         service-id->service-description-fn (fn [in-service-id]
-                                             (is (= service-id in-service-id))
+                                             (is (str/starts-with? in-service-id service-id))
                                              {"idle-timeout-mins" idle-timeout-mins})
         token->token-hash (fn [in-token] (str in-token ".hash1"))
-        reference-type->stale-fn {:direct (constantly false)
-                                  :token (partial service-token-references-stale? token->token-hash)}
+        reference-type->stale-fn {:token #(service-token-references-stale? token->token-hash (:sources %))}
         token->token-metadata-factory (fn [token->token-data]
                                         (fn [in-token]
                                           (-> in-token token->token-data (select-keys token-metadata-keys))))]
@@ -2174,46 +2173,43 @@
     (testing "service with single token is active"
       (let [token->token-data {"t1" {"cpus" 1}}
             service-id->references-fn (fn [in-service-id]
-                                        (is (= service-id in-service-id))
-                                        #{{:sources [{"token" "t1" "version" "t1.hash1"}]
-                                           :type :token}})
+                                        (is (= in-service-id (str service-id "s1")))
+                                        #{{:token {:sources [{"token" "t1" "version" "t1.hash1"}]}}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
                  service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
-                 token-defaults service-id)))))
+                 token-defaults (str service-id "s1"))))))
 
     (testing "direct access service is active"
       (let [token->token-data {"t1" {"cpus" 1}}
             service-id->references-fn (fn [in-service-id]
-                                        (is (= service-id in-service-id))
-                                        #{{:type :direct}})
+                                        (is (= in-service-id (str service-id "s2")))
+                                        #{{}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
                  service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
-                 token-defaults service-id)))))
+                 token-defaults (str service-id "s2"))))))
 
     (testing "service with multiple tokens is active"
       (let [token->token-data {"t1" {"cpus" 1}
                                "t2" {"mem" 2048}}
             service-id->references-fn (fn [in-service-id]
-                                        (is (= service-id in-service-id))
-                                        #{{:sources [{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash1"}]
-                                           :type :token}})
+                                        (is (= in-service-id (str service-id "s3")))
+                                        #{{:token {:sources [{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash1"}]}}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
                  service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
-                 token-defaults service-id)))))
+                 token-defaults (str service-id "s3"))))))
 
     (testing "service outdated but fallback not configured"
       (let [token->token-data {"t1" {"cpus" 1}
                                "t2" {"mem" 2048}}
             service-id->references-fn (fn [in-service-id]
-                                        (is (= service-id in-service-id))
-                                        #{{:sources [{"token" "t1" "version" "t1.hash0"}]
-                                           :type :token}})
+                                        (is (= in-service-id (str service-id "s4")))
+                                        #{{:token {:sources [{"token" "t1" "version" "t1.hash0"}]}}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= (-> (+ fallback-period-secs (dec (-> 1 t/minutes t/in-seconds)))
                  t/seconds
@@ -2221,34 +2217,32 @@
                  (+ stale-timeout-mins))
                (service-id->idle-timeout
                  service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
-                 token-defaults service-id)))))
+                 token-defaults (str service-id "s4"))))))
 
     (testing "service outdated with tokens but direct access possible"
       (let [token->token-data {"t1" {"cpus" 1}
                                "t2" {"mem" 2048}}
             service-id->references-fn (fn [in-service-id]
-                                        (is (= service-id in-service-id))
-                                        #{{:sources [{"token" "t1" "version" "t1.hash0"}]
-                                           :type :token}
-                                          {:type :direct}})
+                                        (is (= in-service-id (str service-id "s5")))
+                                        #{{:token {:sources [{"token" "t1" "version" "t1.hash0"}]}}
+                                          {}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
                  service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
-                 token-defaults service-id)))))
+                 token-defaults (str service-id "s5"))))))
 
     (testing "service outdated and fallback configured on one token"
       (let [token->token-data {"t1" {"cpus" 1 "fallback-period-secs" 300}
                                "t2" {"mem" 2048}}
             service-id->references-fn (fn [in-service-id]
-                                        (is (= service-id in-service-id))
-                                        #{{:sources [{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash0"}]
-                                           :type :token}})
+                                        (is (= in-service-id (str service-id "s6")))
+                                        #{{:token {:sources [{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash0"}]}}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
                  service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
-                 token-defaults service-id)))))
+                 token-defaults (str service-id "s6"))))))
 
     (testing "service outdated on some tokens and fallback and timeout configured on all tokens"
       (let [stale-timeout-mins 45
@@ -2256,16 +2250,15 @@
                                "t2" {"cmd" "tc" "fallback-period-secs" 600 "stale-timeout-mins" stale-timeout-mins}
                                "t3" {"cmd" "tc" "fallback-period-secs" 900}}
             service-id->references-fn (fn [in-service-id]
-                                        (is (= service-id in-service-id))
-                                        #{{:sources [{"token" "t1" "version" "t1.hash1"}
-                                                     {"token" "t2" "version" "t2.hash0"}
-                                                     {"token" "t3" "version" "t3.hash0"}]
-                                           :type :token}})
+                                        (is (= in-service-id (str service-id "s7")))
+                                        #{{:token {:sources [{"token" "t1" "version" "t1.hash1"}
+                                                             {"token" "t2" "version" "t2.hash0"}
+                                                             {"token" "t3" "version" "t3.hash0"}]}}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
                  service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
-                 token-defaults service-id)))))
+                 token-defaults (str service-id "s7"))))))
 
     (testing "service outdated on every token and fallback and timeout configured on all tokens"
       (let [stale-timeout-mins 45
@@ -2273,16 +2266,15 @@
                                "t2" {"cmd" "tc" "fallback-period-secs" 600 "stale-timeout-mins" stale-timeout-mins}
                                "t3" {"cmd" "tc" "fallback-period-secs" 900}}
             service-id->references-fn (fn [in-service-id]
-                                        (is (= service-id in-service-id))
-                                        #{{:sources [{"token" "t1" "version" "t1.hash0"}
-                                                     {"token" "t2" "version" "t2.hash0"}
-                                                     {"token" "t3" "version" "t3.hash0"}]
-                                           :type :token}})
+                                        (is (= in-service-id (str service-id "s8")))
+                                        #{{:token {:sources [{"token" "t1" "version" "t1.hash0"}
+                                                             {"token" "t2" "version" "t2.hash0"}
+                                                             {"token" "t3" "version" "t3.hash0"}]}}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= (-> 900 t/seconds t/in-minutes (+ stale-timeout-mins))
                (service-id->idle-timeout
                  service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
-                 token-defaults service-id)))))
+                 token-defaults (str service-id "s8"))))))
 
     (testing "service using latest of one partial token among many"
       (let [stale-timeout-mins 45
@@ -2291,16 +2283,14 @@
                                "t3" {"cmd" "tc" "fallback-period-secs" 900}
                                "t4" {"fallback-period-secs" 1200 "stale-timeout-mins" (+ stale-timeout-mins 15)}}
             service-id->references-fn (fn [in-service-id]
-                                        (is (= service-id in-service-id))
-                                        #{{:sources [{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash0"}]
-                                           :type :token}
-                                          {:sources [{"token" "t3" "version" "t3.hash0"} {"token" "t4" "version" "t4.hash0"}]
-                                           :type :token}})
+                                        (is (= in-service-id (str service-id "s9")))
+                                        #{{:token {:sources [{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash0"}]}}
+                                          {:token {:sources [{"token" "t3" "version" "t3.hash0"} {"token" "t4" "version" "t4.hash0"}]}}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
                  service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
-                 token-defaults service-id)))))
+                 token-defaults (str service-id "s9"))))))
 
     (testing "service using latest versions of multiple tokens"
       (let [stale-timeout-mins 45
@@ -2309,16 +2299,14 @@
                                "t3" {"cmd" "tc" "fallback-period-secs" 900}
                                "t4" {"fallback-period-secs" 1200 "stale-timeout-mins" (+ stale-timeout-mins 15)}}
             service-id->references-fn (fn [in-service-id]
-                                        (is (= service-id in-service-id))
-                                        #{{:sources [{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash1"}]
-                                           :type :token}
-                                          {:sources [{"token" "t3" "version" "t3.hash1"} {"token" "t4" "version" "t4.hash1"}]
-                                           :type :token}})
+                                        (is (= in-service-id (str service-id "s10")))
+                                        #{{:token {:sources [{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash1"}]}}
+                                          {:token {:sources [{"token" "t3" "version" "t3.hash1"} {"token" "t4" "version" "t4.hash1"}]}}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
                  service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
-                 token-defaults service-id)))))
+                 token-defaults (str service-id "s10"))))))
 
     (testing "service using latest of one set of token entries"
       (let [stale-timeout-mins 45
@@ -2327,16 +2315,14 @@
                                "t3" {"cmd" "tc" "fallback-period-secs" 900}
                                "t4" {"fallback-period-secs" 1200 "stale-timeout-mins" (+ stale-timeout-mins 15)}}
             service-id->references-fn (fn [in-service-id]
-                                        (is (= service-id in-service-id))
-                                        #{{:sources [{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash1"}]
-                                           :type :token}
-                                          {:sources [{"token" "t3" "version" "t3.hash0"} {"token" "t4" "version" "t4.hash0"}]
-                                           :type :token}})
+                                        (is (= in-service-id (str service-id "s11")))
+                                        #{{:token {:sources [{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash1"}]}}
+                                          {:token {:sources [{"token" "t3" "version" "t3.hash0"} {"token" "t4" "version" "t4.hash0"}]}}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
                  service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
-                 token-defaults service-id)))))
+                 token-defaults (str service-id "s11"))))))
 
     (testing "service outdated and fallback and timeout configured on multiple source tokens"
       (let [stale-timeout-mins 45
@@ -2345,17 +2331,15 @@
                                "t3" {"cmd" "tc" "fallback-period-secs" 900}
                                "t4" {"fallback-period-secs" 1200 "stale-timeout-mins" (+ stale-timeout-mins 15)}}
             service-id->references-fn (fn [in-service-id]
-                                        (is (= service-id in-service-id))
-                                        #{{:sources [{"token" "t1" "version" "t1.hash0"} {"token" "t2" "version" "t2.hash0"}]
-                                           :type :token}
-                                          {:sources [{"token" "t3" "version" "t3.hash0"} {"token" "t4" "version" "t4.hash0"}]
-                                           :type :token}})
+                                        (is (= in-service-id (str service-id "s12")))
+                                        #{{:token {:sources [{"token" "t1" "version" "t1.hash0"} {"token" "t2" "version" "t2.hash0"}]}}
+                                          {:token {:sources [{"token" "t3" "version" "t3.hash0"} {"token" "t4" "version" "t4.hash0"}]}}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= (max (-> 900 t/seconds t/in-minutes (+ stale-timeout-mins))
                     (-> 1200 t/seconds t/in-minutes (+ stale-timeout-mins 15)))
                (service-id->idle-timeout
                  service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
-                 token-defaults service-id)))))))
+                 token-defaults (str service-id "s12"))))))))
 
 (defn- synchronize-fn
   [lock f]
@@ -2397,55 +2381,50 @@
     (is (= #{source-tokens-1 source-tokens-3 source-tokens-4}
            (service-id->source-tokens-entries kv-store service-id)))))
 
-(deftest test-store-references!
+(deftest test-store-reference!
   (let [kv-store (kv/->LocalKeyValueStore (atom {}))
         service-id "test-service-id"
-        references-1 {:sources [{"token" "token-1" "version" "v1"}]
-                      :type :token}
+        references-1 {:token {:sources [{"token" "token-1" "version" "v1"}]}}
         references-1-copy {:sources [{"token" "token-1" "version" "v1"}]
                            :type :token}
-        references-2 {:sources [{"token" "token-1" "version" "v1"}
-                                {"token" "token-2" "version" "v2"}]
-                      :type :token}
-        references-3 {:sources [{"token" "token-3" "version" "v3"}
-                                {"token" "token-2" "version" "v2"}]
-                      :type :token}
-        references-3-copy {:sources [{"token" "token-3" "version" "v3"}
-                                     {"token" "token-2" "version" "v2"}]
-                           :type :token}
-        references-4 {:sources [{"token" "token-2" "version" "v2"}
-                                {"token" "token-3" "version" "v3"}]
-                      :type :token}]
+        references-2 {:token {:sources [{"token" "token-1" "version" "v1"}
+                                        {"token" "token-2" "version" "v2"}]}}
+        references-3 {:token {:sources [{"token" "token-3" "version" "v3"}
+                                        {"token" "token-2" "version" "v2"}]}}
+        references-3-copy {:token {:sources [{"token" "token-3" "version" "v3"}
+                                             {"token" "token-2" "version" "v2"}]}}
+        references-4 {:token {:sources [{"token" "token-2" "version" "v2"}
+                                        {"token" "token-3" "version" "v3"}]}}]
 
-    (store-references! synchronize-fn kv-store service-id [references-1])
+    (store-reference! synchronize-fn kv-store service-id references-1)
     (is (contains? (service-id->references kv-store service-id) references-1))
 
-    (store-references! synchronize-fn kv-store service-id [references-1-copy])
+    (store-reference! synchronize-fn kv-store service-id references-1-copy)
     (is (contains? (service-id->references kv-store service-id) references-1))
 
-    (store-references! synchronize-fn kv-store service-id [references-1])
+    (store-reference! synchronize-fn kv-store service-id references-1)
     (is (contains? (service-id->references kv-store service-id) references-1))
 
-    (store-references! synchronize-fn kv-store service-id [references-2])
+    (store-reference! synchronize-fn kv-store service-id references-2)
     (is (contains? (service-id->references kv-store service-id) references-1))
     (is (contains? (service-id->references kv-store service-id) references-2))
 
-    (store-references! synchronize-fn kv-store service-id [references-3])
+    (store-reference! synchronize-fn kv-store service-id references-3)
     (is (contains? (service-id->references kv-store service-id) references-1))
     (is (contains? (service-id->references kv-store service-id) references-2))
     (is (contains? (service-id->references kv-store service-id) references-3))
 
-    (store-references! synchronize-fn kv-store service-id [references-1])
+    (store-reference! synchronize-fn kv-store service-id references-1)
     (is (contains? (service-id->references kv-store service-id) references-1))
     (is (contains? (service-id->references kv-store service-id) references-2))
     (is (contains? (service-id->references kv-store service-id) references-3))
 
-    (store-references! synchronize-fn kv-store service-id [references-3-copy])
+    (store-reference! synchronize-fn kv-store service-id references-3-copy)
     (is (contains? (service-id->references kv-store service-id) references-1))
     (is (contains? (service-id->references kv-store service-id) references-2))
     (is (contains? (service-id->references kv-store service-id) references-3))
 
-    (store-references! synchronize-fn kv-store service-id [references-4])
+    (store-reference! synchronize-fn kv-store service-id references-4)
     (is (contains? (service-id->references kv-store service-id) references-1))
     (is (contains? (service-id->references kv-store service-id) references-2))
     (is (contains? (service-id->references kv-store service-id) references-3))
@@ -2453,6 +2432,7 @@
 
 (deftest test-service-description-builder-state
   (is {} (state (create-default-service-description-builder {}))))
+
 (deftest test-retrieve-most-recently-modified-token-update-time
   (let [descriptor {:sources {:token->token-data {}}}]
     (is (= 0 (retrieve-most-recently-modified-token-update-time descriptor))))

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -820,7 +820,7 @@
 
 (deftest test-compute-service-description-source-tokens
   (let [defaults {"health-check-url" "/ping", "permitted-user" "bob"}
-        source-tokens (Object.)
+        source-tokens [:foo-bar]
         sources {:defaults defaults
                  :service-description-template {"cmd" "token-cmd"}
                  :source-tokens source-tokens}
@@ -2161,111 +2161,128 @@
                         "stale-timeout-mins" stale-timeout-mins}
         idle-timeout-mins 25
         service-id "test-service-id"
+        service-id->service-description-fn (fn [in-service-id]
+                                             (is (= service-id in-service-id))
+                                             {"idle-timeout-mins" idle-timeout-mins})
         token->token-hash (fn [in-token] (str in-token ".hash1"))
-        token->token-metadata-fn (fn [token->token-data]
-                                   (fn token->token-metadata [in-token]
-                                     (-> in-token
-                                         token->token-data
-                                         (select-keys token-metadata-keys))))]
+        reference-type->stale-fn {:direct-access (constantly false)
+                                  :token (partial service-token-references-stale? token->token-hash)}
+        token->token-metadata-factory (fn [token->token-data]
+                                        (fn [in-token]
+                                          (-> in-token token->token-data (select-keys token-metadata-keys))))]
+
     (testing "service with single token is active"
       (let [token->token-data {"t1" {"cpus" 1}}
-            service-id->service-description-fn (fn [in-service-id]
-                                                 (is (= service-id in-service-id))
-                                                 {"idle-timeout-mins" idle-timeout-mins})
-            service-id->source-token-entries-fn (fn [in-service-id]
-                                                  (is (= service-id in-service-id))
-                                                  #{[{"token" "t1" "version" "t1.hash1"}]})
-            token->token-metadata (token->token-metadata-fn token->token-data)]
+            service-id->references-fn (fn [in-service-id]
+                                        (is (= service-id in-service-id))
+                                        #{{:sources [{"token" "t1" "version" "t1.hash1"}]
+                                           :type :token}})
+            token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
-                 service-id->service-description-fn service-id->source-token-entries-fn token->token-hash
-                 token->token-metadata token-defaults service-id)))))
+                 service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
+                 token-defaults service-id)))))
+
+    (testing "direct access service is active"
+      (let [token->token-data {"t1" {"cpus" 1}}
+            service-id->references-fn (fn [in-service-id]
+                                        (is (= service-id in-service-id))
+                                        #{{:type :direct-access}})
+            token->token-metadata (token->token-metadata-factory token->token-data)]
+        (is (= idle-timeout-mins
+               (service-id->idle-timeout
+                 service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
+                 token-defaults service-id)))))
 
     (testing "service with multiple tokens is active"
       (let [token->token-data {"t1" {"cpus" 1}
                                "t2" {"mem" 2048}}
-            service-id->service-description-fn (fn [in-service-id]
-                                                 (is (= service-id in-service-id))
-                                                 {"idle-timeout-mins" idle-timeout-mins})
-            service-id->source-token-entries-fn (fn [in-service-id]
-                                                  (is (= service-id in-service-id))
-                                                  #{[{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash1"}]})
-            token->token-metadata (token->token-metadata-fn token->token-data)]
+            service-id->references-fn (fn [in-service-id]
+                                        (is (= service-id in-service-id))
+                                        #{{:sources [{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash1"}]
+                                           :type :token}})
+            token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
-                 service-id->service-description-fn service-id->source-token-entries-fn token->token-hash
-                 token->token-metadata token-defaults service-id)))))
+                 service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
+                 token-defaults service-id)))))
 
     (testing "service outdated but fallback not configured"
       (let [token->token-data {"t1" {"cpus" 1}
                                "t2" {"mem" 2048}}
-            service-id->service-description-fn (fn [in-service-id]
-                                                 (is (= service-id in-service-id))
-                                                 {"idle-timeout-mins" idle-timeout-mins})
-            service-id->source-token-entries-fn (fn [in-service-id]
-                                                  (is (= service-id in-service-id))
-                                                  #{[{"token" "t1" "version" "t1.hash0"}]})
-            token->token-metadata (token->token-metadata-fn token->token-data)]
+            service-id->references-fn (fn [in-service-id]
+                                        (is (= service-id in-service-id))
+                                        #{{:sources [{"token" "t1" "version" "t1.hash0"}]
+                                           :type :token}})
+            token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= (-> (+ fallback-period-secs (dec (-> 1 t/minutes t/in-seconds)))
-                   t/seconds
-                   t/in-minutes
-                   (+ stale-timeout-mins))
+                 t/seconds
+                 t/in-minutes
+                 (+ stale-timeout-mins))
                (service-id->idle-timeout
-                 service-id->service-description-fn service-id->source-token-entries-fn token->token-hash
-                 token->token-metadata token-defaults service-id)))))
+                 service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
+                 token-defaults service-id)))))
+
+    (testing "service outdated with tokens but direct access possible"
+      (let [token->token-data {"t1" {"cpus" 1}
+                               "t2" {"mem" 2048}}
+            service-id->references-fn (fn [in-service-id]
+                                        (is (= service-id in-service-id))
+                                        #{{:sources [{"token" "t1" "version" "t1.hash0"}]
+                                           :type :token}
+                                          {:type :direct-access}})
+            token->token-metadata (token->token-metadata-factory token->token-data)]
+        (is (= idle-timeout-mins
+               (service-id->idle-timeout
+                 service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
+                 token-defaults service-id)))))
 
     (testing "service outdated and fallback configured on one token"
       (let [token->token-data {"t1" {"cpus" 1 "fallback-period-secs" 300}
                                "t2" {"mem" 2048}}
-            service-id->service-description-fn (fn [in-service-id]
-                                                 (is (= service-id in-service-id))
-                                                 {"idle-timeout-mins" idle-timeout-mins})
-            service-id->source-token-entries-fn (fn [in-service-id]
-                                                  (is (= service-id in-service-id))
-                                                  #{[{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash0"}]})
-            token->token-metadata (token->token-metadata-fn token->token-data)]
+            service-id->references-fn (fn [in-service-id]
+                                        (is (= service-id in-service-id))
+                                        #{{:sources [{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash0"}]
+                                           :type :token}})
+            token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
-                 service-id->service-description-fn service-id->source-token-entries-fn token->token-hash
-                 token->token-metadata token-defaults service-id)))))
+                 service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
+                 token-defaults service-id)))))
 
     (testing "service outdated on some tokens and fallback and timeout configured on all tokens"
       (let [stale-timeout-mins 45
             token->token-data {"t1" {"cpus" 123 "fallback-period-secs" 300}
                                "t2" {"cmd" "tc" "fallback-period-secs" 600 "stale-timeout-mins" stale-timeout-mins}
                                "t3" {"cmd" "tc" "fallback-period-secs" 900}}
-            service-id->service-description-fn (fn [in-service-id]
-                                                 (is (= service-id in-service-id))
-                                                 {"idle-timeout-mins" idle-timeout-mins})
-            service-id->source-token-entries-fn (fn [in-service-id]
-                                                  (is (= service-id in-service-id))
-                                                  #{[{"token" "t1" "version" "t1.hash1"}
+            service-id->references-fn (fn [in-service-id]
+                                        (is (= service-id in-service-id))
+                                        #{{:sources [{"token" "t1" "version" "t1.hash1"}
                                                      {"token" "t2" "version" "t2.hash0"}
-                                                     {"token" "t3" "version" "t3.hash0"}]})
-            token->token-metadata (token->token-metadata-fn token->token-data)]
+                                                     {"token" "t3" "version" "t3.hash0"}]
+                                           :type :token}})
+            token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
-                 service-id->service-description-fn service-id->source-token-entries-fn token->token-hash
-                 token->token-metadata token-defaults service-id)))))
+                 service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
+                 token-defaults service-id)))))
 
     (testing "service outdated on every token and fallback and timeout configured on all tokens"
       (let [stale-timeout-mins 45
             token->token-data {"t1" {"cpus" 123 "fallback-period-secs" 300}
                                "t2" {"cmd" "tc" "fallback-period-secs" 600 "stale-timeout-mins" stale-timeout-mins}
                                "t3" {"cmd" "tc" "fallback-period-secs" 900}}
-            service-id->service-description-fn (fn [in-service-id]
-                                                 (is (= service-id in-service-id))
-                                                 {"idle-timeout-mins" idle-timeout-mins})
-            service-id->source-token-entries-fn (fn [in-service-id]
-                                                  (is (= service-id in-service-id))
-                                                  #{[{"token" "t1" "version" "t1.hash0"}
+            service-id->references-fn (fn [in-service-id]
+                                        (is (= service-id in-service-id))
+                                        #{{:sources [{"token" "t1" "version" "t1.hash0"}
                                                      {"token" "t2" "version" "t2.hash0"}
-                                                     {"token" "t3" "version" "t3.hash0"}]})
-            token->token-metadata (token->token-metadata-fn token->token-data)]
+                                                     {"token" "t3" "version" "t3.hash0"}]
+                                           :type :token}})
+            token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= (-> 900 t/seconds t/in-minutes (+ stale-timeout-mins))
                (service-id->idle-timeout
-                 service-id->service-description-fn service-id->source-token-entries-fn token->token-hash
-                 token->token-metadata token-defaults service-id)))))
+                 service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
+                 token-defaults service-id)))))
 
     (testing "service using latest of one partial token among many"
       (let [stale-timeout-mins 45
@@ -2273,18 +2290,17 @@
                                "t2" {"cmd" "tc" "fallback-period-secs" 600 "stale-timeout-mins" stale-timeout-mins}
                                "t3" {"cmd" "tc" "fallback-period-secs" 900}
                                "t4" {"fallback-period-secs" 1200 "stale-timeout-mins" (+ stale-timeout-mins 15)}}
-            service-id->service-description-fn (fn [in-service-id]
-                                                 (is (= service-id in-service-id))
-                                                 {"idle-timeout-mins" idle-timeout-mins})
-            service-id->source-token-entries-fn (fn [in-service-id]
-                                                  (is (= service-id in-service-id))
-                                                  #{[{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash0"}]
-                                                    [{"token" "t3" "version" "t3.hash0"} {"token" "t4" "version" "t4.hash0"}]})
-            token->token-metadata (token->token-metadata-fn token->token-data)]
+            service-id->references-fn (fn [in-service-id]
+                                        (is (= service-id in-service-id))
+                                        #{{:sources [{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash0"}]
+                                           :type :token}
+                                          {:sources [{"token" "t3" "version" "t3.hash0"} {"token" "t4" "version" "t4.hash0"}]
+                                           :type :token}})
+            token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
-                 service-id->service-description-fn service-id->source-token-entries-fn token->token-hash
-                 token->token-metadata token-defaults service-id)))))
+                 service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
+                 token-defaults service-id)))))
 
     (testing "service using latest versions of multiple tokens"
       (let [stale-timeout-mins 45
@@ -2292,18 +2308,17 @@
                                "t2" {"cmd" "tc" "fallback-period-secs" 600 "stale-timeout-mins" stale-timeout-mins}
                                "t3" {"cmd" "tc" "fallback-period-secs" 900}
                                "t4" {"fallback-period-secs" 1200 "stale-timeout-mins" (+ stale-timeout-mins 15)}}
-            service-id->service-description-fn (fn [in-service-id]
-                                                 (is (= service-id in-service-id))
-                                                 {"idle-timeout-mins" idle-timeout-mins})
-            service-id->source-token-entries-fn (fn [in-service-id]
-                                                  (is (= service-id in-service-id))
-                                                  #{[{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash1"}]
-                                                    [{"token" "t3" "version" "t3.hash1"} {"token" "t4" "version" "t4.hash1"}]})
-            token->token-metadata (token->token-metadata-fn token->token-data)]
+            service-id->references-fn (fn [in-service-id]
+                                        (is (= service-id in-service-id))
+                                        #{{:sources [{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash1"}]
+                                           :type :token}
+                                          {:sources [{"token" "t3" "version" "t3.hash1"} {"token" "t4" "version" "t4.hash1"}]
+                                           :type :token}})
+            token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
-                 service-id->service-description-fn service-id->source-token-entries-fn token->token-hash
-                 token->token-metadata token-defaults service-id)))))
+                 service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
+                 token-defaults service-id)))))
 
     (testing "service using latest of one set of token entries"
       (let [stale-timeout-mins 45
@@ -2311,18 +2326,17 @@
                                "t2" {"cmd" "tc" "fallback-period-secs" 600 "stale-timeout-mins" stale-timeout-mins}
                                "t3" {"cmd" "tc" "fallback-period-secs" 900}
                                "t4" {"fallback-period-secs" 1200 "stale-timeout-mins" (+ stale-timeout-mins 15)}}
-            service-id->service-description-fn (fn [in-service-id]
-                                                 (is (= service-id in-service-id))
-                                                 {"idle-timeout-mins" idle-timeout-mins})
-            service-id->source-token-entries-fn (fn [in-service-id]
-                                                  (is (= service-id in-service-id))
-                                                  #{[{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash1"}]
-                                                    [{"token" "t3" "version" "t3.hash0"} {"token" "t4" "version" "t4.hash0"}]})
-            token->token-metadata (token->token-metadata-fn token->token-data)]
+            service-id->references-fn (fn [in-service-id]
+                                        (is (= service-id in-service-id))
+                                        #{{:sources [{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash1"}]
+                                           :type :token}
+                                          {:sources [{"token" "t3" "version" "t3.hash0"} {"token" "t4" "version" "t4.hash0"}]
+                                           :type :token}})
+            token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
-                 service-id->service-description-fn service-id->source-token-entries-fn token->token-hash
-                 token->token-metadata token-defaults service-id)))))
+                 service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
+                 token-defaults service-id)))))
 
     (testing "service outdated and fallback and timeout configured on multiple source tokens"
       (let [stale-timeout-mins 45
@@ -2330,19 +2344,18 @@
                                "t2" {"cmd" "tc" "fallback-period-secs" 600 "stale-timeout-mins" stale-timeout-mins}
                                "t3" {"cmd" "tc" "fallback-period-secs" 900}
                                "t4" {"fallback-period-secs" 1200 "stale-timeout-mins" (+ stale-timeout-mins 15)}}
-            service-id->service-description-fn (fn [in-service-id]
-                                                 (is (= service-id in-service-id))
-                                                 {"idle-timeout-mins" idle-timeout-mins})
-            service-id->source-token-entries-fn (fn [in-service-id]
-                                                  (is (= service-id in-service-id))
-                                                  #{[{"token" "t1" "version" "t1.hash0"} {"token" "t2" "version" "t2.hash0"}]
-                                                    [{"token" "t3" "version" "t3.hash0"} {"token" "t4" "version" "t4.hash0"}]})
-            token->token-metadata (token->token-metadata-fn token->token-data)]
+            service-id->references-fn (fn [in-service-id]
+                                        (is (= service-id in-service-id))
+                                        #{{:sources [{"token" "t1" "version" "t1.hash0"} {"token" "t2" "version" "t2.hash0"}]
+                                           :type :token}
+                                          {:sources [{"token" "t3" "version" "t3.hash0"} {"token" "t4" "version" "t4.hash0"}]
+                                           :type :token}})
+            token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= (max (-> 900 t/seconds t/in-minutes (+ stale-timeout-mins))
                     (-> 1200 t/seconds t/in-minutes (+ stale-timeout-mins 15)))
                (service-id->idle-timeout
-                 service-id->service-description-fn service-id->source-token-entries-fn token->token-hash
-                 token->token-metadata token-defaults service-id)))))))
+                 service-id->service-description-fn service-id->references-fn token->token-metadata reference-type->stale-fn
+                 token-defaults service-id)))))))
 
 (defn- synchronize-fn
   [lock f]
@@ -2384,9 +2397,62 @@
     (is (= #{source-tokens-1 source-tokens-3 source-tokens-4}
            (service-id->source-tokens-entries kv-store service-id)))))
 
+(deftest test-store-references!
+  (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+        service-id "test-service-id"
+        references-1 {:sources [{"token" "token-1" "version" "v1"}]
+                      :type :token}
+        references-1-copy {:sources [{"token" "token-1" "version" "v1"}]
+                           :type :token}
+        references-2 {:sources [{"token" "token-1" "version" "v1"}
+                                {"token" "token-2" "version" "v2"}]
+                      :type :token}
+        references-3 {:sources [{"token" "token-3" "version" "v3"}
+                                {"token" "token-2" "version" "v2"}]
+                      :type :token}
+        references-3-copy {:sources [{"token" "token-3" "version" "v3"}
+                                     {"token" "token-2" "version" "v2"}]
+                           :type :token}
+        references-4 {:sources [{"token" "token-2" "version" "v2"}
+                                {"token" "token-3" "version" "v3"}]
+                      :type :token}]
+
+    (store-references! synchronize-fn kv-store service-id [references-1])
+    (is (contains? (service-id->references kv-store service-id) references-1))
+
+    (store-references! synchronize-fn kv-store service-id [references-1-copy])
+    (is (contains? (service-id->references kv-store service-id) references-1))
+
+    (store-references! synchronize-fn kv-store service-id [references-1])
+    (is (contains? (service-id->references kv-store service-id) references-1))
+
+    (store-references! synchronize-fn kv-store service-id [references-2])
+    (is (contains? (service-id->references kv-store service-id) references-1))
+    (is (contains? (service-id->references kv-store service-id) references-2))
+
+    (store-references! synchronize-fn kv-store service-id [references-3])
+    (is (contains? (service-id->references kv-store service-id) references-1))
+    (is (contains? (service-id->references kv-store service-id) references-2))
+    (is (contains? (service-id->references kv-store service-id) references-3))
+
+    (store-references! synchronize-fn kv-store service-id [references-1])
+    (is (contains? (service-id->references kv-store service-id) references-1))
+    (is (contains? (service-id->references kv-store service-id) references-2))
+    (is (contains? (service-id->references kv-store service-id) references-3))
+
+    (store-references! synchronize-fn kv-store service-id [references-3-copy])
+    (is (contains? (service-id->references kv-store service-id) references-1))
+    (is (contains? (service-id->references kv-store service-id) references-2))
+    (is (contains? (service-id->references kv-store service-id) references-3))
+
+    (store-references! synchronize-fn kv-store service-id [references-4])
+    (is (contains? (service-id->references kv-store service-id) references-1))
+    (is (contains? (service-id->references kv-store service-id) references-2))
+    (is (contains? (service-id->references kv-store service-id) references-3))
+    (is (contains? (service-id->references kv-store service-id) references-4))))
+
 (deftest test-service-description-builder-state
   (is {} (state (create-default-service-description-builder {}))))
-
 (deftest test-retrieve-most-recently-modified-token-update-time
   (let [descriptor {:sources {:token->token-data {}}}]
     (is (= 0 (retrieve-most-recently-modified-token-update-time descriptor))))

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -2165,7 +2165,7 @@
                                              (is (= service-id in-service-id))
                                              {"idle-timeout-mins" idle-timeout-mins})
         token->token-hash (fn [in-token] (str in-token ".hash1"))
-        reference-type->stale-fn {:direct-access (constantly false)
+        reference-type->stale-fn {:direct (constantly false)
                                   :token (partial service-token-references-stale? token->token-hash)}
         token->token-metadata-factory (fn [token->token-data]
                                         (fn [in-token]
@@ -2187,7 +2187,7 @@
       (let [token->token-data {"t1" {"cpus" 1}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= service-id in-service-id))
-                                        #{{:type :direct-access}})
+                                        #{{:type :direct}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
@@ -2230,7 +2230,7 @@
                                         (is (= service-id in-service-id))
                                         #{{:sources [{"token" "t1" "version" "t1.hash0"}]
                                            :type :token}
-                                          {:type :direct-access}})
+                                          {:type :direct}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -2174,7 +2174,7 @@
       (let [token->token-data {"t1" {"cpus" 1}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s1")))
-                                        #{{:token {:sources [{"token" "t1" "version" "t1.hash1"}]}}})
+                                        #{{:token {:sources [{:token "t1" :version "t1.hash1"}]}}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
@@ -2197,7 +2197,7 @@
                                "t2" {"mem" 2048}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s3")))
-                                        #{{:token {:sources [{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash1"}]}}})
+                                        #{{:token {:sources [{:token "t1" :version "t1.hash1"} {:token "t2" :version "t2.hash1"}]}}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
@@ -2209,7 +2209,7 @@
                                "t2" {"mem" 2048}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s4")))
-                                        #{{:token {:sources [{"token" "t1" "version" "t1.hash0"}]}}})
+                                        #{{:token {:sources [{:token "t1" :version "t1.hash0"}]}}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= (-> (+ fallback-period-secs (dec (-> 1 t/minutes t/in-seconds)))
                  t/seconds
@@ -2224,7 +2224,7 @@
                                "t2" {"mem" 2048}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s5")))
-                                        #{{:token {:sources [{"token" "t1" "version" "t1.hash0"}]}}
+                                        #{{:token {:sources [{:token "t1" :version "t1.hash0"}]}}
                                           {}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
@@ -2237,7 +2237,7 @@
                                "t2" {"mem" 2048}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s6")))
-                                        #{{:token {:sources [{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash0"}]}}})
+                                        #{{:token {:sources [{:token "t1" :version "t1.hash1"} {:token "t2" :version "t2.hash0"}]}}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
@@ -2251,9 +2251,9 @@
                                "t3" {"cmd" "tc" "fallback-period-secs" 900}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s7")))
-                                        #{{:token {:sources [{"token" "t1" "version" "t1.hash1"}
-                                                             {"token" "t2" "version" "t2.hash0"}
-                                                             {"token" "t3" "version" "t3.hash0"}]}}})
+                                        #{{:token {:sources [{:token "t1" :version "t1.hash1"}
+                                                             {:token "t2" :version "t2.hash0"}
+                                                             {:token "t3" :version "t3.hash0"}]}}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
@@ -2267,9 +2267,9 @@
                                "t3" {"cmd" "tc" "fallback-period-secs" 900}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s8")))
-                                        #{{:token {:sources [{"token" "t1" "version" "t1.hash0"}
-                                                             {"token" "t2" "version" "t2.hash0"}
-                                                             {"token" "t3" "version" "t3.hash0"}]}}})
+                                        #{{:token {:sources [{:token "t1" :version "t1.hash0"}
+                                                             {:token "t2" :version "t2.hash0"}
+                                                             {:token "t3" :version "t3.hash0"}]}}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= (-> 900 t/seconds t/in-minutes (+ stale-timeout-mins))
                (service-id->idle-timeout
@@ -2284,8 +2284,8 @@
                                "t4" {"fallback-period-secs" 1200 "stale-timeout-mins" (+ stale-timeout-mins 15)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s9")))
-                                        #{{:token {:sources [{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash0"}]}}
-                                          {:token {:sources [{"token" "t3" "version" "t3.hash0"} {"token" "t4" "version" "t4.hash0"}]}}})
+                                        #{{:token {:sources [{:token "t1" :version "t1.hash1"} {:token "t2" :version "t2.hash0"}]}}
+                                          {:token {:sources [{:token "t3" :version "t3.hash0"} {:token "t4" :version "t4.hash0"}]}}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
@@ -2300,8 +2300,8 @@
                                "t4" {"fallback-period-secs" 1200 "stale-timeout-mins" (+ stale-timeout-mins 15)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s10")))
-                                        #{{:token {:sources [{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash1"}]}}
-                                          {:token {:sources [{"token" "t3" "version" "t3.hash1"} {"token" "t4" "version" "t4.hash1"}]}}})
+                                        #{{:token {:sources [{:token "t1" :version "t1.hash1"} {:token "t2" :version "t2.hash1"}]}}
+                                          {:token {:sources [{:token "t3" :version "t3.hash1"} {:token "t4" :version "t4.hash1"}]}}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
@@ -2316,8 +2316,8 @@
                                "t4" {"fallback-period-secs" 1200 "stale-timeout-mins" (+ stale-timeout-mins 15)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s11")))
-                                        #{{:token {:sources [{"token" "t1" "version" "t1.hash1"} {"token" "t2" "version" "t2.hash1"}]}}
-                                          {:token {:sources [{"token" "t3" "version" "t3.hash0"} {"token" "t4" "version" "t4.hash0"}]}}})
+                                        #{{:token {:sources [{:token "t1" :version "t1.hash1"} {:token "t2" :version "t2.hash1"}]}}
+                                          {:token {:sources [{:token "t3" :version "t3.hash0"} {:token "t4" :version "t4.hash0"}]}}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= idle-timeout-mins
                (service-id->idle-timeout
@@ -2332,8 +2332,8 @@
                                "t4" {"fallback-period-secs" 1200 "stale-timeout-mins" (+ stale-timeout-mins 15)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s12")))
-                                        #{{:token {:sources [{"token" "t1" "version" "t1.hash0"} {"token" "t2" "version" "t2.hash0"}]}}
-                                          {:token {:sources [{"token" "t3" "version" "t3.hash0"} {"token" "t4" "version" "t4.hash0"}]}}})
+                                        #{{:token {:sources [{:token "t1" :version "t1.hash0"} {:token "t2" :version "t2.hash0"}]}}
+                                          {:token {:sources [{:token "t3" :version "t3.hash0"} {:token "t4" :version "t4.hash0"}]}}})
             token->token-metadata (token->token-metadata-factory token->token-data)]
         (is (= (max (-> 900 t/seconds t/in-minutes (+ stale-timeout-mins))
                     (-> 1200 t/seconds t/in-minutes (+ stale-timeout-mins 15)))
@@ -2384,17 +2384,17 @@
 (deftest test-store-reference!
   (let [kv-store (kv/->LocalKeyValueStore (atom {}))
         service-id "test-service-id"
-        references-1 {:token {:sources [{"token" "token-1" "version" "v1"}]}}
-        references-1-copy {:sources [{"token" "token-1" "version" "v1"}]
+        references-1 {:token {:sources [{:token "token-1" :version "v1"}]}}
+        references-1-copy {:sources [{:token "token-1" :version "v1"}]
                            :type :token}
-        references-2 {:token {:sources [{"token" "token-1" "version" "v1"}
-                                        {"token" "token-2" "version" "v2"}]}}
-        references-3 {:token {:sources [{"token" "token-3" "version" "v3"}
-                                        {"token" "token-2" "version" "v2"}]}}
-        references-3-copy {:token {:sources [{"token" "token-3" "version" "v3"}
-                                             {"token" "token-2" "version" "v2"}]}}
-        references-4 {:token {:sources [{"token" "token-2" "version" "v2"}
-                                        {"token" "token-3" "version" "v3"}]}}]
+        references-2 {:token {:sources [{:token "token-1" :version "v1"}
+                                        {:token "token-2" :version "v2"}]}}
+        references-3 {:token {:sources [{:token "token-3" :version "v3"}
+                                        {:token "token-2" :version "v2"}]}}
+        references-3-copy {:token {:sources [{:token "token-3" :version "v3"}
+                                             {:token "token-2" :version "v2"}]}}
+        references-4 {:token {:sources [{:token "token-2" :version "v2"}
+                                        {:token "token-3" :version "v3"}]}}]
 
     (store-reference! synchronize-fn kv-store service-id references-1)
     (is (contains? (service-id->references kv-store service-id) references-1))


### PR DESCRIPTION

## Changes proposed in this PR

- adds support for references in the descriptor
- references are now used to determine if a service is stale

## Why are we making these changes?

We need to allow custom builders to add references to services and also contribute to marking services as stale rather than relying only on tokens going stale.

