### PR TITLE
adds support for YAML format to the CLI

### DIFF
--- a/cli/integration/requirements.txt
+++ b/cli/integration/requirements.txt
@@ -1,5 +1,6 @@
 pip==9.0.1; python_version >= '3.6'
 pytest==4.3.0
 pytest-xdist==1.20.1
+pyyaml==5.1.2
 requests==2.20.0
 retrying==1.3.3

--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -3,10 +3,11 @@ import logging
 import os
 import pty
 import shlex
-
 import subprocess
 import tempfile
 from fcntl import fcntl, F_GETFL, F_SETFL
+
+import yaml
 
 from tests.waiter import util
 
@@ -134,6 +135,13 @@ def write_json(path, config):
         json.dump(config, outfile)
 
 
+def write_yaml(path, config):
+    """Writes the given config map as JSON to the given path."""
+    with open(path, 'w') as outfile:
+        logging.info('echo \'%s\' > %s' % (json.dumps(config), path))
+        yaml.safe_dump(config, outfile)
+
+
 class temp_config_file:
     """
     A context manager used to generate and subsequently delete a temporary
@@ -175,16 +183,22 @@ class temp_token_file:
     token JSON file for the CLI. Takes as input the token dictionary to use.
     """
 
-    def __init__(self, token_data):
+    def __init__(self, token_data, format='json'):
+        self.format = format
         self.token_data = token_data
 
-    def write_temp_json(self):
+    def write_temp_file(self):
         path = tempfile.NamedTemporaryFile(delete=False).name
-        write_json(path, self.token_data)
+        if self.format == 'json':
+            write_json(path, self.token_data)
+        elif self.format == 'yaml':
+            write_yaml(path, self.token_data)
+        else:
+            raise Exception(f'Unsupported format: {self.format}')
         return path
 
     def __enter__(self):
-        self.path = self.write_temp_json()
+        self.path = self.write_temp_file()
         return self.path
 
     def __exit__(self, _, __, ___):
@@ -206,18 +220,45 @@ def __show_json(waiter_url=None, token_name=None, flags=None):
     return cp, data
 
 
-def show_token(waiter_url=None, token_name=None, flags=None):
-    """Shows the token JSON corresponding to the given token name"""
-    cp, data = __show_json(waiter_url, token_name, flags)
+def __show_yaml(waiter_url=None, token_name=None, flags=None):
+    """Invokes show on the given token with --yaml, and returns the parsed YAML"""
+    flags = (flags + ' ') if flags else ''
+    cp = show(waiter_url, token_name, flags, '--yaml')
+    data = yaml.safe_load(stdout(cp))
+    return cp, data
+
+
+def __show(file_format, waiter_url=None, token_name=None, flags=None):
+    if file_format == 'json':
+        return __show_json(waiter_url, token_name, flags)
+    elif file_format == 'yaml':
+        return __show_yaml(waiter_url, token_name, flags)
+    else:
+        raise Exception(f'Unsupported file format: {file_format}')
+
+
+def show_token(file_format, waiter_url=None, token_name=None, flags=None):
+    """Shows the token JSON/YAML corresponding to the given token name"""
+    cp, data = __show(file_format, waiter_url, token_name, flags)
     token_list = [entities['token'] for entities in data['clusters'].values()]
     return cp, token_list
 
 
-def show_token_services(waiter_url=None, token_name=None, flags=None):
-    """Shows the token JSON corresponding to the given token name's services"""
-    cp, data = __show_json(waiter_url, token_name, flags)
+def show_token_services(file_format, waiter_url=None, token_name=None, flags=None):
+    """Shows the token JSON /YAML corresponding to the given token name's services"""
+    cp, data = __show(file_format, waiter_url, token_name, flags)
     services = [s for entities in data['clusters'].values() for s in entities['services']]
     return cp, services
+
+
+def dump(file_format, data):
+    """Serializes data to a string in the specified format."""
+    if file_format == 'json':
+        return json.dumps(data).encode('utf8')
+    elif file_format == 'yaml':
+        return yaml.safe_dump(data).encode('utf8')
+    else:
+        raise Exception(f'Unsupported file format: {file_format}')
 
 
 def output(cp):

--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -128,17 +128,27 @@ def update_minimal(waiter_url=None, token_name=None, flags=None, **kwargs):
     return cp
 
 
+def dump(file_format, data):
+    """Serializes data to a string in the specified format."""
+    if file_format == 'json':
+        return json.dumps(data, indent=2, sort_keys=True).encode('utf8')
+    elif file_format == 'yaml':
+        return yaml.safe_dump(data).encode('utf8')
+    else:
+        raise Exception(f'Unsupported file format: {file_format}')
+
+
 def write_json(path, config):
     """Writes the given config map as JSON to the given path."""
     with open(path, 'w') as outfile:
-        logging.info('echo \'%s\' > %s' % (json.dumps(config), path))
+        logging.info('echo \'%s\' > %s' % (dump('json', config), path))
         json.dump(config, outfile)
 
 
 def write_yaml(path, config):
     """Writes the given config map as JSON to the given path."""
     with open(path, 'w') as outfile:
