### PR TITLE
adds request log entries for internal requests to the backend

### DIFF
--- a/waiter/src/waiter/async_request.clj
+++ b/waiter/src/waiter/async_request.clj
@@ -14,16 +14,20 @@
 ;; limitations under the License.
 ;;
 (ns waiter.async-request
-  (:require [clojure.core.async :as async]
+  (:require [clj-time.core :as t]
+            [clojure.core.async :as async]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [metrics.counters :as counters]
             [metrics.timers :as timers]
             [waiter.correlation-id :as cid]
             [waiter.metrics :as metrics]
+            [waiter.request-log :as rlog]
             [waiter.scheduler :as scheduler]
             [waiter.service :as service]
-            [waiter.statsd :as statsd])
+            [waiter.statsd :as statsd]
+            [waiter.util.http-utils :as hu]
+            [waiter.util.utils :as utils])
   (:import (java.net ConnectException SocketTimeoutException URI URLEncoder)
            (java.util.concurrent TimeoutException)))
 
@@ -170,15 +174,53 @@
                   "from" async-check-interval-ms)
         sanitized-check-interval-ms))))
 
+(defn- make-async-status-get-request
+  "Performs the get request for the async request status and returns the response.
+   Also, adds a corresponding entry into the request log."
+  [make-http-request-fn auth-params-map user-agent {:keys [service-description service-id] :as descriptor}
+   {:keys [host] :as instance} location query-string]
+  (counters/inc! (metrics/service-counter service-id "request-counts" "async-monitor"))
+  (let [{:strs [metric-group backend-proto]} service-description
+        backend-protocol (hu/backend-protocol->http-version backend-proto)
+        backend-scheme (hu/backend-proto->scheme backend-proto)
+        request-stub (assoc auth-params-map
+                       :body nil
+                       :client-protocol backend-protocol
+                       :headers {"host" host
+                                 "user-agent" user-agent
+                                 "x-cid" (cid/get-correlation-id)}
+                       :internal-protocol backend-protocol
+                       :query-string query-string
+                       :request-id (str "waiter-async-status-check-" (utils/unique-identifier))
+                       :request-method :get
+                       :request-time (t/now)
+                       :scheme backend-scheme
+                       :uri location)
+        response-ch (make-http-request-fn instance request-stub location metric-group backend-proto)]
+    (async/go
+      (let [{:keys [error] :as response} (async/<! response-ch)]
+        (let [response (-> (merge auth-params-map response)
+                         (utils/assoc-if-absent :instance instance)
+                         (assoc :descriptor descriptor
+                                :error-class (some-> error .getClass .getCanonicalName)
+                                :instance-proto backend-proto
+                                :latest-service-id service-id
+                                :protocol backend-protocol
+                                :request-type "async-status-check"
+                                :waiter-api-call? false))]
+          (rlog/log-request! request-stub response))
+        response))))
+
 (defn post-process-async-request-response
   "Triggers execution of monitoring system for an async request.
    The function assumes location begins with a slash.
    This method wires up the completion and status check callbacks for the monitoring system.
    It also modifies the status check endpoint in the response header."
-  [router-id async-request-store-atom make-http-request-fn auth-params-map instance-rpc-chan response
-   service-id metric-group backend-proto {:keys [host port] :as instance}
+  [router-id async-request-store-atom make-http-request-fn auth-params-map instance-rpc-chan user-agent
+   response {:keys [service-description service-id] :as descriptor} {:keys [host port] :as instance}
    {:keys [request-id] :as reason-map} request-properties location query-string]
   (let [correlation-id (cid/get-correlation-id)
+        {:strs [metric-group backend-proto]} service-description
         status-endpoint (scheduler/end-point-url backend-proto host port location)
         _ (log/info "status endpoint for async request is" status-endpoint query-string)
         {:keys [async-check-interval-ms async-request-max-status-checks async-request-timeout-ms]} request-properties
@@ -188,13 +230,8 @@
     (counters/inc! (metrics/service-counter service-id "request-counts" "async"))
     ;; trigger execution of monitoring system
     (letfn [(make-get-request-fn []
-              (counters/inc! (metrics/service-counter service-id "request-counts" "async-monitor"))
-              (let [request-stub (assoc auth-params-map
-                                   :body nil
-                                   :headers {}
-                                   :query-string query-string
-                                   :request-method :get)]
-                (make-http-request-fn instance request-stub location metric-group backend-proto)))
+              (make-async-status-get-request make-http-request-fn auth-params-map user-agent descriptor
+                                             instance location query-string))
             (release-instance-fn [status]
               (log/info "decrementing outstanding requests as an async request has completed:" status)
               (counters/dec! (metrics/service-counter service-id "request-counts" "async"))

--- a/waiter/src/waiter/auth/authentication.clj
+++ b/waiter/src/waiter/auth/authentication.clj
@@ -55,6 +55,11 @@
   (cookie-support/add-encoded-cookie response password AUTH-COOKIE-NAME [principal (tc/to-long (t/now))]
                                      (or age-in-seconds (-> 1 t/days t/in-seconds))))
 
+(defn select-auth-params
+  "Returns a map that contains only the auth params from the input map"
+  [m]
+  (select-keys m [:authorization/method :authorization/principal :authorization/user]))
+
 (defn auth-params-map
   "Creates a map intended to be merged into requests/responses."
   ([method principal]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1369,9 +1369,10 @@
                                    (handler/metrics-request-handler request)))
    :not-found-handler-fn (pc/fnk [] handler/not-found-handler)
    :ping-service-handler (pc/fnk [[:daemons router-state-maintainer]
-                                  [:state fallback-state-atom]
+                                  [:state fallback-state-atom user-agent-version]
                                   process-request-handler-fn process-request-wrapper-fn wrap-secure-request-fn]
                            (let [{{:keys [query-state-fn]} :maintainer} router-state-maintainer
+                                 user-agent (str "waiter-ping/" user-agent-version)
                                  handler (process-request-wrapper-fn
                                            (fn inner-ping-service-handler [request]
                                              (let [service-state-fn
@@ -1382,7 +1383,7 @@
                                                         :healthy? (descriptor/service-healthy? fallback-state service-id)
                                                         :service-id service-id
                                                         :status (service/retrieve-service-status-label service-id global-state)}))]
-                                               (pr/ping-service process-request-handler-fn service-state-fn request))))]
+                                               (pr/ping-service user-agent process-request-handler-fn service-state-fn request))))]
                              (wrap-secure-request-fn
                                (fn ping-service-handler [request]
                                  (-> request

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -945,16 +945,17 @@
                                                      instance short-circuit? router-ids "blacklist"
                                                      (partial make-blacklist-request make-inter-router-requests-sync-fn blacklist-period-ms)
                                                      reason))))
