### PR TITLE
configures min-instances to 1 for test-new-app-gc

### DIFF
--- a/waiter/integration/waiter/new_app_test.clj
+++ b/waiter/integration/waiter/new_app_test.clj
@@ -50,8 +50,9 @@
   (testing-using-waiter-url
     (let [idle-timeout-in-mins 1
           {:keys [service-id]} (make-request-with-debug-info
-                                 {:x-waiter-name (rand-name)
-                                  :x-waiter-idle-timeout-mins idle-timeout-in-mins}
+                                 {:x-waiter-idle-timeout-mins idle-timeout-in-mins
+                                  :x-waiter-min-instances 1
+                                  :x-waiter-name (rand-name)}
                                  #(make-kitchen-request waiter-url %))]
       (log/debug "Waiting for" service-id "to show up...")
       (is (wait-for #(= 1 (num-instances waiter-url service-id)) :interval 1))


### PR DESCRIPTION
## Changes proposed in this PR

- configures min-instances to 1 for test-new-app-gc

## Why are we making these changes?

Avoid flaky test.


