### PR TITLE
requires explicit inclusion of service metrics in /apps/<service-id> endpoint

### DIFF
--- a/waiter/integration/waiter/async_request_integration_test.clj
+++ b/waiter/integration/waiter/async_request_integration_test.clj
@@ -37,7 +37,7 @@
       (with-service-cleanup
         service-id
         (testing "validate-in-flight-request-counters"
-          (let [service-data (service-settings waiter-url service-id)
+          (let [service-data (service-settings waiter-url service-id :query-params {"include" "metrics"})
                 {:keys [async outstanding successful total] :or {async 0} :as request-counts}
                 (get-in service-data [:metrics :aggregate :counters :request-counts])]
             (is (= 1 successful) (str request-counts))
@@ -97,7 +97,7 @@
         (testing "validate-in-flight-request-counters"
           (log/info "validate in-flight request counters")
           (is (wait-for
-                #(let [service-data (service-settings waiter-url service-id)
+                #(let [service-data (service-settings waiter-url service-id :query-params {"include" "metrics"})
                        request-counts (get-in service-data [:metrics :aggregate :counters :request-counts])]
                    (log/info "request counts" service-id request-counts)
                    (and (= 1 (get request-counts :async))
@@ -128,7 +128,7 @@
           (testing "validate-303-does-not-reset-in-flight-request-counters"
             (log/info "validating 303 status does not reset in-flight request counters")
             (is (wait-for
-                  #(let [service-data (service-settings waiter-url service-id)
+                  #(let [service-data (service-settings waiter-url service-id :query-params {"include" "metrics"})
                          request-counts (get-in service-data [:metrics :aggregate :counters :request-counts])]
                      (log/info "request counts" service-id request-counts)
                      (and (= 1 (get request-counts :async))
@@ -149,7 +149,7 @@
         (testing "validate-completed-request-counters"
           (log/info "validate completed request counters")
           (is (wait-for
-                #(let [service-data (service-settings waiter-url service-id)
+                #(let [service-data (service-settings waiter-url service-id :query-params {"include" "metrics"})
                        request-counts (get-in service-data [:metrics :aggregate :counters :request-counts])]
                    (log/info "request counts" service-id request-counts)
                    (and (zero? (get request-counts :async))
@@ -228,7 +228,7 @@
           (Thread/sleep inter-router-metrics-interval-ms) ;; allow routers to sync metrics
           (let [expected-total (inc num-threads)
                 {:keys [async outstanding successful total] :as request-counts}
-                (-> (service-settings waiter-url service-id)
+                (-> (service-settings waiter-url service-id :query-params {"include" "metrics"})
                     (get-in [:metrics :aggregate :counters :request-counts]))]
             (is (= expected-total total) (str request-counts))
             (is (= expected-total (+ async successful)) (str request-counts))
@@ -245,7 +245,7 @@
                 (is (str/includes? body "Deleted request-id")))))
           (Thread/sleep inter-router-metrics-interval-ms) ;; allow routers to sync metrics
           (let [{:keys [async outstanding] :as request-counts}
-                (-> (service-settings waiter-url service-id)
+                (-> (service-settings waiter-url service-id :query-params {"include" "metrics"})
                     (get-in [:metrics :aggregate :counters :request-counts]))
                 num-requests-alive (- num-threads num-requests-to-delete)]
             (is (<= 0 async num-requests-alive) (str request-counts))
@@ -275,7 +275,7 @@
             (Thread/sleep inter-router-metrics-interval-ms) ;; allow routers to sync metrics
             (let [expected-total (inc num-threads)
                   {:keys [async outstanding successful total] :as request-counts}
-                  (-> (service-settings waiter-url service-id)
+                  (-> (service-settings waiter-url service-id :query-params {"include" "metrics"})
                       (get-in [:metrics :aggregate :counters :request-counts]))]
               (is (= expected-total total) (str request-counts))
               (is (= expected-total successful) (str request-counts))

--- a/waiter/integration/waiter/instance_reservation_test.clj
+++ b/waiter/integration/waiter/instance_reservation_test.clj
@@ -78,7 +78,7 @@
           ;; allow time for long requests to be processed
           (is (wait-for
                 (fn []
-                  (let [service-data (service-settings waiter-url service-id)
+                  (let [service-data (service-settings waiter-url service-id :query-params {"include" "metrics"})
                         request-counts (get-in service-data [:metrics :aggregate :counters :request-counts])]
                     (= num-routers (get request-counts :outstanding))))
                 :interval 200 :timeout 2000 :unit-multiplier 1))

--- a/waiter/integration/waiter/metrics_output_test.clj
+++ b/waiter/integration/waiter/metrics_output_test.clj
@@ -151,7 +151,9 @@
             (is (empty? (get metrics-response "waiter")) (str metrics-response)))))
 
       (doseq [service-id @all-service-ids-atom]
-        (let [apps-response (service-settings waiter-url service-id :keywordize-keys false)
+        (let [apps-response (service-settings waiter-url service-id
+                                              :keywordize-keys false
+                                              :query-params {"include" "metrics"})
               routers->metrics (get-in apps-response ["metrics" "routers"])
               aggregate-metrics (get-in apps-response ["metrics" "aggregate"])]
           (when (get apps-response "error-messages")

--- a/waiter/integration/waiter/streaming_test.clj
+++ b/waiter/integration/waiter/streaming_test.clj
@@ -50,7 +50,7 @@
           (log/debug "sleeping for" sleep-period "ms")
           (Thread/sleep sleep-period))
         ; assert request response size metrics
-        (let [service-settings (service-settings waiter-url service-id)
+        (let [service-settings (service-settings waiter-url service-id :query-params {"include" "metrics"})
               _ (log/info "metrics" (get service-settings :metrics))
               aggregate-metrics (get-in service-settings [:metrics :aggregate])
               request-counts (get-in aggregate-metrics [:counters :request-counts])

--- a/waiter/integration/waiter/websocket_integration_test.clj
+++ b/waiter/integration/waiter/websocket_integration_test.clj
@@ -603,7 +603,7 @@
           (is (<= (* 0.75 num-requests) (->> iteration-results vals (filter #{:success}) count)) (str iteration-results)))
         (is (pos? (num-instances waiter-url service-id)))
         (Thread/sleep 1000) ;; allow metrics to be sync-ed
-        (let [service-data (service-settings waiter-url service-id)
+        (let [service-data (service-settings waiter-url service-id :query-params {"include" "metrics"})
               request-counts (get-in service-data [:metrics :aggregate :counters :request-counts])
               response-status (get-in service-data [:metrics :aggregate :counters :response-status])]
           (is (= num-requests (reduce + (vals (select-keys response-status [:1000 :1006])))) (str response-status))

--- a/waiter/integration/waiter/work_stealing_integration_test.clj
+++ b/waiter/integration/waiter/work_stealing_integration_test.clj
@@ -36,7 +36,8 @@
           {:keys [service-id]} (request-fn waiter-url extra-headers)
           print-metrics (fn [service-id]
                           (let [router-ids (keys (routers waiter-url))
-                                service-metrics (:metrics (service-settings waiter-url service-id))]
+                                service-data (service-settings waiter-url service-id :query-params {"include" "metrics"})
+                                service-metrics (:metrics service-data)]
                             (log/info "Aggregate process metrics:" (get-in service-metrics [:aggregate :timers :process]))
                             (doseq [router-id router-ids]
                               (log/info router-id " process metrics:" (get-in service-metrics [:routers (keyword router-id) :timers :process])))))]
@@ -71,7 +72,7 @@
             (is (pos? (count responses-map))
                 "Error in receiving responses, a possible bug in parallelize-requests!")
             (log/info (str "Response distribution:" responses-map))
-            (let [service-settings (service-settings waiter-url service-id)
+            (let [service-settings (service-settings waiter-url service-id :query-params {"include" "metrics"})
                   num-instances (count (get-in service-settings [:instances :active-instances]))]
               (log/info (str "Num instances:" num-instances))
               (when (not= num-instances (count responses-map))

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -962,7 +962,7 @@
   {:pre [(not (str/blank? waiter-url))]
    :post [%]}
   (let [routers (routers waiter-url)
-        settings (service-settings waiter-url service-id)
+        settings (service-settings waiter-url service-id :query-params {"include" "metrics"})
         assigned? (fn [router-id]
                     (let [slots (get-in
                                   settings

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -550,6 +550,7 @@
                                                  :port 31045,
                                                  :started-at started-time}]}})
         (let [request {:headers {"accept" "application/json"}
+                       :query-string "include=metrics"
                        :request-method :get
                        :uri (str "/apps/" service-id)}
               {:keys [body headers status]} (ring-handler request)]
@@ -577,7 +578,9 @@
         (reset! router-state-atom {:service-id->failed-instances {service-id [{:id (str service-id ".F"), :service-id service-id}]}
                                    :service-id->healthy-instances {service-id [{:id (str service-id ".A"), :service-id service-id}]}
                                    :service-id->killed-instances {service-id [{:id (str service-id ".K"), :service-id service-id}]}})
-        (let [request {:request-method :get, :uri (str "/apps/" service-id)}
+        (let [request {:query-string "include=metrics"
+                       :request-method :get
+                       :uri (str "/apps/" service-id)}
               {:keys [body headers status]} (ring-handler request)]
           (is (= 200 status))
           (is (= expected-json-response-headers headers))


### PR DESCRIPTION
## Changes proposed in this PR

- requires (**backwards incompatible**) explicit inclusion of service metrics in /apps/<service-id> endpoint

## Why are we making these changes?

Avoids relatively expensive inter-router communication when metrics is not needed in the `/apps/<service-id>` endpoint.

