### PR TITLE
upgrade to jdk 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: xenial
 language: java
-jdk: openjdk8
+jdk: oraclejdk11
 
 addons:
   apt:

--- a/waiter/integration/waiter/metrics_output_test.clj
+++ b/waiter/integration/waiter/metrics_output_test.clj
@@ -69,7 +69,6 @@
 
 (def jvm-metrics-schema
   {(s/required-key "attribute") s/Any
-   (s/required-key "file") s/Any
    (s/required-key "gc") s/Any
    (s/required-key "memory") s/Any
    (s/required-key "thread") {(s/required-key "blocked") counted-gauge-metric-schema

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -93,9 +93,6 @@
                  [org.clojure/tools.logging "0.5.0"]
                  [org.clojure/tools.namespace "0.3.1"]
                  [org.clojure/tools.reader "1.3.2"]
-                 ;; use maven to download this jar so we can set up the boot classpath
-                 [org.mortbay.jetty.alpn/alpn-boot "8.1.13.v20181017"
-                  :scope "provided"]
                  [org.opensaml/opensaml "2.6.4"
                   :exclusions [commons-codec]]
                  [org.slf4j/slf4j-log4j12 "1.7.29"
@@ -131,10 +128,7 @@
              "-Dclojure.core.async.pool-size=64"
              ~(str "-Dwaiter.logFilePrefix=" (System/getenv "WAITER_LOG_FILE_PREFIX"))
              "-XX:+UseG1GC"
-             "-XX:MaxGCPauseMillis=50"
-             ~(str "-Xbootclasspath/p:"
-                (or (System/getenv "WAITER_MAVEN_LOCAL_REPO") (str (System/getenv "HOME") "/.m2/repository"))
-                "/org/mortbay/jetty/alpn/alpn-boot/8.1.13.v20181017/alpn-boot-8.1.13.v20181017.jar")]
+             "-XX:MaxGCPauseMillis=50"]
   :filespecs [{:type :fn
                :fn (fn [p]
                      {:type :bytes :path "git-log"

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -34,19 +34,13 @@
             [waiter.util.http-utils :as hu]
             [waiter.util.utils :as utils])
   (:import java.io.File
-           java.lang.UNIXProcess
            java.util.ArrayList))
 
 (defn pid
-  "Returns the pid of the provided process (if it is a UNIXProcess)"
+  "Returns the pid of the provided process"
   [^Process process]
   (try
-    (when (= UNIXProcess (type process))
-      (let [field (.getDeclaredField (.getClass process) "pid")
-            _ (.setAccessible field true)
-            pid (.getLong field process)]
-        (.setAccessible field false)
-        pid))
+    (.pid process)
     (catch Exception e
       (log/error e "error getting pid from" process))))
 

--- a/waiter/test/waiter/metrics_test.clj
+++ b/waiter/test/waiter/metrics_test.clj
@@ -30,6 +30,7 @@
             [waiter.util.async-utils :as au]
             [waiter.util.utils :as utils])
   (:import (com.codahale.metrics MetricFilter)
+           (com.codahale.metrics.jvm FileDescriptorRatioGauge)
            (org.joda.time DateTime)))
 
 (deftest test-compress-strings
@@ -518,3 +519,11 @@
     (is (= {"bar" {"last-request-time" time-4}, "foo" {"last-request-time" time-2}}
            (cleanup-local-usage-metrics
              {"bar" {"last-request-time" time-4}, "foo" {"last-request-time" time-2}} "cid" "baz")))))
+
+(deftest test-metrics-clojure-jvm-file-descriptor-ratio-gauge
+  (try
+    (.getValue (FileDescriptorRatioGauge.))
+    (is false (str "No exception thrown while accessing FileDescriptorRatioGauge, "
+                   "if you upgraded io.dropwizard.metrics/metrics-jvm fix waiter.main/instrument-jvm and this test"))
+    (catch Exception ex
+      (is true (str "Expected Exception thrown:" (.getMessage ex))))))

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -180,14 +180,9 @@
       (is (= "Hello, World!\n" (slurp (:url (first (filter #(= "stdout" (:name %)) content)))))))))
 
 (deftest test-pid
-  (testing "Getting the pid of a Process"
-
-    (testing "should return nil if it is not a UNIXProcess"
-      (is (nil? (pid (proxy [Process] [])))))
-
-    (testing "should return nil if it catches an Exception"
-      (with-redefs [type (fn [_] (throw (ex-info "ERROR!" {})))]
-        (is (nil? (pid (:process (launch-process "foo" (work-dir) "ls" {})))))))))
+  (testing "Getting the pid of a Process should return nil if it catches an Exception"
+    (with-redefs [type (fn [_] (throw (ex-info "ERROR!" {})))]
+      (is (nil? (pid (Object.)))))))
 
 (defn common-scheduler-config
   []


### PR DESCRIPTION
## Changes proposed in this PR

- simplifies retrieval of process pid due to api change in jdk9
- handles issue with using FileDescriptorRatioGauge which uses invalid … …
- removes bootclasspath requirement on alpn jar

## Why are we making these changes?

We would like to run on an updated JDK.

