### PR TITLE
starts waiter instances sequentially instead of concurrently for CLI tests

### DIFF
--- a/cli/bin/ci/run-integration-tests.sh
+++ b/cli/bin/ci/run-integration-tests.sh
@@ -13,14 +13,6 @@ export GRAPHITE_SERVER_PORT=5555
 # Start netcat to listen to a port. The Codahale Graphite reporter will be able to report without failing and spamming logs.
 nc -kl localhost ${GRAPHITE_SERVER_PORT} > /dev/null &
 
-# Start waiter
-: ${WAITER_PORT:=9091}
-${ROOT_DIR}/waiter/bin/run-using-shell-scheduler.sh ${WAITER_PORT} waiter1 &
-
-# Start a second waiter
-: ${WAITER_PORT_2:=9191}
-${ROOT_DIR}/waiter/bin/run-using-shell-scheduler.sh ${WAITER_PORT_2} waiter2 &
-
 function wait_for_waiter {
     URI=${1}
     while ! curl -s ${URI} >/dev/null;
@@ -39,6 +31,10 @@ else
     echo "WAITER_URI is set to ${WAITER_URI}"
 fi
 
+# Start first waiter
+: ${WAITER_PORT:=9091}
+${ROOT_DIR}/waiter/bin/run-using-shell-scheduler.sh ${WAITER_PORT} waiter1 &
+
 # Wait for waiter to be listening
 timeout 180s bash -c "wait_for_waiter ${WAITER_URI}"
 if [[ $? -ne 0 ]]; then
@@ -53,6 +49,10 @@ if [[ -z ${WAITER_URI_2+x} ]]; then
 else
     echo "WAITER_URI_2 is set to ${WAITER_URI_2}"
 fi
+
+# Start a second waiter, no need to recompile Waiter code
+: ${WAITER_PORT_2:=9191}
+${ROOT_DIR}/waiter/bin/run-using-shell-scheduler.sh ${WAITER_PORT_2} waiter2 0 &
 
 # Wait for second waiter to be listening
 timeout 180s bash -c "wait_for_waiter ${WAITER_URI_2}"


### PR DESCRIPTION

## Changes proposed in this PR

- starts waiter instances sequentially instead of concurrently for CLI tests

## Why are we making these changes?

Avoids flaky failures in CLI tests due to concurrently starting Waiter instances.

Example failed build: https://travis-ci.org/twosigma/waiter/jobs/639266170
```
Starting waiter...
23:47:28 waiter is not listening on 127.0.0.1:9091 yet
23:47:30 waiter is not listening on 127.0.0.1:9091 yet
23:47:32 waiter is not listening on 127.0.0.1:9091 yet
java.lang.Exception: Couldn't create directories: /home/travis/build/twosigma/waiter/waiter/target/classes
 at leiningen.core.utils$mkdirs.invokeStatic (utils.clj:71)
    leiningen.core.utils$mkdirs.invoke (utils.clj:66)
    leiningen.core.eval$prep.invokeStatic (eval.clj:79)
    leiningen.core.eval$prep.invoke (eval.clj:73)
    leiningen.core.eval$eval_in_project.invokeStatic (eval.clj:362)
    leiningen.core.eval$eval_in_project.invoke (eval.clj:356)
    leiningen.core.eval$eval_in_project.invokeStatic (eval.clj:360)
    leiningen.core.eval$eval_in_project.invoke (eval.clj:356)
    leiningen.run$run_main.invokeStatic (run.clj:130)
    leiningen.run$run_main.invoke (run.clj:123)
    leiningen.run$run.invokeStatic (run.clj:157)
    leiningen.run$run.doInvoke (run.clj:134)
    clojure.lang.RestFn.invoke (RestFn.java:423)
    clojure.lang.Var.invoke (Var.java:383)
    clojure.lang.AFn.applyToHelper (AFn.java:156)
    clojure.lang.Var.applyTo (Var.java:700)
    clojure.core$apply.invokeStatic (core.clj:648)
    clojure.core$apply.invoke (core.clj:641)
    leiningen.core.main$partial_task$fn__4667.doInvoke (main.clj:284)
    clojure.lang.RestFn.applyTo (RestFn.java:139)
    clojure.lang.AFunction$1.doInvoke (AFunction.java:29)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invokeStatic (core.clj:648)
    clojure.core$apply.invoke (core.clj:641)
    leiningen.core.main$apply_task.invokeStatic (main.clj:334)
    leiningen.core.main$apply_task.invoke (main.clj:320)
    leiningen.core.main$resolve_and_apply.invokeStatic (main.clj:340)
    leiningen.core.main$resolve_and_apply.invoke (main.clj:336)
    leiningen.core.main$_main$fn__4734.invoke (main.clj:420)
    leiningen.core.main$_main.invokeStatic (main.clj:411)
    leiningen.core.main$_main.doInvoke (main.clj:408)
    clojure.lang.RestFn.invoke (RestFn.java:421)
    clojure.lang.Var.invoke (Var.java:383)
    clojure.lang.AFn.applyToHelper (AFn.java:156)
    clojure.lang.Var.applyTo (Var.java:700)
    clojure.core$apply.invokeStatic (core.clj:646)
    clojure.main$main_opt.invokeStatic (main.clj:314)
    clojure.main$main_opt.invoke (main.clj:310)
    clojure.main$main.invokeStatic (main.clj:421)
    clojure.main$main.doInvoke (main.clj:384)
    clojure.lang.RestFn.invoke (RestFn.java:457)
    clojure.lang.Var.invoke (Var.java:394)
    clojure.lang.AFn.applyToHelper (AFn.java:165)
    clojure.lang.Var.applyTo (Var.java:700)
    clojure.main.main (main.java:37)
Waiter quit with code 1
```




