### PR TITLE
updates jet to 0.7.10-20191223_195635-g6e9ced1

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -45,7 +45,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20190924_091442-gfccc405"
+                 [twosigma/jet "0.7.10-20191223_195635-g6e9ced1"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]


### PR DESCRIPTION
## Changes proposed in this PR

- updates jet to 0.7.10-20191223_195635-g6e9ced1

## Why are we making these changes?

Merges changes from https://github.com/twosigma/jet/pull/42 to avoid NPE due to race in accessing session volatile variable.
