### PR TITLE
Introduces a fast path that avoids async/go blocks to retrieve maintainer channels

### DIFF
--- a/waiter/src/waiter/async_request.clj
+++ b/waiter/src/waiter/async_request.clj
@@ -218,7 +218,7 @@
    The function assumes location begins with a slash.
    This method wires up the completion and status check callbacks for the monitoring system.
    It also modifies the status check endpoint in the response header."
-  [router-id async-request-store-atom make-http-request-fn auth-params-map instance-rpc-chan user-agent
+  [router-id async-request-store-atom make-http-request-fn auth-params-map populate-maintainer-chan! user-agent
    response {:keys [service-description service-id] :as descriptor} {:keys [host port] :as instance}
    {:keys [request-id] :as reason-map} request-properties location query-string]
   (let [correlation-id (cid/get-correlation-id)
@@ -241,7 +241,7 @@
               (when (= :success status)
                 (counters/inc! (metrics/service-counter service-id "request-counts" "successful")))
               (statsd/gauge-delta! metric-group "request_outstanding" -1)
-              (service/release-instance-go instance-rpc-chan instance {:status status, :cid correlation-id, :request-id request-id}))
+              (service/release-instance-go populate-maintainer-chan! instance {:status status, :cid correlation-id, :request-id request-id}))
             (complete-async-request-fn [status]
               (complete-async-request-locally async-request-store-atom release-instance-fn request-id status))
             (request-still-active? []

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -120,6 +120,7 @@
                               ["/router-metrics" :state-router-metrics-handler-fn]
                               ["/scheduler" :state-scheduler-handler-fn]
                               ["/service-description-builder" :state-service-description-builder-handler-fn]
+                              ["/service-maintainer" :state-service-maintainer-handler-fn]
                               ["/statsd" :state-statsd-handler-fn]
                               ["/work-stealing" :state-work-stealing-handler-fn]
                               [["/" :service-id] :state-service-handler-fn]]
@@ -639,7 +640,7 @@
                               :socket-timeout client-connection-idle-timeout-ms})
    :http-clients (pc/fnk [http-client-properties]
                    (hu/prepare-http-clients http-client-properties))
-   :instance-rpc-chan (pc/fnk [] (async/chan 1024)) ; TODO move to service-chan-maintainer
+   :instance-rpc-chan (pc/fnk [] (async/chan 1024)) ; breaks cycle between daemons and routines
    :interstitial-state-atom (pc/fnk [] (atom {:initialized? false
                                               :service-id->interstitial-promise {}}))
    :jwt-authenticator (pc/fnk [[:settings authenticator-config]
@@ -946,9 +947,13 @@
                                                      instance short-circuit? router-ids "blacklist"
                                                      (partial make-blacklist-request make-inter-router-requests-sync-fn blacklist-period-ms)
                                                      reason))))