-        logging.info('echo \'%s\' > %s' % (json.dumps(config), path))
+        logging.info('echo \'%s\' > %s' % (dump('yaml', config), path))
         yaml.safe_dump(config, outfile)
 
 
@@ -251,16 +261,6 @@ def show_token_services(file_format, waiter_url=None, token_name=None, flags=Non
     return cp, services
 
 
-def dump(file_format, data):
-    """Serializes data to a string in the specified format."""
-    if file_format == 'json':
-        return json.dumps(data).encode('utf8')
-    elif file_format == 'yaml':
-        return yaml.safe_dump(data).encode('utf8')
-    else:
-        raise Exception(f'Unsupported file format: {file_format}')
-
-
 def output(cp):
     """Returns a string containing the stdout and stderr from the given CompletedProcess"""
     return f'\nstdout:\n{stdout(cp)}\n\nstderr:\n{decode(cp.stderr)}'
@@ -273,7 +273,7 @@ def plugins_config():
     """
     if 'WAITER_TEST_PLUGIN_JSON' in os.environ:
         path = os.environ['WAITER_TEST_PLUGIN_JSON']
-        content = util.load_json_file(os.path.abspath(path))
+        content = util.load_file('json', os.path.abspath(path))
         return content or {}
     else:
         return {}

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -958,7 +958,7 @@ class WaiterCliTest(util.WaiterTest):
         token_name = self.token_name()
         filename = str(uuid.uuid4())
         flags = f"--cmd '{util.default_cmd()}' --cmd-type shell --health-check-url /status " \
-                f"--{file_format} --file {filename} "
+                f"--name {token_name} --{file_format} --file {filename} "
         cp = cli.init(self.waiter_url, init_flags=flags)
         self.assertEqual(0, cp.returncode, cp.stderr)
         self.assertIn(f'Writing token {file_format.upper()}', cli.stdout(cp))
@@ -968,7 +968,7 @@ class WaiterCliTest(util.WaiterTest):
             util.post_token(self.waiter_url, token_name, token_definition)
             try:
                 token = util.load_token(self.waiter_url, token_name)
-                self.assertEqual('your-app-name', token['name'])
+                self.assertEqual(token_name, token['name'])
                 self.assertEqual('your-metric-group', token['metric-group'])
                 self.assertEqual('shell', token['cmd-type'])
                 self.assertEqual(util.default_cmd(), token['cmd'])

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -222,26 +222,26 @@ class WaiterCliTest(util.WaiterTest):
 
     def test_cli_invalid_file_format_combo(self):
         cp = cli.create(self.waiter_url, create_flags='--json test.json --yaml test.yaml')
-        self.assertEqual(1, cp.returncode, cp.stderr)
-        self.assertIn('JSON and YAML mode cannot be used simultaneously', cli.stderr(cp))
+        self.assertEqual(2, cp.returncode, cp.stderr)
+        self.assertIn('not allowed with argument', cli.stderr(cp))
 
         cp = cli.update(self.waiter_url, update_flags='--json test.json --yaml test.yaml')
-        self.assertEqual(1, cp.returncode, cp.stderr)
-        self.assertIn('JSON and YAML mode cannot be used simultaneously', cli.stderr(cp))
+        self.assertEqual(2, cp.returncode, cp.stderr)
+        self.assertIn('not allowed with argument', cli.stderr(cp))
 
         token_name = self.token_name()
         cp = cli.show(self.waiter_url, token_name, show_flags='--json --yaml')
-        self.assertEqual(1, cp.returncode, cp.stderr)
-        self.assertIn('JSON and YAML mode cannot be used simultaneously', cli.stderr(cp))
+        self.assertEqual(2, cp.returncode, cp.stderr)
+        self.assertIn('not allowed with argument', cli.stderr(cp))
 
         token_name = self.token_name()
         cp = cli.show(self.waiter_url, token_name, show_flags='--json --yaml')
-        self.assertEqual(1, cp.returncode, cp.stderr)
-        self.assertIn('JSON and YAML mode cannot be used simultaneously', cli.stderr(cp))
+        self.assertEqual(2, cp.returncode, cp.stderr)
+        self.assertIn('not allowed with argument', cli.stderr(cp))
 
         cp = cli.tokens(self.waiter_url, tokens_flags='--json --yaml')
-        self.assertEqual(1, cp.returncode, cp.stderr)
-        self.assertIn('JSON and YAML mode cannot be used simultaneously', cli.stderr(cp))
+        self.assertEqual(2, cp.returncode, cp.stderr)
+        self.assertIn('not allowed with argument', cli.stderr(cp))
 
     def test_implicit_update_args(self):
         cp = cli.create(create_flags='--help')
@@ -447,7 +447,8 @@ class WaiterCliTest(util.WaiterTest):
         token_name = self.token_name()
         util.post_token(self.waiter_url, token_name, util.minimal_service_description())
         try:
-            self.logger.info(f'Token: {util.load_token(self.waiter_url, token_name)}')
+            self.logger.info(f'python3'
+                             f'Token: {util.load_token(self.waiter_url, token_name)}')
             service_id = util.ping_token(self.waiter_url, token_name)
             try:
                 cp = cli.delete(self.waiter_url, token_name)

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -10,7 +10,6 @@ import unittest
 import uuid
 
 import pytest
-import yaml
 
 from tests.waiter import util, cli
 
@@ -331,7 +330,7 @@ class WaiterCliTest(util.WaiterTest):
             self.assertEqual(1, cp.returncode, cp.stderr)
             self.assertIn('must specify at least one cluster', cli.decode(cp.stderr))
 
-    def _test_show(self, file_format):
+    def __test_show(self, file_format):
         token_name = self.token_name()
         util.post_token(self.waiter_url, token_name, {'cpus': 0.1})
         try:
@@ -343,10 +342,10 @@ class WaiterCliTest(util.WaiterTest):
             util.delete_token(self.waiter_url, token_name)
 
     def test_show_json(self):
-        self._test_show('json')
+        self.__test_show('json')
 
     def test_show_yaml(self):
-        self._test_show('yaml')
+        self.__test_show('yaml')
 
     @pytest.mark.serial
     def test_create_if_match(self):
@@ -787,7 +786,7 @@ class WaiterCliTest(util.WaiterTest):
         finally:
             util.delete_token(self.waiter_url, token_name)
 
-    def _test_create_token(self, file_format, input_flag=None):
+    def __test_create_token(self, file_format, input_flag=None):
         if input_flag is None:
             input_flag = file_format
 
@@ -814,18 +813,18 @@ class WaiterCliTest(util.WaiterTest):
             util.delete_token(self.waiter_url, token_name)
 
     def test_create_token_json(self):
-        self._test_create_token('json')
+        self.__test_create_token('json')
 
     def test_create_token_yaml(self):
-        self._test_create_token('yaml')
+        self.__test_create_token('yaml')
 
     def test_create_token_json_input(self):
-        self._test_create_token('json', 'input')
+        self.__test_create_token('json', 'input')
 
     def test_create_token_yaml_input(self):
-        self._test_create_token('yaml', 'input')
+        self.__test_create_token('yaml', 'input')
 
-    def _test_update_token(self, file_format):
+    def __test_update_token(self, file_format):
         token_name = self.token_name()
         create_fields = {'cpus': 0.1, 'mem': 128, 'cmd': 'foo'}
         update_fields = {'cpus': 0.2, 'mem': 256}
@@ -853,12 +852,12 @@ class WaiterCliTest(util.WaiterTest):
             util.delete_token(self.waiter_url, token_name)
 
     def test_update_token_json(self):
-        self._test_update_token('json')
+        self.__test_update_token('json')
 
     def test_update_token_yaml(self):
-        self._test_update_token('yaml')
+        self.__test_update_token('yaml')
 
-    def _test_post_token_and_flags(self, file_format):
+    def __test_post_token_and_flags(self, file_format):
         token_name = self.token_name()
         update_fields = {'cpus': 0.2, 'mem': 256}
         with cli.temp_token_file(update_fields, file_format) as path:
@@ -895,12 +894,12 @@ class WaiterCliTest(util.WaiterTest):
                 util.delete_token(self.waiter_url, token_name)
 
     def test_post_token_json_and_flags(self):
-        self._test_post_token_and_flags('json')
+        self.__test_post_token_and_flags('json')
 
     def test_post_token_yaml_and_flags(self):
-        self._test_post_token_and_flags('yaml')
+        self.__test_post_token_and_flags('yaml')
 
-    def _test_post_token_invalid(self, file_format):
+    def __test_post_token_invalid(self, file_format):
         token_name = self.token_name()
 
         stdin = json.dumps([]).encode('utf8')
@@ -919,10 +918,10 @@ class WaiterCliTest(util.WaiterTest):
             self.assertIn(f'Unable to load {file_format.upper()} from', cli.stderr(cp))
 
     def test_post_token_json_invalid(self):
-        self._test_post_token_invalid('json')
+        self.__test_post_token_invalid('json')
 
     def test_post_token_yaml_invalid(self):
-        self._test_post_token_invalid('yaml')
+        self.__test_post_token_invalid('yaml')
 
     def test_kill_service_id(self):
         token_name = self.token_name()
@@ -955,7 +954,7 @@ class WaiterCliTest(util.WaiterTest):
         finally:
             util.delete_token(self.waiter_url, token_name, kill_services=True)
 
-    def _test_init_basic(self, file_format):
+    def __test_init_basic(self, file_format):
         token_name = self.token_name()
         filename = str(uuid.uuid4())
         flags = f"--cmd '{util.default_cmd()}' --cmd-type shell --health-check-url /status " \
@@ -988,10 +987,10 @@ class WaiterCliTest(util.WaiterTest):
             os.remove(filename)
 
     def test_init_basic_json(self):
-        self._test_init_basic('json')
+        self.__test_init_basic('json')
 
     def test_init_basic_yaml(self):
-        self._test_init_basic('yaml')
+        self.__test_init_basic('yaml')
 
     def test_implicit_init_args(self):
         cp = cli.init(init_flags='--help')
@@ -1140,7 +1139,7 @@ class WaiterCliTest(util.WaiterTest):
         finally:
             util.delete_token(self.waiter_url, token_name_1)
 
-    def _test_create_token_containing_token_name(self, file_format):
+    def __test_create_token_containing_token_name(self, file_format):
         token_name = self.token_name()
         with cli.temp_token_file({'token': token_name, 'cpus': 0.1, 'mem': 128}, file_format) as path:
             cp = cli.create(self.waiter_url, create_flags=f'--{file_format} {path}')
@@ -1153,12 +1152,12 @@ class WaiterCliTest(util.WaiterTest):
                 util.delete_token(self.waiter_url, token_name)
 
     def test_create_token_json_containing_token_name(self):
-        self._test_create_token_containing_token_name('json')
+        self.__test_create_token_containing_token_name('json')
 
     def test_create_token_yaml_containing_token_name(self):
-        self._test_create_token_containing_token_name('yaml')
+        self.__test_create_token_containing_token_name('yaml')
 
-    def _test_update_token_containing_token_name(self, file_format):
+    def __test_update_token_containing_token_name(self, file_format):
         token_name = self.token_name()
         util.post_token(self.waiter_url, token_name, {'cpus': 0.1, 'mem': 128, 'cmd': 'foo'})
         try:
@@ -1173,10 +1172,10 @@ class WaiterCliTest(util.WaiterTest):
             util.delete_token(self.waiter_url, token_name)
 
     def test_update_token_json_containing_token_name(self):
-        self._test_update_token_containing_token_name('json')
+        self.__test_update_token_containing_token_name('json')
 
     def test_update_token_yaml_containing_token_name(self):
-        self._test_update_token_containing_token_name('yaml')
+        self.__test_update_token_containing_token_name('yaml')
 
     def test_post_token_over_specified_token_name(self):
         token_name = self.token_name()

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -446,8 +446,7 @@ class WaiterCliTest(util.WaiterTest):
         token_name = self.token_name()
         util.post_token(self.waiter_url, token_name, util.minimal_service_description())
         try:
-            self.logger.info(f'python3'
-                             f'Token: {util.load_token(self.waiter_url, token_name)}')
+            self.logger.info(f'Token: {util.load_token(self.waiter_url, token_name)}')
             service_id = util.ping_token(self.waiter_url, token_name)
             try:
                 cp = cli.delete(self.waiter_url, token_name)

--- a/cli/integration/tests/waiter/test_cli_multi_cluster.py
+++ b/cli/integration/tests/waiter/test_cli_multi_cluster.py
@@ -37,7 +37,7 @@ class MultiWaiterCliTest(util.WaiterTest):
             # Single query for the token name, federated across clusters
             config = self.__two_cluster_config()
             with cli.temp_config_file(config) as path:
-                cp, tokens = cli.show_token(token_name=token_name, flags='--config %s' % path)
+                cp, tokens = cli.show_token('json', token_name=token_name, flags='--config %s' % path)
                 versions = [t['version'] for t in tokens]
                 self.assertEqual(0, cp.returncode, cp.stderr)
                 self.assertEqual(1, len(tokens), tokens)
@@ -48,7 +48,7 @@ class MultiWaiterCliTest(util.WaiterTest):
                 util.post_token(self.waiter_url_2, token_name, {'version': version_2})
                 try:
                     # Again, single query for the token name, federated across clusters
-                    cp, tokens = cli.show_token(token_name=token_name, flags='--config %s' % path)
+                    cp, tokens = cli.show_token('json', token_name=token_name, flags='--config %s' % path)
                     versions = [t['version'] for t in tokens]
                     self.assertEqual(0, cp.returncode, cp.stderr)
                     self.assertEqual(2, len(tokens), tokens)

--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -6,12 +6,12 @@ import logging
 import os
 import random
 import string
+import unittest
 import uuid
 from datetime import datetime
 
-import unittest
-
 import requests
+import yaml
 from retrying import retry
 
 session = importlib.import_module(os.getenv('WAITER_TEST_SESSION_MODULE', 'requests')).Session()
@@ -204,17 +204,22 @@ def wait_until(query, predicate, max_wait_ms=DEFAULT_TIMEOUT_MS, wait_interval_m
         raise
 
 
-def load_json_file(path):
+def load_file(file_format, path):
     """Decode a JSON formatted file."""
     content = None
 
     if os.path.isfile(path):
         with open(path) as json_file:
             try:
-                logging.debug(f'attempting to load json configuration from {path}')
-                content = json.load(json_file)
+                logging.debug(f'attempting to load {file_format} configuration from {path}')
+                if file_format == 'json':
+                    content = json.load(json_file)
+                elif file_format == 'yaml':
+                    content = yaml.safe_load(json_file)
+                else:
+                    raise Exception(f'Unsupported file format: {file_format}')
             except Exception as e:
-                logging.error(e, f'error loading json configuration from {path}')
+                logging.error(e, f'error loading {file_format} configuration from {path}')
     else:
         logging.info(f'{path} is not a file')
 

--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -31,6 +31,10 @@ DEFAULT_WAIT_INTERVAL_MS = int(os.getenv('WAITER_TEST_DEFAULT_WAIT_INTERVAL_MS',
 TOKEN_PREFIX = os.getenv('WAITER_TEST_TOKEN_PREFIX', 'cli')
 
 
+def get_random_string(length):
+    return ''.join(random.choices(string.ascii_letters + string.digits, k=length))
+
+
 class WaiterTest(unittest.TestCase):
     def token_name(self):
         """
@@ -40,7 +44,7 @@ class WaiterTest(unittest.TestCase):
         test_id = self.id()
         test_function = test_id.split('.')[-1]
         timestamp = datetime.now().strftime('%Y%m%dT%H%M%S')
-        random_string = ''.join(random.choices(string.ascii_letters + string.digits, k=8))
+        random_string = get_random_string(8)
         return f'{TOKEN_PREFIX}_{test_function}_{timestamp}_{random_string}'
 
 
@@ -162,6 +166,7 @@ def minimal_service_description(**kwargs):
         'cpus': float(os.getenv('WAITER_TEST_DEFAULT_CPUS', 1.0)),
         'mem': int(os.getenv('WAITER_TEST_DEFAULT_MEM_MB', 256)),
         'metric-group': 'waiter_test',
+        'name': f'service_{get_random_string(10)}',
         'version': str(uuid.uuid4()),
         'cmd-type': 'shell'
     }

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -6,6 +6,7 @@ from setuptools import setup
 requirements = [
     'arrow==0.13.1',
     'humanfriendly==4.18',
+    'pyyaml==5.1.2',
     'requests==2.20.0',
     'tabulate==0.8.3'
 ]

