### PR TITLE
adjusts the min-instances if the max-instances is provided without min-instances and the max-instances is smaller than the default min-instances

### DIFF
--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -1963,8 +1963,23 @@
 (deftest test-merge-defaults-into-service-description
   (testing "Merging defaults into service description"
     (testing "should incorporate metric group mappings"
-      (is (= {"name" "foo", "metric-group" "bar"}
-             (merge-defaults {"name" "foo"} {} [[#"f.." "bar"]]))))))
+      (is (= {"metric-group" "bar"
+              "name" "foo"}
+             (merge-defaults {"name" "foo"} {} [[#"f.." "bar"]]))))
+    (testing "min-instances should be updated when not provided"
+      (is (= {"max-instances" 2
+              "metric-group" "other"
+              "min-instances" 2}
+             (merge-defaults {"max-instances" 2} {"min-instances" 3} [[#"f.." "bar"]]))))
+    (testing "min-instances should not be updated when provided without max-instances"
+      (is (= {"metric-group" "other"
+              "min-instances" 4}
+             (merge-defaults {"min-instances" 4} {"min-instances" 3} [[#"f.." "bar"]]))))
+    (testing "min-instances should not be updated when provided with max-instances"
+      (is (= {"max-instances" 2
+              "metric-group" "other"
+              "min-instances" 4}
+             (merge-defaults {"max-instances" 2 "min-instances" 4} {"min-instances" 3} [[#"f.." "bar"]]))))))
 
 (deftest test-validate-cmd-type
   (testing "DefaultServiceDescriptionBuilder validation"


### PR DESCRIPTION
## Changes proposed in this PR

- adjusts the min-instances if the max-instances is provided without min-instances and the max-instances is smaller than the default min-instances

## Why are we making these changes?

Providing only max instances with a valid value should not cause a request to fail due the default min-instances being greater than the provided max-instances.

Example service that had adjusted parameters when only `max-instances` was provided:
![image](https://user-images.githubusercontent.com/6611249/75577866-7a950680-5a28-11ea-8e54-d834dfe96e67.png)