+   :populate-maintainer-chan-routine! (pc/fnk [[:state instance-rpc-chan]]
+                                        ;; avoid cycle in dependency resolution for functions defined in daemons
+                                        (fn populate-maintainer-chan-routine! [request-map]
+                                          (service/forward-request-to-instance-rpc-chan! instance-rpc-chan request-map)))
    :post-process-async-request-response-fn (pc/fnk [[:settings waiter-principal]
-                                                    [:state async-request-store-atom instance-rpc-chan router-id user-agent-version]
-                                                    make-http-request-fn]
+                                                    [:state async-request-store-atom router-id user-agent-version]
+                                                    make-http-request-fn populate-maintainer-chan-routine!]
                                              (let [auth-params-map (auth/auth-params-map :internal waiter-principal)
                                                    user-agent (str "waiter-async-status-check/" user-agent-version)]
                                                (fn post-process-async-request-response-wrapper
@@ -956,7 +961,7 @@
                                                   reason-map request-properties location query-string]
                                                  (async-req/post-process-async-request-response
                                                    router-id async-request-store-atom make-http-request-fn auth-params-map
-                                                   instance-rpc-chan user-agent response descriptor instance
+                                                   populate-maintainer-chan-routine! user-agent response descriptor instance
                                                    reason-map request-properties location query-string))))
    :prepend-waiter-url (pc/fnk [[:settings hostname port]]
                          (let [hostname (if (sequential? hostname) (first hostname) hostname)]
@@ -1021,14 +1026,15 @@
                              (service/start-new-service
                                scheduler descriptor start-service-cache scheduler-interactions-thread-pool)))
    :start-work-stealing-balancer-fn (pc/fnk [[:settings [:work-stealing offer-help-interval-ms reserve-timeout-ms]]
-                                             [:state instance-rpc-chan offers-allowed-semaphore router-id]
-                                             make-inter-router-requests-async-fn router-metrics-helpers]
+                                             [:state offers-allowed-semaphore router-id]
+                                             make-inter-router-requests-async-fn populate-maintainer-chan-routine!
+                                             router-metrics-helpers]
                                       (fn start-work-stealing-balancer [service-id]
                                         (let [{:keys [service-id->router-id->metrics]} router-metrics-helpers]
                                           (work-stealing/start-work-stealing-balancer
-                                            instance-rpc-chan reserve-timeout-ms offer-help-interval-ms offers-allowed-semaphore
-                                            service-id->router-id->metrics make-inter-router-requests-async-fn
-                                            router-id service-id))))
+                                            populate-maintainer-chan-routine! reserve-timeout-ms offer-help-interval-ms
+                                            offers-allowed-semaphore service-id->router-id->metrics
+                                            make-inter-router-requests-async-fn router-id service-id))))
    :stop-work-stealing-balancer-fn (pc/fnk []
                                      (fn stop-work-stealing-balancer [service-id work-stealing-chan-map]
                                        (log/info "stopping work-stealing balancer for" service-id)
@@ -1112,14 +1118,15 @@
   {:autoscaler (pc/fnk [[:routines router-metrics-helpers service-id->service-description-fn]
                         [:scheduler scheduler]
                         [:settings [:scaling autoscaler-interval-ms max-expired-unhealthy-instances-to-consider]]
-                        [:state instance-rpc-chan leader?-fn scheduler-interactions-thread-pool]
-                        autoscaling-multiplexer router-state-maintainer]
+                        [:state leader?-fn scheduler-interactions-thread-pool]
+                        autoscaling-multiplexer populate-maintainer-chan! router-state-maintainer]
                  (let [service-id->metrics-fn (:service-id->metrics-fn router-metrics-helpers)
                        {{:keys [router-state-push-mult]} :maintainer} router-state-maintainer
                        {:keys [executor-multiplexer-chan]} autoscaling-multiplexer
                        update-service-scale-state! (fn update-service-scale-state! [service-id scaling-state]
                                                      (log/info service-id "updating scaling state to" scaling-state)
-                                                     (service/notify-scaling-state-go instance-rpc-chan service-id scaling-state))]
+                                                     (service/notify-scaling-state-go
+                                                       populate-maintainer-chan! service-id scaling-state))]
                    (scaling/autoscaler-goroutine
                      {} leader?-fn service-id->metrics-fn executor-multiplexer-chan scheduler autoscaler-interval-ms
                      scaling/scale-service service-id->service-description-fn router-state-push-mult
@@ -1129,15 +1136,15 @@
                                       service-id->service-description-fn]
                                      [:scheduler scheduler]
                                      [:settings [:scaling quanta-constraints]]
-                                     [:state instance-rpc-chan scheduler-interactions-thread-pool scaling-timeout-config]
-                                     router-state-maintainer]
+                                     [:state scheduler-interactions-thread-pool scaling-timeout-config]
+                                     populate-maintainer-chan! router-state-maintainer]
                               (let [{{:keys [notify-instance-killed-fn]} :maintainer} router-state-maintainer]
                                 (scaling/service-scaling-multiplexer
                                   (fn scaling-executor-factory [service-id]
                                     (scaling/service-scaling-executor
                                       notify-instance-killed-fn peers-acknowledged-blacklist-requests-fn
                                       delegate-instance-kill-request-fn service-id->service-description-fn
-                                      scheduler instance-rpc-chan quanta-constraints scaling-timeout-config
+                                      scheduler populate-maintainer-chan! quanta-constraints scaling-timeout-config
                                       scheduler-interactions-thread-pool service-id))
                                   {})))
    :codahale-reporters (pc/fnk [[:settings [:metrics-config codahale-reporters]]]
@@ -1191,6 +1198,12 @@
    :messages (pc/fnk [[:settings {messages nil}]]
                (when messages
                  (utils/load-messages messages)))
+   :populate-maintainer-chan! (pc/fnk [[:state instance-rpc-chan]
+                                       service-chan-maintainer]
+                                (let [{:keys [retrieve-maintainer-chan-fn]} service-chan-maintainer]
+                                  (fn populate-maintainer-chan! [request-map]
+                                    (service/populate-maintainer-chan!
+                                      instance-rpc-chan retrieve-maintainer-chan-fn request-map))))
    :router-list-maintainer (pc/fnk [[:settings router-syncer]
                                     [:state discovery]]
                              (let [{:keys [delay-ms interval-ms]} router-syncer
@@ -1252,31 +1265,20 @@
                                       (let [service-description (service-id->service-description-fn service-id)
                                             maintainer-chan-map (state/prepare-and-start-service-chan-responder
                                                                   service-id service-description instance-request-properties blacklist-config)
-                                            workstealing-chan-map (start-work-stealing-balancer-fn service-id)]
+                                            work-stealing-chan-map (start-work-stealing-balancer-fn service-id)]
                                         {:maintainer-chan-map maintainer-chan-map
-                                         :work-stealing-chan-map workstealing-chan-map}))
+                                         :work-stealing-chan-map work-stealing-chan-map}))
                                     remove-service
                                     (fn remove-service [service-id {:keys [maintainer-chan-map work-stealing-chan-map]}]
                                       (state/close-update-state-channel service-id maintainer-chan-map)
                                       (stop-work-stealing-balancer-fn service-id work-stealing-chan-map))