--- a/cli/waiter/data_format.py
+++ b/cli/waiter/data_format.py
@@ -1,0 +1,148 @@
+import json
+import logging
+import os
+import sys
+
+import yaml
+
+
+class DataFormat:
+    def __str__(self):
+        """Returns the name of the format in upper case."""
+        return self.name().upper()
+
+    def name(self):
+        """Returns the name of the format."""
+        raise NotImplementedError('Method has not been implemented!')
+
+    def parse(self, data):
+        """Returns the parsed data."""
+        raise NotImplementedError('Method has not been implemented!')
+
+    def dump(self, out_data, out_file=None):
+        """
+        If the file is provided, writes the string representation of the data to the file.
+        Else it returns the string representation of the data in the format.
+        """
+        raise NotImplementedError('Method has not been implemented!')
+
+
+class JsonDataFormat(DataFormat):
+    def name(self):
+        return 'json'
+
+    def parse(self, data):
+        try:
+            logging.debug(f'parsing input data as json')
+            content = json.loads(data)
+            return content
+        except Exception:
+            raise ValueError('Malformed JSON in input.')
+
+    def dump(self, out_data, out_file=None):
+        if out_file:
+            json.dump(out_data, out_file, indent=2, sort_keys=True)
+        else:
+            return json.dumps(out_data, indent=2, sort_keys=True)
+
+
+class YamlDataFormat(DataFormat):
+    def name(self):
+        return 'yaml'
+
+    def parse(self, data):
+        try:
+            logging.debug(f'parsing input data as yaml')
+            content = yaml.safe_load(data)
+            return content
+        except Exception:
+            raise ValueError('Malformed YAML in input.')
+
+    def dump(self, out_data, out_file=None):
+        if out_file:
+            yaml.safe_dump(out_data, out_file)
+        else:
+            return yaml.safe_dump(out_data)
+
+
+JSON = JsonDataFormat()
+YAML = YamlDataFormat()
+
+
+def validate_options(options):
+    """Validates whether unique file format is specified."""
+    as_json = options.get(JSON.name())
+    as_yaml = options.get(YAML.name())
+    if as_json and as_yaml:
+        raise Exception(f'JSON and YAML mode cannot be used simultaneously!')
+
+
+def determine_format(options):
+    """
+    Determines whether the configured format is YAML or JSON.
+    JSON is the default format if YAML is not explicitly enabled.
+    """
+    validate_options(options)
+    as_yaml = options.get(YAML.name())
+    input_format = YAML if as_yaml else JSON
+    return input_format
+
+
+def read_from_standard_input(input_format):
+    """Prompts for and then reads token JSON from stdin"""
+    logging.debug(f'expecting {input_format} input from stdin')
+    print(f'Enter the raw {input_format} (press Ctrl+D on a blank line to submit)', file=sys.stderr)
+    data = sys.stdin.read()
+    return data
+
+
+def load_file(path):
+    """Loads the file"""
+    content = None
+
+    if os.path.isfile(path):
+        with open(path) as data_file:
+            try:
+                logging.debug(f'attempting to load content from {path}')
+                content = data_file.read()
+            except Exception:
+                logging.exception(f'encountered exception when loading content from {path}')
+    else:
+        logging.info(f'{path} is not a file')
+
+    return content
+
+
+def load_data(options):
+    """
+    Decode a JSON/YAML formatted file.
+    Data must be a dict of attributes.
+    Throws a ValueError if there is a problem parsing the data.
+    """
+    input_format = determine_format(options)
+    input_file = options.get(input_format.name())
+
+    if input_file == '-':
+        logging.debug(f'reading {input_format} input from stdin')
+        content = read_from_standard_input(input_format)
+        if not content:
+            raise Exception(f'Unable to load {input_format} from stdin.')
+    else:
+        logging.debug(f'reading {input_format} input from {input_file}')
+        content = load_file(input_file)
+        if not content:
+            raise Exception(f'Unable to load {input_format} from {input_file}.')
+
+    content = input_format.parse(content)
+    if type(content) is dict:
+        return content
+    else:
+        raise ValueError(f'{input_format} data must be a dictionary of attributes.')
+
+
+def display_data(options, data):
+    """Display data as JSON/YAML format to standard output."""
+    input_format = determine_format(options)
+    result = input_format.dump(data)
+    if result:
+        print(result)

