### PR TITLE
adds command for hard-deleting soft-deleted tokens

### DIFF
--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -18,6 +18,7 @@
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [plumbing.core :as pc]
+            [token-syncer.commands.cleanup :as cleanup]
             [token-syncer.commands.ping :as ping]
             [token-syncer.commands.syncer :as syncer]
             [token-syncer.main :as main])
@@ -840,3 +841,38 @@
                 (is (= expected-result actual-result))))
             (finally
               (cleanup-token waiter-api waiter-urls token-name))))))))
+
+(deftest ^:integration test-cleanup-token
+  (testing "token cleanup on cluster"
+    (let [cluster-url (first (waiter-urls))
+          {:keys [load-token store-token] :as waiter-api} (waiter-api)
+          token-name (str "test-cleanup-token-" (UUID/randomUUID))
+          current-time-ms (System/currentTimeMillis)
+          last-update-time-ms (- current-time-ms 10000)]
+
+      ;; ARRANGE
+      (store-token cluster-url token-name nil
+                   (assoc basic-description
+                     "cluster" (waiter-url->cluster cluster-url)
+                     "cpus" 1.0
+                     "deleted" true
+                     "last-update-time" last-update-time-ms
+                     "last-update-user" "auth-user"
+                     "owner" "test-user"
+                     "root" cluster-url))
+
+      (try
+        ;; ACT
+        (let [actual-result (cleanup/cleanup-tokens waiter-api cluster-url current-time-ms)]
+
+          ;; ASSERT
+          (is (= #{token-name} actual-result))
+          (is (= {:description {}
+                  :headers {"content-type" "application/json"
+                            "etag" ""}
+                  :status 404
+                  :token-etag ""}
+                 (load-token cluster-url token-name))))
+
+        (finally
+          (cleanup-token waiter-api [cluster-url] token-name))))))

--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -230,10 +230,8 @@
                 (is (= expected-result actual-result))
                 (doseq [waiter-url waiter-urls]
                   (is (= {:description {}
-                          :headers {"content-type" "application/json"
-                                    "etag" ""}
-                          :status 404
-                          :token-etag ""}
+                          :headers {"content-type" "application/json"}
+                          :status 404}
                          (load-token waiter-url token-name))))))))
         (finally
           (cleanup-token waiter-api waiter-urls token-name))))))
