### PR TITLE
enables explicit grpc tests

### DIFF
--- a/containers/test-apps/courier/pom.xml
+++ b/containers/test-apps/courier/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>twosigma</groupId>
     <artifactId>courier</artifactId>
-    <version>1.5.14</version>
+    <version>1.5.15</version>
 
     <name>courier</name>
     <url>https://github.com/twosigma/waiter/tree/master/test-apps/courier</url>

--- a/containers/test-apps/courier/src/main/java/com/twosigma/waiter/courier/GrpcServer.java
+++ b/containers/test-apps/courier/src/main/java/com/twosigma/waiter/courier/GrpcServer.java
@@ -82,7 +82,12 @@ public class GrpcServer {
                 final List<Long> timestamps = new ArrayList<Long>(stateEntries.keySet());
                 Collections.sort(timestamps);
                 final Long requestTime = timestamps.get(0);
-                return stateEntries.get(requestTime);
+                final List<String> stateList = stateEntries.get(requestTime);
+                if (stateList == null) {
+                    return null;
+                } else {
+                    return new ArrayList<>(stateList);
+                }
             } else {
                 return new ArrayList<>();
             }

--- a/waiter/integration/waiter/grpc_test.clj
+++ b/waiter/integration/waiter/grpc_test.clj
@@ -227,26 +227,27 @@
           (is (= "INIT" (first states)) assertion-message)
           (is (<= (count-items (take 2 states) "READY") 1) assertion-message)
           (when (pos? (count-items states "SEND_MESSAGE"))
-            (is (= 1 (count-items states "SEND_HEADERS")) assertion-message))
+            (is (= (count-items states "SEND_HEADERS") 1) assertion-message))
           (is (every? #{"HALF_CLOSE" "RECEIVE_MESSAGE" "SEND_MESSAGE" "SEND_HEADERS"} states-middle) assertion-message)
           (is (<= (count-items states "HALF_CLOSE") 1) assertion-message)
-          (is (= 1 (count-items (take-last 3 states) "CANCEL")) assertion-message)
-          (is (= 1 (count-items (take-last 3 states) "CANCEL_HANDLER")) assertion-message)
-          (is (= 1 (count-items (take-last 3 states) "CLOSE")) assertion-message))
+          (is (= (count-items (take-last 3 states) "CANCEL") 1) assertion-message)
+          (is (= (count-items (take-last 3 states) "CANCEL_HANDLER") 1) assertion-message)
+          (is (= (count-items (take-last 3 states) "CLOSE") 1) assertion-message))
         (= ::server-cancel mode)
         (do
           (is (= ["INIT" "READY"] (take 2 states)) assertion-message)
           (is (pos? (count-items states "RECEIVE_MESSAGE")) assertion-message)
+          (is (<= (count-items states "SEND_HEADERS") 1) assertion-message)
           (is (<= (count-items states "HALF_CLOSE") 1) assertion-message)
-          (is (= 1 (count-items states "CLOSE")) assertion-message)
-          (is (= 1 (count-items states "COMPLETE")) assertion-message))
+          (is (= (count-items states "CLOSE") 1) assertion-message)
+          (is (<= (count-items states "COMPLETE") 1) assertion-message))
         (= ::success mode)
         (do
           (is (= ["INIT" "READY"] (take 2 states)) assertion-message)
           (is (pos? (count-items states "RECEIVE_MESSAGE")) assertion-message)
-          (is (= 1 (count-items states "SEND_HEADERS")) assertion-message)
+          (is (= (count-items states "SEND_HEADERS") 1) assertion-message)
           (is (pos? (count-items states "SEND_MESSAGE")) assertion-message)
-          (is (= 1 (count-items states "HALF_CLOSE")) assertion-message)
+          (is (= (count-items states "HALF_CLOSE") 1) assertion-message)
           (is (= ["CLOSE" "COMPLETE"] (take-last 2 states)) assertion-message))))))
 
 (deftest ^:parallel ^:integration-fast test-grpc-unary-call
@@ -879,23 +880,6 @@
                       (assert-grpc-server-exit-status status assertion-message)
                       (is (nil? message-summary) assertion-message))))))))))))
 
-;; FAIL in (test-grpc-client-streaming-server-cancellation) (grpc_test.clj:239)
-;; waiter.grpc-test/test-grpc-client-streaming-server-cancellation 1000 messages server error
-;; {:correlation-id "wgttgcssc796969990733.SEND_ERROR.40-120.1000",
-;;  :mode "server-cancel",
-;;  :reply {:cid "wgttgcssc796969990733.SEND_ERROR.40-120.1000",
-;;  :state ("INIT" "READY" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE"
-;;          "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE"
-;;          "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE"
-;;          "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE"
-;;          "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE"
-;;          "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE"
-;;          "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE" "RECEIVE_MESSAGE"
-;;          "CLOSE" "HALF_CLOSE")},
-;; :service-id "waiter-service-wgttgcssc800602673571-78ab76f80b2ab2c810a3a73b1d505ec4",
-;; :status {:code "OK", :description nil}}
-;; expected: 1
-;;   actual: 0
 (deftest ^:parallel ^:integration-slow test-grpc-client-streaming-server-cancellation
   (testing-using-waiter-url
     (let [num-messages 120

--- a/waiter/integration/waiter/grpc_test.clj
+++ b/waiter/integration/waiter/grpc_test.clj
@@ -203,8 +203,9 @@
        (retrieve-request-state grpc-client request-headers query-correlation-id))))
 
 (defn assert-request-state
-  "Asserts the states on the cid of a previously successful rpc call."
+  "Asserts the states on the cid of a previous grpc call."
   [grpc-client request-headers service-id query-correlation-id mode]
+  (Thread/sleep 1000) ;; sleep to allow completion of grpc server-side internal events
   (let [timeout-secs 10
         rpc-result (retrieve-request-state grpc-client request-headers query-correlation-id timeout-secs)
         ^StateReply reply (.result rpc-result)

--- a/waiter/integration/waiter/grpc_test.clj
+++ b/waiter/integration/waiter/grpc_test.clj
@@ -575,7 +575,7 @@
                     (Thread/sleep 1500) ;; sleep to allow cancellation propagation to backend
                     (assert-request-state grpc-client request-headers service-id correlation-id ::client-cancel)))))))))))
 
