### PR TITLE
updates jetty version to 9.4.24.v20191120

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -45,7 +45,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20190924_091442-gfccc405"
+                 [twosigma/jet "0.7.10-20191203_214328-gfa5b2bb"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]


### PR DESCRIPTION
## Changes proposed in this PR

- updates jetty version to 9.4.24.v20191120

## Why are we making these changes?


