### PR TITLE
upgrades clojure to 1.10.0

### DIFF
--- a/token-syncer/project.clj
+++ b/token-syncer/project.clj
@@ -17,7 +17,7 @@
   :dependencies [[twosigma/jet "0.7.10-20190426_181314-g8d0a48b"]
                  [clj-time "0.15.1"]
                  [commons-codec/commons-codec "1.11"]
-                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/clojure "1.10.1"]
                  [org.clojure/core.async "0.4.490"]
                  [org.clojure/data.json "0.2.6"]
                  [org.clojure/tools.cli "0.4.1"]

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -80,7 +80,7 @@
                                io.netty/netty]]
                  [org.apache.curator/curator-x-discovery "2.11.0"
                   :exclusions [io.netty/netty org.slf4j/slf4j-api]]
-                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/clojure "1.10.1"]
                  [org.clojure/core.async "0.4.490"
                   :exclusions [org.clojure/clojure org.clojure/tools.reader]]
                  [org.clojure/core.memoize "0.7.1"


### PR DESCRIPTION
## Changes proposed in this PR

- upgrades clojure to 1.10.0

## Why are we making these changes?

Upgrade to the latest available version that is safe to use.

