### PR TITLE
adds waiter-api flag to request log

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -153,19 +153,22 @@
 (defn ring-handler-factory
   "Creates the handler for processing http requests."
   [waiter-request?-fn {:keys [process-request-fn] :as handlers}]
-  (fn http-handler [{:keys [uri] :as request}]
-    (if-not (waiter-request?-fn request)
-      (do
-        (counters/inc! (metrics/waiter-counter "requests" "service-request"))
-        (process-request-fn request))
-      (let [{:keys [handler route-params]} (routes-mapper request)
-            request (assoc request :route-params (or route-params {}))
-            handler-fn (get handlers handler process-request-fn)]
-        (when (and (not= handler :process-request-fn) (= handler-fn process-request-fn))
-          (log/warn "using default handler as no mapping found for" handler "at uri" uri))
-        (when handler
-          (counters/inc! (metrics/waiter-counter "requests" (name handler))))
-        (handler-fn request)))))
+  (fn http-handler [{:keys [uri waiter-api-call?] :as request}]
+    (let [waiter-api-call? (if (some? waiter-api-call?)
+                             waiter-api-call?
+                             (waiter-request?-fn request))]
+      (if-not waiter-api-call?
+        (do
+          (counters/inc! (metrics/waiter-counter "requests" "service-request"))
+          (process-request-fn request))
+        (let [{:keys [handler route-params]} (routes-mapper request)
+              request (assoc request :route-params (or route-params {}))
+              handler-fn (get handlers handler process-request-fn)]
+          (when (and (not= handler :process-request-fn) (= handler-fn process-request-fn))
+            (log/warn "using default handler as no mapping found for" handler "at uri" uri))
+          (when handler
+            (counters/inc! (metrics/waiter-counter "requests" (name handler))))
+          (handler-fn request))))))
 
 (defn websocket-handler-factory
   "Creates the handler for processing websocket requests.
@@ -191,10 +194,13 @@
   "Attaches a boolean value for :waiter-api-call? to the response."
   [handler waiter-request?-fn]
   (fn attach-waiter-api-middleware-fn [request]
-    (ru/update-response
-      (handler request)
-      (fn add-waiter-api-call-fn [response]
-        (assoc response :waiter-api-call? (waiter-request?-fn request))))))
+    (let [waiter-api-call? (boolean (waiter-request?-fn request))
+          add-waiter-api-call-fn (fn add-waiter-api-call-fn [http-obj]
+                                   (assoc http-obj :waiter-api-call? waiter-api-call?))]
+      (-> request
+        (add-waiter-api-call-fn)
+        (handler)
+        (ru/update-response add-waiter-api-call-fn)))))
 
 (defn correlation-id-middleware
   "Attaches an x-cid header to the request and response if one is not already provided."

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -187,6 +187,15 @@
                                 (rr/header "server" server-name)))]
       (ru/update-response response add-server-header))))
 
+(defn attach-waiter-api-middleware
+  "Attaches a boolean value for :waiter-api-call? to the response."
+  [handler waiter-request?-fn]
+  (fn attach-waiter-api-middleware-fn [request]
+    (ru/update-response
+      (handler request)
+      (fn add-waiter-api-call-fn [response]
+        (assoc response :waiter-api-call? (waiter-request?-fn request))))))
+
 (defn correlation-id-middleware
   "Attaches an x-cid header to the request and response if one is not already provided."
   [handler]

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -86,6 +86,7 @@
                                                           (cors/wrap-cors-preflight cors-validator (:max-age cors-config) kv-store token-defaults waiter-hostnames)
                                                           core/wrap-error-handling
                                                           (core/wrap-debug generate-log-url-fn)
+                                                          (core/attach-waiter-api-middleware waiter-request?-fn)
                                                           (core/attach-server-header-middleware server-name)
                                                           rlog/wrap-log
                                                           core/correlation-id-middleware

--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -50,7 +50,8 @@
 (defn response->context
   "Convert a response into a context suitable for logging."
   [{:keys [authorization/method authorization/principal backend-response-latency-ns descriptor latest-service-id
-           get-instance-latency-ns handle-request-latency-ns headers instance instance-proto protocol status] :as response}]
+           get-instance-latency-ns handle-request-latency-ns headers instance instance-proto protocol status
+           waiter-api-call?] :as response}]
   (let [{:keys [service-id service-description]} descriptor
         {:strs [content-length content-type grpc-status server]} headers
         {:keys [k8s/node-name k8s/pod-name]} instance]
@@ -75,7 +76,8 @@
       principal (assoc :principal principal)
       protocol (assoc :backend-protocol protocol)
       server (assoc :server server)
-      handle-request-latency-ns (assoc :handle-request-latency-ns handle-request-latency-ns))))
+      handle-request-latency-ns (assoc :handle-request-latency-ns handle-request-latency-ns)
+      (some? waiter-api-call?) (assoc :waiter-api waiter-api-call?))))
 
 (defn log-request!
   "Log a request"

--- a/waiter/test/waiter/request_log_test.clj
+++ b/waiter/test/waiter/request_log_test.clj
@@ -73,7 +73,8 @@
                   :instance-proto "instance-proto"
                   :latest-service-id "latest-service-id"
                   :protocol "HTTP/2.0"
-                  :status 200}]
+                  :status 200
+                  :waiter-api-call? false}]
     (is (= {:authentication-method "cookie"
             :backend-response-latency-ns 1000
             :backend-protocol "HTTP/2.0"
@@ -95,7 +96,8 @@
             :service-id "service-id"
             :service-name "service-name"
             :service-version "service-version"
-            :status 200}
+            :status 200
+            :waiter-api false}
            (response->context response)))))
 
 (deftest test-wrap-log


### PR DESCRIPTION
## Changes proposed in this PR

- adds waiter-api flag to request log

## Why are we making these changes?

We would like to easily distinguish api calls from backend calls.

