### PR TITLE
adds response location header, run-as-user, server-port and token to the request log

### DIFF
--- a/waiter/test/waiter/request_log_test.clj
+++ b/waiter/test/waiter/request_log_test.clj
@@ -33,6 +33,7 @@
                  :request-method :post
                  :request-time (t/date-time 2018 4 11)
                  :scheme "http"
+                 :server-port 9090
                  :uri "/"}]
     (is (= {:cid "123"
             :client-protocol "HTTP/2.0"
@@ -48,6 +49,7 @@
             :request-id "abc"
             :request-time "2018-04-11T00:00:00.000Z"
             :scheme "http"
+            :server-port 9090
             :user-agent "test-user-agent"}
            (request->context request)))))
 
@@ -58,12 +60,16 @@
                   :descriptor {:service-id "service-id"
                                :service-description {"metric-group" "service-metric-group"
                                                      "name" "service-name"
-                                                     "version" "service-version"}}
+                                                     "run-as-user" "john.doe"
+                                                     "version" "service-version"}
+                               :source-tokens [{"token" "test-token1" "version" "E-1234"}
+                                               {"token" "test-token2" "version" "E-4321"}]}
                   :get-instance-latency-ns 500
                   :handle-request-latency-ns 2000
                   :headers {"content-length" "40"
                             "content-type" "application/xml"
                             "grpc-status" "13"
+                            "location" "/foo/bar"
                             "server" "foo-bar"}
                   :instance {:host "instance-host"
                              :id "instance-id"
@@ -92,11 +98,14 @@
             :principal "principal@DOMAIN.COM"
             :response-content-length "40"
             :response-content-type "application/xml"
+            :response-location "/foo/bar"
+            :run-as-user "john.doe"
             :server "foo-bar"
             :service-id "service-id"
             :service-name "service-name"
             :service-version "service-version"
             :status 200
+            :token "test-token1,test-token2"
             :waiter-api false}
            (response->context response)))))
 


### PR DESCRIPTION
## Changes proposed in this PR

- adds response location header, run-as-user, server-port and token to the request log

## Why are we making these changes?

We would like to query the request log for additional data.

Example request log:
```
{"response-location":"/waiter-async/status/362ec0216e86-51aab0b0935230b7-http/r9091-35ebecf101e2-3bea06de4f36a8f2/w9091-warittmar59568416841740-2684ef42e803e41912f0a5ac1c32f3d1/127.0.0.4/10503/async/status?request-id=c3924624-cc48-4975-bc17-d9b1a3b71f6b",
 "run-as-user":"shamsimam",
 "server-port":9091,
 "token":"www.wtrttslf59657441429902.t1.127.0.0.1",
 ...}
```
