### PR TITLE
correctly retrieves git branch name in integration tests

### DIFF
--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -198,24 +198,12 @@
   `(using-waiter-url
      (time-it ~name ~@body)))
 
-(defn- git-show->branch-name [text]
-  (->
-    text
-    (str/trim)
-    (str/split #", ")
-    (last)
-    (str/replace ")" "")
-    (str/replace #"^.+/" "")))
-
-(deftest test-git-show->branch-name
-  (is (= "master" (git-show->branch-name "(HEAD, origin/master)")))
-  (is (= "foo" (git-show->branch-name " (HEAD, origin/foo, foo)"))))
-
 (defn- retrieve-git-branch []
   (->
-    (shell/sh "git" "show" "-s" "--pretty=%d" "HEAD")
-    (:out)
-    (git-show->branch-name)))
+    (shell/sh "git" "rev-parse" "--abbrev-ref" "HEAD")
+    :out
+    (or "_unknown_branch_")
+    str/trim))
 
 (defn make-http-clients
   "Instantiates and returns http1 and http2 clients without a cookie store"


### PR DESCRIPTION
## Changes proposed in this PR

- correctly retrieves git branch name in integration tests

## Why are we making these changes?

Corrects the user-agent string sent in requests from the tests.

```
2020-01-13 15:16:35,703 INFO  waiter.core [qtp1078707552-184] - [CID=test-wbttbf-23709025b0376-666efef08b7856d2] request received: {:headers {user-agent waiter-test/user-agent-git-branch-20200113 .http1, ...}
```
