### PR TITLE
validates health-check-port-index even if ports is not explicitly provided

### DIFF
--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -167,6 +167,7 @@ class WaiterCliTest(util.WaiterTest):
                                                                    '--max-instances 100 '
                                                                    '--restart-backoff-factor 1.1 '
                                                                    '--health-check-port-index 1 '
+                                                                   '--ports 3 '
                                                                    '--concurrency-level 1000 '
                                                                    '--health-check-max-consecutive-failures 10 '
                                                                    '--max-queue-length 1000000 '
@@ -181,6 +182,7 @@ class WaiterCliTest(util.WaiterTest):
             self.assertEqual(100, token['max-instances'])
             self.assertEqual(1.1, token['restart-backoff-factor'])
             self.assertEqual(1, token['health-check-port-index'])
+            self.assertEqual(3, token['ports'])
             self.assertEqual(1000, token['concurrency-level'])
             self.assertEqual(10, token['health-check-max-consecutive-failures'])
             self.assertEqual(1000000, token['max-queue-length'])
@@ -193,6 +195,7 @@ class WaiterCliTest(util.WaiterTest):
                                                                        '--max-instances 200 '
                                                                        '--restart-backoff-factor 2.2 '
                                                                        '--health-check-port-index 2 '
+                                                                       '--ports 3 '
                                                                        '--concurrency-level 2000 '
                                                                        '--health-check-max-consecutive-failures 2 '
                                                                        '--max-queue-length 2000000 '
@@ -206,6 +209,7 @@ class WaiterCliTest(util.WaiterTest):
             self.assertEqual(200, token['max-instances'])
             self.assertEqual(2.2, token['restart-backoff-factor'])
             self.assertEqual(2, token['health-check-port-index'])
+            self.assertEqual(3, token['ports'])
             self.assertEqual(2000, token['concurrency-level'])
             self.assertEqual(2, token['health-check-max-consecutive-failures'])
             self.assertEqual(2000000, token['max-queue-length'])

--- a/waiter/src/waiter/config.clj
+++ b/waiter/src/waiter/config.clj
@@ -30,3 +30,9 @@
   []
   {:pre [(realized? config-promise)]}
   (get-in @config-promise [:cluster-config :name]))
+
+(defn retrieve-service-description-default-ports
+  "Retrieves the configured service description default ports."
+  []
+  {:pre [(realized? config-promise)]}
+  (get-in @config-promise [:service-description-defaults "ports"]))

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -21,6 +21,7 @@
             [clojure.tools.logging :as log]
             [schema.core :as s]
             [waiter.authorization :as authz]
+            [waiter.config :as config]
             [waiter.kv :as kv]
             [waiter.service-description :refer :all]
             [waiter.util.cache-utils :as cu])
@@ -1900,6 +1901,11 @@
         constraints-schema config "min-instances (3) must be less than or equal to max-instances (2)"))
 
     (testing (str "testing invalid health check port index")
+      (with-redefs [config/retrieve-service-description-default-ports (constantly 1)]
+        (run-validate-schema-test
+          (assoc valid-description "health-check-port-index" 1)
+          constraints-schema config
+          "The health check port index (1) must be smaller than ports (1)"))
       (run-validate-schema-test
         (assoc valid-description "health-check-port-index" 1 "ports" 1)
         constraints-schema config


### PR DESCRIPTION

## Changes proposed in this PR

- validates health-check-port-index even if ports is not explicitly provided

## Why are we making these changes?

Disallow invalid configurations from being accepted and run as services.

