### PR TITLE
adds guard to protect against NPE when min-instances default is unavailable

### DIFF
--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -1075,8 +1075,9 @@
 (defn can-manage-service?
   "Returns whether the `username` is allowed to modify the specified service description."
   [kv-store entitlement-manager service-id username]
-  ; the stored service description should already have a run-as-user
-  (let [core-service-description (service-id->service-description kv-store service-id {} [])]
+  ;; the stored service description should already have a run-as-user
+  ;; none of the overridden parameters should affect who can manage a service
+  (let [core-service-description (fetch-core kv-store service-id :refresh false)]
     (authz/manage-service? entitlement-manager username service-id core-service-description)))
 
 (defn consent-cookie-value

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -302,6 +302,7 @@
         ;; the max-instances is smaller than the default min-instances
         (and (integer? provided-max-instances)
              (nil? provided-min-instances)
+             (integer? default-min-instances)
              (> default-min-instances provided-max-instances))
         (assoc "min-instances" (max provided-max-instances minimum-min-instances))))
     (merge service-description-without-defaults)
@@ -1075,8 +1076,8 @@
   "Returns whether the `username` is allowed to modify the specified service description."
   [kv-store entitlement-manager service-id username]
   ; the stored service description should already have a run-as-user
-  (let [service-description (service-id->service-description kv-store service-id {} [])]
-    (authz/manage-service? entitlement-manager username service-id service-description)))
+  (let [core-service-description (service-id->service-description kv-store service-id {} [])]
+    (authz/manage-service? entitlement-manager username service-id core-service-description)))
 
 (defn consent-cookie-value
   "Creates the consent cookie value vector based on the mode.

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -1966,6 +1966,10 @@
       (is (= {"metric-group" "bar"
               "name" "foo"}
              (merge-defaults {"name" "foo"} {} [[#"f.." "bar"]]))))
+    (testing "min-instances default missing but only max-instances provided"
+      (is (= {"max-instances" 2
+              "metric-group" "other"}
+             (merge-defaults {"max-instances" 2} {} [[#"f.." "bar"]]))))
     (testing "min-instances should be updated when not provided"
       (is (= {"max-instances" 2
               "metric-group" "other"


### PR DESCRIPTION

## Changes proposed in this PR

- adds guard to protect against NPE when min-instances default is unavailable

## Why are we making these changes?

On the delete service code path, the default passed in as arguments do not include the min instances and this leads to an NPE preventing users from deleting the service.