--- a/cli/waiter/data_format.py
+++ b/cli/waiter/data_format.py
@@ -83,7 +83,6 @@ class AnySupportedFormat(DataFormat):
                 continue
             except Exception:
                 logging.debug(f'error parsing input data as {input_format}')
-                pass
         if content is None:
             raise ValueError('Malformed data in input.')
         return content

--- a/cli/waiter/subcommands/init.py
+++ b/cli/waiter/subcommands/init.py
@@ -48,11 +48,12 @@ def register(add_parser):
     action = token_post.Action.INIT
     parser = token_post.register_argument_parser(add_parser, action)
     token_post.add_token_flags(parser)
-    parser.add_argument('--json', help='write the data in JSON format', dest='json', action='store_true')
-    parser.add_argument('--yaml', help='write the data in YAML format', dest='yaml', action='store_true')
     parser.add_argument('--file', '-F', help='name of file to write token in JSON (default) or YAML format to',
                         default='token.json')
     parser.add_argument('--force', '-f', help='overwrite existing file', dest='force', action='store_true')
+    format_group = parser.add_mutually_exclusive_group()
+    format_group.add_argument('--json', help='write the data in JSON format', dest='json', action='store_true')
+    format_group.add_argument('--yaml', help='write the data in YAML format', dest='yaml', action='store_true')
     return init_token_json
 
 

