### PR TITLE
allows creation and sharing of custom components

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -897,6 +897,11 @@
 
  ; ---------- Miscellaneous ----------
 
+ ;; Custom components allow sharing of components between the scheduler and service description builder.
+ ;; The values in the entries must contain a :factory-fn and the necessary config for the component.
+ ;; Components also get passed in the :kv-store-factory, :leader?-fn and :synchronize-fn for use in the factory.
+ :custom-components {:in-memory-kv-store {:factory-fn waiter.kv/new-local-kv-store}}
+
  ;; Certain messages that Waiter returns can be customized:
  :messages {:backend-request-failed "Request to service backend failed"
             :backend-request-timed-out "Request to service backend timed out"

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -42,6 +42,7 @@
                                      (s/required-key :name) schema/non-empty-string
                                      (s/required-key :service-prefix) schema/non-empty-string}
    (s/required-key :consent-expiry-days) schema/positive-int
+   (s/required-key :custom-components) {s/Keyword schema/require-symbol-factory-fn}
    (s/required-key :deployment-error-config) {(s/required-key :min-failed-instances) schema/positive-int
                                               (s/required-key :min-hosts) schema/positive-int}
    (s/required-key :entitlement-config) (s/constrained
@@ -276,6 +277,7 @@
                     :name "waiter"
                     :service-prefix "waiter-service-"}
    :consent-expiry-days 90
+   :custom-components {}
    :deployment-error-config {:min-failed-instances 2
                              :min-hosts 2}
    :entitlement-config {:kind :simple


### PR DESCRIPTION
## Changes proposed in this PR

- allows creation and sharing of custom components

## Why are we making these changes?

We may need to allow sharing of components between the scheduler and service description builder. Introducing custom components helps solve this problem for external components.

