### PR TITLE
writes new entries before deleting old ones to avoid intervening index queries from reading empty results

### DIFF
--- a/token-syncer/project.clj
+++ b/token-syncer/project.clj
@@ -14,7 +14,7 @@
 ;; limitations under the License.
 ;;
 (defproject token-syncer "0.1.0-SNAPSHOT"
-  :dependencies [[twosigma/jet "0.7.10-20190426_181314-g8d0a48b"]
+  :dependencies [[twosigma/jet "0.7.10-20191230_163338-g0dabe28"]
                  [clj-time "0.15.2"]
                  [commons-codec/commons-codec "1.13"]
                  [org.clojure/clojure "1.10.1"]


### PR DESCRIPTION

## Changes proposed in this PR

- writes new entries before deleting old ones to avoid intervening index queries from reading empty results

## Why are we making these changes?

We want to avoid intervening index queries from reading empty results while the reindex operation is in progress.


