### PR TITLE
removes dependency on state from curator

### DIFF
--- a/waiter/src/waiter/kv.clj
+++ b/waiter/src/waiter/kv.clj
@@ -25,7 +25,8 @@
             [waiter.curator :as curator]
             [waiter.metrics :as metrics]
             [waiter.util.cache-utils :as cu]
-            [waiter.util.utils :as utils])
+            [waiter.util.utils :as utils]
+            [clojure.string :as str])
   (:import java.util.Arrays
            org.apache.curator.framework.CuratorFramework))
 
@@ -227,7 +228,9 @@
   (state [_]
     {:inner-state (state inner-kv-store), :variant "encrypted"}))
 
-(defn new-encrypted-kv-store [passwords kv-store]
+(defn new-encrypted-kv-store
+  "Returns a new key/value store that decorates the provided kv-store with encryption/decryption of values."
+  [passwords kv-store]
   (if (or (empty? passwords) (some empty? passwords))
     (throw (.IllegalArgumentException "Passwords should not be empty!"))
     (EncryptedKeyValueStore. kv-store passwords)))
@@ -256,7 +259,11 @@
      :inner-state (state inner-kv-store)
      :variant "cache"}))
 
-(defn new-cached-kv-store [{:keys [threshold ttl]} kv-store]
+(defn new-cached-kv-store
+  "Returns a new key/value store that decorates the provided kv-store with a cache."
+  [{:keys [threshold ttl]} kv-store]
+  {:pre [(pos? threshold)
+         (pos? ttl)]}
   (->> {:threshold threshold
         :ttl (-> ttl t/seconds t/in-millis)}
        cu/cache-factory
@@ -274,6 +281,8 @@
 (defn new-kv-store
   "Returns a new key/value store using the given configuration"
   [{:keys [cache encrypt relative-path] :as config} curator base-path passwords]
+  {:pre [(not (str/blank? base-path))
+         (not (str/blank? relative-path))]}
   (let [kv-base-path (str base-path "/" relative-path)
         kv-context {:base-path kv-base-path, :curator curator}
         kv-impl (utils/create-component config :context kv-context)]

--- a/waiter/src/waiter/kv.clj
+++ b/waiter/src/waiter/kv.clj
@@ -16,6 +16,7 @@
 (ns waiter.kv
   (:require [clj-time.core :as t]
             [clojure.java.io :as io]
+            [clojure.string :as str]
             [clojure.tools.logging :as log]
             [digest]
             [metrics.meters :as meters]
@@ -25,8 +26,7 @@
             [waiter.curator :as curator]
             [waiter.metrics :as metrics]
             [waiter.util.cache-utils :as cu]
-            [waiter.util.utils :as utils]
-            [clojure.string :as str])
+            [waiter.util.utils :as utils])
   (:import java.util.Arrays
            org.apache.curator.framework.CuratorFramework))
 

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -75,10 +75,9 @@
    :scheduler core/scheduler
    :settings (pc/fnk dummy-symbol-for-fnk-schema-logic :- settings/settings-schema [] settings)
    :state core/state
-   :http-server (pc/fnk [[:curator kv-store]
-                         [:routines generate-log-url-fn waiter-request?-fn websocket-request-acceptor]
+   :http-server (pc/fnk [[:routines generate-log-url-fn waiter-request?-fn websocket-request-acceptor]
                          [:settings cors-config host port server-options support-info [:token-config token-defaults] websocket-config]
-                         [:state cors-validator router-id server-name waiter-hostnames]
+                         [:state cors-validator kv-store router-id server-name waiter-hostnames]
                          handlers] ; Insist that all systems are running before we start server
                   (let [options (merge (cond-> server-options
                                          (:ssl-port server-options) (assoc :ssl? true))

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -180,10 +180,10 @@
         allowed-to-manage-service? (fn [service-id auth-user]
                                      (sd/can-manage-service? kv-store entitlement-manager service-id auth-user))
         make-inter-router-requests-sync-fn (fn [path _ _] (is (str/includes? path "service-id-")))
-        configuration {:curator {:kv-store kv-store}
-                       :routines {:allowed-to-manage-service?-fn allowed-to-manage-service?
+        configuration {:routines {:allowed-to-manage-service?-fn allowed-to-manage-service?
                                   :make-inter-router-requests-sync-fn make-inter-router-requests-sync-fn
                                   :service-description-defaults service-description-defaults}
+                       :state {:kv-store kv-store}
                        :wrap-secure-request-fn utils/wrap-identity}
         handlers {:service-resume-handler-fn ((:service-resume-handler-fn request-handlers) configuration)
                   :service-suspend-handler-fn ((:service-suspend-handler-fn request-handlers) configuration)}
@@ -224,10 +224,10 @@
         allowed-to-manage-service? (fn [service-id auth-user]
                                      (sd/can-manage-service? kv-store entitlement-manager service-id auth-user))
         make-inter-router-requests-sync-fn (fn [path _ _] (is (str/includes? path "service-id-")))
-        configuration {:curator {:kv-store kv-store}
-                       :routines {:allowed-to-manage-service?-fn allowed-to-manage-service?
+        configuration {:routines {:allowed-to-manage-service?-fn allowed-to-manage-service?
                                   :make-inter-router-requests-sync-fn make-inter-router-requests-sync-fn
                                   :service-description-defaults service-description-defaults}
+                       :state {:kv-store kv-store}
                        :wrap-secure-request-fn utils/wrap-identity}
         handlers {:service-override-handler-fn ((:service-override-handler-fn request-handlers) configuration)}
         request-handler (wrap-error-handling (ring-handler-factory waiter-request?-fn handlers))
@@ -411,8 +411,7 @@
                                      (sd/can-manage-service? kv-store entitlement-manager service-id auth-user))
         scheduler-interactions-thread-pool (Executors/newFixedThreadPool 1)
         delete-service-result-atom (atom nil) ;; with-redefs fails as we are executing inside different threads
-        configuration {:curator {:kv-store nil}
-                       :daemons {:autoscaler {:query-state-fn (constantly {})}
+        configuration {:daemons {:autoscaler {:query-state-fn (constantly {})}
                                  :router-state-maintainer {:maintainer {:query-state-fn (constantly {})}}}
                        :routines {:allowed-to-manage-service?-fn allowed-to-manage-service?
                                   :generate-log-url-fn nil
@@ -427,7 +426,8 @@
                                                     (if (instance? Throwable result)
                                                       (throw result)
                                                       result))))}
-                       :state {:router-id "router-id"
+                       :state {:kv-store nil
+                               :router-id "router-id"
                                :scheduler-interactions-thread-pool scheduler-interactions-thread-pool}
                        :wrap-secure-request-fn utils/wrap-identity}
         handlers {:service-handler-fn ((:service-handler-fn request-handlers) configuration)}]
@@ -507,8 +507,7 @@
         last-request-time (str service-id ".last-request-time")
         service-id->metrics {service-id {"last-request-time" last-request-time}}
         scheduler-interactions-thread-pool (Executors/newFixedThreadPool 1)
-        configuration {:curator {:kv-store nil}
-                       :daemons {:autoscaler {:query-state-fn (constantly {})}
+        configuration {:daemons {:autoscaler {:query-state-fn (constantly {})}
                                  :router-state-maintainer {:maintainer {:query-state-fn (fn [] @router-state-atom)}}}
                        :routines {:allowed-to-manage-service?-fn (constantly true)
                                   :generate-log-url-fn (partial handler/generate-log-url #(str "http://www.example.com" %))
@@ -518,7 +517,8 @@
                                   :service-id->source-tokens-entries-fn (constantly #{})
                                   :token->token-hash identity}
                        :scheduler {:scheduler (Object.)}
-                       :state {:router-id "router-id"
+                       :state {:kv-store nil
+                               :router-id "router-id"
                                :scheduler-interactions-thread-pool scheduler-interactions-thread-pool}
                        :wrap-secure-request-fn utils/wrap-identity}
         handlers {:service-handler-fn ((:service-handler-fn request-handlers) configuration)}
@@ -1055,9 +1055,9 @@
         service-id "service-id"
         discovery (Object.)
         make-inter-router-requests-sync-fn (Object.)
-        configuration {:curator {:discovery discovery}
-                       :make-inter-router-requests-sync-fn make-inter-router-requests-sync-fn
-                       :state {:router-id my-router-id}}
+        configuration {:make-inter-router-requests-sync-fn make-inter-router-requests-sync-fn
+                       :state {:discovery discovery
+                               :router-id my-router-id}}
         delegate-instance-kill-request-fn ((:delegate-instance-kill-request-fn routines) configuration)
         router-ids #{"peer-1" "peer-2" "peer-3"}
         make-kill-instance-peer-ids-atom (atom #{})]


### PR DESCRIPTION
## Changes proposed in this PR

- removes dependency on state from curator

## Why are we making these changes?

Allows components in `:state` (e.g. `:service-description-builder`) to use the `curator` instance.
