### PR TITLE
allows http/2 requests to configure idle timeouts

### DIFF
--- a/waiter/src/waiter/util/http_utils.clj
+++ b/waiter/src/waiter/util/http_utils.clj
@@ -126,7 +126,7 @@
     {:http1-client (http-client-factory (cond-> config
                                           client-name (update :client-name str "-http1")
                                           user-agent (update :user-agent str ".http1")))
-     :http2-client (-> (cond-> config
+     :http2-client (-> (cond-> (dissoc config :conn-timeout :socket-timeout)
                          client-name (update :client-name str "-http2")
                          user-agent (update :user-agent str ".http2"))
                        (assoc :transport http2-transport)

--- a/waiter/src/waiter/util/http_utils.clj
+++ b/waiter/src/waiter/util/http_utils.clj
@@ -126,6 +126,7 @@
     {:http1-client (http-client-factory (cond-> config
                                           client-name (update :client-name str "-http1")
                                           user-agent (update :user-agent str ".http1")))
+     ;; prepare-http2-transport already handles the connect and socket timeouts
      :http2-client (-> (cond-> (dissoc config :conn-timeout :socket-timeout)
                          client-name (update :client-name str "-http2")
                          user-agent (update :user-agent str ".http2"))


### PR DESCRIPTION
## Changes proposed in this PR

- allows http/2 requests to configure idle timeouts

## Why are we making these changes?

Requests configuring idle timeouts should have their timeout values respected.

