### PR TITLE
ensures computed protocol is HTTP/2.0 instead of HTTP/2

### DIFF
--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -1502,6 +1502,16 @@
   (is (= "HTTP" (request->protocol {:scheme :http})))
   (is (= "FOO/BAR" (request->protocol {:headers {"x-forwarded-proto-version" "Foo/Bar"}
                                        :servlet-request (Object.)})))
+  (is (= "HTTP/1.0" (request->protocol {:headers {"x-forwarded-proto-version" "HTTP/1"}
+                                        :servlet-request (Object.)})))
+  (is (= "HTTP/1.0" (request->protocol {:headers {"x-forwarded-proto-version" "HTTP/1.0"}
+                                        :servlet-request (Object.)})))
+  (is (= "HTTP/1.1" (request->protocol {:headers {"x-forwarded-proto-version" "HTTP/1.1"}
+                                        :servlet-request (Object.)})))
+  (is (= "HTTP/2.0" (request->protocol {:headers {"x-forwarded-proto-version" "HTTP/2"}
+                                        :servlet-request (Object.)})))
+  (is (= "HTTP/2.0" (request->protocol {:headers {"x-forwarded-proto-version" "HTTP/2.0"}
+                                        :servlet-request (Object.)})))
   (is (= "HTTP/1.1" (request->protocol {:scheme :http
                                         :servlet-request (reify ServletRequest
                                                            (getProtocol [_] "HTTP/1.1"))})))


### PR DESCRIPTION
## Changes proposed in this PR

- ensures computed protocol is HTTP/2.0 instead of HTTP/2

## Why are we making these changes?

The Waiter code expects the client protocol to be `HTTP/2.0` while processing http/2 requests. This change ensures that we compute the protocol correctly as the rest of the Waiter codes expects `HTTP/2.0` as the value for the client protocol.

