### PR TITLE
adds leadership gauge

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -666,6 +666,7 @@
                    (let [leader-latch-path (str base-path "/" leader-latch-relative-path)
                          latch (LeaderLatch. curator leader-latch-path router-id)]
                      (.start latch)
+                     (metrics/waiter-gauge #(if (.hasLeadership latch) 1 0) "core" "leader")
                      latch))
    :local-usage-agent (pc/fnk [] (agent {}))
    :offers-allowed-semaphore (pc/fnk [[:settings [:work-stealing max-in-flight-offers]]]


### PR DESCRIPTION
## Changes proposed in this PR

- adds leadership gauge

## Why are we making these changes?

Having the metric allows us to track and plot leadership changes.