-   :post-process-async-request-response-fn (pc/fnk [[:state async-request-store-atom instance-rpc-chan router-id]
-                                                    [:settings waiter-principal]
+   :post-process-async-request-response-fn (pc/fnk [[:settings waiter-principal]
+                                                    [:state async-request-store-atom instance-rpc-chan router-id user-agent-version]
                                                     make-http-request-fn]
-                                             (let [auth-params-map (auth/auth-params-map :internal waiter-principal)]
+                                             (let [auth-params-map (auth/auth-params-map :internal waiter-principal)
+                                                   user-agent (str "waiter-async-status-check/" user-agent-version)]
                                                (fn post-process-async-request-response-wrapper
-                                                 [response service-id metric-group backend-proto instance _
+                                                 [response descriptor instance _
                                                   reason-map request-properties location query-string]
                                                  (async-req/post-process-async-request-response
                                                    router-id async-request-store-atom make-http-request-fn auth-params-map
-                                                   instance-rpc-chan response service-id metric-group backend-proto instance
+                                                   instance-rpc-chan user-agent response descriptor instance
                                                    reason-map request-properties location query-string))))
    :prepend-waiter-url (pc/fnk [[:settings hostname port]]
                          (let [hostname (if (sequential? hostname) (first hostname) hostname)]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -831,9 +831,8 @@
                                                      :socket-timeout health-check-timeout-ms
                                                      :user-agent (str "waiter-syncer/" user-agent-version)})
                                       available? (fn scheduler-available?
-                                                   [scheduler-name service-instance health-check-proto health-check-port-index health-check-path]
-                                                   (scheduler/available? http-client scheduler-name service-instance health-check-proto
-                                                                         health-check-port-index health-check-path))]
+                                                   [scheduler-name service-instance service-description]
+                                                   (scheduler/available? http-client scheduler-name service-instance service-description))]
                                   (fn start-scheduler-syncer-fn
                                     [scheduler-name get-service->instances-fn scheduler-state-chan scheduler-syncer-interval-secs]
                                     (let [timer-ch (-> scheduler-syncer-interval-secs t/seconds t/in-millis au/timer-chan)]

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -33,6 +33,7 @@
             [waiter.handler :as handler]
             [waiter.headers :as headers]
             [waiter.metrics :as metrics]
+            [waiter.request-log :as rlog]
             [waiter.scheduler :as scheduler]
             [waiter.service :as service]
             [waiter.statsd :as statsd]
@@ -859,12 +860,11 @@
 (defn make-health-check-request
   "Makes a health check request to the backend using the specified proto and port from the descriptor.
    Returns the health check response from an arbitrary backend or the failure response."
-  [process-request-handler-fn idle-timeout-ms {:keys [descriptor] :as request}]
+  [process-request-handler-fn idle-timeout-ms {:keys [descriptor] :as request} health-check-protocol]
   (async/go
     (try
       (let [{:keys [service-description]} descriptor
             {:strs [health-check-url health-check-port-index]} service-description
-            health-check-protocol (scheduler/service-description->health-check-protocol service-description)
             ctrl-ch (async/chan)
             attach-empty-content (fn attach-empty-content [request]
                                    (-> request
@@ -910,8 +910,8 @@
                        body (str body))]
         (async/close! ctrl-ch)
         (-> health-check-response
-          (assoc :body body-str)
-          (assoc :result (if (= source-ch timeout-ch) :timed-out :received-response))))
+          (assoc :body body-str
+                 :result (if (= source-ch timeout-ch) :timed-out :received-response))))
       (catch Exception ex
         (utils/exception->response ex request)))))
 
@@ -919,12 +919,30 @@
   "Performs a health check on an arbitrary instance of the service specified in the descriptor.
    If the service is not running, an instance will be started.
    The response body contains the following map: {:ping-response ..., :service-state ...}"
-  [process-request-handler-fn service-state-fn {:keys [descriptor headers] :as request}]
+  [user-agent process-request-handler-fn service-state-fn {:keys [descriptor headers] :as request}]
   (async/go
     (try
-      (let [{:keys [core-service-description service-id]} descriptor
+      (let [{:keys [core-service-description service-description service-id]} descriptor
+            request (assoc-in request [:headers "user-agent"] user-agent)
             idle-timeout-ms (Integer/parseInt (get headers "x-waiter-timeout" "300000"))
-            ping-response (async/<! (make-health-check-request process-request-handler-fn idle-timeout-ms request))]
+            health-check-protocol (scheduler/service-description->health-check-protocol service-description)
+            ping-response (async/<! (make-health-check-request process-request-handler-fn idle-timeout-ms request health-check-protocol))]
+        (let [{:strs [health-check-url]} service-description
+              backend-protocol (hu/backend-protocol->http-version health-check-protocol)
+              backend-scheme (hu/backend-proto->scheme health-check-protocol)
+              request (assoc request
+                        :client-protocol backend-protocol
+                        :internal-protocol backend-protocol
+                        :request-method :get
+                        :scheme backend-scheme
+                        :uri health-check-url)
+              auth-params (auth/select-auth-params request)
+              response (-> (merge auth-params ping-response)
+                         (assoc :descriptor descriptor
+                                :latest-service-id service-id
+                                :request-type "ping"
+                                :waiter-api-call? false))]
+          (rlog/log-request! request response))
         (merge
           (dissoc ping-response [:body :error-chan :headers :request :result :status :trailers])
           (utils/clj->json-response

--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -31,11 +31,11 @@
   "Convert a request into a context suitable for logging."
   [{:keys [client-protocol headers internal-protocol query-string remote-addr request-id
            request-method request-time server-port uri] :as request}]
-  (let [{:strs [content-length content-type host origin user-agent x-cid x-forwarded-for]} headers]
+  (let [{:strs [content-length content-type host origin user-agent x-cid x-forwarded-for]} headers
+        remote-address (or x-forwarded-for remote-addr)]
     (cond-> {:cid x-cid
              :host host
              :path uri
-             :remote-addr (or x-forwarded-for remote-addr)
              :request-id request-id
              :scheme (-> request utils/request->scheme name)}
       origin (assoc :origin origin)
@@ -43,6 +43,7 @@
       client-protocol (assoc :client-protocol client-protocol)
       internal-protocol (assoc :internal-protocol internal-protocol)
       query-string (assoc :query-string query-string)
+      remote-address (assoc :remote-addr remote-address)
       content-length (assoc :request-content-length content-length)
       content-type (assoc :request-content-type content-type)
       request-time (assoc :request-time (du/date-to-str request-time))
@@ -53,13 +54,14 @@
   "Convert a response into a context suitable for logging."
   [{:keys [authorization/method authorization/principal backend-response-latency-ns descriptor error-class
            get-instance-latency-ns handle-request-latency-ns headers instance instance-proto latest-service-id
-           protocol status waiter-api-call?] :as response}]
+           protocol request-type status waiter-api-call?] :as response}]
   (let [{:keys [service-id service-description source-tokens]} descriptor
         token (some->> source-tokens (map #(get % "token")) seq (str/join ","))
         {:strs [metric-group run-as-user version]} service-description
         {:strs [content-length content-type grpc-status location server]} headers
         {:keys [k8s/node-name k8s/pod-name]} instance]
-    (cond-> {:status (or status 200)}
+    (cond-> {}
+      status (assoc :status status)
       method (assoc :authentication-method (name method))
       backend-response-latency-ns (assoc :backend-response-latency-ns backend-response-latency-ns)
       content-length (assoc :response-content-length content-length)
@@ -69,17 +71,18 @@
                         :service-id service-id
                         :service-name (get service-description "name")
                         :service-version version)
+      get-instance-latency-ns (assoc :get-instance-latency-ns get-instance-latency-ns)
       grpc-status (assoc :grpc-status grpc-status)
       instance (assoc :instance-host (:host instance)
                       :instance-id (:id instance)
-                      :instance-port (:port instance)
-                      :get-instance-latency-ns get-instance-latency-ns)
+                      :instance-port (:port instance))
       instance-proto (assoc :instance-proto instance-proto)
       latest-service-id (assoc :latest-service-id latest-service-id)
       node-name (assoc :k8s-node-name node-name)
       pod-name (assoc :k8s-pod-name pod-name)
       principal (assoc :principal principal)
       protocol (assoc :backend-protocol protocol)
+      request-type (assoc :request-type request-type)
       server (assoc :server server)
       handle-request-latency-ns (assoc :handle-request-latency-ns handle-request-latency-ns)
       location (assoc :response-location location)

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -319,7 +319,8 @@
   [{:keys [port] :as instance} health-check-proto health-check-port-index health-check-path http-client]
   (if (pos? port)
     (let [_ (log/debug "running health check against" instance)
-          instance-health-check-url (scheduler/health-check-url instance health-check-proto health-check-port-index health-check-path)
+          instance-health-check-url (scheduler/build-health-check-url
+                                      instance health-check-proto health-check-port-index health-check-path)
           {:keys [status error]} (async/<!! (http/get http-client instance-health-check-url))]
       (scheduler/log-health-check-issues instance instance-health-check-url status error)
       (and (not error) (<= 200 status 299)))

--- a/waiter/test/waiter/async_request_test.clj
+++ b/waiter/test/waiter/async_request_test.clj
@@ -284,11 +284,13 @@
       (is (= "remote" @terminate-call-atom)))))
 
 (deftest test-post-process-async-request-response
-  (let [{:keys [host port] :as instance} {:host "www.example.com", :port 1234}
+  (let [instance-host "www.example.com"
+        {:keys [host port] :as instance} {:host instance-host :port 1234}
         router-id "my-router-id"
         service-id "test-service-id"
         metric-group "test-metric-group"
         backend-proto "http"
+        user-agent "waiter-async-status-check/1234"
         async-request-store-atom (atom {})
         request-id "request-2394613984619"
         reason-map {:request-id request-id}
@@ -298,15 +300,25 @@
         auth-params-map (auth/auth-params-map :internal "waiter@example.com")
         make-http-request-fn (fn [in-instance in-request end-route metric-group backend-proto]
                                (is (= instance in-instance))
+                               (is (contains? in-request :request-id))
+                               (is (str/starts-with? (str (:request-id in-request)) "waiter-async-status-check-"))
+                               (is (contains? in-request :request-time))
                                (is (= (assoc auth-params-map
                                         :body nil
-                                        :headers {}
+                                        :client-protocol "HTTP/1.1"
+                                        :headers {"host" instance-host
+                                                  "user-agent" "waiter-async-status-check/1234"
+                                                  "x-cid" "UNKNOWN"}
+                                        :internal-protocol "HTTP/1.1"
                                         :query-string "a=b&c=d|e"
-                                        :request-method :get)
-                                      in-request))
+                                        :request-method :get
+                                        :scheme "http"
+                                        :uri location)
+                                      (dissoc in-request :request-id :request-time)))
                                (is (= "/location/request-2394613984619" end-route))
                                (is (= "test-metric-group" metric-group))
-                               (is (= "http" backend-proto)))
+                               (is (= "http" backend-proto))
+                               (async/go {}))
         instance-rpc-chan (async/chan 1)
         complete-async-request-atom (atom nil)
         response {}]
@@ -321,9 +333,12 @@
                     (is exit-chan)
                     (make-get-request-fn)
                     (reset! complete-async-request-atom complete-async-request-fn))]
-      (let [{:keys [headers]} (post-process-async-request-response
+      (let [descriptor {:service-description {"backend-proto" backend-proto
+                                              "metric-group" metric-group}
+                        :service-id service-id}
+            {:keys [headers]} (post-process-async-request-response
                                 router-id async-request-store-atom make-http-request-fn auth-params-map
-                                instance-rpc-chan response service-id metric-group backend-proto instance reason-map
+                                instance-rpc-chan user-agent response descriptor instance reason-map
                                 request-properties location query-string)]
         (is (get @async-request-store-atom request-id))
         (is (= (str "/waiter-async/status/" request-id "/" router-id "/" service-id "/" host "/" port location "?" query-string)
@@ -334,11 +349,13 @@
           (is (nil? (get @async-request-store-atom request-id))))))))
 
 (deftest test-post-process-async-request-response-sanitized-check-interval
-  (let [{:keys [host port] :as instance} {:host "www.example.com", :port 1234}
+  (let [instance-host "www.example.com"
+        {:keys [host port] :as instance} {:host instance-host :port 1234}
         router-id "my-router-id"
         service-id "test-service-id"
         metric-group "test-metric-group"
         backend-proto "http"
+        user-agent "waiter-async-status-check/1234"
         async-request-store-atom (atom {})
         request-id "request-2394613984619"
         reason-map {:request-id request-id}
@@ -351,15 +368,25 @@
         auth-params-map (auth/auth-params-map :internal "waiter@example.com")
         make-http-request-fn (fn [in-instance in-request end-route metric-group backend-proto]
                                (is (= instance in-instance))
+                               (is (contains? in-request :request-id))
+                               (is (str/starts-with? (str (:request-id in-request)) "waiter-async-status-check-"))
+                               (is (contains? in-request :request-time))
                                (is (= (assoc auth-params-map
                                         :body nil
-                                        :headers {}
+                                        :client-protocol "HTTP/1.1"
+                                        :headers {"host" instance-host
+                                                  "user-agent" "waiter-async-status-check/1234"
+                                                  "x-cid" "UNKNOWN"}
+                                        :internal-protocol "HTTP/1.1"
                                         :query-string "a=b&c=d|e"
-                                        :request-method :get)
-                                      in-request))
+                                        :request-method :get
+                                        :scheme "http"
+                                        :uri location)
+                                      (dissoc in-request :request-id :request-time)))
                                (is (= "/location/request-2394613984619" end-route))
                                (is (= "test-metric-group" metric-group))
-                               (is (= "http" backend-proto)))
+                               (is (= "http" backend-proto))
+                               (async/go {}))
         instance-rpc-chan (async/chan 1)
         complete-async-request-atom (atom nil)
         response {}]
@@ -377,9 +404,12 @@
       (let [request-properties {:async-check-interval-ms async-check-interval-ms
                                 :async-request-max-status-checks async-request-max-status-checks
                                 :async-request-timeout-ms async-request-timeout-ms}
+            descriptor {:service-description {"backend-proto" backend-proto
+                                              "metric-group" metric-group}
+                        :service-id service-id}
             {:keys [headers]} (post-process-async-request-response
                                 router-id async-request-store-atom make-http-request-fn auth-params-map
-                                instance-rpc-chan response service-id metric-group backend-proto instance
+                                instance-rpc-chan user-agent response descriptor instance
                                 reason-map request-properties location query-string)]
         (is (get @async-request-store-atom request-id))
         (is (= (str "/waiter-async/status/" request-id "/" router-id "/" service-id "/" host "/" port location "?" query-string)

--- a/waiter/test/waiter/request_log_test.clj
+++ b/waiter/test/waiter/request_log_test.clj
@@ -80,6 +80,7 @@
                   :instance-proto "instance-proto"
                   :latest-service-id "latest-service-id"
                   :protocol "HTTP/2.0"
+                  :request-type "test-request"
                   :status 200
                   :waiter-api-call? false}]
     (is (= {:authentication-method "cookie"
@@ -97,6 +98,7 @@
             :latest-service-id "latest-service-id"
             :metric-group "service-metric-group"
             :principal "principal@DOMAIN.COM"
+            :request-type "test-request"
             :response-content-length "40"
             :response-content-type "application/xml"
             :response-location "/foo/bar"


### PR DESCRIPTION
## Changes proposed in this PR

- adds request type to the request log
- adds request log for health check requests
- adds request log for waiter ping requests
- adds request log for async status check requests


## Why are we making these changes?

Simplifies debugging of waiter-async and health check requests to the backend.

### Example request logs:

<img width="1600" alt="request-log-example" src="https://user-images.githubusercontent.com/6611249/70730966-898ed700-1ccb-11ea-811a-33e93daa5c9e.png">

