### PR TITLE
Introduces separate grpc cleartext port

### DIFF
--- a/waiter/integration/waiter/grpc_test.clj
+++ b/waiter/integration/waiter/grpc_test.clj
@@ -80,7 +80,7 @@
 (defn start-courier-instance
   [waiter-url]
   (let [[host _] (str/split waiter-url #":")
-        h2c-port (Integer/parseInt (retrieve-h2c-port waiter-url))
+        h2c-port (Integer/parseInt (retrieve-grpc-cleartext-port waiter-url))
         request-headers (basic-grpc-service-parameters)
         {:keys [cookies headers] :as response} (ping-courier-service waiter-url request-headers)
         cookie-header (str/join "; " (map #(str (:name %) "=" (:value %)) cookies))

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -115,6 +115,12 @@
   (or (System/getenv "WAITER_H2C_PORT")
       (retrieve-waiter-port waiter-url)))
 
+(defn retrieve-grpc-cleartext-port
+  "Retrieves the Waiter port for receiving grpc requests over cleartext."
+  [waiter-url]
+  (or (System/getenv "WAITER_GRPC_CLEARTEXT_PORT")
+      (retrieve-h2c-port waiter-url)))
+
 (defn retrieve-h2c-url
   "Retrieves the Waiter url for receiving h2c requests."
   [waiter-url]


### PR DESCRIPTION
## Changes proposed in this PR

- adds extra environment variable for grpc cleartext port lookup

## Why are we making these changes?

We are enabling grpc support by default.