@@ -683,10 +681,8 @@
                   (map
                     (fn [waiter-url]
                       (is (= {:description {}
-                              :headers {"content-type" "application/json"
-                                        "etag" ""}
-                              :status 404
-                              :token-etag ""}
+                              :headers {"content-type" "application/json"}
+                              :status 404}
                              (load-token waiter-url token-name))))
                     waiter-urls))))))
         (finally
@@ -868,10 +864,8 @@
           ;; ASSERT
           (is (= #{token-name} actual-result))
           (is (= {:description {}
-                  :headers {"content-type" "application/json"
-                            "etag" ""}
-                  :status 404
-                  :token-etag ""}
+                  :headers {"content-type" "application/json"}
+                  :status 404}
                  (load-token cluster-url token-name))))
 
         (finally

--- a/token-syncer/src/token_syncer/commands/cleanup.clj
+++ b/token-syncer/src/token_syncer/commands/cleanup.clj
@@ -1,0 +1,63 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns token-syncer.commands.cleanup
+  (:require [clj-time.core :as t]
+            [clojure.tools.logging :as log]
+            [token-syncer.utils :as utils]))
+
+(defn cleanup-tokens
+  "Reads the latest tokens from the specified cluster and hard-deletes all the soft-deleted tokens last
+   updated before the specified time."
+  [{:keys [hard-delete-token load-token-list]} cluster-url before-epoch-time]
+  (let [index-entries (load-token-list cluster-url)
+        soft-deleted-index-entries (filter (fn [{:strs [deleted last-update-time]}]
+                                             (and (true? deleted)
+                                                  (< (utils/iso8601->millis last-update-time) before-epoch-time)))
+                                           index-entries)]
+    (log/info "found" (count soft-deleted-index-entries) "qualifying soft-deleted token(s) out of"
+              (count index-entries) "total token(s) on" cluster-url)
+    (doseq [{:strs [etag last-update-time token]} soft-deleted-index-entries]
+      (log/info "hard-deleting token" token "with etag" etag "last updated on" last-update-time)
+      (hard-delete-token cluster-url token etag))
+    (log/info "hard-deleted" (count soft-deleted-index-entries) "token(s) on cluster" cluster-url)
+    (->> soft-deleted-index-entries
+      (map #(get % "token"))
+      (into #{}))))
+
+(def cleanup-tokens-config
+  {:execute-command (fn execute-cleanup-tokens-command
+                      [{:keys [waiter-api]} {:keys [options]} arguments]
+                      (let [{:keys [before]} options]
+                        (if-not (= (count arguments) 1)
+                          {:exit-code 1
+                           :message (str "expected one argument URL, provided " (count arguments) ": " (vec arguments))}
+                          (let [before-time (if before
+                                              (Long/parseLong before)
+                                              (- (System/currentTimeMillis) (-> 1 t/weeks t/in-millis)))
+                                cluster-url (first arguments)]
+                            (log/info "hard-deleting tokens from" cluster-url "soft-deleted before"
+                                      (utils/millis->iso8601 before-time))
+                            (cleanup-tokens waiter-api cluster-url before-time)
+                            {:exit-code 0
+                             :message "exiting with code 0"}))))
+   :option-specs [["-b" "--before"
+                   (str "Hard-delete tokens soft-deleted before the specified time. "
+                        "Must be specified in as an epoch time. "
+                        "The default value is 7 days before now.")]]
+   :retrieve-documentation (fn retrieve-sync-clusters-documentation
+                             [command-name _]
+                             {:description (str "Hard-deletes soft-deleted tokens on the specified cluster")
+                              :usage (str command-name " [OPTION]... URL")})})

--- a/token-syncer/src/token_syncer/main.clj
+++ b/token-syncer/src/token_syncer/main.clj
@@ -19,6 +19,7 @@
             [qbits.jet.client.http :as http]
             [token-syncer.cli :as cli]
             [token-syncer.commands.backup :as backup]
+            [token-syncer.commands.cleanup :as cleanup]
             [token-syncer.commands.ping :as ping]
             [token-syncer.commands.syncer :as syncer]
             [token-syncer.waiter :as waiter])
@@ -113,6 +114,7 @@
     (log/info "command-line arguments:" (vec args))
     (let [token-syncer-command-config (assoc base-command-config :command-name "token-syncer")
           context {:sub-command->config {"backup-tokens" backup/backup-tokens-config
+                                         "cleanup-tokens" cleanup/cleanup-tokens-config
                                          "ping-token" ping/ping-token-config
                                          "sync-clusters" syncer/sync-clusters-config}}
           {:keys [exit-code message]} (cli/process-command token-syncer-command-config context args)]

--- a/token-syncer/src/token_syncer/utils.clj
+++ b/token-syncer/src/token_syncer/utils.clj
@@ -18,6 +18,8 @@
             [clj-time.core :as t]
             [clj-time.format :as f]))
 
+(def ^:private iso8601-formatter (f/with-zone (:date-time f/formatters) (t/default-time-zone)))
+
 (defn successful?
   "Returns true if the response has a 2XX status code."
   [{:keys [status]}]
@@ -26,14 +28,9 @@
 (defn iso8601->millis
   "Convert the ISO 8601 string to numeric milliseconds."
   [date-str]
-  (-> (:date-time f/formatters)
-    (f/with-zone (t/default-time-zone))
-    (f/parse date-str)
-    .getMillis))
+  (.getMillis (f/parse iso8601-formatter date-str)))
 
 (defn millis->iso8601
   "Convert the numeric milliseconds to ISO 8601 string."
   [epoch-time]
-  (-> (:date-time f/formatters)
-    (f/with-zone (t/default-time-zone))
-    (f/unparse (tc/from-long epoch-time))))
+  (f/unparse iso8601-formatter (tc/from-long epoch-time)))

--- a/token-syncer/src/token_syncer/utils.clj
+++ b/token-syncer/src/token_syncer/utils.clj
@@ -13,9 +13,27 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(ns token-syncer.utils)
+(ns token-syncer.utils
+  (:require [clj-time.coerce :as tc]
+            [clj-time.core :as t]
+            [clj-time.format :as f]))
 
 (defn successful?
   "Returns true if the response has a 2XX status code."
   [{:keys [status]}]
   (and (integer? status) (<= 200 status 299)))
+
+(defn iso8601->millis
+  "Convert the ISO 8601 string to numeric milliseconds."
+  [date-str]
+  (-> (:date-time f/formatters)
+    (f/with-zone (t/default-time-zone))
+    (f/parse date-str)
+    .getMillis))
+
+(defn millis->iso8601
+  "Convert the numeric milliseconds to ISO 8601 string."
+  [epoch-time]
+  (-> (:date-time f/formatters)
+    (f/with-zone (t/default-time-zone))
+    (f/unparse (tc/from-long epoch-time))))

--- a/token-syncer/src/token_syncer/waiter.clj
+++ b/token-syncer/src/token_syncer/waiter.clj
@@ -100,20 +100,12 @@
                        :status status
                        :url token-list-url})))))
 
