### PR TITLE
moves sanitize-history to utils

### DIFF
--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -29,11 +29,6 @@
 
 (def ^:const ANY-USER "*")
 
-(defn sanitize-history
-  "Limits the history length stored in the token-data."
-  [token-data history-length]
-  (utils/dissoc-in token-data (repeat history-length "previous")))
-
 (defn ensure-history
   "Ensures a non-nil previous entry exists in `token-data`.
    If one already was present when this function was called, returns `token-data` unmodified.
@@ -125,7 +120,7 @@
           ; Store the service description
           (kv/store kv-store token (-> new-token-data
                                        (ensure-history existing-token-data)
-                                       (sanitize-history history-length)))
+                                       (utils/sanitize-history history-length "previous")))
           ; Remove token from previous owner
           (let [existing-owner (get raw-token-data "owner")]
             (when (and existing-owner (not= owner existing-owner))
@@ -163,7 +158,7 @@
                                      "last-update-user" authenticated-user)]
                 (kv/store kv-store token (-> new-token-data
                                              (assoc "previous" existing-token-data)
-                                             (sanitize-history history-length)))))))
+                                             (utils/sanitize-history history-length "previous")))))))
         ; Remove token from owner (hard-delete) or set the deleted flag (soft-delete)
         (when owner
           (let [owner->owner-key (kv/fetch kv-store token-owners-key)

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -610,5 +610,5 @@
 (defn sanitize-history
   "Limits the history length stored in the nested map."
   [data history-length history-key]
-  (dissoc-in token-data (repeat history-length history-key)))
+  (dissoc-in data (repeat history-length history-key)))
 

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -606,3 +606,9 @@
     (pos? scale-amount) :scale-up
     (neg? scale-amount) :scale-down
     :else :stable))
+
+(defn sanitize-history
+  "Limits the history length stored in the nested map."
+  [token-data history-length history-key]
+  (dissoc-in token-data (repeat history-length history-key)))
+

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -609,6 +609,6 @@
 
 (defn sanitize-history
   "Limits the history length stored in the nested map."
-  [token-data history-length history-key]
+  [data history-length history-key]
   (dissoc-in token-data (repeat history-length history-key)))
 


### PR DESCRIPTION
## Changes proposed in this PR

- moves sanitize-history to utils

## Why are we making these changes?

Refactoring of utility method to `utils`.