-                                    retrieve-channel
-                                    (fn retrieve-channel [channel-map method]
-                                      (let [method-chan (case method
-                                                          :blacklist [:maintainer-chan-map :blacklist-instance-chan]
-                                                          :kill [:maintainer-chan-map :kill-instance-chan]
-                                                          :offer [:maintainer-chan-map :work-stealing-chan]
-                                                          :query-state [:maintainer-chan-map :query-state-chan]
-                                                          :query-work-stealing [:work-stealing-chan-map :query-chan]
-                                                          :release [:maintainer-chan-map :release-instance-chan]
-                                                          :reserve [:maintainer-chan-map :reserve-instance-chan-in]
-                                                          :scaling-state [:maintainer-chan-map :scaling-state-chan]
-                                                          :update-state [:maintainer-chan-map :update-state-chan])]
-                                        (get-in channel-map method-chan)))
+                                    retrieve-channel state/retrieve-maintainer-channel
                                     {{:keys [router-state-push-mult]} :maintainer} router-state-maintainer
                                     state-chan (au/latest-chan)]
                                 (async/tap router-state-push-mult state-chan)
                                 (state/start-service-chan-maintainer
-                                  {} instance-rpc-chan state-chan query-service-maintainer-chan start-service remove-service retrieve-channel)))
+                                  {} instance-rpc-chan state-chan query-service-maintainer-chan start-service
+                                  remove-service retrieve-channel)))
    :state-sources (pc/fnk [[:scheduler scheduler]
                            [:state query-service-maintainer-chan]
                            autoscaler autoscaling-multiplexer gc-for-transient-metrics interstitial-maintainer
@@ -1318,19 +1320,19 @@
                               (wrap-secure-request-fn
                                 (fn async-status-handler-fn [request]
                                   (handler/async-status-handler async-trigger-terminate-fn make-http-request-fn service-id->service-description-fn request))))
-   :blacklist-instance-handler-fn (pc/fnk [[:daemons router-state-maintainer]
-                                           [:state instance-rpc-chan]
+   :blacklist-instance-handler-fn (pc/fnk [[:daemons populate-maintainer-chan! router-state-maintainer]
                                            wrap-router-auth-fn]
                                     (let [{{:keys [notify-instance-killed-fn]} :maintainer} router-state-maintainer]
                                       (wrap-router-auth-fn
                                         (fn blacklist-instance-handler-fn [request]
-                                          (handler/blacklist-instance notify-instance-killed-fn instance-rpc-chan request)))))
-   :blacklisted-instances-list-handler-fn (pc/fnk [[:state instance-rpc-chan]]
+                                          (handler/blacklist-instance notify-instance-killed-fn populate-maintainer-chan! request)))))
+   :blacklisted-instances-list-handler-fn (pc/fnk [[:daemons populate-maintainer-chan!]]
                                             (fn blacklisted-instances-list-handler-fn [{{:keys [service-id]} :route-params :as request}]
-                                              (handler/get-blacklisted-instances instance-rpc-chan service-id request)))
-   :default-websocket-handler-fn (pc/fnk [[:routines determine-priority-fn service-id->password-fn start-new-service-fn]
+                                              (handler/get-blacklisted-instances populate-maintainer-chan! service-id request)))
+   :default-websocket-handler-fn (pc/fnk [[:daemons populate-maintainer-chan!]
+                                          [:routines determine-priority-fn service-id->password-fn start-new-service-fn]
                                           [:settings instance-request-properties]
-                                          [:state instance-rpc-chan local-usage-agent passwords websocket-client]
+                                          [:state local-usage-agent passwords websocket-client]
                                           wrap-descriptor-fn]
                                    (let [password (first passwords)
                                          make-request-fn (fn make-ws-request
@@ -1339,7 +1341,7 @@
                                                            (ws/make-request websocket-client service-id->password-fn instance request request-properties
                                                                             passthrough-headers end-route metric-group backend-proto proto-version))
                                          process-request-fn (fn process-request-fn [request]
-                                                              (pr/process make-request-fn instance-rpc-chan start-new-service-fn
+                                                              (pr/process make-request-fn populate-maintainer-chan! start-new-service-fn
                                                                           instance-request-properties determine-priority-fn ws/process-response!
                                                                           ws/abort-request-callback-factory local-usage-agent request))]
                                      (->> process-request-fn
@@ -1354,18 +1356,18 @@
                          (fn favicon-handler-fn [_]
                            {:body (io/input-stream (io/resource "web/favicon.ico"))
                             :content-type "image/png"}))
-   :kill-instance-handler-fn (pc/fnk [[:daemons router-state-maintainer]
+   :kill-instance-handler-fn (pc/fnk [[:daemons populate-maintainer-chan! router-state-maintainer]
                                       [:routines peers-acknowledged-blacklist-requests-fn]
                                       [:scheduler scheduler]
-                                      [:state instance-rpc-chan scaling-timeout-config scheduler-interactions-thread-pool]
+                                      [:state scaling-timeout-config scheduler-interactions-thread-pool]
                                       wrap-router-auth-fn]
                                (let [{{:keys [notify-instance-killed-fn]} :maintainer} router-state-maintainer]
                                  (wrap-router-auth-fn
                                    (fn kill-instance-handler-fn [request]
                                      (scaling/kill-instance-handler
                                        notify-instance-killed-fn peers-acknowledged-blacklist-requests-fn
-                                       scheduler instance-rpc-chan scaling-timeout-config scheduler-interactions-thread-pool
-                                       request)))))
+                                       scheduler populate-maintainer-chan! scaling-timeout-config
+                                       scheduler-interactions-thread-pool request)))))
    :metrics-request-handler-fn (pc/fnk []
                                  (fn metrics-request-handler-fn [request]
                                    (handler/metrics-request-handler request)))
@@ -1393,10 +1395,11 @@
                                    (handler))))))
    :process-request-fn (pc/fnk [process-request-handler-fn process-request-wrapper-fn]
                          (process-request-wrapper-fn process-request-handler-fn))