-(defn- iso8601->millis
-  "Convert the ISO 8601 string to numeric milliseconds."
-  [date-str]
-  (-> (:date-time f/formatters)
-      (f/with-zone (t/default-time-zone))
-      (f/parse date-str)
-      .getMillis))
-
 (defn- convert-iso8601->millis
   [token-description]
   (loop [loop-token-description token-description
          nested-last-update-time-path ["last-update-time"]]
     (if (get-in loop-token-description nested-last-update-time-path)
-      (recur (update-in loop-token-description nested-last-update-time-path iso8601->millis)
+      (recur (update-in loop-token-description nested-last-update-time-path utils/iso8601->millis)
              (concat ["previous"] nested-last-update-time-path))
       loop-token-description)))
 

--- a/token-syncer/test/token_syncer/commands/cleanup_test.clj
+++ b/token-syncer/test/token_syncer/commands/cleanup_test.clj
@@ -1,0 +1,86 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns token-syncer.commands.cleanup-test
+  (:require [clojure.test :refer :all]
+            [token-syncer.cli :as cli]
+            [token-syncer.commands.cleanup :refer :all]
+            [token-syncer.utils :as utils]))
+
+(deftest test-cleanup
+  (let [test-cluster-url "http://www.test-cluster.com"
+        current-time-ms (System/currentTimeMillis)
+        one-week-ago-ms (- current-time-ms (* 7 24 60 60 1000))
+        deleted-tokens-atom (atom #{})
+        waiter-api {:hard-delete-token (fn [cluster-url token etag]
+                                         (is (= test-cluster-url cluster-url))
+                                         (is (= etag (str "etag-" token)))
+                                         (swap! deleted-tokens-atom conj token))
+                    :load-token-list (fn [cluster-url]
+                                       (is (= test-cluster-url cluster-url))
+                                       [{"etag" "etag-token-1"
+                                         "last-update-time" (utils/millis->iso8601 (- one-week-ago-ms 10000))
+                                         "token" "token-1"}
+                                        {"deleted" true
+                                         "etag" "etag-token-2"
+                                         "last-update-time" (utils/millis->iso8601 (- one-week-ago-ms 10000))
+                                         "token" "token-2"}
+                                        {"deleted" true
+                                         "etag" "etag-token-3"
+                                         "last-update-time" (utils/millis->iso8601 (+ one-week-ago-ms 10000))
+                                         "token" "token-3"}
+                                        {"deleted" true
+                                         "etag" "etag-token-4"
+                                         "last-update-time" (utils/millis->iso8601 (- one-week-ago-ms 30000))
+                                         "token" "token-4"}
+                                        {"deleted" false
+                                         "etag" "etag-token-5"
+                                         "last-update-time" (utils/millis->iso8601 (- one-week-ago-ms 10000))
+                                         "token" "token-5"}])}
+        actual-result (cleanup-tokens waiter-api test-cluster-url current-time-ms)
+        expected-result #{"token-2" "token-3" "token-4"}]
+
+    (is (= expected-result actual-result))
+    (is (= expected-result @deleted-tokens-atom))))
+
+(deftest test-cleanup-tokens-config
+  (let [test-command-config (assoc cleanup-tokens-config :command-name "test-command")
+        waiter-api {:load-token (constantly {})
+                    :load-token-list (constantly {})}
+        context {:waiter-api waiter-api}]
+    (let [args []]
+      (is (= {:exit-code 1
+              :message "test-command: expected one argument URL, provided 0: []"}
+             (cli/process-command test-command-config context args))))
+    (with-out-str
+      (let [args ["-h"]]
+        (is (= {:exit-code 0
+                :message "test-command: displayed documentation"}
+               (cli/process-command test-command-config context args)))))
+    (let [args ["some-file.txt" "cluster-1.com"]]
+      (is (= {:exit-code 1
+              :message "test-command: expected one argument URL, provided 2: [\"some-file.txt\" \"cluster-1.com\"]"}
+             (cli/process-command test-command-config context args))))
+    (let [args ["http://cluster-1.com"]
+          invocation-promise (promise)]
+      (with-redefs [cleanup-tokens (fn [in-waiter-api cluster-url before-epoch-time]
+                                     (is (= waiter-api in-waiter-api))
+                                     (is (= (first args) cluster-url))
+                                     (is (number? before-epoch-time))
+                                     (deliver invocation-promise ::invoked))]
+        (is (= {:exit-code 0
+                :message "test-command: exiting with code 0"}
+               (cli/process-command test-command-config context args)))
+        (is (= ::invoked (deref invocation-promise 0 ::un-initialized)))))))

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -350,7 +350,7 @@
                      (assoc "root" token-root))))
           :headers {"etag" token-hash}))
       (throw (ex-info (str "Couldn't find token " token)
-                      {:headers {"etag" token-hash}
+                      {:headers {}
                        :status 404
                        :token token
                        :log-level :warn})))))


### PR DESCRIPTION
## Changes proposed in this PR

- adds command for hard-deleting soft-deleted tokens

## Why are we making these changes?

We would like to clean up soft-deleted tokens from waiter clusters.

