### PR TITLE
fixes test to not depend upon min-instances being 1

### DIFF
--- a/waiter/config-composite.edn
+++ b/waiter/config-composite.edn
@@ -77,6 +77,9 @@
                                                          :work-directory "scheduler/shell-low"}}
                                 :default-scheduler :shell-high}}
 
+ ; ---------- Service Descriptions ----------
+ :service-description-defaults {"min-instances" 2}
+
  ; ---------- CORS ----------
  :cors-config {:kind :allow-all}
 

--- a/waiter/integration/waiter/async_request_integration_test.clj
+++ b/waiter/integration/waiter/async_request_integration_test.clj
@@ -46,9 +46,10 @@
 
 (defn- make-async-request
   [waiter-url processing-time-ms]
-  (let [headers {:x-waiter-name (rand-name)
+  (let [headers {:x-waiter-concurrency-level 100
                  :x-waiter-max-instances 1
-                 :x-waiter-concurrency-level 100}
+                 :x-waiter-min-instances 1
+                 :x-waiter-name (rand-name)}
         {:keys [request-headers service-id cookies]}
         (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))
         async-request-headers (-> request-headers

--- a/waiter/integration/waiter/autoscaling_test.clj
+++ b/waiter/integration/waiter/autoscaling_test.clj
@@ -42,6 +42,7 @@
     (let [concurrency-level 3
           custom-headers {:x-kitchen-delay-ms 5000
                           :x-waiter-concurrency-level concurrency-level
+                          :x-waiter-min-instances 1
                           :x-waiter-scale-up-factor 0.9
                           :x-waiter-scale-down-factor 0.9
                           :x-waiter-name (rand-name)}]
@@ -55,6 +56,7 @@
                           :x-waiter-scale-up-factor 0.9
                           :x-waiter-scale-down-factor 0.9
                           :x-waiter-grace-period-secs 600
+                          :x-waiter-min-instances 1
                           :x-waiter-name (rand-name)
                           :x-waiter-cmd "sleep 600"
                           :x-waiter-queue-timeout 5000}]
@@ -96,6 +98,7 @@
           expected-instances (int (* num-threads scale-factor)) ;; all requests to the same router
           extra-headers {:x-kitchen-delay-ms (-> delay-secs t/seconds t/in-millis)
                          :x-waiter-max-instances (inc expected-instances)
+                         :x-waiter-min-instances 1
                          :x-waiter-name (rand-name)
                          :x-waiter-scale-down-factor 0.001
                          :x-waiter-scale-factor scale-factor
@@ -120,6 +123,7 @@
           extra-headers {:x-kitchen-delay-ms (-> delay-secs t/seconds t/in-millis)
                          :x-waiter-concurrency-level concurrency-level
                          :x-waiter-max-instances 5
+                         :x-waiter-min-instances 1
                          :x-waiter-name (rand-name)
                          :x-waiter-scale-down-factor 0.25
                          :x-waiter-scale-up-factor 0.99}
@@ -195,8 +199,8 @@
           requests-per-thread 20
           request-delay-ms 2000
           custom-headers {:x-kitchen-delay-ms request-delay-ms
-                          :x-waiter-min-instances 2
                           :x-waiter-max-instances 5
+                          :x-waiter-min-instances 2
                           :x-waiter-name (rand-name)
                           :x-waiter-scale-up-factor 0.99}
           request-fn (fn [& {:keys [cookies] :or {cookies {}}}]

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -665,6 +665,7 @@
   (testing-using-waiter-url
     (let [headers {:x-waiter-name (rand-name)
                    :x-waiter-max-instances 5
+                   :x-waiter-min-instances 1
                    :x-waiter-scale-up-factor 0.99
                    :x-waiter-scale-down-factor 0.99
                    :x-kitchen-delay-ms 5000}
@@ -698,7 +699,8 @@
   (testing-using-waiter-url
     (let [headers {:x-waiter-name (rand-name)
                    :x-waiter-distribution-scheme "simple" ;; disallow work-stealing interference from balanced
-                   :x-waiter-max-instances 1}
+                   :x-waiter-max-instances 1
+                   :x-waiter-min-instances 1}
           {:keys [cookies service-id]} (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))
           router-url (some-router-url-with-assigned-slots waiter-url service-id)
           response-priorities-atom (atom [])

--- a/waiter/integration/waiter/busy_instance_test.clj
+++ b/waiter/integration/waiter/busy_instance_test.clj
@@ -71,6 +71,7 @@
           stagger-ms 100
           headers {:x-waiter-name (rand-name)
                    :x-waiter-max-instances 1
+                   :x-waiter-min-instances 1
                    :x-waiter-max-queue-length max-queue-length
                    ;; disallow work-stealing interference from balanced
                    :x-waiter-distribution-scheme "simple"

--- a/waiter/integration/waiter/health_check_test.clj
+++ b/waiter/integration/waiter/health_check_test.clj
@@ -195,6 +195,7 @@
              :x-waiter-concurrency-level 128
              :x-waiter-health-check-interval-secs 5
              :x-waiter-health-check-max-consecutive-failures 10
+             :x-waiter-min-instances 1
              :x-waiter-name (rand-name)}
             #(make-kitchen-request waiter-url % :path "/hello"))
           check-filtered-instances (fn [target-url healthy-filter-fn]

--- a/waiter/integration/waiter/instance_reservation_test.clj
+++ b/waiter/integration/waiter/instance_reservation_test.clj
@@ -107,8 +107,9 @@
     (log/info (str "Testing instance allocation for concurrent service for each request (will take "
                    (colored-time (str "~3 minutes"))
                    " to complete)."))
-    (let [extra-headers {:x-waiter-name (rand-name)
-                         :x-waiter-concurrency-level 100
+    (let [extra-headers {:x-waiter-concurrency-level 100
+                         :x-waiter-min-instances 1
+                         :x-waiter-name (rand-name)
                          :x-waiter-scale-up-factor 0.99}
           request-fn (fn [time & {:keys [cookies] :or {cookies {}}}]
                        (make-request-with-debug-info

--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -79,6 +79,7 @@
               headers {:x-waiter-concurrency-level 1
                        :x-waiter-distribution-scheme "simple"
                        :x-waiter-max-instances 2
+                       :x-waiter-min-instances 1
                        :x-waiter-name (rand-name)
                        :x-waiter-scale-down-factor 0.99
                        :x-waiter-scale-up-factor 0.99}

--- a/waiter/integration/waiter/latency_test.clj
+++ b/waiter/integration/waiter/latency_test.clj
@@ -82,6 +82,7 @@
             total-requests 100000
             name (rand-name)
             extra-headers {:x-waiter-max-instances max-instances
+                           :x-waiter-min-instances 1
                            :x-waiter-name name
                            :x-waiter-scale-down-factor 0.001
                            :x-waiter-scale-up-factor 0.999

--- a/waiter/integration/waiter/new_app_test.clj
+++ b/waiter/integration/waiter/new_app_test.clj
@@ -23,6 +23,7 @@
   (testing-using-waiter-url
     (let [headers {:x-kitchen-delay-ms 10000 ;; allow Waiter router state to sync
                    :x-kitchen-echo "true"
+                   :x-waiter-min-instances 1
                    :x-waiter-name (rand-name)}
           lorem-ipsum "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
           {:keys [body cookies router-id service-id] :as response}

--- a/waiter/integration/waiter/request_timeout_test.clj
+++ b/waiter/integration/waiter/request_timeout_test.clj
@@ -162,6 +162,7 @@
           extra-headers {:x-waiter-cmd (kitchen-cmd "-p $PORT0")
                          :x-waiter-concurrency-level num-routers
                          :x-waiter-max-instances 1
+                         :x-waiter-min-instances 1
                          :x-waiter-name (rand-name)}
           {:keys [cookies instance-id service-id] :as response} (make-request-fn waiter-url extra-headers nil)]
       (assert-response-status response 200)

--- a/waiter/integration/waiter/websocket_integration_test.clj
+++ b/waiter/integration/waiter/websocket_integration_test.clj
@@ -382,6 +382,7 @@
                            "x-waiter-metric-group" "waiter_ws_test"
                            "x-waiter-name" (rand-name)
                            "x-waiter-max-instances" "1"
+                           "x-waiter-min-instances" "1"
                            "x-waiter-concurrency-level" "20")]
       (is auth-cookie-value)
       (try

--- a/waiter/integration/waiter/work_stealing_integration_test.clj
+++ b/waiter/integration/waiter/work_stealing_integration_test.clj
@@ -29,6 +29,7 @@
           extra-headers (merge (kitchen-request-headers)
                                {:x-waiter-name (rand-name)
                                 :x-waiter-max-instances max-instances
+                                :x-waiter-min-instances 1
                                 :x-waiter-scale-up-factor 0.999
                                 :x-waiter-scale-down-factor 0.001
                                 :x-waiter-work-stealing true})

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -445,6 +445,7 @@
    :idle-timeout-mins 10
    :mem 256
    :metric-group "waiter_test"
+   :min-instances 1
    :version "version-does-not-matter"})
 
 (defn kitchen-request-headers


### PR DESCRIPTION
## Changes proposed in this PR

- addresses tests which fail when the default min-instances changes

## Why are we making these changes?

The tests should not expect the `min-instances` to be `1`.

