### PR TITLE
upgrade clojure dependencies

### DIFF
--- a/token-syncer/project.clj
+++ b/token-syncer/project.clj
@@ -15,14 +15,14 @@
 ;;
 (defproject token-syncer "0.1.0-SNAPSHOT"
   :dependencies [[twosigma/jet "0.7.10-20190426_181314-g8d0a48b"]
-                 [clj-time "0.15.1"]
-                 [commons-codec/commons-codec "1.11"]
+                 [clj-time "0.15.2"]
+                 [commons-codec/commons-codec "1.13"]
                  [org.clojure/clojure "1.10.1"]
-                 [org.clojure/core.async "0.4.490"]
+                 [org.clojure/core.async "0.5.527"]
                  [org.clojure/data.json "0.2.6"]
-                 [org.clojure/tools.cli "0.4.1"]
-                 [org.clojure/tools.logging "0.4.1"]
-                 [org.slf4j/slf4j-log4j12 "1.7.25"]
+                 [org.clojure/tools.cli "0.4.2"]
+                 [org.clojure/tools.logging "0.5.0"]
+                 [org.slf4j/slf4j-log4j12 "1.7.29"]
                  [prismatic/plumbing "0.5.5"]]
   :jvm-opts ["-server"
              "-XX:+UseG1GC"

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -30,12 +30,12 @@
                    :dev :dev
                    :perf (every-pred :perf (complement :explicit))}
 
-  :dependencies [[bidi "2.1.5"
+  :dependencies [[bidi "2.1.6"
                   :exclusions [prismatic/schema ring/ring-core]]
                  [buddy/buddy-sign "3.1.0"
                   :exclusions [[commons-codec]]]
                  ;; resolve the cheshire dependency used by buddy and jet
-                 [cheshire "5.8.1"]
+                 [cheshire "5.9.0"]
                  [twosigma/courier "1.5.14"
                   :exclusions [com.google.guava/guava io.grpc/grpc-core]
                   :scope "test"]
@@ -49,20 +49,20 @@
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]
-                 [clj-time "0.15.1"
+                 [clj-time "0.15.2"
                   :exclusions [joda-time]]
                  [com.google.guava/guava "20.0"]
                  [com.taoensso/nippy "2.14.0"
                   :exclusions [org.clojure/clojure org.clojure/tools.reader]]
                  [comb "0.1.1"
                   :exclusions [org.clojure/clojure]]
-                 [digest "1.4.8"
+                 [digest "1.4.9"
                   :exclusions [org.clojure/clojure]]
                  [fullcontact/full.async "1.0.0"
                   :exclusions [org.clojure/clojure org.clojure/clojurescript org.clojure/core.async]]
                  [io.dropwizard.metrics/metrics-graphite "3.1.1"
                   :exclusions [org.slf4j/slf4j-api]]
-                 [joda-time "2.10.1"]
+                 [joda-time "2.10.5"]
                  [twosigma/metrics-clojure "2.6.0-20180124_201441-g72cee16"
                   :exclusions [org.clojure/clojure io.netty/netty org.slf4j/slf4j-api]]
                  [metrics-clojure-jvm "2.10.0"
@@ -81,31 +81,31 @@
                  [org.apache.curator/curator-x-discovery "2.11.0"
                   :exclusions [io.netty/netty org.slf4j/slf4j-api]]
                  [org.clojure/clojure "1.10.1"]
-                 [org.clojure/core.async "0.4.490"
+                 [org.clojure/core.async "0.5.527"
                   :exclusions [org.clojure/clojure org.clojure/tools.reader]]
-                 [org.clojure/core.memoize "0.7.1"
+                 [org.clojure/core.memoize "0.8.2"
                   :exclusions [org.clojure/clojure]]
                  [org.clojure/data.codec "0.1.1"]
                  [org.clojure/data.json "0.2.6"]
                  [org.clojure/data.priority-map "0.0.10"]
-                 [org.clojure/data.zip "0.1.2"]
-                 [org.clojure/tools.cli "0.4.1"]
-                 [org.clojure/tools.logging "0.4.1"]
-                 [org.clojure/tools.namespace "0.2.11"]
+                 [org.clojure/data.zip "0.1.3"]
+                 [org.clojure/tools.cli "0.4.2"]
+                 [org.clojure/tools.logging "0.5.0"]
+                 [org.clojure/tools.namespace "0.3.1"]
                  [org.clojure/tools.reader "1.3.2"]
                  ;; use maven to download this jar so we can set up the boot classpath
                  [org.mortbay.jetty.alpn/alpn-boot "8.1.13.v20181017"
                   :scope "provided"]
                  [org.opensaml/opensaml "2.6.4"
                   :exclusions [commons-codec]]
-                 [org.slf4j/slf4j-log4j12 "1.7.25"
+                 [org.slf4j/slf4j-log4j12 "1.7.29"
                   :exclusions [log4j]]
                  [potemkin "0.4.5"]
                  [prismatic/plumbing "0.5.5"]
-                 [prismatic/schema "1.1.10"]
+                 [prismatic/schema "1.1.12"]
                  [reaver "0.1.2"
                   :scope "test"]
-                 [ring/ring-core "1.7.1"
+                 [ring/ring-core "1.8.0"
                   :exclusions [org.clojure/tools.reader]]
                  [ring/ring-ssl "0.3.0"
                   :exclusions [ring/ring-core]]


### PR DESCRIPTION
## Changes proposed in this PR

- upgrades clojure dependencies

## Why are we making these changes?

Using the latest version of our dependencies to benefit from bug fixes and performance improvements.

### Dependency changes:

```
$ diff -y -W 175 deps-master.txt deps-updates.txt | grep '|'
 [bidi "2.1.5" :exclusions [[prismatic/schema] [ring/ring-core]]]                     |  [bidi "2.1.6" :exclusions [[prismatic/schema] [ring/ring-core]]]
 [cheshire "5.8.1"]                                                                   |  [cheshire "5.9.0"]
   [com.fasterxml.jackson.core/jackson-core "2.9.6"]                                  |    [com.fasterxml.jackson.core/jackson-core "2.9.9"]
   [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.9.6"]                 |    [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.9.9"]
   [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.9.6"]                |    [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.9.9"]
 [clj-time "0.15.1" :exclusions [[joda-time]]]                                        |  [clj-time "0.15.2" :exclusions [[joda-time]]]
 [digest "1.4.8" :exclusions [[org.clojure/clojure]]]                                 |  [digest "1.4.9" :exclusions [[org.clojure/clojure]]]
 [joda-time "2.10.1"]                                                                 |  [joda-time "2.10.5"]
 [org.clojure/core.async "0.4.490" :exclusions [[org.clojure/clojure] [org.clojure/to |  [org.clojure/core.async "0.5.527" :exclusions [[org.clojure/clojure] [org.clojure/to
 [org.clojure/core.memoize "0.7.1" :exclusions [[org.clojure/clojure]]]               |  [org.clojure/core.memoize "0.8.2" :exclusions [[org.clojure/clojure]]]
   [org.clojure/core.cache "0.7.1"]                                                   |    [org.clojure/core.cache "0.8.2"]
 [org.clojure/data.zip "0.1.2"]                                                       |  [org.clojure/data.zip "0.1.3"]
 [org.clojure/tools.cli "0.4.1"]                                                      |  [org.clojure/tools.cli "0.4.2"]
 [org.clojure/tools.logging "0.4.1"]                                                  |  [org.clojure/tools.logging "0.5.0"]
 [org.clojure/tools.namespace "0.2.11"]                                               |  [org.clojure/tools.namespace "0.3.1"]
 [org.slf4j/slf4j-log4j12 "1.7.25" :exclusions [[log4j]]]                             |  [org.slf4j/slf4j-log4j12 "1.7.29" :exclusions [[log4j]]]
   [org.slf4j/slf4j-api "1.7.25"]                                                     |    [org.slf4j/slf4j-api "1.7.29"]
 [prismatic/schema "1.1.10"]                                                          |  [prismatic/schema "1.1.12"]
 [ring/ring-core "1.7.1" :exclusions [[org.clojure/tools.reader]]]                    |  [ring/ring-core "1.8.0" :exclusions [[org.clojure/tools.reader]]]
   [commons-fileupload "1.3.3"]                                                       |    [commons-fileupload "1.4"]
   [ring/ring-codec "1.1.1"]                                                          |    [ring/ring-codec "1.1.2"]
```

`lein deps :tree` reports no conflicts:

```
$ lein deps :tree
 [bidi "2.1.6" :exclusions [[prismatic/schema] [ring/ring-core]]]
 [buddy/buddy-sign "3.1.0" :exclusions [[commons-codec]]]
   [buddy/buddy-core "1.6.0"]
     [net.i2p.crypto/eddsa "0.3.0"]
     [org.bouncycastle/bcpkix-jdk15on "1.62"]
     [org.bouncycastle/bcprov-jdk15on "1.62"]
 [cheshire "5.9.0"]
   [com.fasterxml.jackson.core/jackson-core "2.9.9"]
   [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.9.9"]
   [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.9.9"]
   [tigris "0.1.1"]
 [clj-time "0.15.2" :exclusions [[joda-time]]]
 [clojure-complete "0.2.5" :exclusions [[org.clojure/clojure]]]
 [com.google.guava/guava "20.0"]
 [com.taoensso/nippy "2.14.0" :exclusions [[org.clojure/clojure] [org.clojure/tools.reader]]]
   [com.taoensso/encore "2.93.0"]
     [com.taoensso/truss "1.5.0"]
   [net.jpountz.lz4/lz4 "1.3"]
   [org.iq80.snappy/snappy "0.4"]
   [org.tukaani/xz "1.6"]
 [comb "0.1.1" :exclusions [[org.clojure/clojure]]]
 [digest "1.4.9" :exclusions [[org.clojure/clojure]]]
 [fullcontact/full.async "1.0.0" :exclusions [[org.clojure/clojure] [org.clojure/clojurescript] [org.clojure/core.async]]]
 [io.dropwizard.metrics/metrics-graphite "3.1.1" :exclusions [[org.slf4j/slf4j-api]]]
   [io.dropwizard.metrics/metrics-core "3.1.1"]
 [io.grpc/grpc-core "1.20.0" :scope "test" :exclusions [[com.google.guava/guava]]]
   [com.google.android/annotations "4.1.1.4" :scope "test"]
   [com.google.code.findbugs/jsr305 "3.0.2" :scope "test"]
   [com.google.code.gson/gson "2.7" :scope "test"]
   [com.google.errorprone/error_prone_annotations "2.3.2" :scope "test"]
   [io.grpc/grpc-context "1.20.0" :scope "test"]
   [io.opencensus/opencensus-api "0.19.2" :scope "test" :exclusions [[com.google.code.findbugs/jsr305] [com.google.guava/guava] [io.grpc/grpc-context]]]
   [io.opencensus/opencensus-contrib-grpc-metrics "0.19.2" :scope "test" :exclusions [[com.google.code.findbugs/jsr305] [com.google.guava/guava] [io.grpc/grpc-context]]]
   [org.codehaus.mojo/animal-sniffer-annotations "1.17" :scope "test"]
 [joda-time "2.10.5"]
 [metrics-clojure-jvm "2.10.0" :exclusions [[io.dropwizard.metrics/metrics-core] [io.netty/netty] [metrics-clojure] [org.clojure/clojure] [org.slf4j/slf4j-api]]]
   [io.dropwizard.metrics/metrics-jvm "3.2.2"]
 [nrepl "0.6.0" :exclusions [[org.clojure/clojure]]]
 [org.apache.curator/curator-framework "2.11.0" :exclusions [[io.netty/netty] [org.slf4j/slf4j-api]]]
   [org.apache.curator/curator-client "2.11.0"]
 [org.apache.curator/curator-recipes "2.11.0" :exclusions [[io.netty/netty] [org.slf4j/slf4j-api]]]
 [org.apache.curator/curator-test "2.11.0" :exclusions [[com.google.guava/guava] [io.netty/netty]]]
   [org.apache.commons/commons-math "2.2"]
   [org.apache.zookeeper/zookeeper "3.4.6" :exclusions [[com.sun.jmx/jmxri] [com.sun.jdmk/jmxtools] [javax.jms/jms] [junit] [org.slf4j/slf4j-log4j12]]]
     [jline "0.9.94"]
     [log4j "1.2.16"]
   [org.javassist/javassist "3.18.1-GA"]
 [org.apache.curator/curator-x-discovery "2.11.0" :exclusions [[io.netty/netty] [org.slf4j/slf4j-api]]]
   [org.codehaus.jackson/jackson-mapper-asl "1.9.13"]
     [org.codehaus.jackson/jackson-core-asl "1.9.13"]
 [org.clojure/clojure "1.10.1"]
   [org.clojure/core.specs.alpha "0.2.44"]
   [org.clojure/spec.alpha "0.2.176"]
 [org.clojure/core.async "0.5.527" :exclusions [[org.clojure/clojure] [org.clojure/tools.reader]]]
   [org.clojure/tools.analyzer.jvm "0.7.2"]
     [org.clojure/tools.analyzer "0.6.9"]
     [org.ow2.asm/asm-all "4.2"]
 [org.clojure/core.memoize "0.8.2" :exclusions [[org.clojure/clojure]]]
   [org.clojure/core.cache "0.8.2"]
 [org.clojure/data.codec "0.1.1"]
 [org.clojure/data.json "0.2.6"]
 [org.clojure/data.priority-map "0.0.10"]
 [org.clojure/data.zip "0.1.3"]
 [org.clojure/tools.cli "0.4.2"]
 [org.clojure/tools.logging "0.5.0"]
 [org.clojure/tools.namespace "0.3.1"]
   [org.clojure/java.classpath "0.3.0"]
 [org.clojure/tools.reader "1.3.2"]
 [org.mortbay.jetty.alpn/alpn-boot "8.1.13.v20181017" :scope "provided"]
 [org.opensaml/opensaml "2.6.4" :exclusions [[commons-codec]]]
   [commons-collections "3.2.1"]
   [commons-lang "2.6"]
   [org.apache.santuario/xmlsec "1.5.7"]
   [org.apache.velocity/velocity "1.7" :exclusions [[oro]]]
   [org.opensaml/openws "1.5.4"]
     [commons-httpclient "3.1" :exclusions [[commons-logging]]]
     [org.opensaml/xmltooling "1.4.4"]
       [ca.juliusdavies/not-yet-commons-ssl "0.3.9" :exclusions [[log4j] [commons-logging]]]
   [org.owasp.esapi/esapi "2.0.1" :exclusions [[commons-configuration] [commons-beanutils/commons-beanutils-core] [commons-fileupload] [commons-io] [commons-collections] [log4j] [xom] [org.beanshell/bsh-core] [org.owasp.antisamy/antisamy]]]
 [org.slf4j/slf4j-log4j12 "1.7.29" :exclusions [[log4j]]]
   [org.slf4j/slf4j-api "1.7.29"]
 [potemkin "0.4.5"]
   [clj-tuple "0.2.2"]
   [riddley "0.1.12"]
 [prismatic/plumbing "0.5.5"]
   [de.kotka/lazymap "3.1.0" :exclusions [[org.clojure/clojure]]]
 [prismatic/schema "1.1.12"]
 [reaver "0.1.2" :scope "test"]
   [org.jsoup/jsoup "1.8.3"]
 [ring-basic-authentication "1.0.5"]
 [ring/ring-core "1.8.0" :exclusions [[org.clojure/tools.reader]]]
   [commons-fileupload "1.4"]
   [commons-io "2.6"]
   [crypto-equality "1.0.0"]
   [crypto-random "1.2.0"]
   [ring/ring-codec "1.1.2"]
     [commons-codec "1.11"]
 [ring/ring-ssl "0.3.0" :exclusions [[ring/ring-core]]]
 [slingshot "0.12.2"]
 [try-let "1.3.1" :exclusions [[org.clojure/clojure]]]
 [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5" :exclusions [[commons-codec] [commons-io] [org.clojure/tools.reader] [potemkin] [slingshot]]]
   [com.cognitect/transit-clj "0.8.259" :exclusions [[org.clojure/clojure]]]
     [com.cognitect/transit-java "0.8.269"]
       [com.fasterxml.jackson.datatype/jackson-datatype-json-org "2.3.2"]
         [com.fasterxml.jackson.core/jackson-databind "2.3.2"]
           [com.fasterxml.jackson.core/jackson-annotations "2.3.0"]
         [org.json/json "20090211"]
       [org.apache.directory.studio/org.apache.commons.codec "1.8"]
       [org.msgpack/msgpack "0.6.10"]
         [com.googlecode.json-simple/json-simple "1.1.1" :exclusions [[junit]]]
     [org.clojure/test.check "0.5.9"]
   [crouton "0.1.2" :exclusions [[org.clojure/clojure]]]
   [org.apache.httpcomponents/httpclient "4.3.5" :exclusions [[org.clojure/clojure]]]
     [commons-logging "1.1.3"]
   [org.apache.httpcomponents/httpcore "4.3.3" :exclusions [[org.clojure/clojure]]]
   [org.apache.httpcomponents/httpmime "4.3.5" :exclusions [[org.clojure/clojure]]]
 [twosigma/courier "1.5.14" :scope "test" :exclusions [[com.google.guava/guava] [io.grpc/grpc-core]]]
   [com.google.protobuf/protobuf-java-util "3.7.1" :scope "test"]
   [io.grpc/grpc-netty-shaded "1.20.0" :scope "test"]
   [io.grpc/grpc-protobuf "1.20.0" :scope "test"]
     [com.google.api.grpc/proto-google-common-protos "1.12.0" :scope "test" :exclusions [[com.google.protobuf/protobuf-java] [com.google.api/api-common]]]
     [com.google.protobuf/protobuf-java "3.7.1" :scope "test"]
     [io.grpc/grpc-protobuf-lite "1.20.0" :scope "test" :exclusions [[com.google.protobuf/protobuf-lite]]]
   [io.grpc/grpc-stub "1.20.0" :scope "test"]
 [twosigma/jet "0.7.10-20190924_091442-gfccc405" :exclusions [[org.mortbay.jetty.alpn/alpn-boot]]]
   [org.eclipse.jetty.alpn/alpn-api "1.1.3.v20160715"]
   [org.eclipse.jetty.http2/http2-client "9.4.20.v20190813"]
   [org.eclipse.jetty.http2/http2-common "9.4.20.v20190813"]
     [org.eclipse.jetty.http2/http2-hpack "9.4.20.v20190813"]
   [org.eclipse.jetty.http2/http2-http-client-transport "9.4.20.v20190813"]
   [org.eclipse.jetty.http2/http2-server "9.4.20.v20190813"]
   [org.eclipse.jetty.websocket/websocket-client "9.4.20.v20190813"]
     [org.eclipse.jetty/jetty-util "9.4.20.v20190813"]
     [org.eclipse.jetty/jetty-xml "9.4.20.v20190813"]
   [org.eclipse.jetty.websocket/websocket-server "9.4.20.v20190813"]
     [org.eclipse.jetty.websocket/websocket-common "9.4.20.v20190813"]
     [org.eclipse.jetty/jetty-servlet "9.4.20.v20190813"]
       [org.eclipse.jetty/jetty-security "9.4.20.v20190813"]
   [org.eclipse.jetty.websocket/websocket-servlet "9.4.20.v20190813"]
     [org.eclipse.jetty.websocket/websocket-api "9.4.20.v20190813"]
   [org.eclipse.jetty/jetty-alpn-openjdk8-client "9.4.20.v20190813"]
     [org.eclipse.jetty/jetty-alpn-client "9.4.20.v20190813"]
   [org.eclipse.jetty/jetty-alpn-openjdk8-server "9.4.20.v20190813"]
     [org.eclipse.jetty/jetty-alpn-server "9.4.20.v20190813"]
   [org.eclipse.jetty/jetty-client "9.4.20.v20190813"]
   [org.eclipse.jetty/jetty-server "9.4.20.v20190813"]
     [javax.servlet/javax.servlet-api "3.1.0"]
     [org.eclipse.jetty/jetty-http "9.4.20.v20190813"]
     [org.eclipse.jetty/jetty-io "9.4.20.v20190813"]
 [twosigma/metrics-clojure "2.6.0-20180124_201441-g72cee16" :exclusions [[org.clojure/clojure] [io.netty/netty] [org.slf4j/slf4j-api]]]
```