### PR TITLE
JWT auth defaults

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -248,7 +248,11 @@
                               ;; The token type expected in the access token header
                               :token-type "JWT"
                               ;; The interval at which to refresh the keys from the authorization server:
-                              :update-interval-ms 60000}
+                              :update-interval-ms 60000
+                              ;; Whether JWT authentication is the default for services and Waiter API requests.
+                              ;; For services, the value of USE_BEARER_AUTH environment variable overrides this value.
+                              ;; The default is false.
+                              :use-bearer-auth-default? false}
 
                         ;; :kind :one-user allows anonymous access to services (for testing purposes only):
                         :one-user {;; Custom implementations should specify a :factory-fn

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -225,7 +225,14 @@
                         ;; Waiter supports JWT access token-based authentication before trying the configured authenticator.
                         ;; JWT authentication can be disabled by specifying a value of :disabled instead of configuring the map below:
                         ;; :jwt :disabled
-                        :jwt {;; JWT relies on periodically refreshing the list of available keys from a JWKS
+                        :jwt {;; Whether JWT authentication is allowed for Waiter API requests.
+                              ;; When not configured, the value is assumed to be true.
+                              :allow-bearer-auth-api? true
+                              ;; Whether JWT authentication is the allowed for service (proxy) requests.
+                              ;; The value of USE_BEARER_AUTH environment variable of the service overrides this value.
+                              ;; When not configured, the value is assumed to be false.
+                              :allow-bearer-auth-services? false
+                              ;; JWT relies on periodically refreshing the list of available keys from a JWKS
                               :http-options {;; The HTTP options that will be used when accessing the authorization server:
                                              :conn-timeout 10000
                                              :socket-timeout 10000
@@ -248,15 +255,7 @@
                               ;; The token type expected in the access token header
                               :token-type "JWT"
                               ;; The interval at which to refresh the keys from the authorization server:
-                              :update-interval-ms 60000
-                              ;; Whether JWT authentication is the default for Waiter API requests.
-                              ;; For services, the value of USE_BEARER_AUTH environment variable overrides this value.
-                              ;; The default is true.
-                              :use-bearer-auth-default-for-api? true
-                              ;; Whether JWT authentication is the default for services proxy requests.
-                              ;; The value of USE_BEARER_AUTH environment variable of the service overrides this value.
-                              ;; The default is false.
-                              :use-bearer-auth-default-for-service? false}
+                              :update-interval-ms 60000}
 
                         ;; :kind :one-user allows anonymous access to services (for testing purposes only):
                         :one-user {;; Custom implementations should specify a :factory-fn

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -249,10 +249,14 @@
                               :token-type "JWT"
                               ;; The interval at which to refresh the keys from the authorization server:
                               :update-interval-ms 60000
-                              ;; Whether JWT authentication is the default for services and Waiter API requests.
+                              ;; Whether JWT authentication is the default for Waiter API requests.
                               ;; For services, the value of USE_BEARER_AUTH environment variable overrides this value.
+                              ;; The default is true.
+                              :use-bearer-auth-default-for-api? true
+                              ;; Whether JWT authentication is the default for services proxy requests.
+                              ;; The value of USE_BEARER_AUTH environment variable of the service overrides this value.
                               ;; The default is false.
-                              :use-bearer-auth-default? false}
+                              :use-bearer-auth-default-for-service? false}
 
                         ;; :kind :one-user allows anonymous access to services (for testing purposes only):
                         :one-user {;; Custom implementations should specify a :factory-fn

--- a/waiter/src/waiter/auth/jwt.clj
+++ b/waiter/src/waiter/auth/jwt.clj
@@ -365,19 +365,19 @@
 (defn wrap-auth-handler
   "Wraps the request handler with a handler to trigger JWT access token authentication."
   [{:keys [issuer-constraints keys-cache max-expiry-duration-ms password subject-key subject-regex supported-algorithms
-           token-type use-bearer-auth-default]}
+           token-type use-bearer-auth-default?]}
    request-handler]
   (fn jwt-auth-handler [{:keys [waiter-api-call?] :as request}]
     (if (and (not (auth/request-authenticated? request))
              (auth/select-auth-header request access-token?)
              (or
-               ;; service requests will enable JWT auth based on env variable or when absent, the use-bearer-auth-default
+               ;; service requests will enable JWT auth based on env variable or when absent, the use-bearer-auth-default?
                (and (not waiter-api-call?)
                     (= "true" (get-in request [:waiter-discovery :service-parameter-template "env" "USE_BEARER_AUTH"]
-                                      (str use-bearer-auth-default))))
-               ;; waiter api requests will enable JWT auth based on use-bearer-auth-default
+                                      (str use-bearer-auth-default?))))
+               ;; waiter api requests will enable JWT auth based on use-bearer-auth-default?
                (and waiter-api-call?
-                    use-bearer-auth-default)))
+                    use-bearer-auth-default?)))
       (authenticate-request request-handler token-type issuer-constraints subject-key subject-regex supported-algorithms
                             (:key-id->jwk @keys-cache) password max-expiry-duration-ms request)
       (request-handler request))))
