### PR TITLE
handles writing Nan and infinite double/float values to json

### DIFF
--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -143,6 +143,12 @@
     (instance? Process v) (str v)
     (instance? ValidationError v) (str v)
     (symbol? v) (str v)
+    (or
+      (and (double? v) (or (Double/isInfinite v) (Double/isNaN v)))
+      (and (float? v) (or (Float/isInfinite v) (Float/isNaN v))))
+    (do
+      (log/warn "Unsupported json value for number where" k "maps to" v)
+      (str v))
     :else v))
 
 (defn clj->json

--- a/waiter/test/waiter/util/utils_test.clj
+++ b/waiter/test/waiter/util/utils_test.clj
@@ -396,7 +396,15 @@
       (is (= '(("foo" "bar") ("baz" "qux")) (stringify-elements :k [[#"foo" "bar"] [#"baz" "qux"]]))))
 
     (testing "should convert symbols to strings, inlcuding their namespace"
-      (is (= "waiter.cors/pattern-based-validator" (stringify-elements :k 'waiter.cors/pattern-based-validator))))))
+      (is (= "waiter.cors/pattern-based-validator" (stringify-elements :k 'waiter.cors/pattern-based-validator))))
+
+    (testing "NaN and Infinity"
+      (is (= "NaN" (stringify-elements :k Double/NaN)))
+      (is (= "Infinity" (stringify-elements :k Double/POSITIVE_INFINITY)))
+      (is (= "-Infinity" (stringify-elements :k Double/NEGATIVE_INFINITY)))
+      (is (= "NaN" (stringify-elements :k Float/NaN)))
+      (is (= "Infinity" (stringify-elements :k Float/POSITIVE_INFINITY)))
+      (is (= "-Infinity" (stringify-elements :k Float/NEGATIVE_INFINITY))))))
 
 (deftest test-deep-sort-map
   (let [deep-seq (fn [data] (walk/postwalk #(if (or (map? %) (seq? %)) (seq %) %) data))]


### PR DESCRIPTION
## Changes proposed in this PR

- handles writing Nan and infinite double/float values to json

## Why are we making these changes?

We've seen exceptions thrown in production code where data is NaN.


