### PR TITLE
sorts nested map parameters to ensure deterministic service-id

### DIFF
--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -351,7 +351,7 @@
              (if k
                (recur kvs (-> acc
                               (conj! k)
-                              (conj! (str v))))
+                              (conj! (str (cond->> v (map? v) (into (sorted-map)))))))
                (str (digest/digest "MD5" (str/join "" (persistent! acc))))))]
     (log/debug "got ID" id "for" sorted-parameters)
     id))

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -206,7 +206,16 @@
                           :expected (str service-id-prefix "fum1234a-a1030ca63357baad681c25935eb4e494")}
                          {:name "service-description->service-id:invalid-chars-present-in--name"
                           :input-data {"name" "fum-!@#$%.,:()"}
-                          :expected (str service-id-prefix "fum-df72716b57632adfc64b74165eb7d7f2")})]
+                          :expected (str service-id-prefix "fum-df72716b57632adfc64b74165eb7d7f2")}
+                         {:name "service-description->service-id:map-data"
+                          :input-data {"env" {"bar" "baz"}}
+                          :expected (str service-id-prefix "23dcf01c78e18f56be504c40c236438a")}
+                         {:name "service-description->service-id:map-data"
+                          :input-data {"env" {"bar" "baz", "fee" "fie", "foe" "fum"}}
+                          :expected (str service-id-prefix "49c060d06a02e18e102568b60abc48a9")}
+                         {:name "service-description->service-id:map-data-reordered"
+                          :input-data {"env" {"foe" "fum", "bar" "baz", "fee" "fie"}}
+                          :expected (str service-id-prefix "49c060d06a02e18e102568b60abc48a9")})]
         (doseq [{:keys [name input-data expected]} test-cases]
           (testing (str "Test " name)
             (is (= expected (service-description->service-id service-id-prefix input-data)))))))


### PR DESCRIPTION
## Changes proposed in this PR

- sorts nested map parameters to ensure deterministic service-id

## Why are we making these changes?

Service descriptions that contain nested maps that are equal (as they contain the same key-value mappings) should map to the same service-id. However, the current code does not sort the maps while computing the service-id and as a result, equal configurations produce different service-ids.

**Note**: This solution can end up changing the service-ids of existing services which uses map parameters like `env`, `metadata`, etc with multiple entries.

