### PR TITLE
adds request and response streaming telemetry

### DIFF
--- a/waiter/src/waiter/metrics.clj
+++ b/waiter/src/waiter/metrics.clj
@@ -504,7 +504,10 @@
    :stream-onto-resp-chan (service-timer service-id "stream-onto-resp-chan")
    :stream-read-body (service-timer service-id "stream-read-body")
    :stream-request-rate (service-meter service-id "stream-request-rate")
-   :throughput-meter (service-meter service-id "stream-throughput")})
+   :throughput-meter (service-meter service-id "stream-throughput")
+   :throughput-meter-global (waiter-meter "streaming" "response-bytes")
+   :throughput-packets-meter (service-meter service-id "streaming" "response-packets")
+   :throughput-packets-meter-global (waiter-meter "streaming" "response-packets")})
 
 (defn duration-between
   "Returns the duration (interval) elapsed between the start and end times.

--- a/waiter/src/waiter/metrics.clj
+++ b/waiter/src/waiter/metrics.clj
@@ -504,10 +504,10 @@
    :stream-onto-resp-chan (service-timer service-id "stream-onto-resp-chan")
    :stream-read-body (service-timer service-id "stream-read-body")
    :stream-request-rate (service-meter service-id "stream-request-rate")
+   :throughput-iterations-meter (service-meter service-id "streaming" "response-iterations")
+   :throughput-iterations-meter-global (waiter-meter "streaming" "response-iterations")
    :throughput-meter (service-meter service-id "stream-throughput")
-   :throughput-meter-global (waiter-meter "streaming" "response-bytes")
-   :throughput-packets-meter (service-meter service-id "streaming" "response-packets")
-   :throughput-packets-meter-global (waiter-meter "streaming" "response-packets")})
+   :throughput-meter-global (waiter-meter "streaming" "response-bytes")})
 
 (defn duration-between
   "Returns the duration (interval) elapsed between the start and end times.

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -297,8 +297,8 @@
                                           (when (pos? bytes-read)
                                             (meters/mark! throughput-meter bytes-read)
                                             (meters/mark! throughput-meter-global bytes-read)
-                                            (meters/mark! throughput-packets-meter 1)
-                                            (meters/mark! throughput-packets-meter-global 1)
+                                            (meters/mark! throughput-packets-meter)
+                                            (meters/mark! throughput-packets-meter-global)
                                             (swap! bytes-streamed-atom + bytes-read)
                                             (swap! statsd-unreported-bytes-atom + bytes-read))
                                           (if complete?
@@ -495,8 +495,8 @@
                             (do
                               (meters/mark! throughput-meter bytes-read)
                               (meters/mark! throughput-meter-global bytes-read)
-                              (meters/mark! throughput-packets-meter 1)
-                              (meters/mark! throughput-packets-meter-global 1)
+                              (meters/mark! throughput-packets-meter)
+                              (meters/mark! throughput-packets-meter-global)
                               (if (or (zero? bytes-read) ;; don't write empty buffer, channel may be potentially closed
                                       (timers/start-stop-time!
                                         stream-onto-resp-chan

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -290,15 +290,15 @@
                                           statsd-unreported-bytes-atom (atom 0)
                                           throughput-meter (metrics/service-meter service-id "streaming" "request-bytes")
                                           throughput-meter-global (metrics/waiter-meter "streaming" "request-bytes")
-                                          throughput-packets-meter (metrics/service-meter service-id "streaming" "request-packets")
-                                          throughput-packets-meter-global (metrics/waiter-meter "streaming" "request-packets")]
+                                          throughput-iterations-meter (metrics/service-meter service-id "streaming" "request-iterations")
+                                          throughput-iterations-meter-global (metrics/waiter-meter "streaming" "request-iterations")]
                                       (fn report-request-size-metrics [bytes-read complete?]
                                         (try
                                           (when (pos? bytes-read)
                                             (meters/mark! throughput-meter bytes-read)
                                             (meters/mark! throughput-meter-global bytes-read)
-                                            (meters/mark! throughput-packets-meter)
-                                            (meters/mark! throughput-packets-meter-global)
+                                            (meters/mark! throughput-iterations-meter)
+                                            (meters/mark! throughput-iterations-meter-global)
                                             (swap! bytes-streamed-atom + bytes-read)
                                             (swap! statsd-unreported-bytes-atom + bytes-read))
                                           (if complete?
@@ -469,7 +469,7 @@
    {:keys [requests-streaming requests-waiting-to-stream service-id
            stream stream-back-pressure stream-complete-rate stream-exception-meter
            stream-onto-resp-chan stream-read-body stream-request-rate
-           throughput-meter throughput-meter-global throughput-packets-meter throughput-packets-meter-global]}]
+           throughput-iterations-meter throughput-iterations-meter-global throughput-meter throughput-meter-global]}]
   (async/go
     (let [output-stream-atom (atom nil)]
       (try
@@ -495,8 +495,8 @@
                             (do
                               (meters/mark! throughput-meter bytes-read)
                               (meters/mark! throughput-meter-global bytes-read)
-                              (meters/mark! throughput-packets-meter)
-                              (meters/mark! throughput-packets-meter-global)
+                              (meters/mark! throughput-iterations-meter)
+                              (meters/mark! throughput-iterations-meter-global)
                               (if (or (zero? bytes-read) ;; don't write empty buffer, channel may be potentially closed
                                       (timers/start-stop-time!
                                         stream-onto-resp-chan

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -287,10 +287,18 @@
         request-body-streaming-counter (metrics/service-counter service-id "request-counts" "request-body-streaming")
         body-ch (async/chan 2048)
         report-request-size-metrics (let [bytes-streamed-atom (atom 0)
-                                          statsd-unreported-bytes-atom (atom 0)]
+                                          statsd-unreported-bytes-atom (atom 0)
+                                          throughput-meter (metrics/service-meter service-id "streaming" "request-bytes")
+                                          throughput-meter-global (metrics/waiter-meter "streaming" "request-bytes")
+                                          throughput-packets-meter (metrics/service-meter service-id "streaming" "request-packets")
+                                          throughput-packets-meter-global (metrics/waiter-meter "streaming" "request-packets")]
                                       (fn report-request-size-metrics [bytes-read complete?]
                                         (try
                                           (when (pos? bytes-read)
+                                            (meters/mark! throughput-meter bytes-read)
+                                            (meters/mark! throughput-meter-global bytes-read)
+                                            (meters/mark! throughput-packets-meter 1)
+                                            (meters/mark! throughput-packets-meter-global 1)
                                             (swap! bytes-streamed-atom + bytes-read)
                                             (swap! statsd-unreported-bytes-atom + bytes-read))
                                           (if complete?
@@ -458,10 +466,10 @@
   [{:keys [body error-chan]} confirm-live-connection request-abort-callback resp-chan
    {:keys [streaming-timeout-ms]}
    reservation-status-promise request-state-chan metric-group waiter-debug-enabled?
-   {:keys [throughput-meter requests-streaming requests-waiting-to-stream
-           stream-request-rate stream-complete-rate
-           stream-exception-meter stream-back-pressure stream-read-body
-           stream-onto-resp-chan stream service-id]}]
+   {:keys [requests-streaming requests-waiting-to-stream service-id
+           stream stream-back-pressure stream-complete-rate stream-exception-meter
+           stream-onto-resp-chan stream-read-body stream-request-rate
+           throughput-meter throughput-meter-global throughput-packets-meter throughput-packets-meter-global]}]
   (async/go
     (let [output-stream-atom (atom nil)]
       (try
@@ -486,6 +494,9 @@
                           (if-not (= -1 bytes-read)
                             (do
                               (meters/mark! throughput-meter bytes-read)
+                              (meters/mark! throughput-meter-global bytes-read)
+                              (meters/mark! throughput-packets-meter 1)
+                              (meters/mark! throughput-packets-meter-global 1)
                               (if (or (zero? bytes-read) ;; don't write empty buffer, channel may be potentially closed
                                       (timers/start-stop-time!
                                         stream-onto-resp-chan

--- a/waiter/src/waiter/websocket.clj
+++ b/waiter/src/waiter/websocket.clj
@@ -274,8 +274,8 @@
                      (fn ws-bytes-uploaded [bytes-streamed]
                        (meters/mark! throughput-meter bytes-streamed)
                        (meters/mark! throughput-meter-global bytes-streamed)
-                       (meters/mark! throughput-packets-meter 1)
-                       (meters/mark! throughput-packets-meter-global 1)
+                       (meters/mark! throughput-packets-meter)
+                       (meters/mark! throughput-packets-meter-global)
                        (send local-usage-agent metrics/update-last-request-time-usage-metric service-id (t/now))
                        (histograms/update! (metrics/service-histogram service-id "request-size") bytes-streamed)
                        (statsd/inc! metric-group "request_bytes" bytes-streamed))))
@@ -288,8 +288,8 @@
                      (fn ws-bytes-downloaded [bytes-streamed]
                        (meters/mark! throughput-meter bytes-streamed)
                        (meters/mark! throughput-meter-global bytes-streamed)
-                       (meters/mark! throughput-packets-meter 1)
-                       (meters/mark! throughput-packets-meter-global 1)
+                       (meters/mark! throughput-packets-meter)
+                       (meters/mark! throughput-packets-meter-global)
                        (histograms/update! (metrics/service-histogram service-id "response-size") bytes-streamed)
                        (statsd/inc! metric-group "response_bytes" bytes-streamed))))))
 

--- a/waiter/src/waiter/websocket.clj
+++ b/waiter/src/waiter/websocket.clj
@@ -257,27 +257,39 @@
    It is assumed the body is an input stream.
    The function buffers bytes, and pushes byte input streams onto the channel until the body input stream is exhausted."
   [request response descriptor {:keys [streaming-timeout-ms]} reservation-status-promise request-close-chan local-usage-agent
-   {:keys [requests-streaming requests-waiting-to-stream stream-back-pressure stream-read-body stream-onto-resp-chan throughput-meter]}]
+   {:keys [requests-streaming requests-waiting-to-stream stream-back-pressure stream-read-body stream-onto-resp-chan] :as metric-map}]
   (let [{:keys [service-description service-id]} descriptor
         {:strs [metric-group]} service-description]
     (counters/dec! requests-waiting-to-stream)
     (counters/inc! requests-streaming)
     ;; launch go-block to stream data from client to instance
     (let [client-in (:in request)
-          instance-out (-> response :request :out)]
+          instance-out (-> response :request :out)
+          throughput-meter (metrics/service-meter service-id "streaming" "request-bytes")
+          throughput-meter-global (metrics/waiter-meter "streaming" "request-bytes")
+          throughput-packets-meter (metrics/service-meter service-id "streaming" "request-packets")
+          throughput-packets-meter-global (metrics/waiter-meter "streaming" "request-packets")]
       (stream-helper "client" client-in "instance" instance-out streaming-timeout-ms reservation-status-promise
                      :instance-error request-close-chan stream-read-body stream-back-pressure
                      (fn ws-bytes-uploaded [bytes-streamed]
+                       (meters/mark! throughput-meter bytes-streamed)
+                       (meters/mark! throughput-meter-global bytes-streamed)
+                       (meters/mark! throughput-packets-meter 1)
+                       (meters/mark! throughput-packets-meter-global 1)
                        (send local-usage-agent metrics/update-last-request-time-usage-metric service-id (t/now))
                        (histograms/update! (metrics/service-histogram service-id "request-size") bytes-streamed)
                        (statsd/inc! metric-group "request_bytes" bytes-streamed))))
     ;; launch go-block to stream data from instance to client
     (let [client-out (:out request)
-          instance-in (-> response :request :in)]
+          instance-in (-> response :request :in)
+          {:keys [throughput-meter throughput-meter-global throughput-packets-meter throughput-packets-meter-global]} metric-map]
       (stream-helper "instance" instance-in "client" client-out streaming-timeout-ms reservation-status-promise
                      :client-error request-close-chan stream-onto-resp-chan stream-back-pressure
                      (fn ws-bytes-downloaded [bytes-streamed]
                        (meters/mark! throughput-meter bytes-streamed)
+                       (meters/mark! throughput-meter-global bytes-streamed)
+                       (meters/mark! throughput-packets-meter 1)
+                       (meters/mark! throughput-packets-meter-global 1)
                        (histograms/update! (metrics/service-histogram service-id "response-size") bytes-streamed)
                        (statsd/inc! metric-group "response_bytes" bytes-streamed))))))
 


### PR DESCRIPTION
## Changes proposed in this PR

- adds request and response streaming telemetry

## Why are we making these changes?

Helps us diagnose whether services are sending small/large packets of data.