--- a/cli/waiter/subcommands/show.py
+++ b/cli/waiter/subcommands/show.py
@@ -131,8 +131,9 @@ def register(add_parser):
     """Adds this sub-command's parser and returns the action function"""
     show_parser = add_parser('show', help='show token by name')
     show_parser.add_argument('token', nargs=1)
-    show_parser.add_argument('--json', help='show the data in JSON format', dest='json', action='store_true')
-    show_parser.add_argument('--yaml', help='show the data in YAML format', dest='yaml', action='store_true')
     show_parser.add_argument('--no-services', help="don't show the token's services",
                              dest='no-services', action='store_true')
+    format_group = show_parser.add_mutually_exclusive_group()
+    format_group.add_argument('--json', help='show the data in JSON format', dest='json', action='store_true')
+    format_group.add_argument('--yaml', help='show the data in YAML format', dest='yaml', action='store_true')
     return show

--- a/cli/waiter/subcommands/show.py
+++ b/cli/waiter/subcommands/show.py
@@ -1,9 +1,9 @@
 import collections
-import json
 
 from tabulate import tabulate
 
 from waiter import terminal
+from waiter.data_format import display_data
 from waiter.format import format_field_name, format_last_request_time, format_mem_field, format_memory_amount, \
     format_status, format_timestamp_string
 
