### PR TITLE
adds fallback to and GC support for outdated service-IDs

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1261,7 +1261,7 @@
                                          service-gc-go-routine (partial service-gc-go-routine gc-state-reader-fn gc-state-writer-fn leader?-fn clock)]
                                      (scheduler/scheduler-broken-services-gc service-gc-go-routine query-state-fn scheduler scheduler-gc-config)))
    :scheduler-services-gc (pc/fnk [[:curator gc-state-reader-fn gc-state-writer-fn]
-                                   [:routines router-metrics-helpers service-id->idle-timeout]
+                                   [:routines router-metrics-helpers service-id->idle-timeout service-id->service-description-fn]
                                    [:scheduler scheduler]
                                    [:settings scheduler-gc-config]
                                    [:state clock leader?-fn]
@@ -1271,7 +1271,7 @@
                                   service-gc-go-routine (partial service-gc-go-routine gc-state-reader-fn gc-state-writer-fn leader?-fn clock)]
                               (scheduler/scheduler-services-gc
                                 scheduler query-state-fn service-id->metrics-fn scheduler-gc-config service-gc-go-routine
-                                service-id->idle-timeout)))
+                                service-id->idle-timeout service-id->service-description-fn)))
    :service-chan-maintainer (pc/fnk [[:routines service-id->service-description-fn
                                       start-work-stealing-balancer-fn stop-work-stealing-balancer-fn]
                                      [:settings blacklist-config instance-request-properties]

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -350,8 +350,10 @@
                   acc (transient [])]
              (if k
                (recur kvs (-> acc
-                              (conj! k)
-                              (conj! (str (cond->> v (map? v) (into (sorted-map)))))))
+                            (conj! k)
+                            (conj! (str (cond->> v
+                                          (map? v) (into (sorted-map))
+                                          (set? v) (into (sorted-set)))))))
                (str (digest/digest "MD5" (str/join "" (persistent! acc))))))]
     (log/debug "got ID" id "for" sorted-parameters)
     id))

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -342,6 +342,22 @@
       (merge-defaults defaults metric-group-mappings)
       (merge-overrides (:overrides (service-id->overrides kv-store service-id)))))
 
+;; TODO remove this function after it is no longer needed (e.g. one release cycle with the service-ID change)
+(defn parameters->id-v0
+  "Generates a ID from the input parameter map.
+   This is the old implementation of the function."
+  [parameters]
+  (let [sorted-parameters (sort parameters)
+        id (loop [[[k v] & kvs] sorted-parameters
+                  acc (transient [])]
+             (if k
+               (recur kvs (-> acc
+                            (conj! k)
+                            (conj! (str v))))
+               (str (digest/digest "MD5" (str/join "" (persistent! acc))))))]
+    (log/debug "got ID" id "for" sorted-parameters)
+    id))
+
 (defn parameters->id
   "Generates a deterministic ID from the input parameter map."
   [parameters]

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -207,15 +207,24 @@
                          {:name "service-description->service-id:invalid-chars-present-in--name"
                           :input-data {"name" "fum-!@#$%.,:()"}
                           :expected (str service-id-prefix "fum-df72716b57632adfc64b74165eb7d7f2")}
-                         {:name "service-description->service-id:map-data"
+                         {:name "service-description->service-id:map-data-single"
                           :input-data {"env" {"bar" "baz"}}
                           :expected (str service-id-prefix "23dcf01c78e18f56be504c40c236438a")}
-                         {:name "service-description->service-id:map-data"
+                         {:name "service-description->service-id:map-data-multiple"
                           :input-data {"env" {"bar" "baz", "fee" "fie", "foe" "fum"}}
                           :expected (str service-id-prefix "49c060d06a02e18e102568b60abc48a9")}
-                         {:name "service-description->service-id:map-data-reordered"
+                         {:name "service-description->service-id:map-data-multiple-reordered"
                           :input-data {"env" {"foe" "fum", "bar" "baz", "fee" "fie"}}
-                          :expected (str service-id-prefix "49c060d06a02e18e102568b60abc48a9")})]
+                          :expected (str service-id-prefix "49c060d06a02e18e102568b60abc48a9")}
+                         {:name "service-description->service-id:set-data-single"
+                          :input-data {"allowed-params" #{"BAR"}}
+                          :expected (str service-id-prefix "4e28656c8cc43f88b079257d05d4e3e1")}
+                         {:name "service-description->service-id:set-data-multiple"
+                          :input-data {"allowed-params" #{"BAR" "BAZ" "FEE" "FIE"}}
+                          :expected (str service-id-prefix "7e5ab6daf954c9ab9c7ef02b734eef13")}
+                         {:name "service-description->service-id:set-data-multiple-reordered"
+                          :input-data {"allowed-params" #{"BAZ" "FIE" "FEE" "BAR"}}
+                          :expected (str service-id-prefix "7e5ab6daf954c9ab9c7ef02b734eef13")})]
         (doseq [{:keys [name input-data expected]} test-cases]
           (testing (str "Test " name)
             (is (= expected (service-description->service-id service-id-prefix input-data)))))))


### PR DESCRIPTION
## Changes proposed in this PR

- handles sets in service parameters while producing deterministic service id
- GCs services whose service-IDs have changed after the deterministic ID fix
- adds support to fallback to older (v0) service-id

## Why are we making these changes?

We need to cleanup services running with an outdated service-ID computation scheme as they will no longer receive main traffic and it is wasteful to keep them running.
Allow fallback to the older service.
