### PR TITLE
adds jetty server metrics for threads and connectors

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -45,7 +45,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20191223_195635-g6e9ced1"
+                 [twosigma/jet "0.7.10-20191230_163338-g0dabe28"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]


### PR DESCRIPTION
## Related jet change: 

- https://github.com/twosigma/jet/pull/43

## Changes proposed in this PR

- adds jetty server metrics for threads and connectors

## Why are we making these changes?

It provides visibility into the state of the server threads and connection acceptances.

### Example metrics output:

<img width="437" alt="Screen Shot 2019-12-30 at 1 41 11 PM" src="https://user-images.githubusercontent.com/6611249/71597770-16c68e00-2b0a-11ea-9a08-d42b189e550e.png">

