### PR TITLE
enables synchronization when roots mismatch but updated by same user

### DIFF
--- a/token-syncer/bin/test.sh
+++ b/token-syncer/bin/test.sh
@@ -38,11 +38,14 @@ export WAITER_URIS=${WAITER_URIS:-http://127.0.0.1:9091,http://127.0.0.1:9092}
 # Wait for waiter to be listening
 for WAITER_URI in ${WAITER_URIS//,/ }
 do
-  timeout 180s bash -c "wait_for_server ${WAITER_URI}"
-  if [ $? -ne 0 ]; then
-    echo "$(date +%H:%M:%S) timed out waiting for waiter to start listening on ${WAITER_URI}, displaying waiter log"
+  timeout 240s bash -c "wait_for_server ${WAITER_URI}"
+  if [[ $? -ne 0 ]]; then
+    echo "$(date +%H:%M:%S) ERROR timed out waiting for waiter to start listening on ${WAITER_URI}"
+    echo "$(date +%H:%M:%S) displaying waiter log:"
     cat ${WAITER_DIR}/log/*waiter.log
     exit 1
+  else
+    echo "$(date +%H:%M:%S) waiter server listening on ${WAITER_URI} started"
   fi
 done
 

--- a/token-syncer/src/token_syncer/commands/syncer.clj
+++ b/token-syncer/src/token_syncer/commands/syncer.clj
@@ -83,8 +83,8 @@
             cluster-result
             (try
               (let [{:keys [description error status] :as token-data} (get cluster-url->token-data cluster-url)
-                    latest-root (get latest-token-description "root")
-                    cluster-root (get description "root")]
+                    {latest-root "root" latest-update-user "last-update-user"} latest-token-description
+                    {cluster-root "root" cluster-update-user "last-update-user"} description]
                 (cond
                   error
                   {:code :error/token-read
@@ -117,9 +117,10 @@
                           (apply dissoc description system-metadata-keys)))
                   {:code :skip/token-sync}
 
-                  ;; token user-specified content different, and roots also different
+                  ;; token user-specified content, last update user, or root different
                   (and (seq description)
                        (not= latest-root cluster-root)
+                       (not= latest-update-user cluster-update-user)
                        (not= (apply dissoc description ignored-root-mismatch-equality-comparison-keys)
                              (apply dissoc latest-token-description ignored-root-mismatch-equality-comparison-keys)))
                   {:code :error/root-mismatch

--- a/token-syncer/src/token_syncer/commands/syncer.clj
+++ b/token-syncer/src/token_syncer/commands/syncer.clj
@@ -117,7 +117,7 @@
                           (apply dissoc description system-metadata-keys)))
                   {:code :skip/token-sync}
 
-                  ;; token user-specified content, last update user, or root different
+                  ;; token user-specified content, last update user, and root different
                   (and (seq description)
                        (not= latest-root cluster-root)
                        (not= latest-update-user cluster-update-user)

--- a/token-syncer/test/token_syncer/commands/backup_test.clj
+++ b/token-syncer/test/token_syncer/commands/backup_test.clj
@@ -129,11 +129,13 @@
         (is (= {:exit-code 1
                 :message "test-command: expected 2 arguments FILE URL, provided 3: [\"some-file.txt\" \"http://cluster-1.com\" \"http://cluster-2.com\"]"}
                (cli/process-command test-command-config context args))))
-      (let [args ["some-file.txt" "http://cluster-1.com"]]
+      (let [args ["some-file.txt" "http://cluster-1.com"]
+            invocation-promise (promise)]
         (with-redefs [backup-tokens (fn [in-waiter-api in-file-operations-api cluster-url file accrete]
                                       (is (= waiter-api in-waiter-api))
                                       (is (= file-operations-api in-file-operations-api))
-                                      (println "backup-tokens:" cluster-url file accrete))]
+                                      (deliver invocation-promise ::invoked))]
           (is (= {:exit-code 0
                   :message "test-command: exiting with code 0"}
-                 (cli/process-command test-command-config context args))))))))
+                 (cli/process-command test-command-config context args)))
+          (is (= ::invoked (deref invocation-promise 0 ::un-initialized))))))))


### PR DESCRIPTION
## Changes proposed in this PR

- enables synchronization when roots mismatch but updated by same user

## Why are we making these changes?

Enables syncing tokens across clusters when they have been edited by the same user.