-(deftest ^:parallel ^:integration-slow ^:explicit test-grpc-bidi-streaming-server-exit
+(deftest ^:parallel ^:integration-slow test-grpc-bidi-streaming-server-exit
   (testing-using-waiter-url
     (let [num-messages 120
           num-iterations 3
@@ -724,7 +724,7 @@
 ;;  :status {:code "OK", :description nil}}
 ;; expected: "INIT"
 ;;   actual: nil
-(deftest ^:parallel ^:integration-fast ^:explicit test-grpc-client-streaming-client-cancellation
+(deftest ^:parallel ^:integration-fast test-grpc-client-streaming-client-cancellation
   (testing-using-waiter-url
     ;; TODO undo after fix to https://github.com/haproxy/haproxy/issues/172
     (when-not (behind-proxy? waiter-url)
@@ -791,7 +791,7 @@
 ;; {:body nil, :result "timed-out"}
 ;; expected: "received-response"
 ;;   actual: "timed-out"
-(deftest ^:parallel ^:integration-fast ^:explicit test-grpc-client-streaming-deadline-exceeded
+(deftest ^:parallel ^:integration-fast test-grpc-client-streaming-deadline-exceeded
   (testing-using-waiter-url
     (let [{:keys [h2c-port host request-headers service-id]} (start-courier-instance waiter-url)
           correlation-id-prefix (rand-name)]
@@ -896,7 +896,7 @@
 ;; :status {:code "OK", :description nil}}
 ;; expected: 1
 ;;   actual: 0
-(deftest ^:parallel ^:integration-slow ^:explicit test-grpc-client-streaming-server-cancellation
+(deftest ^:parallel ^:integration-slow test-grpc-client-streaming-server-cancellation
   (testing-using-waiter-url
     (let [num-messages 120
           num-iterations 3

--- a/waiter/integration/waiter/grpc_test.clj
+++ b/waiter/integration/waiter/grpc_test.clj
@@ -181,7 +181,7 @@
 
 (defn retrieve-request-state
   "Retrieves the request state for the specified correlation-id.
-   When timeout is proivded, retries for specified interval until state contains CLOSED."
+   When timeout is provided, retries for specified interval until state contains CLOSED."
   ([grpc-client request-headers query-correlation-id]
    (let [state-correlation-id (rand-name)
          state-request-headers (assoc request-headers "x-cid" state-correlation-id)]
@@ -191,8 +191,10 @@
          (fn retrieve-closed-request-state []
            (when-let [^GrpcClient$RpcResult rpc-result
                       (retrieve-request-state grpc-client request-headers query-correlation-id)]
+             (log/info "retrieve-request-state:" query-correlation-id
+                       {:result(.result rpc-result) :status (.status rpc-result)})
              (let [^StateReply reply (.result rpc-result)
-                   states (seq (.getStateList reply))]
+                   states (some-> reply .getStateList seq)]
                (log/info "retrieve-request-state:" query-correlation-id
                          {:cid (some-> reply .getCid) :state (some-> reply .getStateList)})
                (when (some #(= "CLOSE" %) states)

--- a/waiter/integration/waiter/grpc_test.clj
+++ b/waiter/integration/waiter/grpc_test.clj
@@ -346,9 +346,7 @@
             (assert-grpc-deadline-exceeded-status status assertion-message)
             (is (nil? reply) assertion-message)
             (.await sleep-duration-latch)
-            ;; TODO undo after fix to https://github.com/haproxy/haproxy/issues/172
-            (when-not (behind-proxy? waiter-url)
-              (assert-request-state grpc-client request-headers service-id correlation-id ::deadline-exceeded))))))))
+            (assert-request-state grpc-client request-headers service-id correlation-id ::deadline-exceeded)))))))
 
 (deftest ^:parallel ^:integration-fast test-grpc-unary-call-server-cancellation
   (testing-using-waiter-url
@@ -483,98 +481,94 @@
 
 (deftest ^:parallel ^:integration-slow test-grpc-bidi-streaming-client-cancellation
   (testing-using-waiter-url
-    ;; TODO undo after fix to https://github.com/haproxy/haproxy/issues/172
-    (when-not (behind-proxy? waiter-url)
-      (let [{:keys [h2c-port host request-headers service-id]} (start-courier-instance waiter-url)
-            correlation-id-prefix (rand-name)]
-        (with-service-cleanup
-          service-id
-          (doseq [cancel-policy [cancel-policy-context cancel-policy-exception cancel-policy-observer]]
-            (doseq [max-message-length [1000 50000]]
-              (let [num-messages 120
-                    messages (doall (repeatedly num-messages #(rand-str (inc (rand-int max-message-length)))))]
+    (let [{:keys [h2c-port host request-headers service-id]} (start-courier-instance waiter-url)
+          correlation-id-prefix (rand-name)]
+      (with-service-cleanup
+        service-id
+        (doseq [cancel-policy [cancel-policy-context cancel-policy-exception cancel-policy-observer]]
+          (doseq [max-message-length [1000 50000]]
+            (let [num-messages 120
+                  messages (doall (repeatedly num-messages #(rand-str (inc (rand-int max-message-length)))))]
 
-                (testing (str "independent mode " max-message-length " messages completion " cancel-policy)
-                  (log/info "starting streaming to and from server - independent mode test")
-                  (let [cancel-threshold (/ num-messages 2)
-                        from (rand-name "f")
-                        correlation-id (str correlation-id-prefix "-in-" max-message-length "-" cancel-policy)
-                        request-headers (assoc request-headers "x-cid" correlation-id)
-                        ids (map #(str "id-inde-" %) (range num-messages))
-                        grpc-client (initialize-grpc-client correlation-id host h2c-port)
-                        rpc-result (.collectPackages grpc-client request-headers ids from messages 100 false cancel-threshold cancel-policy 60000)
-                        summaries (.result rpc-result)
-                        ^Status status (.status rpc-result)
-                        assertion-message (->> (cond-> {:correlation-id correlation-id
-                                                        :service-id service-id
-                                                        :summaries (map (fn [^CourierSummary s]
-                                                                          {:num-messages (.getNumMessages s)
-                                                                           :total-length (.getTotalLength s)})
-                                                                        summaries)}
-                                                 status (assoc :status {:code (-> status .getCode str)
-                                                                        :description (.getDescription status)}))
-                                               (into (sorted-map))
-                                               str)]
-                    (log/info correlation-id "collecting independent packages...")
-                    (cond
-                      (= cancel-policy-context cancel-policy)
-                      (assert-grpc-cancel-status status "Context cancelled" assertion-message)
-                      (= cancel-policy-exception cancel-policy)
-                      (assert-grpc-unknown-status status nil assertion-message)
-                      (= cancel-policy-observer cancel-policy)
-                      (assert-grpc-unknown-status status "call was cancelled" assertion-message))
-                    ;; allow for cancellation to trigger before message has been received and processed on server-side
-                    (is (<= (count summaries) (inc cancel-threshold)) assertion-message)
-                    (when (seq summaries)
-                      (is (= (range 1 (inc (count summaries)))
-                             (map #(.getNumMessages ^CourierSummary %) summaries))
-                          assertion-message)
-                      (is (= (reductions + (map count (take (count summaries) messages)))
-                             (map #(.getTotalLength ^CourierSummary %) summaries))
-                          assertion-message))
-                    ;; TODO undo after fix to https://github.com/haproxy/haproxy/issues/172
-                    (when-not (behind-proxy? waiter-url)
-                      (assert-request-state grpc-client request-headers service-id correlation-id ::client-cancel))))
+              (testing (str "independent mode " max-message-length " messages completion " cancel-policy)
+                (log/info "starting streaming to and from server - independent mode test")
+                (let [cancel-threshold (/ num-messages 2)
+                      from (rand-name "f")
+                      correlation-id (str correlation-id-prefix "-in-" max-message-length "-" cancel-policy)
+                      request-headers (assoc request-headers "x-cid" correlation-id)
+                      ids (map #(str "id-inde-" %) (range num-messages))
+                      grpc-client (initialize-grpc-client correlation-id host h2c-port)
+                      rpc-result (.collectPackages grpc-client request-headers ids from messages 100 false cancel-threshold cancel-policy 60000)
+                      summaries (.result rpc-result)
+                      ^Status status (.status rpc-result)
+                      assertion-message (->> (cond-> {:correlation-id correlation-id
+                                                      :service-id service-id
+                                                      :summaries (map (fn [^CourierSummary s]
+                                                                        {:num-messages (.getNumMessages s)
+                                                                         :total-length (.getTotalLength s)})
+                                                                      summaries)}
+                                               status (assoc :status {:code (-> status .getCode str)
+                                                                      :description (.getDescription status)}))
+                                          (into (sorted-map))
+                                          str)]
+                  (log/info correlation-id "collecting independent packages...")
+                  (cond
+                    (= cancel-policy-context cancel-policy)
+                    (assert-grpc-cancel-status status "Context cancelled" assertion-message)
+                    (= cancel-policy-exception cancel-policy)
+                    (assert-grpc-unknown-status status nil assertion-message)
+                    (= cancel-policy-observer cancel-policy)
+                    (assert-grpc-unknown-status status "call was cancelled" assertion-message))
+                  ;; allow for cancellation to trigger before message has been received and processed on server-side
+                  (is (<= (count summaries) (inc cancel-threshold)) assertion-message)
+                  (when (seq summaries)
+                    (is (= (range 1 (inc (count summaries)))
+                           (map #(.getNumMessages ^CourierSummary %) summaries))
+                        assertion-message)
+                    (is (= (reductions + (map count (take (count summaries) messages)))
+                           (map #(.getTotalLength ^CourierSummary %) summaries))
+                        assertion-message))
+                  (assert-request-state grpc-client request-headers service-id correlation-id ::client-cancel)))
 
-                (testing (str "lock-step mode " max-message-length " messages completion")
-                  (log/info "starting streaming to and from server - lock-step mode test")
-                  (let [cancel-threshold (/ num-messages 2)
-                        from (rand-name "f")
-                        correlation-id (str correlation-id-prefix "-ls-" max-message-length "-" cancel-policy)
-                        request-headers (assoc request-headers "x-cid" correlation-id)
-                        ids (map #(str "id-lock-" %) (range num-messages))
-                        grpc-client (initialize-grpc-client correlation-id host h2c-port)
-                        rpc-result (.collectPackages grpc-client request-headers ids from messages 100 true cancel-threshold cancel-policy 60000)
-                        summaries (.result rpc-result)
-                        ^Status status (.status rpc-result)
-                        assertion-message (->> (cond-> {:correlation-id correlation-id
-                                                        :service-id service-id
-                                                        :summaries (map (fn [^CourierSummary s]
-                                                                          {:num-messages (.getNumMessages s)
-                                                                           :total-length (.getTotalLength s)})
-                                                                        summaries)}
-                                                 status (assoc :status {:code (-> status .getCode str)
-                                                                        :description (.getDescription status)}))
-                                               (into (sorted-map))
-                                               str)]
-                    (log/info correlation-id "collecting lock-step packages...")
-                    (cond
-                      (= cancel-policy-context cancel-policy)
-                      (assert-grpc-cancel-status status "Context cancelled" assertion-message)
-                      (= cancel-policy-exception cancel-policy)
-                      (assert-grpc-unknown-status status nil assertion-message)
-                      (= cancel-policy-observer cancel-policy)
-                      (assert-grpc-unknown-status status "call was cancelled" assertion-message))
-                    (is (<= (count summaries) (inc cancel-threshold)) assertion-message)
-                    (when (seq summaries)
-                      (is (= (range 1 (inc (count summaries)))
-                             (map #(.getNumMessages ^CourierSummary %) summaries))
-                          assertion-message)
-                      (is (= (reductions + (map count (take (count summaries) messages)))
-                             (map #(.getTotalLength ^CourierSummary %) summaries))
-                          assertion-message))
-                    (Thread/sleep 1500) ;; sleep to allow cancellation propagation to backend
-                    (assert-request-state grpc-client request-headers service-id correlation-id ::client-cancel)))))))))))
+              (testing (str "lock-step mode " max-message-length " messages completion")
+                (log/info "starting streaming to and from server - lock-step mode test")
+                (let [cancel-threshold (/ num-messages 2)
+                      from (rand-name "f")
+                      correlation-id (str correlation-id-prefix "-ls-" max-message-length "-" cancel-policy)
+                      request-headers (assoc request-headers "x-cid" correlation-id)
+                      ids (map #(str "id-lock-" %) (range num-messages))
+                      grpc-client (initialize-grpc-client correlation-id host h2c-port)
+                      rpc-result (.collectPackages grpc-client request-headers ids from messages 100 true cancel-threshold cancel-policy 60000)
+                      summaries (.result rpc-result)
+                      ^Status status (.status rpc-result)
+                      assertion-message (->> (cond-> {:correlation-id correlation-id
+                                                      :service-id service-id
+                                                      :summaries (map (fn [^CourierSummary s]
+                                                                        {:num-messages (.getNumMessages s)
+                                                                         :total-length (.getTotalLength s)})
+                                                                      summaries)}
+                                               status (assoc :status {:code (-> status .getCode str)
+                                                                      :description (.getDescription status)}))
+                                          (into (sorted-map))
+                                          str)]
+                  (log/info correlation-id "collecting lock-step packages...")
+                  (cond
+                    (= cancel-policy-context cancel-policy)
+                    (assert-grpc-cancel-status status "Context cancelled" assertion-message)
+                    (= cancel-policy-exception cancel-policy)
+                    (assert-grpc-unknown-status status nil assertion-message)
+                    (= cancel-policy-observer cancel-policy)
+                    (assert-grpc-unknown-status status "call was cancelled" assertion-message))
+                  (is (<= (count summaries) (inc cancel-threshold)) assertion-message)
+                  (when (seq summaries)
+                    (is (= (range 1 (inc (count summaries)))
+                           (map #(.getNumMessages ^CourierSummary %) summaries))
+                        assertion-message)
+                    (is (= (reductions + (map count (take (count summaries) messages)))
+                           (map #(.getTotalLength ^CourierSummary %) summaries))
+                        assertion-message))
+                  (Thread/sleep 1500) ;; sleep to allow cancellation propagation to backend
+                  (assert-request-state grpc-client request-headers service-id correlation-id ::client-cancel))))))))))
 
 (deftest ^:parallel ^:integration-slow test-grpc-bidi-streaming-server-exit
   (testing-using-waiter-url
@@ -727,65 +721,60 @@
 ;;   actual: nil
 (deftest ^:parallel ^:integration-fast test-grpc-client-streaming-client-cancellation
   (testing-using-waiter-url
-    ;; TODO undo after fix to https://github.com/haproxy/haproxy/issues/172
-    (when-not (behind-proxy? waiter-url)
-      (let [{:keys [h2c-port host request-headers service-id]} (start-courier-instance waiter-url)
-            correlation-id-prefix (rand-name)]
-        (with-service-cleanup
-          service-id
-          (doseq [cancel-policy [cancel-policy-context cancel-policy-exception cancel-policy-observer]]
-            (doseq [max-message-length [1000 50000]]
-              (let [num-messages 120
-                    messages (doall (repeatedly num-messages #(rand-str (inc (rand-int max-message-length)))))]
+    (let [{:keys [h2c-port host request-headers service-id]} (start-courier-instance waiter-url)
+          correlation-id-prefix (rand-name)]
+      (with-service-cleanup
+        service-id
+        (doseq [cancel-policy [cancel-policy-context cancel-policy-exception cancel-policy-observer]]
+          (doseq [max-message-length [1000 50000]]
+            (let [num-messages 120
+                  messages (doall (repeatedly num-messages #(rand-str (inc (rand-int max-message-length)))))]
 
-                (testing (str max-message-length " messages completion " cancel-policy)
-                  (log/info "starting streaming to and from server - independent mode test")
-                  (let [cancel-threshold (/ num-messages 2)
-                        from (rand-name "f")
-                        correlation-id (str correlation-id-prefix "-in-" max-message-length "-" cancel-policy)
-                        request-headers (assoc request-headers "x-cid" correlation-id)
-                        ids (map #(str "id-" %) (range num-messages))
-                        grpc-client (initialize-grpc-client correlation-id host h2c-port)
-                        rpc-result (.aggregatePackages grpc-client request-headers ids from messages 10 cancel-threshold cancel-policy 60000)
-                        ^CourierSummary summary (.result rpc-result)
-                        ^Status status (.status rpc-result)
-                        assertion-message (->> (cond-> {:correlation-id correlation-id
-                                                        :service-id service-id}
-                                                 summary (assoc :summary {:num-messages (.getNumMessages summary)
-                                                                          :total-length (.getTotalLength summary)})
-                                                 status (assoc :status {:code (-> status .getCode str)
-                                                                        :description (.getDescription status)}))
-                                               (into (sorted-map))
-                                               str)]
-                    (log/info correlation-id "aggregated packages...")
-                    (cond
-                      (= cancel-policy-context cancel-policy)
-                      (assert-grpc-cancel-status status "Context cancelled" assertion-message)
-                      (= cancel-policy-exception cancel-policy)
-                      (assert-grpc-unknown-status status nil assertion-message)
-                      (= cancel-policy-observer cancel-policy)
-                      (assert-grpc-unknown-status status "call was cancelled" assertion-message))
-                    (is (nil? summary) assertion-message)
-                    ;; TODO undo after fix to https://github.com/haproxy/haproxy/issues/172
-                    (when-not (behind-proxy? waiter-url)
-                      (assert-request-state grpc-client request-headers service-id correlation-id ::client-cancel))))))))))))
+              (testing (str max-message-length " messages completion " cancel-policy)
+                (log/info "starting streaming to and from server - independent mode test")
+                (let [cancel-threshold (/ num-messages 2)
+                      from (rand-name "f")
+                      correlation-id (str correlation-id-prefix "-in-" max-message-length "-" cancel-policy)
+                      request-headers (assoc request-headers "x-cid" correlation-id)
+                      ids (map #(str "id-" %) (range num-messages))
+                      grpc-client (initialize-grpc-client correlation-id host h2c-port)
+                      rpc-result (.aggregatePackages grpc-client request-headers ids from messages 10 cancel-threshold cancel-policy 60000)
+                      ^CourierSummary summary (.result rpc-result)
+                      ^Status status (.status rpc-result)
+                      assertion-message (->> (cond-> {:correlation-id correlation-id
+                                                      :service-id service-id}
+                                               summary (assoc :summary {:num-messages (.getNumMessages summary)
+                                                                        :total-length (.getTotalLength summary)})
+                                               status (assoc :status {:code (-> status .getCode str)
+                                                                      :description (.getDescription status)}))
+                                          (into (sorted-map))
+                                          str)]
+                  (log/info correlation-id "aggregated packages...")
+                  (cond
+                    (= cancel-policy-context cancel-policy)
+                    (assert-grpc-cancel-status status "Context cancelled" assertion-message)
+                    (= cancel-policy-exception cancel-policy)
+                    (assert-grpc-unknown-status status nil assertion-message)
+                    (= cancel-policy-observer cancel-policy)
+                    (assert-grpc-unknown-status status "call was cancelled" assertion-message))
+                  (is (nil? summary) assertion-message)
+                  (assert-request-state grpc-client request-headers service-id correlation-id ::client-cancel))))))))))
 
 (deftest ^:parallel ^:integration-slow test-grpc-bidi-streaming-client-exit
   (testing-using-waiter-url
-    (when-not (behind-proxy? waiter-url)
-      (let [{:keys [h2c-port host request-headers service-id]} (start-courier-instance waiter-url)
-            {:strs [cookie]} request-headers]
-        (with-service-cleanup
-          service-id
-          (let [correlation-id (rand-name)
-                {:keys [err out]} (sh/sh "lein" "exec" "-p"
-                                         "test-files/grpc/grpc_client_exit.clj"
-                                         host (str h2c-port) service-id correlation-id cookie)]
-            (log/info "exec stdout:" out)
-            (log/info "exec stderr:" err)
-            (Thread/sleep 1500) ;; sleep to allow cancellation propagation to backend
-            (let [grpc-client (initialize-grpc-client correlation-id host h2c-port)]
-              (assert-request-state grpc-client request-headers service-id correlation-id ::client-cancel))))))))
+    (let [{:keys [h2c-port host request-headers service-id]} (start-courier-instance waiter-url)
+          {:strs [cookie]} request-headers]
+      (with-service-cleanup
+        service-id
+        (let [correlation-id (rand-name)
+              {:keys [err out]} (sh/sh "lein" "exec" "-p"
+                                       "test-files/grpc/grpc_client_exit.clj"
+                                       host (str h2c-port) service-id correlation-id cookie)]
+          (log/info "exec stdout:" out)
+          (log/info "exec stderr:" err)
+          (Thread/sleep 1500) ;; sleep to allow cancellation propagation to backend
+          (let [grpc-client (initialize-grpc-client correlation-id host h2c-port)]
+            (assert-request-state grpc-client request-headers service-id correlation-id ::client-cancel)))))))
 
 ;; FAIL in (test-grpc-client-streaming-deadline-exceeded) (grpc_test.clj:96)
 ;; waiter.grpc-test/test-grpc-client-streaming-deadline-exceeded
@@ -830,15 +819,12 @@
                                         str)]
                 (log/info correlation-id "aggregated packages...")
                 ;; TODO undo after fix to https://github.com/haproxy/haproxy/issues/172
-                (if (and (behind-proxy? waiter-url)
-                         (= "UNAVAILABLE" (some-> status .getCode str)))
+                (if (= "UNAVAILABLE" (some-> status .getCode str))
                   (assert-grpc-status status "UNAVAILABLE" "Received Rst Stream" assertion-message)
                   (assert-grpc-deadline-exceeded-status status assertion-message))
                 (is (nil? summary) assertion-message)
                 (.await sleep-duration-latch)
-                ;; TODO undo after fix to https://github.com/haproxy/haproxy/issues/172
-                (when-not (behind-proxy? waiter-url)
-                  (assert-request-state grpc-client request-headers service-id correlation-id ::deadline-exceeded))))))))))
+                (assert-request-state grpc-client request-headers service-id correlation-id ::deadline-exceeded)))))))))
 
 (deftest ^:parallel ^:integration-slow test-grpc-client-streaming-server-exit
   (testing-using-waiter-url

--- a/waiter/integration/waiter/grpc_test.clj
+++ b/waiter/integration/waiter/grpc_test.clj
@@ -349,7 +349,8 @@
             (assert-grpc-deadline-exceeded-status status assertion-message)
             (is (nil? reply) assertion-message)
             (.await sleep-duration-latch)
-            (assert-request-state grpc-client request-headers service-id correlation-id ::deadline-exceeded)))))))
+            (when (grpc-cancellations-supported? waiter-url)
+              (assert-request-state grpc-client request-headers service-id correlation-id ::deadline-exceeded))))))))
 
 (deftest ^:parallel ^:integration-fast test-grpc-unary-call-server-cancellation
   (testing-using-waiter-url
@@ -484,94 +485,95 @@
 
 (deftest ^:parallel ^:integration-slow test-grpc-bidi-streaming-client-cancellation
   (testing-using-waiter-url
-    (let [{:keys [h2c-port host request-headers service-id]} (start-courier-instance waiter-url)
-          correlation-id-prefix (rand-name)]
-      (with-service-cleanup
-        service-id
-        (doseq [cancel-policy [cancel-policy-context cancel-policy-exception cancel-policy-observer]]
-          (doseq [max-message-length [1000 50000]]
-            (let [num-messages 120
-                  messages (doall (repeatedly num-messages #(rand-str (inc (rand-int max-message-length)))))]
+    (when (grpc-cancellations-supported? waiter-url)
+      (let [{:keys [h2c-port host request-headers service-id]} (start-courier-instance waiter-url)
+            correlation-id-prefix (rand-name)]
+        (with-service-cleanup
+          service-id
+          (doseq [cancel-policy [cancel-policy-context cancel-policy-exception cancel-policy-observer]]
+            (doseq [max-message-length [1000 50000]]
+              (let [num-messages 120
+                    messages (doall (repeatedly num-messages #(rand-str (inc (rand-int max-message-length)))))]
 
-              (testing (str "independent mode " max-message-length " messages completion " cancel-policy)
-                (log/info "starting streaming to and from server - independent mode test")
-                (let [cancel-threshold (/ num-messages 2)
-                      from (rand-name "f")
-                      correlation-id (str correlation-id-prefix "-in-" max-message-length "-" cancel-policy)
-                      request-headers (assoc request-headers "x-cid" correlation-id)
-                      ids (map #(str "id-inde-" %) (range num-messages))
-                      grpc-client (initialize-grpc-client correlation-id host h2c-port)
-                      rpc-result (.collectPackages grpc-client request-headers ids from messages 100 false cancel-threshold cancel-policy 60000)
-                      summaries (.result rpc-result)
-                      ^Status status (.status rpc-result)
-                      assertion-message (->> (cond-> {:correlation-id correlation-id
-                                                      :service-id service-id
-                                                      :summaries (map (fn [^CourierSummary s]
-                                                                        {:num-messages (.getNumMessages s)
-                                                                         :total-length (.getTotalLength s)})
-                                                                      summaries)}
-                                               status (assoc :status {:code (-> status .getCode str)
-                                                                      :description (.getDescription status)}))
-                                          (into (sorted-map))
-                                          str)]
-                  (log/info correlation-id "collecting independent packages...")
-                  (cond
-                    (= cancel-policy-context cancel-policy)
-                    (assert-grpc-cancel-status status "Context cancelled" assertion-message)
-                    (= cancel-policy-exception cancel-policy)
-                    (assert-grpc-unknown-status status nil assertion-message)
-                    (= cancel-policy-observer cancel-policy)
-                    (assert-grpc-unknown-status status "call was cancelled" assertion-message))
-                  ;; allow for cancellation to trigger before message has been received and processed on server-side
-                  (is (<= (count summaries) (inc cancel-threshold)) assertion-message)
-                  (when (seq summaries)
-                    (is (= (range 1 (inc (count summaries)))
-                           (map #(.getNumMessages ^CourierSummary %) summaries))
-                        assertion-message)
-                    (is (= (reductions + (map count (take (count summaries) messages)))
-                           (map #(.getTotalLength ^CourierSummary %) summaries))
-                        assertion-message))
-                  (assert-request-state grpc-client request-headers service-id correlation-id ::client-cancel)))
+                (testing (str "independent mode " max-message-length " messages completion " cancel-policy)
+                  (log/info "starting streaming to and from server - independent mode test")
+                  (let [cancel-threshold (/ num-messages 2)
+                        from (rand-name "f")
+                        correlation-id (str correlation-id-prefix "-in-" max-message-length "-" cancel-policy)
+                        request-headers (assoc request-headers "x-cid" correlation-id)
+                        ids (map #(str "id-inde-" %) (range num-messages))
+                        grpc-client (initialize-grpc-client correlation-id host h2c-port)
+                        rpc-result (.collectPackages grpc-client request-headers ids from messages 100 false cancel-threshold cancel-policy 60000)
+                        summaries (.result rpc-result)
+                        ^Status status (.status rpc-result)
+                        assertion-message (->> (cond-> {:correlation-id correlation-id
+                                                        :service-id service-id
+                                                        :summaries (map (fn [^CourierSummary s]
+                                                                          {:num-messages (.getNumMessages s)
+                                                                           :total-length (.getTotalLength s)})
+                                                                        summaries)}
+                                                 status (assoc :status {:code (-> status .getCode str)
+                                                                        :description (.getDescription status)}))
+                                               (into (sorted-map))
+                                               str)]
+                    (log/info correlation-id "collecting independent packages...")
+                    (cond
+                      (= cancel-policy-context cancel-policy)
+                      (assert-grpc-cancel-status status "Context cancelled" assertion-message)
+                      (= cancel-policy-exception cancel-policy)
+                      (assert-grpc-unknown-status status nil assertion-message)
+                      (= cancel-policy-observer cancel-policy)
+                      (assert-grpc-unknown-status status "call was cancelled" assertion-message))
+                    ;; allow for cancellation to trigger before message has been received and processed on server-side
+                    (is (<= (count summaries) (inc cancel-threshold)) assertion-message)
+                    (when (seq summaries)
+                      (is (= (range 1 (inc (count summaries)))
+                             (map #(.getNumMessages ^CourierSummary %) summaries))
+                          assertion-message)
+                      (is (= (reductions + (map count (take (count summaries) messages)))
+                             (map #(.getTotalLength ^CourierSummary %) summaries))
+                          assertion-message))
+                    (assert-request-state grpc-client request-headers service-id correlation-id ::client-cancel)))
 
-              (testing (str "lock-step mode " max-message-length " messages completion")
-                (log/info "starting streaming to and from server - lock-step mode test")
-                (let [cancel-threshold (/ num-messages 2)
-                      from (rand-name "f")
-                      correlation-id (str correlation-id-prefix "-ls-" max-message-length "-" cancel-policy)
-                      request-headers (assoc request-headers "x-cid" correlation-id)
-                      ids (map #(str "id-lock-" %) (range num-messages))
-                      grpc-client (initialize-grpc-client correlation-id host h2c-port)
-                      rpc-result (.collectPackages grpc-client request-headers ids from messages 100 true cancel-threshold cancel-policy 60000)
-                      summaries (.result rpc-result)
-                      ^Status status (.status rpc-result)
-                      assertion-message (->> (cond-> {:correlation-id correlation-id
-                                                      :service-id service-id
-                                                      :summaries (map (fn [^CourierSummary s]
-                                                                        {:num-messages (.getNumMessages s)
-                                                                         :total-length (.getTotalLength s)})
-                                                                      summaries)}
-                                               status (assoc :status {:code (-> status .getCode str)
-                                                                      :description (.getDescription status)}))
-                                          (into (sorted-map))
-                                          str)]
-                  (log/info correlation-id "collecting lock-step packages...")
-                  (cond
-                    (= cancel-policy-context cancel-policy)
-                    (assert-grpc-cancel-status status "Context cancelled" assertion-message)
-                    (= cancel-policy-exception cancel-policy)
-                    (assert-grpc-unknown-status status nil assertion-message)
-                    (= cancel-policy-observer cancel-policy)
-                    (assert-grpc-unknown-status status "call was cancelled" assertion-message))
-                  (is (<= (count summaries) (inc cancel-threshold)) assertion-message)
-                  (when (seq summaries)
-                    (is (= (range 1 (inc (count summaries)))
-                           (map #(.getNumMessages ^CourierSummary %) summaries))
-                        assertion-message)
-                    (is (= (reductions + (map count (take (count summaries) messages)))
-                           (map #(.getTotalLength ^CourierSummary %) summaries))
-                        assertion-message))
-                  (Thread/sleep 1500) ;; sleep to allow cancellation propagation to backend
-                  (assert-request-state grpc-client request-headers service-id correlation-id ::client-cancel))))))))))
+                (testing (str "lock-step mode " max-message-length " messages completion")
+                  (log/info "starting streaming to and from server - lock-step mode test")
+                  (let [cancel-threshold (/ num-messages 2)
+                        from (rand-name "f")
+                        correlation-id (str correlation-id-prefix "-ls-" max-message-length "-" cancel-policy)
+                        request-headers (assoc request-headers "x-cid" correlation-id)
+                        ids (map #(str "id-lock-" %) (range num-messages))
+                        grpc-client (initialize-grpc-client correlation-id host h2c-port)
+                        rpc-result (.collectPackages grpc-client request-headers ids from messages 100 true cancel-threshold cancel-policy 60000)
+                        summaries (.result rpc-result)
+                        ^Status status (.status rpc-result)
+                        assertion-message (->> (cond-> {:correlation-id correlation-id
+                                                        :service-id service-id
+                                                        :summaries (map (fn [^CourierSummary s]
+                                                                          {:num-messages (.getNumMessages s)
+                                                                           :total-length (.getTotalLength s)})
+                                                                        summaries)}
+                                                 status (assoc :status {:code (-> status .getCode str)
+                                                                        :description (.getDescription status)}))
+                                               (into (sorted-map))
+                                               str)]
+                    (log/info correlation-id "collecting lock-step packages...")
+                    (cond
+                      (= cancel-policy-context cancel-policy)
+                      (assert-grpc-cancel-status status "Context cancelled" assertion-message)
+                      (= cancel-policy-exception cancel-policy)
+                      (assert-grpc-unknown-status status nil assertion-message)
+                      (= cancel-policy-observer cancel-policy)
+                      (assert-grpc-unknown-status status "call was cancelled" assertion-message))
+                    (is (<= (count summaries) (inc cancel-threshold)) assertion-message)
+                    (when (seq summaries)
+                      (is (= (range 1 (inc (count summaries)))
+                             (map #(.getNumMessages ^CourierSummary %) summaries))
+                          assertion-message)
+                      (is (= (reductions + (map count (take (count summaries) messages)))
+                             (map #(.getTotalLength ^CourierSummary %) summaries))
+                          assertion-message))
+                    (Thread/sleep 1500) ;; sleep to allow cancellation propagation to backend
+                    (assert-request-state grpc-client request-headers service-id correlation-id ::client-cancel)))))))))))
 
 (deftest ^:parallel ^:integration-slow test-grpc-bidi-streaming-server-exit
   (testing-using-waiter-url
@@ -715,60 +717,62 @@
 
 (deftest ^:parallel ^:integration-fast test-grpc-client-streaming-client-cancellation
   (testing-using-waiter-url
-    (let [{:keys [h2c-port host request-headers service-id]} (start-courier-instance waiter-url)
-          correlation-id-prefix (rand-name)]
-      (with-service-cleanup
-        service-id
-        (doseq [cancel-policy [cancel-policy-context cancel-policy-exception cancel-policy-observer]]
-          (doseq [max-message-length [1000 50000]]
-            (let [num-messages 120
-                  messages (doall (repeatedly num-messages #(rand-str (inc (rand-int max-message-length)))))]
+    (when (grpc-cancellations-supported? waiter-url)
+      (let [{:keys [h2c-port host request-headers service-id]} (start-courier-instance waiter-url)
+            correlation-id-prefix (rand-name)]
+        (with-service-cleanup
+          service-id
+          (doseq [cancel-policy [cancel-policy-context cancel-policy-exception cancel-policy-observer]]
+            (doseq [max-message-length [1000 50000]]
+              (let [num-messages 120
+                    messages (doall (repeatedly num-messages #(rand-str (inc (rand-int max-message-length)))))]
 
-              (testing (str max-message-length " messages completion " cancel-policy)
-                (log/info "starting streaming to and from server - independent mode test")
-                (let [cancel-threshold (/ num-messages 2)
-                      from (rand-name "f")
-                      correlation-id (str correlation-id-prefix "-in-" max-message-length "-" cancel-policy)
-                      request-headers (assoc request-headers "x-cid" correlation-id)
-                      ids (map #(str "id-" %) (range num-messages))
-                      grpc-client (initialize-grpc-client correlation-id host h2c-port)
-                      rpc-result (.aggregatePackages grpc-client request-headers ids from messages 10 cancel-threshold cancel-policy 60000)
-                      ^CourierSummary summary (.result rpc-result)
-                      ^Status status (.status rpc-result)
-                      assertion-message (->> (cond-> {:correlation-id correlation-id
-                                                      :service-id service-id}
-                                               summary (assoc :summary {:num-messages (.getNumMessages summary)
-                                                                        :total-length (.getTotalLength summary)})
-                                               status (assoc :status {:code (-> status .getCode str)
-                                                                      :description (.getDescription status)}))
-                                          (into (sorted-map))
-                                          str)]
-                  (log/info correlation-id "aggregated packages...")
-                  (cond
-                    (= cancel-policy-context cancel-policy)
-                    (assert-grpc-cancel-status status "Context cancelled" assertion-message)
-                    (= cancel-policy-exception cancel-policy)
-                    (assert-grpc-unknown-status status nil assertion-message)
-                    (= cancel-policy-observer cancel-policy)
-                    (assert-grpc-unknown-status status "call was cancelled" assertion-message))
-                  (is (nil? summary) assertion-message)
-                  (assert-request-state grpc-client request-headers service-id correlation-id ::client-cancel))))))))))
+                (testing (str max-message-length " messages completion " cancel-policy)
+                  (log/info "starting streaming to and from server - independent mode test")
+                  (let [cancel-threshold (/ num-messages 2)
+                        from (rand-name "f")
+                        correlation-id (str correlation-id-prefix "-in-" max-message-length "-" cancel-policy)
+                        request-headers (assoc request-headers "x-cid" correlation-id)
+                        ids (map #(str "id-" %) (range num-messages))
+                        grpc-client (initialize-grpc-client correlation-id host h2c-port)
+                        rpc-result (.aggregatePackages grpc-client request-headers ids from messages 10 cancel-threshold cancel-policy 60000)
+                        ^CourierSummary summary (.result rpc-result)
+                        ^Status status (.status rpc-result)
+                        assertion-message (->> (cond-> {:correlation-id correlation-id
+                                                        :service-id service-id}
+                                                 summary (assoc :summary {:num-messages (.getNumMessages summary)
+                                                                          :total-length (.getTotalLength summary)})
+                                                 status (assoc :status {:code (-> status .getCode str)
+                                                                        :description (.getDescription status)}))
+                                               (into (sorted-map))
+                                               str)]
+                    (log/info correlation-id "aggregated packages...")
+                    (cond
+                      (= cancel-policy-context cancel-policy)
+                      (assert-grpc-cancel-status status "Context cancelled" assertion-message)
+                      (= cancel-policy-exception cancel-policy)
+                      (assert-grpc-unknown-status status nil assertion-message)
+                      (= cancel-policy-observer cancel-policy)
+                      (assert-grpc-unknown-status status "call was cancelled" assertion-message))
+                    (is (nil? summary) assertion-message)
+                    (assert-request-state grpc-client request-headers service-id correlation-id ::client-cancel)))))))))))
 
 (deftest ^:parallel ^:integration-slow test-grpc-bidi-streaming-client-exit
   (testing-using-waiter-url
-    (let [{:keys [h2c-port host request-headers service-id]} (start-courier-instance waiter-url)
-          {:strs [cookie]} request-headers]
-      (with-service-cleanup
-        service-id
-        (let [correlation-id (rand-name)
-              {:keys [err out]} (sh/sh "lein" "exec" "-p"
-                                       "test-files/grpc/grpc_client_exit.clj"
-                                       host (str h2c-port) service-id correlation-id cookie)]
-          (log/info "exec stdout:" out)
-          (log/info "exec stderr:" err)
-          (Thread/sleep 1500) ;; sleep to allow cancellation propagation to backend
-          (let [grpc-client (initialize-grpc-client correlation-id host h2c-port)]
-            (assert-request-state grpc-client request-headers service-id correlation-id ::client-cancel)))))))
+    (when (grpc-cancellations-supported? waiter-url)
+      (let [{:keys [h2c-port host request-headers service-id]} (start-courier-instance waiter-url)
+            {:strs [cookie]} request-headers]
+        (with-service-cleanup
+          service-id
+          (let [correlation-id (rand-name)
+                {:keys [err out]} (sh/sh "lein" "exec" "-p"
+                                         "test-files/grpc/grpc_client_exit.clj"
+                                         host (str h2c-port) service-id correlation-id cookie)]
+            (log/info "exec stdout:" out)
+            (log/info "exec stderr:" err)
+            (Thread/sleep 1500) ;; sleep to allow cancellation propagation to backend
+            (let [grpc-client (initialize-grpc-client correlation-id host h2c-port)]
+              (assert-request-state grpc-client request-headers service-id correlation-id ::client-cancel))))))))
 
 (deftest ^:parallel ^:integration-fast test-grpc-client-streaming-deadline-exceeded
   (testing-using-waiter-url
@@ -807,15 +811,19 @@
                                         (into (sorted-map))
                                         str)]
                 (log/info correlation-id "aggregated packages...")
-                (condp = (some-> status .getCode str)
-                  "INVALID_ARGUMENT"
+                (cond
+                  (and (grpc-cancellations-supported? waiter-url)
+                       (= "UNAVAILABLE" (some-> status .getCode str)))
+                  (assert-grpc-status status "UNAVAILABLE" "Received Rst Stream" assertion-message)
+                  (= "INVALID_ARGUMENT" (some-> status .getCode str))
                   (assert-grpc-status status "INVALID_ARGUMENT" "Client action means stream is no longer needed"
                                       assertion-message)
-                  ;; default
+                  :else
                   (assert-grpc-deadline-exceeded-status status assertion-message))
                 (is (nil? summary) assertion-message)
                 (.await sleep-duration-latch)
-                (assert-request-state grpc-client request-headers service-id correlation-id ::deadline-exceeded)))))))))
+                (when (grpc-cancellations-supported? waiter-url)
+                  (assert-request-state grpc-client request-headers service-id correlation-id ::deadline-exceeded))))))))))
 
 (deftest ^:parallel ^:integration-slow test-grpc-client-streaming-server-exit
   (testing-using-waiter-url

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -36,7 +36,7 @@
                   :exclusions [[commons-codec]]]
                  ;; resolve the cheshire dependency used by buddy and jet
                  [cheshire "5.9.0"]
-                 [twosigma/courier "1.5.14"
+                 [twosigma/courier "1.5.15"
                   :exclusions [com.google.guava/guava io.grpc/grpc-core]
                   :scope "test"]
                  ;; avoids the following:

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -150,8 +150,13 @@
 
 (defn grpc-cancellations-supported?
   "Returns true if gRPC cancellations are supported.
-   Certain proxies, e.g. haproxy https://github.com/haproxy/haproxy/issues/172, do not support cancellations.
-   Other proxies, e.g. Envoy, do support gRPC cancellations."
+   Waiter routers support gRPC client and server cancellation.
+   However, sometimes traffic to the Waiter routers are fronted by another proxy, e.g. haproxy or envoy.
+   Certain proxies, e.g. haproxy https://github.com/haproxy/haproxy/issues/172, do not support cancellations due to
+   how they terminate http/2 connections.
+   Other proxies, e.g. Envoy, do support gRPC cancellations as they respect the http/2 protocol for closing connections.
+   We require the presence of WAITER_GRPC_CLEARTEXT_PORT env variable to signal that gRPC cancellation is
+   supported by the proxy intercepting traffic to Waiter routers."
   [waiter-url]
   (or (not (behind-proxy? waiter-url))
       (not (str/blank? (System/getenv "WAITER_GRPC_CLEARTEXT_PORT")))))

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -142,12 +142,6 @@
        ":"
        (retrieve-ssl-port ssl-port)))
 
-(defn behind-proxy?
-  "Returns true if Waiter if running behind a proxy."
-  [waiter-url]
-  (not= (retrieve-waiter-port waiter-url)
-        (retrieve-h2c-port waiter-url)))
-
 (defn interval-to-str [^Period interval]
   (let [builder (doto (PeriodFormatterBuilder.)
                   (.printZeroNever)

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -142,6 +142,20 @@
        ":"
        (retrieve-ssl-port ssl-port)))
 
+(defn behind-proxy?
+  "Returns true if Waiter if running behind a proxy."
+  [waiter-url]
+  (not= (retrieve-waiter-port waiter-url)
+        (retrieve-h2c-port waiter-url)))
+
+(defn grpc-cancellations-supported?
+  "Returns true if gRPC cancellations are supported.
+   Certain proxies, e.g. haproxy https://github.com/haproxy/haproxy/issues/172, do not support cancellations.
+   Other proxies, e.g. Envoy, do support gRPC cancellations."
+  [waiter-url]
+  (or (not (behind-proxy? waiter-url))
+      (not (str/blank? (System/getenv "WAITER_GRPC_CLEARTEXT_PORT")))))
+
 (defn interval-to-str [^Period interval]
   (let [builder (doto (PeriodFormatterBuilder.)
                   (.printZeroNever)


### PR DESCRIPTION
## Changes proposed in this PR

- enables grpc cancellation tests when custom grpc port environment variable is provided
- fixes ConcurrentModificationException while iterating on data returned from trackState()
- deflakes previously explicit flaky tests

## Why are we making these changes?

We wish to run the full suite of gRPC integration tests and assertions including client and server cancellation tests.
