### PR TITLE
allows configuring the JVM DNS cache

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -105,6 +105,7 @@
                               ["/autoscaler" :state-autoscaler-handler-fn]
                               ["/autoscaling-multiplexer" :state-autoscaling-multiplexer-handler-fn]
                               ["/codahale-reporters" :state-codahale-reporters-handler-fn]
+                              ["/dns-cache" :state-dns-cache-handler-fn]
                               ["/fallback" :state-fallback-handler-fn]
                               ["/gc-broken-services" :state-gc-for-broken-services]
                               ["/gc-services" :state-gc-for-services]
@@ -1509,6 +1510,12 @@
                                               router-id
                                               #(pc/map-vals reporter/state codahale-reporters)
                                               request)))
+   :state-dns-cache-handler-fn (pc/fnk [[:state router-id]]
+                                 (fn state-dns-cache-handler-fn [request]
+                                   (handler/get-query-fn-state
+                                     router-id
+                                     #(hu/retrieve-dns-cache)
+                                     request)))
    :state-fallback-handler-fn (pc/fnk [[:daemons fallback-maintainer]
                                        [:state router-id]
                                        wrap-secure-request-fn]

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -629,7 +629,7 @@
           scheme (some-> request utils/request->scheme name)
           make-url (fn make-url [path]
                      (str (when scheme (str scheme "://")) host "/state/" path))]
-      (utils/clj->streaming-json-response {:details (->> ["autoscaler" "autoscaling-multiplexer" "codahale-reporters" "fallback"
+      (utils/clj->streaming-json-response {:details (->> ["autoscaler" "autoscaling-multiplexer" "codahale-reporters" "dns-cache" "fallback"
                                                           "gc-broken-services" "gc-services" "gc-transient-metrics" "interstitial"
                                                           "jwt-authenticator" "kv-store" "launch-metrics" "leader" "local-usage"
                                                           "maintainer" "router-metrics" "scheduler" "service-description-builder"

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -35,6 +35,7 @@
             [waiter.util.utils :as utils])
   (:import clojure.core.async.impl.channels.ManyToManyChannel
            java.io.IOException
+           java.security.Security
            javax.servlet.ServletInputStream)
   (:gen-class))
 
@@ -107,6 +108,9 @@
   (try
     (cid/replace-pattern-layout-in-log4j-appenders)
     (log/info "starting waiter...")
+    (when-let [dns-ttl-secs (System/getProperty "networkaddress.cache.ttl")]
+      (log/info "DNS name lookups will be cached for" dns-ttl-secs "seconds")
+      (Security/setProperty "networkaddress.cache.ttl" dns-ttl-secs))
     (let [async-threads (System/getProperty "clojure.core.async.pool-size")
           settings (assoc (settings/load-settings config-file (retrieve-git-version))
                      :async-threads async-threads


### PR DESCRIPTION
## Changes proposed in this PR

- allows configuring the JVM DNS cache

## Why are we making these changes?

We would like to control the ttl on the DNS caching in the JVM.