@@ -105,11 +105,14 @@ def show(clusters, args, _):
     """Prints info for the token with the given token name."""
     guard_no_cluster(clusters)
     as_json = args.get('json')
+    as_yaml = args.get('yaml')
     token_name = args.get('token')[0]
     include_services = not args.get('no-services')
+
     query_result = query_token(clusters, token_name, include_services=include_services)
-    if as_json:
-        print(json.dumps(query_result))
+
+    if as_json or as_yaml:
+        display_data(args, query_result)
     else:
         for cluster_name, entities in sorted(query_result['clusters'].items()):
             services = entities['services'] if include_services else []
@@ -119,7 +122,7 @@ def show(clusters, args, _):
     if query_result['count'] > 0:
         return 0
     else:
-        if not as_json:
+        if not as_json and not as_yaml:
             print_no_data(clusters)
         return 1
 
@@ -129,6 +132,7 @@ def register(add_parser):
     show_parser = add_parser('show', help='show token by name')
     show_parser.add_argument('token', nargs=1)
     show_parser.add_argument('--json', help='show the data in JSON format', dest='json', action='store_true')
+    show_parser.add_argument('--yaml', help='show the data in YAML format', dest='yaml', action='store_true')
     show_parser.add_argument('--no-services', help="don't show the token's services",
                              dest='no-services', action='store_true')
     return show