@@ -391,7 +391,7 @@
     {:cache-data cache-data}))
 
 (defrecord JwtAuthenticator [issuer-constraints keys-cache max-expiry-duration-ms password subject-key subject-regex
-                             supported-algorithms token-type use-bearer-auth-default])
+                             supported-algorithms token-type use-bearer-auth-default?])
 
 (def ^:const default-subject-regex #"([a-zA-Z0-9]+)@([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+([a-zA-Z]{2,})$")
 
@@ -404,10 +404,10 @@
 (defn jwt-authenticator
   "Factory function for creating jwt authenticator middleware"
   [{:keys [http-options issuer jwks-url max-expiry-duration-ms password subject-key subject-regex
-           supported-algorithms token-type update-interval-ms use-bearer-auth-default]
+           supported-algorithms token-type update-interval-ms use-bearer-auth-default?]
     :or {max-expiry-duration-ms (-> 24 t/hours t/in-millis)
          subject-regex default-subject-regex
-         use-bearer-auth-default false}}]
+         use-bearer-auth-default? false}}]
   {:pre [(map? http-options)
          (vector? (issuer->issuer-constraints issuer))
          (seq (issuer->issuer-constraints issuer))
@@ -427,7 +427,7 @@
          (not (str/blank? token-type))
          (and (integer? update-interval-ms)
               (not (neg? update-interval-ms)))
-         (boolean? use-bearer-auth-default)]}
+         (boolean? use-bearer-auth-default?)]}
   (let [keys-cache (atom {})
         http-client (-> http-options
                       (utils/assoc-if-absent :client-name "waiter-jwt")
@@ -436,4 +436,4 @@
         issuer-constraints (issuer->issuer-constraints issuer)]
     (start-jwt-cache-maintainer http-client http-options jwks-url update-interval-ms supported-algorithms keys-cache)
     (->JwtAuthenticator issuer-constraints keys-cache max-expiry-duration-ms password subject-key subject-regex
-                        supported-algorithms token-type use-bearer-auth-default)))
+                        supported-algorithms token-type use-bearer-auth-default?)))

--- a/waiter/src/waiter/schema.clj
+++ b/waiter/src/waiter/schema.clj
@@ -129,5 +129,6 @@
      (s/optional-key :subject-regex) s/Regex
      (s/required-key :supported-algorithms) #{s/Keyword}
      (s/required-key :token-type) non-empty-string
