### PR TITLE
includes last auth update time in k8s scheduler state

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -438,8 +438,10 @@
                                  :authentication {;; Unary function which can be called periodically (or just once if :refresh-delay-mins is omitted)
                                                   ;; to obtain an Authorization string for use when authenticating with the Kubernetes API server.
                                                   ;; This map is passed to the function as its single `context` argument.
-                                                  ;; The function must return a string that can be used as the value for the Authorization HTTP header.
-                                                  ;; The sample function given below simply returns the string from the WAITER_K8S_AUTH_STRING environment variable.
+                                                  ;; The function must return a map with an entry for :auth-token which maps
+                                                  ;; to a string that can be used as the value for the Authorization HTTP header.
+                                                  ;; The sample function given below simply returns the string from the
+                                                  ;; WAITER_K8S_AUTH_STRING environment variable.
                                                   :action-fn waiter.scheduler.kubernetes/authorization-from-environment
 
                                                   ;; Number of minutes to wait between attempts to refresh the credentials.

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -923,8 +923,9 @@
                              (if auth-token
                                (do
                                  (reset! auth-renewer-state-atom
-                                         (assoc auth-state
-                                           :last-token-retrieve-time (t/now)))
+                                         (-> auth-state
+                                           (update :auth-token utils/truncate 20)
+                                           (assoc :k8s/retrieve-time (t/now))))
                                  (reset! k8s-api-auth-str auth-token))
                                (log/info "auth token renewal failed:" auth-state))))]
     (assert (fn? refresh!) "Refresh function must be a Clojure fn")

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -931,8 +931,8 @@
 
 (defn test-auth-refresher
   "Test implementation of the authentication action-fn"
-  [{:keys [refresh-value] :as context}]
-  refresh-value)
+  [{:keys [refresh-value]}]
+  {:auth-token refresh-value})
 
 (deftest test-kubernetes-scheduler
   (let [context {:is-waiter-service?-fn (constantly nil)


### PR DESCRIPTION
## Changes proposed in this PR

- includes last auth token update time in k8s scheduler state
- changes the :action-fn signature to return a map

## Why are we making these changes?

Allows visibility into the state of the scheduler, in this case, by letting us know the last authentication token update time.

### Example state output:

```
      "kubernetes": {
        "auth-token-renewer": {
          "auth-token": "Bearer foobarfief...",
          "expiry-time": "2020-04-05T04:21:43.1234Z",
          "k8s/retrieve-time": "2020-04-04T05:14:21.514Z"
        }
...
```


