### PR TITLE
improves CORS preflight check

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -1106,7 +1106,7 @@
                 (assert-response-status response 200))
               (finally
                 (delete-token-and-assert waiter-url token)))))
-        (testing "CORS prefilght allowed no methods"
+        (testing "CORS preflight allowed no methods"
           (let [token (rand-name)
                 response (post-token waiter-url (assoc (kitchen-params)
                                                   :name token
@@ -1115,7 +1115,9 @@
             (try
               (assert-response-status response 200)
               (let [{:keys [headers] :as response} (make-request-with-debug-info
-                                                     {:host test-host
+                                                     {:access-control-request-method "PUT"
+                                                      :access-control-request-headers "origin"
+                                                      :host test-host
                                                       :origin test-origin
                                                       :x-waiter-token token}
                                                      #(make-kitchen-request waiter-url % :method :options :path ""))]
@@ -1123,7 +1125,7 @@
                 (is (= (str/join ", " schema/http-methods) (get headers "access-control-allow-methods"))))
               (finally
                 (delete-token-and-assert waiter-url token)))))
-        (testing "CORS prefilght allowed methods"
+        (testing "CORS preflight allowed methods"
           (let [token (rand-name)
                 methods ["GET", "PUT", "OPTIONS"]
                 response (post-token waiter-url (assoc (kitchen-params)
@@ -1133,7 +1135,9 @@
             (try
               (assert-response-status response 200)
               (let [{:keys [headers] :as response} (make-request-with-debug-info
-                                                     {:host test-host
+                                                     {:access-control-request-method "PUT"
+                                                      :access-control-request-headers "origin"
+                                                      :host test-host
                                                       :origin test-origin
                                                       :x-waiter-token token}
                                                      #(make-kitchen-request waiter-url % :method :options :path ""))]
@@ -1141,7 +1145,7 @@
                 (is (= (str/join ", " methods) (get headers "access-control-allow-methods"))))
               (finally
                 (delete-token-and-assert waiter-url token)))))
-        (testing "CORS prefilght allowed methods - can't do preflight"
+        (testing "CORS preflight allowed methods - can't do preflight"
           (let [token (rand-name)
                 methods ["GET", "PUT"]
                 response (post-token waiter-url (assoc (kitchen-params)
@@ -1151,7 +1155,9 @@
             (try
               (assert-response-status response 200)
               (let [response (make-request-with-debug-info
-                               {:host test-host
+                               {:access-control-request-method "OPTIONS"
+                                :access-control-request-headers "origin"
+                                :host test-host
                                 :origin test-origin
                                 :x-waiter-token token}
                                #(make-kitchen-request waiter-url % :method :options :path ""))]

--- a/waiter/src/waiter/cors.clj
+++ b/waiter/src/waiter/cors.clj
@@ -39,9 +39,16 @@
      :summary is a map that contains a summary of all the checks that were performed."))
 
 (defn preflight-request?
-  "Determines if a request is a CORS preflight request."
-  [request]
-  (= :options (:request-method request)))
+  "Determines if a request is a CORS preflight request.
+   A CORS preflight request is a CORS request that checks to see if the CORS protocol is understood.
+   It is an OPTIONS request, using three HTTP request headers:
+   Access-Control-Request-Method, Access-Control-Request-Headers, and the Origin header.
+   Source: https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request"
+  [{:keys [headers request-method] :as request}]
+  (and (= :options request-method)
+       (contains? headers "origin")
+       (contains? headers "access-control-request-method")
+       (contains? headers "access-control-request-headers")))
 
 (defn wrap-cors-preflight
   "Preflight request handling middleware.


### PR DESCRIPTION
## Changes proposed in this PR

- improves CORS preflight check

## Why are we making these changes?

A CORS preflight request is a CORS request that checks to see if the CORS protocol is understood. It is an OPTIONS request, using three HTTP request headers: `Access-Control-Request-Method`, `Access-Control-Request-Headers`, and the `Origin` header.

Source: https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
