### PR TITLE
uses waiter principal in async status check requests

### DIFF
--- a/waiter/config-composite.edn
+++ b/waiter/config-composite.edn
@@ -1,6 +1,8 @@
 {
  ; ---------- Cluster ----------
 
+ :waiter-principal "waiter@example.com"
+
  :zookeeper {
              ;; Use an in-process ZK (not for production use):
              :connect-string :in-process}

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -60,6 +60,10 @@
                   ;; It's best to keep this unique across clusters:
                   :service-prefix "waiter-c1-"}
 
+ ;; The principal to use for requests, e.g. async request status checks, originating in Waiter.
+ ;; It is expected to be of the format name@domain.
+ :waiter-principal "waiter@example.com"
+
  :zookeeper {
              ;; The root path to which Waiter will write data:
              :base-path "/waiter"

--- a/waiter/config-k8s.edn
+++ b/waiter/config-k8s.edn
@@ -1,6 +1,8 @@
 {
  ; ---------- Cluster ----------
 
+ :waiter-principal "waiter@example.com"
+
  :zookeeper {;; Use an in-process ZK (not for production use):
              :connect-string :in-process}
 

--- a/waiter/config-minimal.edn
+++ b/waiter/config-minimal.edn
@@ -6,6 +6,8 @@
 {
  ; ---------- Cluster ----------
 
+ :waiter-principal "waiter@example.com"
+
  :zookeeper {
              ;; Use an in-process ZK (not for production use):
              :connect-string :in-process}

--- a/waiter/config-minimesos.edn
+++ b/waiter/config-minimesos.edn
@@ -1,6 +1,8 @@
 {
  ; ---------- Cluster ----------
 
+ :waiter-principal "waiter@example.com"
+
  :zookeeper {:connect-string #config/env "WAITER_ZOOKEEPER_CONNECT_STRING"}
 
  ; ---------- Metrics - Internal ----------

--- a/waiter/config-shell.edn
+++ b/waiter/config-shell.edn
@@ -3,6 +3,8 @@
 
  :cluster-config {:name #config/env "WAITER_CLUSTER_NAME"}
 
+ :waiter-principal "waiter@example.com"
+
  :zookeeper {
              ;; Use an in-process ZK (not for production use):
              :connect-string :in-process}

--- a/waiter/src/waiter/async_request.clj
+++ b/waiter/src/waiter/async_request.clj
@@ -175,7 +175,7 @@
    The function assumes location begins with a slash.
    This method wires up the completion and status check callbacks for the monitoring system.
    It also modifies the status check endpoint in the response header."
-  [router-id async-request-store-atom make-http-request-fn instance-rpc-chan response
+  [router-id async-request-store-atom make-http-request-fn auth-params-map instance-rpc-chan response
    service-id metric-group backend-proto {:keys [host port] :as instance}
    {:keys [request-id] :as reason-map} request-properties location query-string]
   (let [correlation-id (cid/get-correlation-id)
@@ -189,7 +189,11 @@
     ;; trigger execution of monitoring system
     (letfn [(make-get-request-fn []
               (counters/inc! (metrics/service-counter service-id "request-counts" "async-monitor"))
-              (let [request-stub {:body nil :headers {} :query-string query-string :request-method :get}]
+              (let [request-stub (assoc auth-params-map
+                                   :body nil
+                                   :headers {}
+                                   :query-string query-string
+                                   :request-method :get)]
                 (make-http-request-fn instance request-stub location metric-group backend-proto)))
             (release-instance-fn [status]
               (log/info "decrementing outstanding requests as an async request has completed:" status)

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -944,14 +944,16 @@
                                                      (partial make-blacklist-request make-inter-router-requests-sync-fn blacklist-period-ms)
                                                      reason))))
    :post-process-async-request-response-fn (pc/fnk [[:state async-request-store-atom instance-rpc-chan router-id]
+                                                    [:settings waiter-principal]
                                                     make-http-request-fn]
-                                             (fn post-process-async-request-response-wrapper
-                                               [response service-id metric-group backend-proto instance _
-                                                reason-map request-properties location query-string]
-                                               (async-req/post-process-async-request-response
-                                                 router-id async-request-store-atom make-http-request-fn instance-rpc-chan response
-                                                 service-id metric-group backend-proto instance reason-map request-properties
-                                                 location query-string)))
+                                             (let [auth-params-map (auth/auth-params-map :internal waiter-principal)]
+                                               (fn post-process-async-request-response-wrapper
+                                                 [response service-id metric-group backend-proto instance _
+                                                  reason-map request-properties location query-string]
+                                                 (async-req/post-process-async-request-response
+                                                   router-id async-request-store-atom make-http-request-fn auth-params-map
+                                                   instance-rpc-chan response service-id metric-group backend-proto instance
+                                                   reason-map request-properties location query-string))))
    :prepend-waiter-url (pc/fnk [[:settings hostname port]]
                          (let [hostname (if (sequential? hostname) (first hostname) hostname)]
                            (fn [endpoint-url]

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -179,6 +179,7 @@
                                    (s/required-key :token-defaults) {(s/required-key "fallback-period-secs") schema/non-negative-int
                                                                      (s/required-key "https-redirect") s/Bool
                                                                      (s/required-key "stale-timeout-mins") schema/non-negative-int}}
+   (s/required-key :waiter-principal) schema/non-empty-string
    (s/required-key :websocket-config) {(s/required-key :ws-max-binary-message-size) schema/positive-int
                                        (s/required-key :ws-max-text-message-size) schema/positive-int}
    (s/required-key :work-stealing) {(s/required-key :max-in-flight-offers) schema/non-negative-int

--- a/waiter/test/waiter/async_request_test.clj
+++ b/waiter/test/waiter/async_request_test.clj
@@ -19,6 +19,7 @@
             [clojure.test :refer :all]
             [plumbing.core :as pc]
             [waiter.async-request :refer :all]
+            [waiter.auth.authentication :as auth]
             [waiter.service :as service])
   (:import java.net.URLDecoder))
 
@@ -294,9 +295,15 @@
         request-properties {:async-check-interval-ms 100 :async-request-max-status-checks 50 :async-request-timeout-ms 200}
         location (str "/location/" request-id)
         query-string "a=b&c=d|e"
+        auth-params-map (auth/auth-params-map :internal "waiter@example.com")
         make-http-request-fn (fn [in-instance in-request end-route metric-group backend-proto]
                                (is (= instance in-instance))
-                               (is (= {:body nil :headers {} :query-string "a=b&c=d|e" :request-method :get} in-request))
+                               (is (= (assoc auth-params-map
+                                        :body nil
+                                        :headers {}
+                                        :query-string "a=b&c=d|e"
+                                        :request-method :get)
+                                      in-request))
                                (is (= "/location/request-2394613984619" end-route))
                                (is (= "test-metric-group" metric-group))
                                (is (= "http" backend-proto)))
@@ -315,9 +322,9 @@
                     (make-get-request-fn)
                     (reset! complete-async-request-atom complete-async-request-fn))]
       (let [{:keys [headers]} (post-process-async-request-response
-                                router-id async-request-store-atom make-http-request-fn instance-rpc-chan response
-                                service-id metric-group backend-proto instance reason-map request-properties
-                                location query-string)]
+                                router-id async-request-store-atom make-http-request-fn auth-params-map
+                                instance-rpc-chan response service-id metric-group backend-proto instance reason-map
+                                request-properties location query-string)]
         (is (get @async-request-store-atom request-id))
         (is (= (str "/waiter-async/status/" request-id "/" router-id "/" service-id "/" host "/" port location "?" query-string)
                (get headers "location")))
@@ -341,9 +348,15 @@
         sanitized-check-interval-ms (sanitize-check-interval async-request-timeout-ms async-check-interval-ms async-request-max-status-checks)
         location (str "/location/" request-id)
         query-string "a=b&c=d|e"
+        auth-params-map (auth/auth-params-map :internal "waiter@example.com")
         make-http-request-fn (fn [in-instance in-request end-route metric-group backend-proto]
                                (is (= instance in-instance))
-                               (is (= {:body nil :headers {} :query-string "a=b&c=d|e" :request-method :get} in-request))
+                               (is (= (assoc auth-params-map
+                                        :body nil
+                                        :headers {}
+                                        :query-string "a=b&c=d|e"
+                                        :request-method :get)
+                                      in-request))
                                (is (= "/location/request-2394613984619" end-route))
                                (is (= "test-metric-group" metric-group))
                                (is (= "http" backend-proto)))
@@ -365,9 +378,9 @@
                                 :async-request-max-status-checks async-request-max-status-checks
                                 :async-request-timeout-ms async-request-timeout-ms}
             {:keys [headers]} (post-process-async-request-response
-                                router-id async-request-store-atom make-http-request-fn instance-rpc-chan response
-                                service-id metric-group backend-proto instance reason-map request-properties
-                                location query-string)]
+                                router-id async-request-store-atom make-http-request-fn auth-params-map
+                                instance-rpc-chan response service-id metric-group backend-proto instance
+                                reason-map request-properties location query-string)]
         (is (get @async-request-store-atom request-id))
         (is (= (str "/waiter-async/status/" request-id "/" router-id "/" service-id "/" host "/" port location "?" query-string)
                (get headers "location")))


### PR DESCRIPTION
## Changes proposed in this PR

- adds the required waiter-principal settings
- uses waiter principal in async status check requests

## Why are we making these changes?

Ensures requests to the backend from Waiter have a valid principal in the request.
