### PR TITLE
adds kv-store and leadership operations in the service description builder

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -673,7 +673,10 @@
    :scheduler-interactions-thread-pool (pc/fnk [] (Executors/newFixedThreadPool 20))
    :scheduler-state-chan (pc/fnk [] (au/latest-chan))
    :server-name (pc/fnk [[:settings git-version]] (str "waiter/" (str/join (take 7 git-version))))
-   :service-description-builder (pc/fnk [[:settings service-description-builder-config service-description-constraints]]
+   :service-description-builder (pc/fnk [[:curator curator synchronize-fn]
+                                         [:settings service-description-builder-config service-description-constraints
+                                          [:zookeeper base-path]]
+                                         leader?-fn passwords]
                                   (when-let [unknown-keys (-> service-description-constraints
                                                             keys
                                                             set
@@ -682,8 +685,13 @@
                                     (throw (ex-info "Unsupported keys present in the service description constraints"
                                                     {:service-description-constraints service-description-constraints
                                                      :unsupported-keys (-> unknown-keys vec sort)})))
-                                  (utils/create-component
-                                    service-description-builder-config :context {:constraints service-description-constraints}))
+                                  (let [kv-store-factory (fn kv-store-factory [kv-config]
+                                                           (kv/new-kv-store kv-config curator base-path passwords))
+                                        context {:constraints service-description-constraints
+                                                 :kv-store-factory kv-store-factory
+                                                 :leader?-fn leader?-fn
+                                                 :synchronize-fn synchronize-fn}]
+                                    (utils/create-component service-description-builder-config :context context)))
    :service-id-prefix (pc/fnk [[:settings [:cluster-config service-prefix]]] service-prefix)
    :start-service-cache (pc/fnk []
                           (cu/cache-factory {:threshold 100


### PR DESCRIPTION
## Changes proposed in this PR

- adds kv-store and leadership operations in the service description builder

## Why are we making these changes?

Allows the builder to create its own key-value store if needed.