-   :process-request-handler-fn (pc/fnk [[:routines determine-priority-fn make-basic-auth-fn post-process-async-request-response-fn
+   :process-request-handler-fn (pc/fnk [[:daemons populate-maintainer-chan!]
+                                        [:routines determine-priority-fn make-basic-auth-fn post-process-async-request-response-fn
                                          service-id->password-fn start-new-service-fn]
                                         [:settings instance-request-properties]
-                                        [:state http-clients instance-rpc-chan local-usage-agent]]
+                                        [:state http-clients local-usage-agent]]
                                  (let [make-request-fn (fn [instance request request-properties passthrough-headers end-route metric-group
                                                             backend-proto proto-version]
                                                          (pr/make-request
@@ -1405,7 +1408,7 @@
                                                            backend-proto proto-version))
                                        process-response-fn (partial pr/process-http-response post-process-async-request-response-fn)]
                                    (fn inner-process-request [request]
-                                     (pr/process make-request-fn instance-rpc-chan start-new-service-fn
+                                     (pr/process make-request-fn populate-maintainer-chan! start-new-service-fn
                                                  instance-request-properties determine-priority-fn process-response-fn
                                                  pr/abort-http-request-callback-factory local-usage-agent request))))
    :process-request-wrapper-fn (pc/fnk [[:state interstitial-state-atom]
@@ -1624,12 +1627,19 @@
                                                        router-id
                                                        #(sd/state service-description-builder)
                                                        request)))
-   :state-service-handler-fn (pc/fnk [[:daemons state-sources]
-                                      [:state instance-rpc-chan local-usage-agent router-id]
+   :state-service-maintainer-handler-fn (pc/fnk [[:daemons service-chan-maintainer]
+                                                 [:state router-id]
+                                                 wrap-secure-request-fn]
+                                          (let [{:keys [query-state-fn]} service-chan-maintainer]
+                                            (wrap-secure-request-fn
+                                              (fn state-service-maintainer-handler-fn [request]
+                                                (handler/get-query-fn-state router-id query-state-fn request)))))
+   :state-service-handler-fn (pc/fnk [[:daemons populate-maintainer-chan! state-sources]
+                                      [:state local-usage-agent router-id]
                                       wrap-secure-request-fn]
                                (wrap-secure-request-fn
                                  (fn service-state-handler-fn [{{:keys [service-id]} :route-params :as request}]
-                                   (handler/get-service-state router-id instance-rpc-chan local-usage-agent
+                                   (handler/get-service-state router-id populate-maintainer-chan! local-usage-agent
                                                               service-id state-sources request))))
    :state-statsd-handler-fn (pc/fnk [[:state router-id]
                                      wrap-secure-request-fn]
@@ -1719,11 +1729,11 @@
                                                  (interstitial/display-interstitial-handler request))))
    :welcome-handler-fn (pc/fnk [settings]
                          (partial handler/welcome-handler settings))
-   :work-stealing-handler-fn (pc/fnk [[:state instance-rpc-chan]
+   :work-stealing-handler-fn (pc/fnk [[:daemons populate-maintainer-chan!]
                                       wrap-router-auth-fn]
                                (wrap-router-auth-fn
                                  (fn [request]
-                                   (handler/work-stealing-handler instance-rpc-chan request))))
+                                   (handler/work-stealing-handler populate-maintainer-chan! request))))
    :wrap-auth-bypass-fn (pc/fnk []
                           (fn wrap-auth-bypass-fn
                             [handler]

--- a/waiter/src/waiter/service.clj
+++ b/waiter/src/waiter/service.clj
@@ -38,14 +38,14 @@
 (defmacro blacklist-instance!
   "Sends a rpc to the router state to blacklist the given instance.
    Throws an exception if a blacklist channel cannot be found for the specfied service."
-  [instance-rpc-chan service-id instance-id blacklist-period-ms response-chan]
+  [populate-maintainer-chan! service-id instance-id blacklist-period-ms response-chan]
   `(let [response-chan# (async/promise-chan)]
      (log/info "Requesting blacklist channel for" ~service-id)
      (->> {:cid (cid/get-correlation-id)
            :method :blacklist
            :response-chan response-chan#
            :service-id ~service-id}
-          (async/put! ~instance-rpc-chan))
+          (~populate-maintainer-chan!))
      (if-let [blacklist-chan# (async/<! response-chan#)]
        (do
          (log/info "Received blacklist channel, making blacklist request.")
@@ -63,10 +63,10 @@
 
 (defn blacklist-instance-go
   "Sends a rpc to the router state to blacklist the lock on the given instance."
-  [instance-rpc-chan service-id instance-id blacklist-period-ms response-chan]
+  [populate-maintainer-chan! service-id instance-id blacklist-period-ms response-chan]
   (async/go
     (try
-      (blacklist-instance! instance-rpc-chan service-id instance-id blacklist-period-ms response-chan)
+      (blacklist-instance! populate-maintainer-chan! service-id instance-id blacklist-period-ms response-chan)
       (catch Exception e
         (log/error e "Error while blacklisting instance" instance-id)))))
 
@@ -74,7 +74,7 @@
 (defmacro offer-instance!
   "Sends a rpc to the proxy state to offer the given instance.
    Throws an exception if a work-stealing channel cannot be found for the specified service."
-  [instance-rpc-chan service-id offer-params]
+  [populate-maintainer-chan! service-id offer-params]
   `(let [offer-params# ~offer-params
          response-chan# (async/promise-chan)]
      (log/debug "Requesting offer channel for" ~service-id)
@@ -82,7 +82,7 @@
            :method :offer
            :response-chan response-chan#
            :service-id ~service-id}
-          (async/put! ~instance-rpc-chan))
+          (~populate-maintainer-chan!))
      (if-let [work-stealing-chan# (async/<! response-chan#)]
        (do
          (log/info "received offer channel, making offer request.")
@@ -99,28 +99,28 @@
 
 (defn offer-instance-go
   "Sends a rpc to the proxy state to offer the lock on the given instance."
-  [instance-rpc-chan service-id offer-params]
+  [populate-maintainer-chan! service-id offer-params]
   (async/go
     (try
-      (offer-instance! instance-rpc-chan service-id offer-params)
+      (offer-instance! populate-maintainer-chan! service-id offer-params)
       (catch Exception e
         (log/error e "Error while offering instance to service" {:service-id service-id, :offer-params offer-params})))))
 
 ;; Query Service State
 (defmacro query-maintainer-channel-map!
   "Sends a rpc to retrieve the channel on which to query the state of the given service."
-  [instance-rpc-chan service-id response-chan query-type]
+  [populate-maintainer-chan! service-id response-chan query-type]
   `(->> {:cid (cid/get-correlation-id)
          :method ~query-type
          :response-chan ~response-chan
          :service-id ~service-id}
-        (async/put! ~instance-rpc-chan)))
+        (~populate-maintainer-chan!)))
 
 (defmacro query-maintainer-channel-map-with-timeout!
   "Sends a rpc to retrieve the channel on which to query the state of the given service."
-  [instance-rpc-chan service-id timeout-ms query-type]
+  [populate-maintainer-chan! service-id timeout-ms query-type]
   `(let [response-chan# (async/promise-chan)]
-     (query-maintainer-channel-map! ~instance-rpc-chan ~service-id response-chan# ~query-type)
+     (query-maintainer-channel-map! ~populate-maintainer-chan! ~service-id response-chan# ~query-type)
      (async/alt!
        response-chan# ([result-channel#] result-channel#)
        (async/timeout ~timeout-ms) ([ignore#] {:message "Request timed-out!"})
@@ -129,9 +129,9 @@
 (defmacro query-instance!
   "Sends a rpc to the router state to query the state of the given service.
    Throws an exception if a query channel cannot be found for the specfied service."
-  [instance-rpc-chan service-id response-chan]
+  [populate-maintainer-chan! service-id response-chan]
   `(let [response-chan# (async/promise-chan)]
-     (query-maintainer-channel-map! ~instance-rpc-chan ~service-id response-chan# :query-state)
+     (query-maintainer-channel-map! ~populate-maintainer-chan! ~service-id response-chan# :query-state)
      (if-let [query-state-chan# (async/<! response-chan#)]
        (when-not (au/offer! query-state-chan# {:cid (cid/get-correlation-id)
                                                :response-chan ~response-chan
@@ -145,10 +145,10 @@
 
 (defn query-instance-go
   "Sends a rpc to the router state to query the state of the given service."
-  [instance-rpc-chan service-id response-chan]
+  [populate-maintainer-chan! service-id response-chan]
   (async/go
     (try
-      (query-instance! instance-rpc-chan service-id response-chan)
+      (query-instance! populate-maintainer-chan! service-id response-chan)
       (catch Exception e
         (log/error e "Error while querying state of" service-id)))))
 
@@ -156,14 +156,14 @@
 (defmacro release-instance!
   "Sends a rpc to the router state to release the lock on the given instance.
    Throws an exception if a release channel cannot be found for the specified service."
-  [instance-rpc-chan instance reservation-result]
+  [populate-maintainer-chan! instance reservation-result]
   `(let [response-chan# (async/promise-chan)
          service-id# (scheduler/instance->service-id ~instance)]
      (->> {:cid (cid/get-correlation-id)
            :method :release
            :response-chan response-chan#
            :service-id service-id#}
-          (async/put! ~instance-rpc-chan))
+          (~populate-maintainer-chan!))
      (if-let [release-chan# (async/<! response-chan#)]
        (when-not (au/offer! release-chan# [~instance ~reservation-result])
          (throw (ex-info "Unable to put instance on release-chan."
@@ -174,17 +174,17 @@
 
 (defn release-instance-go
   "Sends a rpc to the router state to release the lock on the given instance."
-  [instance-rpc-chan instance reservation-result]
+  [populate-maintainer-chan! instance reservation-result]
   (async/go
     (try
-      (release-instance! instance-rpc-chan instance reservation-result)
+      (release-instance! populate-maintainer-chan! instance reservation-result)
       (catch Exception e
         (log/error e "Error while releasing instance" instance)))))
 
 (defmacro notify-scaling-state!
   "Sends a rpc to the router state to notify the scaling mode of a service.
    Throws an exception if a release channel cannot be found for the specified service."
-  [instance-rpc-chan service-id scaling-state]
+  [populate-maintainer-chan! service-id scaling-state]
   `(let [response-chan# (async/promise-chan)
          service-id# ~service-id
          scaling-state# ~scaling-state]
@@ -192,7 +192,7 @@
            :method :scaling-state
            :response-chan response-chan#
            :service-id service-id#}
-       (async/put! ~instance-rpc-chan))
+       (~populate-maintainer-chan!))
      (if-let [release-chan# (async/<! response-chan#)]
        (when-not (au/offer! release-chan# {:scaling-state scaling-state#})
          (throw (ex-info "Unable to put scaling-state on release-chan."
@@ -203,10 +203,10 @@
 
 (defn notify-scaling-state-go
   "Sends a rpc to the router state to notify the scaling mode of a service."
-  [instance-rpc-chan service-id scaling-state]
+  [populate-maintainer-chan! service-id scaling-state]
   (async/go
     (try
-      (notify-scaling-state! instance-rpc-chan service-id scaling-state)
+      (notify-scaling-state! populate-maintainer-chan! service-id scaling-state)
       (catch Exception e
         (log/error e "Error while notifying scaling mode" service-id scaling-state)))))
 
@@ -215,7 +215,7 @@
 
    Will return an instance if the service exists and an instance is available,
    will return nil if the service is unknown or no instances are available"
-  [instance-rpc-chan service-id reason-map exclude-ids-set timeout-in-millis]
+  [populate-maintainer-chan! service-id reason-map exclude-ids-set timeout-in-millis]
   `(timers/start-stop-time!
      (metrics/service-timer ~service-id "get-task")
      (let [response-chan# (async/promise-chan)
@@ -229,7 +229,7 @@
              :method method#
              :response-chan response-chan#
              :service-id ~service-id}
-            (async/put! ~instance-rpc-chan))
+            (~populate-maintainer-chan!))
        (when-let [service-chan# (async/<! response-chan#)]
          (log/debug "found reservation channel for" ~service-id)
          (timers/start-stop-time!
@@ -245,14 +245,14 @@
   "Starts a `clojure.core.async/go` block to query the router state to get an
    available instance to send a request. It will continue to query the state until
    an instance is available."
-  [instance-rpc-chan service-id {:keys [cid] :as reason-map} service-not-found-fn queue-timeout-ms metric-group]
+  [populate-maintainer-chan! service-id {:keys [cid] :as reason-map} service-not-found-fn queue-timeout-ms metric-group]
   (async/go
     (try
       (counters/inc! (metrics/service-counter service-id "request-counts" "waiting-for-available-instance"))
       (statsd/gauge-delta! metric-group "request_waiting_for_instance" +1)
       (let [expiry-time (t/plus (t/now) (t/millis queue-timeout-ms))]
         (loop [iterations 1]
-          (let [instance (get-rand-inst instance-rpc-chan service-id reason-map #{} queue-timeout-ms)]
+          (let [instance (get-rand-inst populate-maintainer-chan! service-id reason-map #{} queue-timeout-ms)]
             (if-not (nil? (:id instance)) ; instance is nil or :no-matching-instance-found
               (do
                 (histograms/update!
@@ -346,3 +346,24 @@
   (let [deployment-error (get service-id->deployment-error service-id)
         instance-counts (get service-id->instance-counts service-id)]
     (utils/message (resolve-service-status deployment-error instance-counts))))
+
+(defn forward-request-to-instance-rpc-chan!
+  "Forwards the request to the instance-rpc-chan which will eventually populate/close response-chan.
+   If the forwarding fails, closes the input response-chan immediately."
+  [instance-rpc-chan {:keys [cid response-chan] :as request-map}]
+  (when-not (try
+              (async/put! instance-rpc-chan request-map)
+              (catch Throwable th
+                (cid/cerror cid th "error in forwarding request to instance-rpc-chan")))
+    (cid/cinfo cid "put! on instance-rpc-chan unsuccessful, closing response-chan")
+    (async/close! response-chan)))
+
+(defn populate-maintainer-chan!
+  "Retrieves the maintainer channel responsible for the requested method for the specific service.
+   The result channel is populated into the provided response channel.
+   Returns nil."
+  [instance-rpc-chan retrieve-maintainer-chan-fn
+   {:keys [method response-chan service-id] :as request-map}]
+  (if-let [result-chan (retrieve-maintainer-chan-fn service-id method)]
+    (async/put! response-chan result-chan)
+    (forward-request-to-instance-rpc-chan! instance-rpc-chan request-map)))

--- a/waiter/src/waiter/state.clj
+++ b/waiter/src/waiter/state.clj
@@ -801,6 +801,22 @@
       (start-service-chan-responder service-id trigger-unblacklist-process timeout-config channel-map initial-state))
     channel-map))
 
+(defn retrieve-maintainer-channel
+  "Retrieves the channel mapped to the provided method."
+  [channel-map method]
+  (let [maintainer-chan-keyword :maintainer-chan-map
+        method-chan (case method
+                      :blacklist [maintainer-chan-keyword :blacklist-instance-chan]
+                      :kill [maintainer-chan-keyword :kill-instance-chan]
+                      :offer [maintainer-chan-keyword :work-stealing-chan]
+                      :query-state [maintainer-chan-keyword :query-state-chan]
+                      :query-work-stealing [:work-stealing-chan-map :query-chan]
+                      :release [maintainer-chan-keyword :release-instance-chan]
+                      :reserve [maintainer-chan-keyword :reserve-instance-chan-in]
+                      :scaling-state [maintainer-chan-keyword :scaling-state-chan]
+                      :update-state [maintainer-chan-keyword :update-state-chan])]
+    (get-in channel-map method-chan)))
+
 (defn close-update-state-channel
   "Closes the update-state channelfor the responder"
   [service-id {:keys [update-state-chan]}]
@@ -817,26 +833,36 @@
    Services are destroyed (when the service is missing in state updates) by invoking
    `(remove-service service-id channel-map)`.
 
-   Requests for service-chan-responder channels is passed into request-chan
-      It is expected that messages on the channel have a map with keys
+   Requests for service-chan-responder channels is passed into instance-rpc-chan
+   It is expected that messages on the channel have a map with keys
       `:cid`, `:method`, `:response-chan`, and `:service-id`.
-      The `method` should be either `:blacklist`, `:kill`, `:query-state`, `:reserve`, `:release`, or `:scaling-state`.
-      The `service-id` is the service for the request and
-      `response-chan` will have the corresponding channel placed onto it by invoking
-      `(retrieve-channel channel-map method)`.
+   The `method` should be either `:blacklist`, `:kill`, `:query-state`, `:reserve`,
+      `:release`, or `:scaling-state`.
+   The `service-id` is the service for the request and `response-chan` will have the
+       corresponding channel placed onto it by invoking `(retrieve-channel channel-map method)`.
+   The returned `retrieve-maintainer-chan-fn` function can be used as a fast-path to bypass
+       a message on instance-rpc-chan and instead retrieve the channel by invoking
+       `(retrieve-channel channel-map method)`.
 
    Updated state for the router is passed into `state-chan` and then propogated to the
    service-chan-responders.
 
    `query-service-maintainer-chan` return the current state of the maintainer."
-  [initial-state request-chan state-chan query-service-maintainer-chan
+  [initial-state instance-rpc-chan state-chan query-service-maintainer-chan
    start-service remove-service retrieve-channel]
   (let [exit-chan (async/chan 1)
+        state-atom (atom {:last-update-time (t/now)
+                          :service-id->channel-map nil})
         update-state-timer (metrics/waiter-timer "state" "service-chan-maintainer" "update-state")]
     (async/go
       (try
         (loop [service-id->channel-map (or (:service-id->channel-map initial-state) {})
                last-state-update-time (:last-state-update-time initial-state)]
+          (swap!
+            state-atom
+            assoc
+            :last-update-time last-state-update-time
+            :service-id->channel-map service-id->channel-map)
           (let [new-state
                 (async/alt!
                   exit-chan
@@ -895,7 +921,7 @@
                           (log/error ex "[service-chan-maintainer] error in updating router state")
                           (throw ex)))))
 
-                  request-chan
+                  instance-rpc-chan
                   ([message]
                     (let [{:keys [cid method response-chan service-id]} message]
                       (cid/cdebug cid "[service-chan-maintainer]" service-id "received request of type" method)
@@ -931,7 +957,20 @@
         (catch Exception e
           (log/error e "fatal error in service-chan-maintainer")
           (System/exit 1))))
-    {:exit-chan exit-chan}))
+    {:exit-chan exit-chan
+     :query-state-fn (fn query-service-chan-maintainer-state []
+                       (-> @state-atom
+                         (update :service-id->channel-map keys)
+                         (set/rename-keys {:service-id->channel-map :service-ids})))
+     :retrieve-maintainer-chan-fn (fn retrieve-maintainer-chan-fn [service-id method]
+                                    (let [{:keys [service-id->channel-map]} @state-atom]
+                                      (if-let [channel-map (get service-id->channel-map service-id)]
+                                        (do
+                                          (counters/inc! (metrics/service-counter service-id "maintainer" "fast-path" "hit"))
+                                          (retrieve-channel channel-map method))
+                                        (do
+                                          (counters/inc! (metrics/service-counter service-id "maintainer" "fast-path" "miss"))
+                                          nil))))}))
 
 (defn md5-hash-function
   "Computes the md5 hash after concatenating the input strings."

--- a/waiter/test/waiter/async_request_test.clj
+++ b/waiter/test/waiter/async_request_test.clj
@@ -20,7 +20,8 @@
             [plumbing.core :as pc]
             [waiter.async-request :refer :all]
             [waiter.auth.authentication :as auth]
-            [waiter.service :as service])
+            [waiter.service :as service]
+            [waiter.test-helpers :refer :all])
   (:import java.net.URLDecoder))
 
 (deftest test-monitor-async-request
@@ -320,6 +321,7 @@
                                (is (= "http" backend-proto))
                                (async/go {}))
         instance-rpc-chan (async/chan 1)
+        populate-maintainer-chan! (make-populate-maintainer-chan! instance-rpc-chan)
         complete-async-request-atom (atom nil)
         response {}]
     (with-redefs [service/release-instance-go (constantly nil)
@@ -338,7 +340,7 @@
                         :service-id service-id}
             {:keys [headers]} (post-process-async-request-response
                                 router-id async-request-store-atom make-http-request-fn auth-params-map
-                                instance-rpc-chan user-agent response descriptor instance reason-map
+                                populate-maintainer-chan! user-agent response descriptor instance reason-map
                                 request-properties location query-string)]
         (is (get @async-request-store-atom request-id))
         (is (= (str "/waiter-async/status/" request-id "/" router-id "/" service-id "/" host "/" port location "?" query-string)
@@ -388,6 +390,7 @@
                                (is (= "http" backend-proto))
                                (async/go {}))
         instance-rpc-chan (async/chan 1)
+        populate-maintainer-chan! (make-populate-maintainer-chan! instance-rpc-chan)
         complete-async-request-atom (atom nil)
         response {}]
     (with-redefs [service/release-instance-go (constantly nil)
@@ -409,7 +412,7 @@
                         :service-id service-id}
             {:keys [headers]} (post-process-async-request-response
                                 router-id async-request-store-atom make-http-request-fn auth-params-map
-                                instance-rpc-chan user-agent response descriptor instance
+                                populate-maintainer-chan! user-agent response descriptor instance
                                 reason-map request-properties location query-string)]
         (is (get @async-request-store-atom request-id))
         (is (= (str "/waiter-async/status/" request-id "/" router-id "/" service-id "/" host "/" port location "?" query-string)

--- a/waiter/test/waiter/state_test.clj
+++ b/waiter/test/waiter/state_test.clj
@@ -1453,10 +1453,11 @@
        actual-state#)))
 
 (let [service-channel-map-atom (atom {})
-      start-service (fn [service-id]
+      start-service! (fn [populate-maintainer-chan! service-id]
+                      (is (function? populate-maintainer-chan!))
                       (swap! service-channel-map-atom assoc service-id {:update-state-chan (au/latest-chan)})
                       {:channel-map-for service-id})
-      remove-service (fn [service-id {:keys [channel-map-for]}]
+      remove-service! (fn [service-id {:keys [channel-map-for]}]
                        (is (= service-id channel-map-for))
                        (swap! service-channel-map-atom dissoc service-id))
       retrieve-channel (fn [{:keys [channel-map-for]} method]
@@ -1467,11 +1468,10 @@
   (deftest test-start-service-chan-maintainer-initialization
     (testing "test-start-service-chan-maintainer-initialization"
       (let [state-source-chan (async/chan)
-            request-chan (async/chan 1)
             query-chan (async/chan 1)
             {:keys [exit-chan query-state-fn]}
-            (start-service-chan-maintainer {} request-chan state-source-chan query-chan
-                                           start-service remove-service retrieve-channel)]
+            (start-service-chan-maintainer
+              {} state-source-chan query-chan start-service! remove-service! retrieve-channel)]
         (check-service-maintainer-state-fn query-chan query-state-fn nil
                                            {:service-id->channel-map {}, :last-state-update-time nil})
         (async/>!! exit-chan :exit))))
@@ -1479,13 +1479,12 @@
   (deftest test-start-service-chan-maintainer-start-services
     (testing "test-start-service-chan-maintainer-start-services"
       (let [state-source-chan (async/chan)
-            request-chan (async/chan 1)
             query-chan (async/chan 1)
             current-time (t/now)
             initial-state {}
             {:keys [exit-chan query-state-fn]}
-            (start-service-chan-maintainer initial-state request-chan state-source-chan query-chan
-                                           start-service remove-service retrieve-channel)]
+            (start-service-chan-maintainer
+              initial-state state-source-chan query-chan start-service! remove-service! retrieve-channel)]
 
         (let [state-map {:service-id->my-instance->slots {"service-1" {"service-1.A" 1, "service-1.B" 2}
                                                           "service-2" {"service-2.A" 3}
@@ -1511,7 +1510,6 @@
   (deftest test-start-service-chan-maintainer-remove-services
     (testing "test-start-service-chan-maintainer-remove-services"
       (let [state-source-chan (async/chan)
-            request-chan (async/chan 1)
             query-chan (async/chan 1)
             current-time (t/now)
             initial-state {:service-id->channel-map {"service-1" {:channel-map-for "service-1"}
@@ -1519,10 +1517,10 @@
                                                      "service-3" {:channel-map-for "service-3"}}
                            :last-state-update-time (t/minus current-time (t/seconds 10))}
             {:keys [exit-chan query-state-fn]}
-            (start-service-chan-maintainer initial-state request-chan state-source-chan query-chan
-                                           start-service remove-service retrieve-channel)]
+            (start-service-chan-maintainer
+              initial-state state-source-chan query-chan start-service! remove-service! retrieve-channel)]
         (doseq [service-id ["service-1" "service-2" "service-3"]]
-          (start-service service-id))
+          (start-service! identity service-id))
 
         (let [state-map {:service-id->my-instance->slots {"service-1" {"service-1.A" 1, "service-1.B" 2}
                                                           "service-3" {"service-3.A" 6, "service-3.B" 8}}
@@ -1545,7 +1543,6 @@
   (deftest test-start-service-chan-maintainer-start-and-remove-services
     (testing "test-start-service-chan-maintainer-start-and-remove-services"
       (let [state-source-chan (async/chan)
-            request-chan (async/chan 1)
             query-chan (async/chan 1)
             current-time (t/now)
             initial-state {:service-id->channel-map {"service-1" {:channel-map-for "service-1"}
@@ -1553,10 +1550,10 @@
                                                      "service-3" {:channel-map-for "service-3"}}
                            :last-state-update-time (t/minus current-time (t/seconds 10))}
             {:keys [exit-chan query-state-fn]}
-            (start-service-chan-maintainer initial-state request-chan state-source-chan query-chan
-                                           start-service remove-service retrieve-channel)]
+            (start-service-chan-maintainer
+              initial-state state-source-chan query-chan start-service! remove-service! retrieve-channel)]
         (doseq [service-id ["service-1" "service-2" "service-3"]]
-          (start-service service-id))
+          (start-service! identity service-id))
 
         (let [state-map {:service-id->my-instance->slots {"service-1" {"service-1.A" 11, "service-1.B" 12}
                                                           "service-3" {"service-3.A" 6, "service-3.B" 8}
@@ -1615,20 +1612,20 @@
 
         (async/>!! exit-chan :exit))))
 
-  (deftest test-start-service-chan-maintainer-request-channel
-    (testing "test-start-service-chan-maintainer-request-channel"
+  (deftest test-start-service-chan-maintainer-instance-rpc-channel
+    (testing "test-start-service-chan-maintainer-instance-rpc-channel"
       (let [state-source-chan (async/chan)
-            request-chan (async/chan 1)
             query-chan (async/chan 1)
             current-time (t/now)
             initial-state {:service-id->channel-map {"service-1" {:channel-map-for "service-1"}
                                                      "service-2" {:channel-map-for "service-2"}
                                                      "service-3" {:channel-map-for "service-3"}}
                            :last-state-update-time (t/minus current-time (t/seconds 10))}
-            {:keys [exit-chan]} (start-service-chan-maintainer initial-state request-chan state-source-chan query-chan
-                                                               start-service remove-service retrieve-channel)]
+            {:keys [exit-chan instance-rpc-chan]}
+            (start-service-chan-maintainer
+              initial-state state-source-chan query-chan start-service! remove-service! retrieve-channel)]
         (doseq [service-id ["service-1" "service-2" "service-3"]]
-          (start-service service-id))
+          (start-service! identity service-id))
 
         (doseq [service-id ["service-2" "service-1" "service-3"]]
           (let [response-chan (async/promise-chan)]
@@ -1636,7 +1633,7 @@
                   :method :method
                   :response-chan response-chan
                   :service-id service-id}
-                 (async/>!! request-chan))
+                 (async/>!! instance-rpc-chan))
             (is (= (str service-id "::method") (async/<!! response-chan)))))
 
         (async/>!! exit-chan :exit)))))

--- a/waiter/test/waiter/test_helpers.clj
+++ b/waiter/test/waiter/test_helpers.clj
@@ -397,3 +397,7 @@
        (finally
          (.removeMatching mc/default-registry all-metrics-match-filter)))))
 
+(defn make-populate-maintainer-chan!
+  [instance-rpc-chan]
+  (fn populate-maintainer-chan!-put! [request-map]
+    (async/put! instance-rpc-chan request-map)))

--- a/waiter/test/waiter/work_stealing_test.clj
+++ b/waiter/test/waiter/work_stealing_test.clj
@@ -20,6 +20,7 @@
             [clojure.walk :as walk]
             [waiter.test-helpers]
             [waiter.util.semaphore :as semaphore]
+            [waiter.test-helpers :refer :all]
             [waiter.util.utils :as utils]
             [waiter.work-stealing :refer :all]))
 
@@ -551,6 +552,7 @@
         service-id "test-service-id"
         request-id "test-request-id"
         instance-rpc-chan (async/chan 100)
+        populate-maintainer-chan! (make-populate-maintainer-chan! instance-rpc-chan)
         reserve-timeout-ms 1000
         offer-help-interval-ms 1000
         service-id->router-id->metrics {}
@@ -578,7 +580,7 @@
       (testing "2XX response - missing status"
         (let [offers-allowed-semaphore (semaphore/create-semaphore 10)
               make-inter-router-requests-fn (make-inter-router-requests-fn-factory 200 {})]
-          (start-work-stealing-balancer instance-rpc-chan reserve-timeout-ms offer-help-interval-ms offers-allowed-semaphore
+          (start-work-stealing-balancer populate-maintainer-chan! reserve-timeout-ms offer-help-interval-ms offers-allowed-semaphore
                                         service-id->router-id->metrics make-inter-router-requests-fn router-id service-id)
           (is @offer-help-fn-atom)
           (let [offer-help-fn @offer-help-fn-atom
@@ -590,7 +592,7 @@
       (testing "2XX response - success"
         (let [offers-allowed-semaphore (semaphore/create-semaphore 10)
               make-inter-router-requests-fn (make-inter-router-requests-fn-factory 200 {:response-status "successful"})]
-          (start-work-stealing-balancer instance-rpc-chan reserve-timeout-ms offer-help-interval-ms offers-allowed-semaphore
+          (start-work-stealing-balancer populate-maintainer-chan! reserve-timeout-ms offer-help-interval-ms offers-allowed-semaphore
                                         service-id->router-id->metrics make-inter-router-requests-fn router-id service-id)
           (is @offer-help-fn-atom)
           (let [offer-help-fn @offer-help-fn-atom
@@ -602,7 +604,7 @@
       (testing "2XX response - failure"
         (let [offers-allowed-semaphore (semaphore/create-semaphore 10)
               make-inter-router-requests-fn (make-inter-router-requests-fn-factory 200 {:response-status "failure"})]
-          (start-work-stealing-balancer instance-rpc-chan reserve-timeout-ms offer-help-interval-ms offers-allowed-semaphore
+          (start-work-stealing-balancer populate-maintainer-chan! reserve-timeout-ms offer-help-interval-ms offers-allowed-semaphore
                                         service-id->router-id->metrics make-inter-router-requests-fn router-id service-id)
           (is @offer-help-fn-atom)
           (let [offer-help-fn @offer-help-fn-atom
@@ -614,7 +616,7 @@
       (testing "4XX response - failure"
         (let [offers-allowed-semaphore (semaphore/create-semaphore 10)
               make-inter-router-requests-fn (make-inter-router-requests-fn-factory 400 {:response-status "failure"})]
-          (start-work-stealing-balancer instance-rpc-chan reserve-timeout-ms offer-help-interval-ms offers-allowed-semaphore
+          (start-work-stealing-balancer populate-maintainer-chan! reserve-timeout-ms offer-help-interval-ms offers-allowed-semaphore
                                         service-id->router-id->metrics make-inter-router-requests-fn router-id service-id)
           (is @offer-help-fn-atom)
           (let [offer-help-fn @offer-help-fn-atom
@@ -626,7 +628,7 @@
       (testing "5XX response - failure"
         (let [offers-allowed-semaphore (semaphore/create-semaphore 10)
               make-inter-router-requests-fn (make-inter-router-requests-fn-factory 500 {:response-status "failure"})]
-          (start-work-stealing-balancer instance-rpc-chan reserve-timeout-ms offer-help-interval-ms offers-allowed-semaphore
+          (start-work-stealing-balancer populate-maintainer-chan! reserve-timeout-ms offer-help-interval-ms offers-allowed-semaphore
                                         service-id->router-id->metrics make-inter-router-requests-fn router-id service-id)
           (is @offer-help-fn-atom)
           (let [offer-help-fn @offer-help-fn-atom


### PR DESCRIPTION
## Changes proposed in this PR

Introduces a fast path that avoids async/go blocks to retrieve maintainer channels. The maintainer state is maintained in an atom and the fast path looks up the atom and avoids the async block when there is a hit.

## Why are we making these changes?

Avoiding go-blocks allows avoiding context switching to retrieve the channel data thus improving the time required to reserve an instance.

### Example metrics:

<img width="625" alt="Screen Shot 2020-01-22 at 9 04 45 PM" src="https://user-images.githubusercontent.com/6611249/72953992-8839db00-3d5c-11ea-9bf3-f7733888dffb.png">


