### PR TITLE
randomizes the token in test-token-param-support-name

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1098,7 +1098,7 @@
                                :env {"BINARY" binary
                                      "FEE" "FIE"
                                      "FOO" "BAR"}
-                               :name "test-token-param-support"
+                               :name (rand-name)
                                :version "does-not-matter"}
           kitchen-request #(make-kitchen-request waiter-url % :path "/environment")]
       (try


### PR DESCRIPTION
## Changes proposed in this PR

- randomizes the token in test-token-param-support-name

## Why are we making these changes?

We want tests to be able to run in parallel and be unaffected by other concurrently running tests.