--- a/cli/waiter/subcommands/tokens.py
+++ b/cli/waiter/subcommands/tokens.py
@@ -53,6 +53,7 @@ def register(add_parser):
     """Adds this sub-command's parser and returns the action function"""
     parser = add_parser('tokens', help='list tokens by owner')
     parser.add_argument('--user', '-u', help='list tokens owned by a user', default=getpass.getuser())
-    parser.add_argument('--json', help='show the data in JSON format', dest='json', action='store_true')
-    parser.add_argument('--yaml', help='show the data in YAML format', dest='yaml', action='store_true')
+    format_group = parser.add_mutually_exclusive_group()
+    format_group.add_argument('--json', help='show the data in JSON format', dest='json', action='store_true')
+    format_group.add_argument('--yaml', help='show the data in YAML format', dest='yaml', action='store_true')
     return tokens

--- a/cli/waiter/subcommands/tokens.py
+++ b/cli/waiter/subcommands/tokens.py
@@ -1,9 +1,9 @@
 import collections
 import getpass
-import json
 
 from tabulate import tabulate
 
+from waiter.data_format import display_data
 from waiter.format import format_timestamp_string
 from waiter.querying import print_no_data, query_tokens
 from waiter.util import guard_no_cluster
@@ -32,17 +32,19 @@ def tokens(clusters, args, _):
     """Prints info for the tokens owned by the given user."""
     guard_no_cluster(clusters)
     as_json = args.get('json')
+    as_yaml = args.get('yaml')
     user = args.get('user')
+
     query_result = query_tokens(clusters, user)
-    if as_json:
-        print(json.dumps(query_result))
+    if as_json or as_yaml:
+        display_data(args, query_result)
     else:
         print_as_table(query_result)
 
     if query_result['count'] > 0:
         return 0
     else:
-        if not as_json:
+        if not as_json and not as_yaml:
             print_no_data(clusters)
         return 1
 
@@ -52,4 +54,5 @@ def register(add_parser):
     parser = add_parser('tokens', help='list tokens by owner')
     parser.add_argument('--user', '-u', help='list tokens owned by a user', default=getpass.getuser())
     parser.add_argument('--json', help='show the data in JSON format', dest='json', action='store_true')
+    parser.add_argument('--yaml', help='show the data in YAML format', dest='yaml', action='store_true')
     return tokens

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -123,9 +123,10 @@ def create_or_update_token(clusters, args, _, action):
 def add_arguments(parser):
     """Adds arguments to the given parser"""
     add_token_flags(parser)
-    parser.add_argument('--json', help='provide the data in a JSON file', dest='json')
-    parser.add_argument('--yaml', help='provide the data in a YAML file', dest='yaml')
     parser.add_argument('token', nargs='?')
+    format_group = parser.add_mutually_exclusive_group()
+    format_group.add_argument('--json', help='provide the data in a JSON file', dest='json')
+    format_group.add_argument('--yaml', help='provide the data in a YAML file', dest='yaml')
 
 
 def add_token_flags(parser):

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -76,9 +76,12 @@ def create_or_update_token(clusters, args, _, action):
     token_name_from_args = args.pop('token', None)
     json_file = args.pop('json', None)
     yaml_file = args.pop('yaml', None)
+    input_file = args.pop('input', None)
 
-    if json_file or yaml_file:
-        token_fields_from_json = load_data({'json': json_file, 'yaml': yaml_file})
+    if input_file or json_file or yaml_file:
+        token_fields_from_json = load_data({'data': input_file,
+                                            'json': json_file,
+                                            'yaml': yaml_file})
     else:
         token_fields_from_json = {}
 
@@ -127,6 +130,7 @@ def add_arguments(parser):
     format_group = parser.add_mutually_exclusive_group()
     format_group.add_argument('--json', help='provide the data in a JSON file', dest='json')
     format_group.add_argument('--yaml', help='provide the data in a YAML file', dest='yaml')
+    format_group.add_argument('--input', help='provide the data in a JSON/YAML file', dest='input')
 
 
 def add_token_flags(parser):

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -7,8 +7,8 @@ import requests
 
 from waiter import terminal, http_util
 from waiter.querying import get_token, query_token
-from waiter.util import FALSE_STRINGS, print_info, response_message, TRUE_STRINGS, guard_no_cluster, str2bool, \
-    load_json_file
+from waiter.data_format import load_data
+from waiter.util import FALSE_STRINGS, print_info, response_message, TRUE_STRINGS, guard_no_cluster, str2bool
 
 BOOL_STRINGS = TRUE_STRINGS + FALSE_STRINGS
 INT_PARAM_SUFFIXES = ['-failures', '-index', '-instances', '-length', '-level', '-mins', '-secs']
@@ -69,61 +69,34 @@ def create_or_update(cluster, token_name, token_fields, action):
         print_info(f'{message}\n')
 
 
