### PR TITLE
makes async-request-max-status-checks configurable

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -739,9 +739,15 @@
                                ;; It makes calls to the backend instance and inspects the responses to
                                ;; decide when to treat the request as complete. A request is not
                                ;; considered complete as long as the backend keeps returning a 200
-                               ;; response. This dictates the interval (milliseconds) at which Waiter
-                               ;; will poll the backend instance:
+                               ;; response. This dictates the default value of the interval (milliseconds)
+                               ;; at which Waiter will poll the backend instance:
                                :async-check-interval-ms 3000
+
+                               ;; Waiter monitors the state of an async request at specified intervals.
+                               ;; However, using too low an async-check-interval-ms can lead to many requests
+                               ;; in short durations. We can restrict the maximum number of such status check
+                               ;; requests per async request using the following value:
+                               :async-request-max-status-checks 50
 
                                ;; After this amount of time (milliseconds) the async request will be
                                ;; considered timed out, and Waiter will release the allocated

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -59,6 +59,7 @@
    (s/required-key :hostname) (s/if string? schema/non-empty-string (s/constrained [schema/non-empty-string]
                                                                                    not-empty))
    (s/required-key :instance-request-properties) {(s/required-key :async-check-interval-ms) schema/positive-int
+                                                  (s/required-key :async-request-max-status-checks) schema/positive-int
                                                   (s/required-key :async-request-timeout-ms) schema/positive-int
                                                   (s/required-key :client-connection-idle-timeout-ms) schema/positive-int
                                                   (s/required-key :connection-timeout-ms) schema/positive-int
@@ -282,6 +283,7 @@
    :host "0.0.0.0"
    :hostname "localhost"
    :instance-request-properties {:async-check-interval-ms 3000
+                                 :async-request-max-status-checks 50
                                  :async-request-timeout-ms 60000
                                  :client-connection-idle-timeout-ms 10000 ; 10 seconds
                                  :connection-timeout-ms 5000 ; 5 seconds


### PR DESCRIPTION
## Changes proposed in this PR

- makes async-request-max-status-checks configurable

## Why are we making these changes?

Allows configuring the maximum number of status checks per async request from the async request monitor. Avoids having to recompile the code if we ever need to change this value.

