### PR TITLE
adds a default timeout for connections in the client connections pool

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -749,6 +749,9 @@
                                ;; service description:
                                :async-request-timeout-ms 60000
 
+                               ;; The max time (milliseconds) a connection can be idle in the client connection pool:
+                               :client-connection-idle-timeout-ms 10000
+
                                ;; The HTTP connect timeout (milliseconds) for instance requests:
                                :connection-timeout-ms 5000
 

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -629,11 +629,12 @@
                           (utils/create-component entitlement-config))
    :fallback-state-atom (pc/fnk [] (atom {:available-service-ids #{}
                                           :healthy-service-ids #{}}))
-   :http-clients (pc/fnk [[:settings [:instance-request-properties connection-timeout-ms]]]
+   :http-clients (pc/fnk [[:settings [:instance-request-properties client-connection-idle-timeout-ms connection-timeout-ms]]]
                    (hu/prepare-http-clients
                      {:client-name "waiter-client"
                       :conn-timeout connection-timeout-ms
-                      :follow-redirects? false}))
+                      :follow-redirects? false
+                      :socket-timeout client-connection-idle-timeout-ms}))
    :instance-rpc-chan (pc/fnk [] (async/chan 1024)) ; TODO move to service-chan-maintainer
    :interstitial-state-atom (pc/fnk [] (atom {:initialized? false
                                               :service-id->interstitial-promise {}}))

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -60,6 +60,7 @@
                                                                                    not-empty))
    (s/required-key :instance-request-properties) {(s/required-key :async-check-interval-ms) schema/positive-int
                                                   (s/required-key :async-request-timeout-ms) schema/positive-int
+                                                  (s/required-key :client-connection-idle-timeout-ms) schema/positive-int
                                                   (s/required-key :connection-timeout-ms) schema/positive-int
                                                   (s/required-key :initial-socket-timeout-ms) schema/positive-int
                                                   (s/required-key :lingering-request-threshold-ms) schema/positive-int
@@ -282,6 +283,7 @@
    :hostname "localhost"
    :instance-request-properties {:async-check-interval-ms 3000
                                  :async-request-timeout-ms 60000
+                                 :client-connection-idle-timeout-ms 10000 ; 10 seconds
                                  :connection-timeout-ms 5000 ; 5 seconds
                                  :initial-socket-timeout-ms 900000 ; 15 minutes
                                  :lingering-request-threshold-ms 60000 ; 1 minute


### PR DESCRIPTION
## Changes proposed in this PR

- adds a default timeout for connections in the client connections pool

## Why are we making these changes?

Reduces the amount of time connections need to be idle in the client connection pool before they are closed.