-     (s/required-key :update-interval-ms) positive-int}
+     (s/required-key :update-interval-ms) positive-int
+     (s/optional-key :use-bearer-auth-default) s/Bool}
     (s/constrained s/Keyword #(= :disabled %))))

--- a/waiter/src/waiter/schema.clj
+++ b/waiter/src/waiter/schema.clj
@@ -121,7 +121,9 @@
   a non-empty string (representing a connection string), or the keyword
   :in-process, indicating that ZK should be started in-process"
   (s/either
-    {(s/required-key :http-options) {s/Keyword s/Any}
+    {(s/optional-key :allow-bearer-auth-api?) s/Bool
+     (s/optional-key :allow-bearer-auth-services?) s/Bool
+     (s/required-key :http-options) {s/Keyword s/Any}
      (s/required-key :issuer) valid-jwt-issuer-config
      (s/required-key :jwks-url) s/Str
      (s/optional-key :max-expiry-duration-ms) positive-int
@@ -129,7 +131,5 @@
      (s/optional-key :subject-regex) s/Regex
      (s/required-key :supported-algorithms) #{s/Keyword}
      (s/required-key :token-type) non-empty-string
-     (s/required-key :update-interval-ms) positive-int
-     (s/optional-key :use-bearer-auth-default-for-api?) s/Bool
-     (s/optional-key :use-bearer-auth-default-for-service?) s/Bool}
+     (s/required-key :update-interval-ms) positive-int}
     (s/constrained s/Keyword #(= :disabled %))))

--- a/waiter/src/waiter/schema.clj
+++ b/waiter/src/waiter/schema.clj
@@ -130,5 +130,6 @@
      (s/required-key :supported-algorithms) #{s/Keyword}
      (s/required-key :token-type) non-empty-string
      (s/required-key :update-interval-ms) positive-int
-     (s/optional-key :use-bearer-auth-default?) s/Bool}
+     (s/optional-key :use-bearer-auth-default-for-api?) s/Bool
+     (s/optional-key :use-bearer-auth-default-for-service?) s/Bool}
     (s/constrained s/Keyword #(= :disabled %))))

--- a/waiter/src/waiter/schema.clj
+++ b/waiter/src/waiter/schema.clj
@@ -130,5 +130,5 @@
      (s/required-key :supported-algorithms) #{s/Keyword}
      (s/required-key :token-type) non-empty-string
      (s/required-key :update-interval-ms) positive-int
-     (s/optional-key :use-bearer-auth-default) s/Bool}
+     (s/optional-key :use-bearer-auth-default?) s/Bool}
     (s/constrained s/Keyword #(= :disabled %))))

--- a/waiter/test/waiter/auth/jwt_test.clj
+++ b/waiter/test/waiter/auth/jwt_test.clj
@@ -516,8 +516,8 @@
         (is (instance? JwtAuthenticator (jwt-authenticator (assoc config :issuer ["w8r" #"w8r.*"]))))
         (is (instance? JwtAuthenticator (jwt-authenticator (assoc config :max-expiry-duration-ms 900000))))
         (is (instance? JwtAuthenticator (jwt-authenticator (assoc config :supported-algorithms #{:eddsa :rs256}))))
-        (is (instance? JwtAuthenticator (jwt-authenticator (assoc config :use-bearer-auth-default true))))
-        (is (instance? JwtAuthenticator (jwt-authenticator (assoc config :use-bearer-auth-default false)))))
+        (is (instance? JwtAuthenticator (jwt-authenticator (assoc config :use-bearer-auth-default? true))))
+        (is (instance? JwtAuthenticator (jwt-authenticator (assoc config :use-bearer-auth-default? false)))))
 
       (testing "invalid configuration"
         (is (thrown? Throwable (jwt-authenticator (dissoc config :http-options))))
@@ -536,7 +536,7 @@
         (is (thrown? Throwable (jwt-authenticator (assoc config :supported-algorithms [:eddsa :rs256]))))
         (is (thrown? Throwable (jwt-authenticator (assoc config :supported-algorithms #{:hs256}))))
         (is (thrown? Throwable (jwt-authenticator (dissoc config :update-interval-ms))))
-        (is (thrown? Throwable (jwt-authenticator (assoc config :use-bearer-auth-default "true"))))))))
+        (is (thrown? Throwable (jwt-authenticator (assoc config :use-bearer-auth-default? "true"))))))))
 
 (deftest test-jwt-auth-handler
   (let [handler (fn [{:keys [source]}] {:body source})

--- a/waiter/test/waiter/auth/jwt_test.clj
+++ b/waiter/test/waiter/auth/jwt_test.clj
@@ -654,7 +654,36 @@
                  {:authorization/principal "user@test.com"
                   :authorization/user "user"
                   :headers {"authorization" "Bearer abcd"}
-                  :source ::standard-request}))))
+                  :source ::standard-request})))
+
+        (is (= {:body ::standard-request}
+               (jwt-handler
+                 (attach-bearer-auth-env
+                   {:headers {"authorization" "Bearer wxyz,Bearer ab.cd.ef"}
+                    :source ::standard-request
+                    :waiter-api-call? true}
+                   true))))
+        (is (= {:body ::standard-request}
+               (jwt-handler
+                 (attach-bearer-auth-env
+                   {:headers {"authorization" "Negotiate abcd,Bearer ab.cd.ef"}
+                    :source ::standard-request
+                    :waiter-api-call? true}
+                   true))))
+        (is (= {:body ::standard-request}
+               (jwt-handler
+                 (attach-bearer-auth-env
+                   {:headers {"authorization" "Bearer ab.cd.ef,Negotiate wxyz"}
+                    :source ::standard-request
+                    :waiter-api-call? true}
+                   true))))
+        (is (= {:body ::standard-request}
+               (jwt-handler
+                 (attach-bearer-auth-env
+                   {:headers {"authorization" "Negotiate abcd,Bearer ab.cd.ef,Negotiate wxyz"}
+                    :source ::standard-request
+                    :waiter-api-call? true}
+                   true)))))
 
       (let [authenticator (->JwtAuthenticator issuer-constraints keys-cache max-expiry-duration-ms "password" :sub
                                               subject-regex supported-algorithms "jwt+type" true)
@@ -698,4 +727,36 @@
                  (attach-bearer-auth-env
                    {:headers {"authorization" "Negotiate abcd,Bearer ab.cd.ef,Negotiate wxyz"}
                     :source ::standard-request}
+                   false)))))
+
+      (let [authenticator (->JwtAuthenticator issuer-constraints keys-cache max-expiry-duration-ms "password" :sub
+                                              subject-regex supported-algorithms "jwt+type" true)
+            jwt-handler (wrap-auth-handler authenticator handler)]
+        (is (= {:body ::jwt-auth}
+               (jwt-handler
+                 (attach-bearer-auth-env
+                   {:headers {"authorization" "Bearer wxyz,Bearer ab.cd.ef"}
+                    :source ::standard-request
+                    :waiter-api-call? true}
+                   false))))
+        (is (= {:body ::jwt-auth}
+               (jwt-handler
+                 (attach-bearer-auth-env
+                   {:headers {"authorization" "Negotiate abcd,Bearer ab.cd.ef"}
+                    :source ::standard-request
+                    :waiter-api-call? true}
+                   false))))
+        (is (= {:body ::jwt-auth}
+               (jwt-handler
+                 (attach-bearer-auth-env
+                   {:headers {"authorization" "Bearer ab.cd.ef,Negotiate wxyz"}
+                    :source ::standard-request
+                    :waiter-api-call? true}
+                   false))))
+        (is (= {:body ::jwt-auth}
+               (jwt-handler
+                 (attach-bearer-auth-env
+                   {:headers {"authorization" "Negotiate abcd,Bearer ab.cd.ef,Negotiate wxyz"}
+                    :source ::standard-request
+                    :waiter-api-call? true}
                    false))))))))


### PR DESCRIPTION
## Changes proposed in this PR

- adds option to enable JWT auth by default for tokens
- adds JWT auth support for waiter api requests

## Why are we making these changes?

We would like to allow Waiter API requests and service requests to get JWT authentication by default.
