### PR TITLE
updates jet to 0.7.10-20190924_091442-gfccc405

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -45,7 +45,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20190906_000617-g0895ffe"
+                 [twosigma/jet "0.7.10-20190924_091442-gfccc405"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]


### PR DESCRIPTION
## Changes proposed in this PR

- updates jet to 0.7.10-20190924_091442-gfccc405

## Why are we making these changes?

We want the ability to configure the socket backlog size.

