### PR TITLE
makes JWT auth per request opt-in by tokens

### DIFF
--- a/waiter/integration/waiter/authentication_test.clj
+++ b/waiter/integration/waiter/authentication_test.clj
@@ -170,12 +170,13 @@
                                     :target-url target-url})]
         (assert-response-status response 200)
         (is (= (retrieve-username) (str body)))
-        (is (= "jwt" (get headers "x-waiter-auth-method")) assertion-message)
+        (is (not= "jwt" (get headers "x-waiter-auth-method")) assertion-message)
         (is (= (retrieve-username) (get headers "x-waiter-auth-user")) assertion-message)
         (assert-auth-cookie set-cookie assertion-message))
       (log/info "JWT authentication is disabled"))))
 
-(deftest ^:parallel ^:integration-fast test-forbidden-jwt-authentication-waiter-realm
+;; Test disabled because JWT support is, currently, only for tokens
+(deftest ^:parallel ^:integration-fast ^:explicit test-forbidden-jwt-authentication-waiter-realm
   (testing-using-waiter-url
     (if (jwt-auth-enabled? waiter-url)
       (let [waiter-host (-> waiter-url sanitize-waiter-url utils/authority->host)
@@ -216,7 +217,8 @@
         (is (string/blank? set-cookie) assertion-message))
       (log/info "JWT authentication is disabled"))))
 
-(deftest ^:parallel ^:integration-fast test-unauthorized-jwt-authentication-waiter-realm
+;; Test disabled because JWT support is, currently, only for tokens
+(deftest ^:parallel ^:integration-fast ^:explicit test-unauthorized-jwt-authentication-waiter-realm
   (testing-using-waiter-url
     (if (jwt-auth-enabled? waiter-url)
       (let [waiter-host (-> waiter-url sanitize-waiter-url utils/authority->host)
@@ -275,7 +277,9 @@
     (if (jwt-auth-enabled? waiter-url)
       (let [waiter-host (-> waiter-url sanitize-waiter-url utils/authority->host)
             host (create-token-name waiter-url (rand-name))
-            service-parameters (assoc (kitchen-params) :name (rand-name))
+            service-parameters (assoc (kitchen-params)
+                                 :env {"USE_BEARER_AUTH" "true"}
+                                 :name (rand-name))
             token-response (post-token waiter-url (assoc service-parameters
                                                     :run-as-user (retrieve-username)
                                                     "token" host))
@@ -311,7 +315,9 @@
     (if (jwt-auth-enabled? waiter-url)
       (let [waiter-host (-> waiter-url sanitize-waiter-url utils/authority->host)
             host (create-token-name waiter-url (rand-name))
-            service-parameters (assoc (kitchen-params) :name (rand-name))
+            service-parameters (assoc (kitchen-params)
+                                 :env {"USE_BEARER_AUTH" "true"}
+                                 :name (rand-name))
             token-response (post-token waiter-url (assoc service-parameters
                                                     :run-as-user (retrieve-username)
                                                     "token" host))

--- a/waiter/integration/waiter/authentication_test.clj
+++ b/waiter/integration/waiter/authentication_test.clj
@@ -152,7 +152,8 @@
      (is (string/includes? set-cookie# "Path=/") assertion-message#)
      (is (string/includes? set-cookie# "HttpOnly=true") assertion-message#)))
 
-(deftest ^:parallel ^:integration-fast test-successful-jwt-authentication-waiter-realm
+;; Test disabled because JWT support is, currently, only for tokens
+(deftest ^:parallel ^:integration-fast ^:explicit test-successful-jwt-authentication-waiter-realm
   (testing-using-waiter-url
     (if (jwt-auth-enabled? waiter-url)
       (let [waiter-host (-> waiter-url sanitize-waiter-url utils/authority->host)
@@ -170,7 +171,7 @@
                                     :target-url target-url})]
         (assert-response-status response 200)
         (is (= (retrieve-username) (str body)))
-        (is (not= "jwt" (get headers "x-waiter-auth-method")) assertion-message)
+        (is (= "jwt" (get headers "x-waiter-auth-method")) assertion-message)
         (is (= (retrieve-username) (get headers "x-waiter-auth-user")) assertion-message)
         (assert-auth-cookie set-cookie assertion-message))
       (log/info "JWT authentication is disabled"))))

--- a/waiter/src/waiter/auth/jwt.clj
+++ b/waiter/src/waiter/auth/jwt.clj
@@ -325,6 +325,7 @@
   [{:keys [issuer keys-cache password subject-key supported-algorithms token-type]} request-handler]
   (fn jwt-auth-handler [request]
     (if (and (not (auth/request-authenticated? request))
+             (= "true" (get-in request [:waiter-discovery :service-parameter-template "env" "USE_BEARER_AUTH"]))
              (auth/select-auth-header request access-token?))
       (authenticate-request request-handler token-type issuer subject-key supported-algorithms
                             (:key-id->jwk @keys-cache) password request)


### PR DESCRIPTION
## Changes proposed in this PR

- introduces function to guard JWT auth per request

## Why are we making these changes?

We wish to decide on a per request basis whether or not to perform JWT authentication.


