### PR TITLE
fixes retrieve-most-recently-modified-token-update-time

### DIFF
--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -1023,7 +1023,7 @@
     (some->> descriptor
       :sources
       :token->token-data
-      (pc/map-vals (fn [[_ {:strs [last-update-time]}]] (or last-update-time 0)))
+      (pc/map-vals (fn [{:strs [last-update-time]}] (or last-update-time 0)))
       vals
       (apply max))
     0))

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -2386,3 +2386,21 @@
 
 (deftest test-service-description-builder-state
   (is {} (state (create-default-service-description-builder {}))))
+
+(deftest test-retrieve-most-recently-modified-token-update-time
+  (let [descriptor {:sources {:token->token-data {}}}]
+    (is (= 0 (retrieve-most-recently-modified-token-update-time descriptor))))
+  (let [descriptor {:sources {:token->token-data {"t1" {}}}}]
+    (is (= 0 (retrieve-most-recently-modified-token-update-time descriptor))))
+  (let [descriptor {:sources {:token->token-data {"t1" {"last-update-time" 100}}}}]
+    (is (= 100 (retrieve-most-recently-modified-token-update-time descriptor))))
+  (let [descriptor {:sources {:token->token-data {"t1" {"last-update-time" 200}
+                                                  "t2" {}}}}]
+    (is (= 200 (retrieve-most-recently-modified-token-update-time descriptor))))
+  (let [descriptor {:sources {:token->token-data {"t1" {"last-update-time" 200}
+                                                  "t2" {"last-update-time" 150}}}}]
+    (is (= 200 (retrieve-most-recently-modified-token-update-time descriptor))))
+  (let [descriptor {:sources {:token->token-data {"t1" {"last-update-time" 200}
+                                                  "t2" {"last-update-time" 150}
+                                                  "t3" {"last-update-time" 250}}}}]
+    (is (= 250 (retrieve-most-recently-modified-token-update-time descriptor)))))


### PR DESCRIPTION
## Changes proposed in this PR

- fixes incorrect destructuring in `retrieve-most-recently-modified-token-update-time`

## Why are we making these changes?

Fixing a bug in the data destructuring in `retrieve-most-recently-modified-token-update-time`