-def parse_raw_token_spec(r):
-    """
-    Parse a JSON string containing raw token data.
-    Token data must be a dict of token attributes.
-    Throws a ValueError if there is a problem parsing the data.
-    """
-    try:
-        content = json.loads(r)
-    except Exception:
-        raise ValueError('Malformed JSON for raw token.')
-
-    if type(content) is dict:
-        return content
-    else:
-        raise ValueError('Token must be a dictionary of attributes.')
-
-
-def read_token_from_stdin():
-    """Prompts for and then reads token JSON from stdin"""
-    print('Enter the raw token JSON (press Ctrl+D on a blank line to submit)', file=sys.stderr)
-    token_json = sys.stdin.read()
-    return token_json
-
-
 def create_or_update_token(clusters, args, _, action):
     """Creates (or updates) a Waiter token"""
     guard_no_cluster(clusters)
     logging.debug('args: %s' % args)
     token_name_from_args = args.pop('token', None)
     json_file = args.pop('json', None)
-    if json_file:
-        if json_file == '-':
-            token_json = read_token_from_stdin()
-            token_fields_from_json = parse_raw_token_spec(token_json)
-        else:
-            token_fields_from_json = load_json_file(json_file)
-            if not token_fields_from_json:
-                raise Exception(f'Unable to load token JSON from {json_file}.')
+    yaml_file = args.pop('yaml', None)
+
+    if json_file or yaml_file:
+        token_fields_from_json = load_data({'json': json_file, 'yaml': yaml_file})
     else:
         token_fields_from_json = {}
 
     token_fields_from_args = args
     shared_keys = set(token_fields_from_json).intersection(token_fields_from_args)
     if shared_keys:
-        raise Exception(f'You cannot specify the same parameter in both a token JSON file and token field flags at '
-                        f'the same time ({", ".join(shared_keys)}).')
+        raise Exception(f'You cannot specify the same parameter in both an input file '
+                        f'and token field flags at the same time ({", ".join(shared_keys)}).')
 
     token_fields = {**token_fields_from_json, **token_fields_from_args}
     token_name_from_json = token_fields.pop('token', None)
     if token_name_from_args and token_name_from_json:
-        raise Exception('You cannot specify the token name both as an argument and in the token JSON file.')
+        raise Exception('You cannot specify the token name both as an argument and in the input file.')
 
     token_name = token_name_from_args or token_name_from_json
     if not token_name:
-        raise Exception('You must specify the token name either as an argument or in a token JSON file via --json.')
+        raise Exception('You must specify the token name either as an argument or in an input file via '
+                        '--json or --yaml.')
 
     if len(clusters) > 1:
         default_for_create = [c for c in clusters if c.get('default-for-create', False)]
@@ -151,6 +124,7 @@ def add_arguments(parser):
     """Adds arguments to the given parser"""
     add_token_flags(parser)
     parser.add_argument('--json', help='provide the data in a JSON file', dest='json')
+    parser.add_argument('--yaml', help='provide the data in a YAML file', dest='yaml')
     parser.add_argument('token', nargs='?')
 
 


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for YAML format to the CLI

## Why are we making these changes?

Add support for a format that allows comments in the input files.

### Examples

#### Help output

```
$ waiter create -h | grep yaml
                     [--ports PORTS] [--json JSON] [--yaml YAML]
  --yaml YAML           provide the data in a YAML file

$ waiter init -h | grep yaml
                   [--ports PORTS] [--json] [--yaml] [--file FILE] [--force]
  --yaml                write the data in YAML format

$ waiter show -h | grep yaml
usage: waiter show [-h] [--json] [--yaml] [--no-services] token
  --yaml         show the data in YAML format

$ waiter tokens -h | grep yaml
usage: waiter tokens [-h] [--user USER] [--json] [--yaml]
  --yaml                show the data in YAML format

$ waiter update -h | grep yaml
                     [--ports PORTS] [--json JSON] [--yaml YAML]
  --yaml YAML           provide the data in a YAML file
```

#### Token create example

```
$ waiter create --yaml -
Enter the raw YAML (press Ctrl+D on a blank line to submit)
cpus: 1
mem: 2048        
token: test_token

Attempting to create token on WAITER1...
Successfully created test_token.
```
#### Token show example

```
$ waiter show --yaml test_token
clusters:
  WAITER1:
    count: 1
    etag: E-e5306e7778e044519060d8180a497877
    services: []
    token:
      cluster: c9091
      cpus: 1
      last-update-time: '2020-01-13T18:34:01.480Z'
      last-update-user: shamsimam
      mem: 2048
      owner: shamsimam
      previous: {}
      root: c9091
count: 1
```

#### Tokens example

```
$ waiter tokens --yaml
clusters:
  WAITER1:
    count: 1
    tokens:
    - deleted: false
      etag: E-e5306e7778e044519060d8180a497877
      last-update-time: '2020-01-13T18:34:01.480Z'
      owner: shamsimam
      token: test_token
count: 1
```
