### PR TITLE
waits for scaling state to become available on the service endpoint on all routers

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -466,7 +466,8 @@
           service-id
           (assert-service-on-all-routers waiter-url service-id cookies)
           ;; wait for scaling state to become available on the service endpoint
-          (is (wait-for (fn [] (get (service waiter-url service-id {}) "scaling-state"))))
+          (doseq [[_ router-url] (routers waiter-url)]
+            (is (wait-for (fn [] (get (service router-url service-id {} :cookies cookies) "scaling-state")))))
 
           (testing "without parameters"
             (let [service (service waiter-url service-id {})] ;; see my app as myself
@@ -526,7 +527,8 @@
         (with-service-cleanup
           (assert-service-on-all-routers waiter-url service-id cookies)
           ;; wait for scaling state to become available on the service endpoint
-          (is (wait-for (fn [] (get (service waiter-url service-id {}) "scaling-state"))))
+          (doseq [[_ router-url] (routers waiter-url)]
+            (is (wait-for (fn [] (get (service router-url service-id {} :cookies cookies) "scaling-state")))))
           (testing "list-apps-with-waiter-user-disabled-and-see-another-app" ;; can see another user's app
             (let [service (service waiter-url service-id {"force" "false", "run-as-user" current-user})]
               (is service)

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -915,11 +915,12 @@
 
 (defn service
   "Retrieves the service (from /apps) corresponding to the provided service-id"
-  [waiter-url service-id query-params & {:keys [interval timeout] :or {interval 2, timeout 30}}]
+  [waiter-url service-id query-params & {:keys [cookies interval timeout]
+                                         :or {cookies [] interval 2 timeout 30}}]
   ; allow time for router to receive updates from marathon
   (wait-for
     (fn []
-      (let [{:keys [body]} (make-request waiter-url "/apps" :query-params query-params)
+      (let [{:keys [body]} (make-request waiter-url "/apps" :cookies cookies :query-params query-params)
             _ (log/debug "Response body:" body)
             parsed-body (try-parse-json body)
             service (first (filter #(= service-id (get % "service-id")) parsed-body))]


### PR DESCRIPTION

## Changes proposed in this PR

- waits for scaling state to become available on the service endpoint on all routers

## Why are we making these changes?

Reduces test flakiness.
