### PR TITLE
adds codahale timer for inter-router metrics computation

### DIFF
--- a/waiter/src/waiter/metrics.clj
+++ b/waiter/src/waiter/metrics.clj
@@ -261,7 +261,7 @@
    :slots-available (counters/value (service-counter service-id "instance-counts" "slots-available"))})
 
 (defn is-quantile-metric?
-  "Returns true if the input map represents a quantile metric (timer or historgram).
+  "Returns true if the input map represents a quantile metric (timer or histogram).
    Warning: Not foolproof."
   [value]
   (and (map? value)
@@ -275,7 +275,7 @@
               (contains? value-entry "0.75")))))
 
 (defn- merge-quantile-metrics
-  "Merges the quantile metrics (timers and historgrams) using a weighted sum reduction."
+  "Merges the quantile metrics (timers and histograms) using a weighted sum reduction."
   [& values]
   (let [non-nil-values (remove nil? values)]
     (when-not (every? is-quantile-metric? non-nil-values)


### PR DESCRIPTION
## Changes proposed in this PR

- adds codahaler timer for inter-router metrics computation

## Why are we making these changes?

Allows us to track the number of services and the time spent computing the inter-router metrics.


