### PR TITLE
ensures metric group for services created from the CLI tests

### DIFF
--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -161,6 +161,7 @@ def minimal_service_description(**kwargs):
         'cmd': default_cmd(),
         'cpus': float(os.getenv('WAITER_TEST_DEFAULT_CPUS', 1.0)),
         'mem': int(os.getenv('WAITER_TEST_DEFAULT_MEM_MB', 256)),
+        'metric-group': 'waiter_test',
         'version': str(uuid.uuid4()),
         'cmd-type': 'shell'
     }


### PR DESCRIPTION
## Changes proposed in this PR

- ensures metric group for services created from the CLI tests

## Why are we making these changes?

Makes it easy to identify test services and attribute any relevant metrics.

