### PR TITLE
adds support for the profile parameter

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -685,6 +685,14 @@
 
  ; ---------- Service Descriptions ----------
 
+ ;; Profiles allow creating different sets of defaults for service parameters.
+ ;; The profile config maps a profile name to overridden default parameters.
+ ;; In the example below:
+ ;; - the 'webapp' profile overrides the default configuration defined in :service-description-defaults
+ ;;   by increasing the concurrency-level and changing the load balancing scheme to random
+ :profile-config {"webapp" {:service-parameters {"concurrency-level" 120
+                                                 "load-balancing" "random"}}}
+
  :service-description-builder-config {
                                       ;; :kind :default invokes the DefaultServiceDescriptionBuilder
                                       :kind :default

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1644,3 +1644,30 @@
                   (is (= service-id-1 (:service-id response-2))))))))
         (finally
           (delete-token-and-assert waiter-url token))))))
+
+(deftest ^:parallel ^:integration-fast test-profile-inside-token
+  (testing-using-waiter-url
+    (let [{:keys [profile-config]} (waiter-settings waiter-url)
+          token (rand-name)
+          base-description {:cmd "will-not-work"
+                            :cmd-type "shell"
+                            :cpus 1
+                            :health-check-url "/ping"
+                            :mem 100
+                            :name token
+                            :permitted-user "*"
+                            :run-as-user (retrieve-username)
+                            :version "1"}]
+      (doseq [profile (keys profile-config)]
+        (let [token-description (assoc base-description
+                                  :profile (name profile)
+                                  :token token)
+              register-response (post-token waiter-url token-description)
+              _ (assert-response-status register-response 200)
+              {:keys [body]} (get-token waiter-url token)]
+          (is (= (:profile token-description) (-> body str json/read-str (get "profile"))))
+          (let [service-id (retrieve-service-id waiter-url {"x-waiter-token" token})
+                _ (is service-id "No service created by using token!")
+                service-description (service-id->service-description waiter-url service-id)]
+            (is (= service-description (dissoc token-description :token))))
+          (delete-token-and-assert waiter-url token))))))

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1648,26 +1648,29 @@
 (deftest ^:parallel ^:integration-fast test-profile-inside-token
   (testing-using-waiter-url
     (let [{:keys [profile-config]} (waiter-settings waiter-url)
-          token (rand-name)
           base-description {:cmd "will-not-work"
                             :cmd-type "shell"
                             :cpus 1
                             :health-check-url "/ping"
                             :mem 100
-                            :name token
+                            :metric-group "waiter_test"
+                            :name "test-profile-inside-token"
                             :permitted-user "*"
                             :run-as-user (retrieve-username)
                             :version "1"}]
       (doseq [profile (keys profile-config)]
-        (let [token-description (assoc base-description
+        (let [token (rand-name)
+              token-description (assoc base-description
                                   :profile (name profile)
                                   :token token)
-              register-response (post-token waiter-url token-description)
-              _ (assert-response-status register-response 200)
-              {:keys [body]} (get-token waiter-url token)]
-          (is (= (:profile token-description) (-> body str json/read-str (get "profile"))))
-          (let [service-id (retrieve-service-id waiter-url {"x-waiter-token" token})
-                _ (is service-id "No service created by using token!")
-                service-description (service-id->service-description waiter-url service-id)]
-            (is (= service-description (dissoc token-description :token))))
-          (delete-token-and-assert waiter-url token))))))
+              register-response (post-token waiter-url token-description)]
+          (try
+            (assert-response-status register-response 200)
+            (let [{:keys [body]} (get-token waiter-url token)]
+              (is (= (:profile token-description) (-> body str json/read-str (get "profile"))))
+              (let [service-id (retrieve-service-id waiter-url {"x-waiter-token" token})
+                    _ (is service-id "No service created by using token!")
+                    service-description (service-id->service-description waiter-url service-id)]
+                (is (= service-description (dissoc token-description :token)))))
+            (finally
+              (delete-token-and-assert waiter-url token))))))))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -701,6 +701,11 @@
                       _ (password-store/check-empty-passwords passwords)
                       processed-passwords (mapv #(vector :cached %) passwords)]
                   processed-passwords))
+   :profile->defaults (pc/fnk [[:settings profile-config service-description-defaults]]
+                        (let [custom-profiles (pc/for-map [[profile {:keys [service-parameters]}] profile-config]
+                                                  (name profile)
+                                                  (merge service-description-defaults service-parameters))]
+                          (assoc custom-profiles "" service-description-defaults)))
    :query-service-maintainer-chan (pc/fnk [] (au/latest-chan)) ; TODO move to service-chan-maintainer
    :router-metrics-agent (pc/fnk [router-id] (metrics-sync/new-router-metrics-agent router-id {}))
    :router-id (pc/fnk [[:settings router-id-prefix]]
@@ -837,12 +842,12 @@
                                  (digest/md5 (str service-id (first passwords)))))
    ; This function is only included here for initializing the scheduler above.
    ; Prefer accessing the non-starred version of this function through the routines map.
-   :service-id->service-description-fn* (pc/fnk [[:settings service-description-defaults metric-group-mappings]
-                                                 [:state kv-store]]
+   :service-id->service-description-fn* (pc/fnk [[:settings metric-group-mappings]
+                                                 [:state kv-store profile->defaults]]
                                           (fn service-id->service-description
                                             [service-id & {:keys [effective?] :or {effective? true}}]
                                             (sd/service-id->service-description
-                                              kv-store service-id service-description-defaults
+                                              kv-store service-id profile->defaults
                                               metric-group-mappings :effective? effective?)))
    :start-scheduler-syncer-fn (pc/fnk [[:settings [:health-check-config health-check-timeout-ms failed-check-threshold]]
                                        [:state clock user-agent-version]
@@ -977,14 +982,15 @@
    :refresh-service-descriptions-fn (pc/fnk [[:state kv-store]]
                                       (fn refresh-service-descriptions-fn [service-ids]
                                         (sd/refresh-service-descriptions kv-store service-ids)))
-   :request->descriptor-fn (pc/fnk [[:settings [:token-config history-length token-defaults] metric-group-mappings service-description-defaults]
-                                    [:state fallback-state-atom kv-store service-description-builder service-id-prefix waiter-hostnames]
+   :request->descriptor-fn (pc/fnk [[:settings [:token-config history-length token-defaults] metric-group-mappings]
+                                    [:state fallback-state-atom kv-store profile->defaults
+                                     service-description-builder service-id-prefix waiter-hostnames]
                                     assoc-run-as-user-approved? can-run-as?-fn store-reference-fn store-source-tokens-fn]
                              (fn request->descriptor-fn [request]
                                (let [{:keys [latest-descriptor] :as result}
                                      (descriptor/request->descriptor
                                        assoc-run-as-user-approved? can-run-as?-fn fallback-state-atom kv-store metric-group-mappings
-                                       history-length service-description-builder service-description-defaults service-id-prefix
+                                       history-length service-description-builder profile->defaults service-id-prefix
                                        token-defaults waiter-hostnames request)
                                      {:keys [reference-type->entry service-id source-tokens]} latest-descriptor]
                                  (when (seq source-tokens)
@@ -1067,7 +1073,7 @@
                             (fn token->token-metadata [token]
                               (sd/token->token-metadata kv-store token :error-on-missing false)))
    :validate-service-description-fn (pc/fnk [[:settings service-description-defaults]
-                                             [:state authenticator service-description-builder]]
+                                             [:state authenticator profile->defaults service-description-builder]]
                                       (let [authentication-providers (into #{"disabled" "standard"} (auth/get-authentication-providers authenticator))
                                             default-authentication (get service-description-defaults "authentication")]
                                         (fn validate-service-description [service-description]
@@ -1076,7 +1082,8 @@
                                               (throw (ex-info (str "authentication must be one of: '"
                                                                    (str/join "', '" (sort authentication-providers)) "'")
                                                               {:authentication authentication :status 400}))))
-                                          (sd/validate service-description-builder service-description {}))))
+                                          (sd/validate service-description-builder service-description
+                                                       {:profile->defaults profile->defaults}))))
    :waiter-request?-fn (pc/fnk [[:state waiter-hostnames]]
                          (let [local-router (InetAddress/getLocalHost)
                                waiter-router-hostname (.getCanonicalHostName local-router)

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -705,7 +705,7 @@
                         (let [custom-profiles (pc/for-map [[profile {:keys [service-parameters]}] profile-config]
                                                   (name profile)
                                                   (merge service-description-defaults service-parameters))]
-                          (assoc custom-profiles "" service-description-defaults)))
+                          (assoc custom-profiles :default service-description-defaults)))
    :query-service-maintainer-chan (pc/fnk [] (au/latest-chan)) ; TODO move to service-chan-maintainer
    :router-metrics-agent (pc/fnk [router-id] (metrics-sync/new-router-metrics-agent router-id {}))
    :router-id (pc/fnk [[:settings router-id-prefix]]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -701,10 +701,15 @@
                       _ (password-store/check-empty-passwords passwords)
                       processed-passwords (mapv #(vector :cached %) passwords)]
                   processed-passwords))
-   :profile->overrides (pc/fnk [[:settings profile-config]]
+   :profile->overrides (pc/fnk [[:settings profile-config service-description-constraints]]
                          (pc/for-map [[profile {:keys [service-parameters]}] profile-config]
                            (name profile)
-                           service-parameters))
+                           (let [max-constraints-schema (sd/extract-max-constraints-schema service-description-constraints)]
+                             ;; validate the profile's service parameters
+                             (sd/validate-schema service-parameters max-constraints-schema
+                                                 {:allow-missing-required-fields? true
+                                                  :profile->overrides {}})
+                             service-parameters)))
    :query-service-maintainer-chan (pc/fnk [] (au/latest-chan)) ; TODO move to service-chan-maintainer
    :router-metrics-agent (pc/fnk [router-id] (metrics-sync/new-router-metrics-agent router-id {}))
    :router-id (pc/fnk [[:settings router-id-prefix]]

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -258,7 +258,7 @@
   "Creates the service descriptor from the request.
    The result map contains the following elements:
    {:keys [waiter-headers passthrough-headers sources service-id service-description core-service-description suspended-state]}"
-  [service-description-defaults token-defaults service-id-prefix kv-store waiter-hostnames request metric-group-mappings
+  [profile->defaults token-defaults service-id-prefix kv-store waiter-hostnames request metric-group-mappings
    service-description-builder assoc-run-as-user-approved?]
   (let [current-request-user (get request :authorization/user)
         build-service-description-and-id-helper (sd/make-build-service-description-and-id-helper
@@ -266,7 +266,7 @@
                                                   service-description-builder assoc-run-as-user-approved?)
         descriptor
         (-> (headers/split-headers (:headers request))
-          (sd/merge-service-description-sources kv-store waiter-hostnames service-description-defaults token-defaults)
+          (sd/merge-service-description-sources kv-store waiter-hostnames profile->defaults token-defaults)
           (attach-token-fallback-source token-defaults build-service-description-and-id-helper)
           (build-service-description-and-id-helper true))]
     (when-let [throwable (sd/validate-service-description kv-store service-description-builder descriptor)]
@@ -303,14 +303,14 @@
     "Extract the service descriptor from a request.
      It also performs the necessary authorization."
     [assoc-run-as-user-approved? can-run-as? fallback-state-atom kv-store metric-group-mappings
-     search-history-length service-description-builder service-description-defaults service-id-prefix token-defaults
-     waiter-hostnames {:keys [request-time] :as request}]
+     search-history-length service-description-builder profile->defaults service-id-prefix
+     token-defaults waiter-hostnames {:keys [request-time] :as request}]
     (timers/start-stop-time!
       request->descriptor-timer
       (let [auth-user (:authorization/user request)
             service-approved? (fn service-approved? [service-id] (assoc-run-as-user-approved? request service-id))
             latest-descriptor (compute-descriptor
-                                service-description-defaults token-defaults service-id-prefix kv-store waiter-hostnames
+                                profile->defaults token-defaults service-id-prefix kv-store waiter-hostnames
                                 request metric-group-mappings service-description-builder service-approved?)
             descriptor->previous-descriptor
             (fn descriptor->previous-descriptor-fn

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -258,15 +258,16 @@
   "Creates the service descriptor from the request.
    The result map contains the following elements:
    {:keys [waiter-headers passthrough-headers sources service-id service-description core-service-description suspended-state]}"
-  [profile->defaults token-defaults service-id-prefix kv-store waiter-hostnames request metric-group-mappings
-   service-description-builder assoc-run-as-user-approved?]
+  [service-description-defaults profile->overrides token-defaults service-id-prefix kv-store waiter-hostnames request
+   metric-group-mappings service-description-builder assoc-run-as-user-approved?]
   (let [current-request-user (get request :authorization/user)
         build-service-description-and-id-helper (sd/make-build-service-description-and-id-helper
                                                   kv-store service-id-prefix current-request-user metric-group-mappings
                                                   service-description-builder assoc-run-as-user-approved?)
         descriptor
         (-> (headers/split-headers (:headers request))
-          (sd/merge-service-description-sources kv-store waiter-hostnames profile->defaults token-defaults)
+          (sd/merge-service-description-sources
+            kv-store waiter-hostnames service-description-defaults profile->overrides token-defaults)
           (attach-token-fallback-source token-defaults build-service-description-and-id-helper)
           (build-service-description-and-id-helper true))]
     (when-let [throwable (sd/validate-service-description kv-store service-description-builder descriptor)]
@@ -303,15 +304,15 @@
     "Extract the service descriptor from a request.
      It also performs the necessary authorization."
     [assoc-run-as-user-approved? can-run-as? fallback-state-atom kv-store metric-group-mappings
-     search-history-length service-description-builder profile->defaults service-id-prefix
-     token-defaults waiter-hostnames {:keys [request-time] :as request}]
+     search-history-length service-description-builder service-description-defaults profile->overrides
+     service-id-prefix token-defaults waiter-hostnames {:keys [request-time] :as request}]
     (timers/start-stop-time!
       request->descriptor-timer
       (let [auth-user (:authorization/user request)
             service-approved? (fn service-approved? [service-id] (assoc-run-as-user-approved? request service-id))
             latest-descriptor (compute-descriptor
-                                profile->defaults token-defaults service-id-prefix kv-store waiter-hostnames
-                                request metric-group-mappings service-description-builder service-approved?)
+                                service-description-defaults profile->overrides token-defaults service-id-prefix kv-store
+                                waiter-hostnames request metric-group-mappings service-description-builder service-approved?)
             descriptor->previous-descriptor
             (fn descriptor->previous-descriptor-fn
               [descriptor]

--- a/waiter/src/waiter/headers.clj
+++ b/waiter/src/waiter/headers.clj
@@ -28,7 +28,7 @@
 (def ^:const params-with-str-value
   #{"allowed-params" "authentication" "backend-proto" "cmd" "cmd-type" "distribution-scheme" "endpoint-path"
     "health-check-authentication" "health-check-proto" "health-check-url" "image" "load-balancing"
-    "metric-group" "name" "namespace" "permitted-user" "run-as-user" "token" "version"})
+    "metric-group" "name" "namespace" "permitted-user" "profile" "run-as-user" "token" "version"})
 
 (def ^:const waiter-headers-with-str-value (set (map #(str waiter-header-prefix %) params-with-str-value)))
 

--- a/waiter/src/waiter/schema.clj
+++ b/waiter/src/waiter/schema.clj
@@ -133,3 +133,7 @@
      (s/required-key :token-type) non-empty-string
      (s/required-key :update-interval-ms) positive-int}
     (s/constrained s/Keyword #(= :disabled %))))
+
+(def profile-definition
+  "Validator for profile parameters."
+  {(s/required-key :service-parameters) {non-empty-string s/Any}})

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -78,6 +78,7 @@
    (s/optional-key "namespace") schema/non-empty-string
    (s/optional-key "permitted-user") schema/non-empty-string
    (s/optional-key "ports") schema/valid-number-of-ports
+   (s/optional-key "profile") schema/non-empty-string
    ; start-up related
    (s/optional-key "grace-period-secs") (s/both s/Int (s/pred #(<= 0 % (t/in-seconds (t/minutes 60))) 'at-most-60-minutes))
    (s/optional-key "health-check-authentication") schema/valid-health-check-authentication
@@ -131,8 +132,8 @@
 (def ^:const service-non-override-keys
   #{"allowed-params" "backend-proto" "cmd" "cmd-type" "cpus" "env"
     "health-check-authentication" "health-check-port-index" "health-check-proto" "health-check-url"
-    "image" "mem" "metadata" "metric-group" "name" "namespace" "permitted-user" "ports" "run-as-user"
-    "scheduler" "version"})
+    "image" "mem" "metadata" "metric-group" "name" "namespace" "permitted-user" "ports" "profile"
+    "run-as-user" "scheduler" "version"})
 
 ; keys used as parameters in the service description
 (def ^:const service-parameter-keys
@@ -343,6 +344,33 @@
       (merge-defaults defaults metric-group-mappings)
       (merge-overrides (:overrides (service-id->overrides kv-store service-id)))))
 
+(defn- compute-valid-profiles-str
+  "Computes the string representation of valid custom profiles"
+  [profile->defaults]
+  (let [supported-profiles-str (->> profile->defaults keys sort (remove str/blank?) (str/join ", "))]
+    (if (str/blank? supported-profiles-str)
+      ", there are no supported profiles"
+      (str ", supported profile(s) are " supported-profiles-str))))
+
+(defn validate-profile-parameter
+  "Throws an exception when the profile parameter is provided but does not map to a supported profile."
+  [profile->defaults profile]
+  (when (some? profile)
+    (when-not (contains? profile->defaults profile)
+      (let [supported-profiles-str (compute-valid-profiles-str profile->defaults)]
+        (sling/throw+ {:type :service-description-error
+                       :friendly-error-message (str "Unsupported profile: " profile supported-profiles-str)
+                       :status 400
+                       :log-level :warn})))))
+
+(defn compute-profile-defaults
+  "Returns the default service parameters for the specified profile.
+   The 'default' profile is chosen if no profile is provided.
+   Throws an error if the profile is not supported."
+  [profile->defaults profile]
+  (validate-profile-parameter profile->defaults profile)
+  (get profile->defaults (or profile "")))
+
 (defn parameters->id
   "Generates a deterministic ID from the input parameter map."
   [parameters]
@@ -389,7 +417,9 @@
   "Validates the provided service description template.
    When requested to do so, it populates required fields to ensure validation does not fail for missing required fields."
   [service-description-template max-constraints-schema
-   {:keys [allow-missing-required-fields?] :or {allow-missing-required-fields? true} :as args-map}]
+   {:keys [allow-missing-required-fields? profile->defaults]
+    :or {allow-missing-required-fields? true}
+    :as args-map}]
   (let [default-valid-service-description (when allow-missing-required-fields?
                                             {"cpus" 1
                                              "mem" 1
@@ -479,6 +509,10 @@
                                            (attach-error-message-for-parameter
                                              parameter->issues :ports "ports must be an integer in the range [1, 10].")
                                            (attach-error-message-for-parameter
+                                             parameter->issues :profile
+                                             (str "profile must be a non-empty string"
+                                                  (compute-valid-profiles-str profile->defaults)))
+                                           (attach-error-message-for-parameter
                                              parameter->issues :version "version must be a non-empty string."))
               unresolved-parameters (set/difference (-> parameter->issues keys set)
                                                     (->> parameter->error-message keys (map name) set))
@@ -542,7 +576,12 @@
         (sling/throw+ {:type :service-description-error
                        :friendly-error-message "Service namespace must either be omitted or match the run-as-user."
                        :status 400
-                       :log-level :warn})))))
+                       :log-level :warn})))
+
+    ; validate the profile when it is configured
+    (let [{:strs [profile]} service-description-to-use]
+      (when-not (str/blank? profile)
+        (validate-profile-parameter profile->defaults profile)))))
 
 (defprotocol ServiceDescriptionBuilder
   "A protocol for constructing a service description from the various sources. Implementations
@@ -580,18 +619,20 @@
   ServiceDescriptionBuilder
 
   (build [_ user-service-description
-          {:keys [assoc-run-as-user-approved? component->previous-descriptor-fns defaults kv-store
+          {:keys [assoc-run-as-user-approved? component->previous-descriptor-fns kv-store profile->defaults
                   metric-group-mappings reference-type->entry service-id-prefix source-tokens username]}]
-    (let [core-service-description (if (get user-service-description "run-as-user")
-                                     user-service-description
-                                     (let [candidate-service-description (assoc-run-as-requester-fields user-service-description username)
-                                           candidate-service-id (service-description->service-id service-id-prefix candidate-service-description)]
-                                       (if (assoc-run-as-user-approved? candidate-service-id)
-                                         (do
-                                           (log/debug "appending run-as-user into pre-approved service" candidate-service-id)
-                                           candidate-service-description)
-                                         user-service-description)))
+    (let [{:strs [profile] :as core-service-description}
+          (if (get user-service-description "run-as-user")
+            user-service-description
+            (let [candidate-service-description (assoc-run-as-requester-fields user-service-description username)
+                  candidate-service-id (service-description->service-id service-id-prefix candidate-service-description)]
+              (if (assoc-run-as-user-approved? candidate-service-id)
+                (do
+                  (log/debug "appending run-as-user into pre-approved service" candidate-service-id)
+                  candidate-service-description)
+                user-service-description)))
           service-id (service-description->service-id service-id-prefix core-service-description)
+          defaults (compute-profile-defaults profile->defaults profile)
           service-description (default-and-override core-service-description metric-group-mappings
                                                     kv-store defaults service-id)
           reference-type->entry (cond-> (or reference-type->entry {})
@@ -886,7 +927,7 @@
         (assoc sanitized-service-description "metadata" renamed-metadata-map)))))
 
 (defn prepare-service-description-sources
-  [{:keys [waiter-headers passthrough-headers]} kv-store waiter-hostnames service-description-defaults token-defaults]
+  [{:keys [waiter-headers passthrough-headers]} kv-store waiter-hostnames profile->defaults token-defaults]
   "Prepare the service description sources from the current request.
    Populates the service description for on-the-fly waiter-specific headers.
    Also populates for the service description for a token (first looked in headers and then using the host name).
@@ -900,14 +941,14 @@
                                                       (sanitize-service-description service-description-from-header-keys))]
     (-> (prepare-service-description-template-from-tokens
           waiter-headers passthrough-headers kv-store waiter-hostnames token-defaults)
-        (assoc :defaults service-description-defaults
-               :headers service-description-template-from-headers))))
+        (assoc :headers service-description-template-from-headers
+               :profile->defaults profile->defaults))))
 
 (defn merge-service-description-sources
-  [descriptor kv-store waiter-hostnames service-description-defaults token-defaults]
+  [descriptor kv-store waiter-hostnames profile->defaults token-defaults]
   "Merges the sources for a service-description into the descriptor."
   (->> (prepare-service-description-sources
-         descriptor kv-store waiter-hostnames service-description-defaults token-defaults)
+         descriptor kv-store waiter-hostnames profile->defaults token-defaults)
        (assoc descriptor :sources)))
 
 (defn- sanitize-metadata [{:strs [metadata] :as service-description}]
@@ -932,7 +973,7 @@
      If a non-param on-the-fly header is provided, the username is included as the run-as-user in on-the-fly headers.
      If after the merge a run-as-user is not available, then `username` becomes the run-as-user.
      If after the merge a permitted-user is not available, then `username` becomes the permitted-user."
-    [{:keys [defaults headers service-description-template source-tokens token-authentication-disabled token-preauthorized]}
+    [{:keys [headers profile->defaults service-description-template source-tokens token-authentication-disabled token-preauthorized]}
      waiter-headers passthrough-headers component->previous-descriptor-fns kv-store service-id-prefix username
      metric-group-mappings assoc-run-as-user-approved? service-description-builder]
     (let [headers-without-params (dissoc headers "param")
@@ -987,9 +1028,9 @@
         (let [build-map (build service-description-builder user-service-description
                                {:assoc-run-as-user-approved? assoc-run-as-user-approved?
                                 :component->previous-descriptor-fns component->previous-descriptor-fns
-                                :defaults defaults
                                 :kv-store kv-store
                                 :metric-group-mappings metric-group-mappings
+                                :profile->defaults profile->defaults
                                 :reference-type->entry {}
                                 :service-id-prefix service-id-prefix
                                 :source-tokens source-tokens
@@ -1012,14 +1053,19 @@
     "Returns nil if the provided descriptor contains a valid service description.
      Else it returns an instance of Throwable that reflects the validation error."
     [kv-store service-description-builder
-     {:keys [core-service-description passthrough-headers service-description service-id waiter-headers]}]
+     {:keys [core-service-description passthrough-headers service-description service-id sources waiter-headers]}]
     (sling/try+
       (let [stored-service-description (fetch-core kv-store service-id)]
         ; Validating is expensive, so avoid validating if we've validated before, relying on the fact
         ; that we'll only store validated service descriptions
         (when-not (seq stored-service-description)
-          (validate service-description-builder core-service-description {:allow-missing-required-fields? false})
-          (validate service-description-builder service-description {:allow-missing-required-fields? false}))
+          (let [{:keys [profile->defaults]} sources]
+            (validate service-description-builder core-service-description
+                      {:allow-missing-required-fields? false
+                       :profile->defaults profile->defaults})
+            (validate service-description-builder service-description
+                      {:allow-missing-required-fields? false
+                       :profile->defaults profile->defaults})))
         nil)
       (catch [:type :service-description-error] ex-data
         (ex-info (:message ex-data)
@@ -1078,9 +1124,11 @@
 
 (defn service-id->service-description
   "Loads the service description for the specified service-id including any overrides."
-  [kv-store service-id service-description-defaults metric-group-mappings & {:keys [effective?] :or {effective? true}}]
-  (cond-> (fetch-core kv-store service-id :refresh false)
-    effective? (default-and-override metric-group-mappings kv-store service-description-defaults service-id)))
+  [kv-store service-id profile->defaults metric-group-mappings & {:keys [effective?] :or {effective? true}}]
+  (let [{:strs [profile] :as core-service-description} (fetch-core kv-store service-id :refresh false)
+        service-description-defaults (compute-profile-defaults profile->defaults profile)]
+    (cond-> core-service-description
+      effective? (default-and-override metric-group-mappings kv-store service-description-defaults service-id))))
 
 (defn can-manage-service?
   "Returns whether the `username` is allowed to modify the specified service description."

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -345,19 +345,19 @@
       (merge-overrides (:overrides (service-id->overrides kv-store service-id)))))
 
 (defn- compute-valid-profiles-str
-  "Computes the string representation of valid custom profiles"
-  [profile->defaults]
-  (let [supported-profiles-str (->> profile->defaults keys (remove keyword?) sort (str/join ", "))]
+  "Computes the string representation of supported profiles"
+  [profile->overrides]
+  (let [supported-profiles-str (->> profile->overrides keys sort (str/join ", "))]
     (if (str/blank? supported-profiles-str)
       ", there are no supported profiles"
       (str ", supported profile(s) are " supported-profiles-str))))
 
 (defn validate-profile-parameter
   "Throws an exception when the profile parameter is provided but does not map to a supported profile."
-  [profile->defaults profile]
+  [profile->overrides profile]
   (when (some? profile)
-    (when-not (contains? profile->defaults profile)
-      (let [supported-profiles-str (compute-valid-profiles-str profile->defaults)]
+    (when-not (contains? profile->overrides profile)
+      (let [supported-profiles-str (compute-valid-profiles-str profile->overrides)]
         (sling/throw+ {:type :service-description-error
                        :friendly-error-message (str "Unsupported profile: " profile supported-profiles-str)
                        :status 400
@@ -365,11 +365,13 @@
 
 (defn compute-profile-defaults
   "Returns the default service parameters for the specified profile.
-   The 'default' profile is chosen if no profile is provided.
-   Throws an error if the profile is not supported."
-  [profile->defaults profile]
-  (validate-profile-parameter profile->defaults profile)
-  (get profile->defaults (or profile :default)))
+   Throws an error if the profile is not supported.
+   The service-description-defaults are overridden with overrides from a specified profile."
+  [service-description-defaults profile->overrides profile]
+  (validate-profile-parameter profile->overrides profile)
+  (cond-> service-description-defaults
+    (contains? profile->overrides profile)
+    (merge (get profile->overrides profile))))
 
 (defn parameters->id
   "Generates a deterministic ID from the input parameter map."
@@ -417,7 +419,7 @@
   "Validates the provided service description template.
    When requested to do so, it populates required fields to ensure validation does not fail for missing required fields."
   [service-description-template max-constraints-schema
-   {:keys [allow-missing-required-fields? profile->defaults]
+   {:keys [allow-missing-required-fields? profile->overrides]
     :or {allow-missing-required-fields? true}
     :as args-map}]
   (let [default-valid-service-description (when allow-missing-required-fields?
@@ -511,7 +513,7 @@
                                            (attach-error-message-for-parameter
                                              parameter->issues :profile
                                              (str "profile must be a non-empty string"
-                                                  (compute-valid-profiles-str profile->defaults)))
+                                                  (compute-valid-profiles-str profile->overrides)))
                                            (attach-error-message-for-parameter
                                              parameter->issues :version "version must be a non-empty string."))
               unresolved-parameters (set/difference (-> parameter->issues keys set)
@@ -581,7 +583,7 @@
     ; validate the profile when it is configured
     (let [{:strs [profile]} service-description-to-use]
       (when-not (str/blank? profile)
-        (validate-profile-parameter profile->defaults profile)))))
+        (validate-profile-parameter profile->overrides profile)))))
 
 (defprotocol ServiceDescriptionBuilder
   "A protocol for constructing a service description from the various sources. Implementations
@@ -619,8 +621,8 @@
   ServiceDescriptionBuilder
 
   (build [_ user-service-description
-          {:keys [assoc-run-as-user-approved? component->previous-descriptor-fns kv-store profile->defaults
-                  metric-group-mappings reference-type->entry service-id-prefix source-tokens username]}]
+          {:keys [assoc-run-as-user-approved? component->previous-descriptor-fns kv-store service-description-defaults
+                  profile->overrides metric-group-mappings reference-type->entry service-id-prefix source-tokens username]}]
     (let [{:strs [profile] :as core-service-description}
           (if (get user-service-description "run-as-user")
             user-service-description
@@ -632,7 +634,7 @@
                   candidate-service-description)
                 user-service-description)))
           service-id (service-description->service-id service-id-prefix core-service-description)
-          defaults (compute-profile-defaults profile->defaults profile)
+          defaults (compute-profile-defaults service-description-defaults profile->overrides profile)
           service-description (default-and-override core-service-description metric-group-mappings
                                                     kv-store defaults service-id)
           reference-type->entry (cond-> (or reference-type->entry {})
@@ -927,7 +929,8 @@
         (assoc sanitized-service-description "metadata" renamed-metadata-map)))))
 
 (defn prepare-service-description-sources
-  [{:keys [waiter-headers passthrough-headers]} kv-store waiter-hostnames profile->defaults token-defaults]
+  [{:keys [waiter-headers passthrough-headers]} kv-store waiter-hostnames
+   service-description-defaults profile->overrides token-defaults]
   "Prepare the service description sources from the current request.
    Populates the service description for on-the-fly waiter-specific headers.
    Also populates for the service description for a token (first looked in headers and then using the host name).
@@ -942,13 +945,14 @@
     (-> (prepare-service-description-template-from-tokens
           waiter-headers passthrough-headers kv-store waiter-hostnames token-defaults)
         (assoc :headers service-description-template-from-headers
-               :profile->defaults profile->defaults))))
+               :profile->overrides profile->overrides
+               :service-description-defaults service-description-defaults))))
 
 (defn merge-service-description-sources
-  [descriptor kv-store waiter-hostnames profile->defaults token-defaults]
+  [descriptor kv-store waiter-hostnames service-description-defaults profile->overrides token-defaults]
   "Merges the sources for a service-description into the descriptor."
   (->> (prepare-service-description-sources
-         descriptor kv-store waiter-hostnames profile->defaults token-defaults)
+         descriptor kv-store waiter-hostnames service-description-defaults profile->overrides token-defaults)
        (assoc descriptor :sources)))
 
 (defn- sanitize-metadata [{:strs [metadata] :as service-description}]
@@ -973,7 +977,8 @@
      If a non-param on-the-fly header is provided, the username is included as the run-as-user in on-the-fly headers.
      If after the merge a run-as-user is not available, then `username` becomes the run-as-user.
      If after the merge a permitted-user is not available, then `username` becomes the permitted-user."
-    [{:keys [headers profile->defaults service-description-template source-tokens token-authentication-disabled token-preauthorized]}
+    [{:keys [headers profile->overrides service-description-defaults service-description-template source-tokens
+             token-authentication-disabled token-preauthorized]}
      waiter-headers passthrough-headers component->previous-descriptor-fns kv-store service-id-prefix username
      metric-group-mappings assoc-run-as-user-approved? service-description-builder]
     (let [headers-without-params (dissoc headers "param")
@@ -1030,7 +1035,8 @@
                                 :component->previous-descriptor-fns component->previous-descriptor-fns
                                 :kv-store kv-store
                                 :metric-group-mappings metric-group-mappings
-                                :profile->defaults profile->defaults
+                                :profile->overrides profile->overrides
+                                :service-description-defaults service-description-defaults
                                 :reference-type->entry {}
                                 :service-id-prefix service-id-prefix
                                 :source-tokens source-tokens
@@ -1059,13 +1065,13 @@
         ; Validating is expensive, so avoid validating if we've validated before, relying on the fact
         ; that we'll only store validated service descriptions
         (when-not (seq stored-service-description)
-          (let [{:keys [profile->defaults]} sources]
+          (let [{:keys [profile->overrides]} sources]
             (validate service-description-builder core-service-description
                       {:allow-missing-required-fields? false
-                       :profile->defaults profile->defaults})
+                       :profile->overrides profile->overrides})
             (validate service-description-builder service-description
                       {:allow-missing-required-fields? false
-                       :profile->defaults profile->defaults})))
+                       :profile->overrides profile->overrides})))
         nil)
       (catch [:type :service-description-error] ex-data
         (ex-info (:message ex-data)
@@ -1124,9 +1130,10 @@
 
 (defn service-id->service-description
   "Loads the service description for the specified service-id including any overrides."
-  [kv-store service-id profile->defaults metric-group-mappings & {:keys [effective?] :or {effective? true}}]
+  [kv-store service-id service-description-defaults profile->overrides metric-group-mappings
+   & {:keys [effective?] :or {effective? true}}]
   (let [{:strs [profile] :as core-service-description} (fetch-core kv-store service-id :refresh false)
-        service-description-defaults (compute-profile-defaults profile->defaults profile)]
+        service-description-defaults (compute-profile-defaults service-description-defaults profile->overrides profile)]
     (cond-> core-service-description
       effective? (default-and-override metric-group-mappings kv-store service-description-defaults service-id))))
 

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -347,7 +347,7 @@
 (defn- compute-valid-profiles-str
   "Computes the string representation of valid custom profiles"
   [profile->defaults]
-  (let [supported-profiles-str (->> profile->defaults keys sort (remove str/blank?) (str/join ", "))]
+  (let [supported-profiles-str (->> profile->defaults keys (remove keyword?) sort (str/join ", "))]
     (if (str/blank? supported-profiles-str)
       ", there are no supported profiles"
       (str ", supported profile(s) are " supported-profiles-str))))
@@ -369,7 +369,7 @@
    Throws an error if the profile is not supported."
   [profile->defaults profile]
   (validate-profile-parameter profile->defaults profile)
-  (get profile->defaults (or profile "")))
+  (get profile->defaults (or profile :default)))
 
 (defn parameters->id
   "Generates a deterministic ID from the input parameter map."

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -92,6 +92,7 @@
    ;; TODO port belongs in server-options?
    (s/required-key :port) (s/either schema/positive-int
                                     [schema/positive-int])
+   (s/required-key :profile-config) {schema/non-empty-string schema/profile-definition}
    (s/required-key :router-id-prefix) s/Str
    (s/required-key :router-syncer) {(s/required-key :delay-ms) schema/positive-int
                                     (s/required-key :interval-ms) schema/positive-int}
@@ -330,6 +331,8 @@
                            :configured {:factory-fn 'waiter.password-store/configured-provider
                                         :passwords ["open-sesame"]}}
    :port 9091
+   :profile-config {"webapp" {:service-parameters {"concurrency-level" 120
+                                                   "load-balancing" "random"}}}
    :router-id-prefix ""
    :router-syncer {:delay-ms 750
                    :interval-ms 1500}

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -331,8 +331,7 @@
                            :configured {:factory-fn 'waiter.password-store/configured-provider
                                         :passwords ["open-sesame"]}}
    :port 9091
-   :profile-config {"webapp" {:service-parameters {"concurrency-level" 120
-                                                   "load-balancing" "random"}}}
+   :profile-config {}
    :router-id-prefix ""
    :router-syncer {:delay-ms 750
                    :interval-ms 1500}

--- a/waiter/test/waiter/descriptor_test.clj
+++ b/waiter/test/waiter/descriptor_test.clj
@@ -476,8 +476,8 @@
                                                 assoc-run-as-user-approved?)]
 
   (deftest test-descriptor->previous-descriptor-no-token
-    (let [sources {:defaults {"permitted-user" "*"}
-                   :headers {}
+    (let [sources {:headers {}
+                   :profile->defaults {"" {"permitted-user" "*"}}
                    :service-description-template {"cmd" "ls" "cpus" 1 "mem" 32 "run-as-user" "ru" "version" "foo"}
                    :token->token-data {}
                    :token-authentication-disabled false
@@ -493,8 +493,8 @@
 
   (deftest test-descriptor->previous-descriptor-single-token-without-previous
     (let [service-description-1 {"cmd" "ls" "cpus" 1 "mem" 32 "run-as-user" "ru" "version" "foo"}
-          sources {:defaults {"permitted-user" "*"}
-                   :headers {}
+          sources {:headers {}
+                   :profile->defaults {"" {"permitted-user" "*"}}
                    :service-description-template service-description-1
                    :token->token-data {"token-1" {"cmd" "ls" "cpus" 1 "mem" 32 "run-as-user" "ru" "version" "foo"}}
                    :token-authentication-disabled false
@@ -647,8 +647,8 @@
           service-description-1 token-data-1
           token-data-2 {"cmd" "ls" "cpus" 2 "mem" 64 "previous" token-data-1 "run-as-user" "ru" "version" "foo2"}
           service-description-2 token-data-2
-          sources {:defaults {"metric-group" "other" "permitted-user" "*"}
-                   :headers {}
+          sources {:headers {}
+                   :profile->defaults {"" {"metric-group" "other" "permitted-user" "*"}}
                    :service-description-template service-description-2
                    :token->token-data {test-token token-data-2}
                    :token-authentication-disabled false
@@ -668,7 +668,7 @@
               :passthrough-headers passthrough-headers
               :reference-type->entry {:token {:sources [(reference-tokens-entry test-token token-data-1)]}}
               :service-authentication-disabled false
-              :service-description (merge (:defaults sources) service-description-1)
+              :service-description (merge (get-in sources [:profile->defaults ""]) service-description-1)
               :service-id (sd/service-description->service-id service-id-prefix service-description-1)
               :service-preauthorized false
               :source-tokens [(sd/source-tokens-entry test-token token-data-1)]
@@ -688,8 +688,8 @@
           token-data-2 {"cmd" 1234 "cpus" 2 "mem" 64 "previous" token-data-1 "run-as-user" 9876 "version" "foo2"}
           token-data-3 {"cmd" "ls" "cpus" 2 "mem" 64 "previous" token-data-2 "run-as-user" "ru" "version" "foo2"}
           service-description-3 token-data-3
-          sources {:defaults {"metric-group" "other" "permitted-user" "*"}
-                   :headers {}
+          sources {:headers {}
+                   :profile->defaults {"" {"metric-group" "other" "permitted-user" "*"}}
                    :service-description-template service-description-3
                    :token->token-data {test-token token-data-3}
                    :token-authentication-disabled false
@@ -709,7 +709,7 @@
               :passthrough-headers passthrough-headers
               :reference-type->entry {:token {:sources [(reference-tokens-entry test-token token-data-1)]}}
               :service-authentication-disabled false
-              :service-description (merge (:defaults sources) service-description-1)
+              :service-description (merge (get-in sources [:profile->defaults ""]) service-description-1)
               :service-id (sd/service-description->service-id service-id-prefix service-description-1)
               :service-preauthorized false
               :source-tokens [(sd/source-tokens-entry test-token token-data-1)]
@@ -729,8 +729,8 @@
           token-data-2 {"cmd" 1234 "cpus" 2 "mem" 64 "previous" token-data-1 "run-as-user" 9876 "version" "foo2"}
           token-data-3 {"cmd" "ls" "cpus" 2 "mem" 64 "previous" token-data-2 "run-as-user" "ru" "version" "foo2"}
           service-description-3 token-data-3
-          sources {:defaults {"metric-group" "other" "permitted-user" "*"}
-                   :headers {}
+          sources {:headers {}
+                   :profile->defaults {"" {"metric-group" "other" "permitted-user" "*"}}
                    :service-description-template service-description-3
                    :token->token-data {test-token token-data-3}
                    :token-authentication-disabled false
@@ -760,7 +760,7 @@
               :passthrough-headers passthrough-headers
               :reference-type->entry {:token {:sources [(reference-tokens-entry test-token token-data-1)]}}
               :service-authentication-disabled false
-              :service-description (merge (:defaults sources) service-description-1)
+              :service-description (merge (get-in sources [:profile->defaults ""]) service-description-1)
               :service-id (sd/service-description->service-id service-id-prefix service-description-1)
               :service-preauthorized false
               :source-tokens [(sd/source-tokens-entry test-token token-data-1)]
@@ -780,8 +780,8 @@
           token-data-2 {"cpus" 2 "mem" 64 "previous" token-data-1 "run-as-user" "ru" "version" "foo2"}
           token-data-3 {"cmd" "ls-3" "cpus" 3 "mem" 128 "previous" token-data-2 "run-as-user" "ru" "version" "foo3"}
           service-description-3 token-data-2
-          sources {:defaults {"metric-group" "other" "permitted-user" "*"}
-                   :headers {}
+          sources {:headers {}
+                   :profile->defaults {"" {"metric-group" "other" "permitted-user" "*"}}
                    :service-description-template service-description-3
                    :token->token-data {test-token token-data-3}
                    :token-authentication-disabled false
@@ -801,7 +801,7 @@
               :passthrough-headers passthrough-headers
               :reference-type->entry {:token {:sources [(reference-tokens-entry test-token token-data-1)]}}
               :service-authentication-disabled false
-              :service-description (merge (:defaults sources) service-description-1)
+              :service-description (merge (get-in sources [:profile->defaults ""]) service-description-1)
               :service-id (sd/service-description->service-id service-id-prefix service-description-1)
               :service-preauthorized false
               :source-tokens [(sd/source-tokens-entry test-token token-data-1)]
@@ -820,9 +820,9 @@
           service-description-1 token-data-1
           token-data-2 {"cmd" "ls" "cpus" 2 "mem" 64 "previous" token-data-1 "run-as-user" "ru2" "version" "foo2"}
           service-description-2 token-data-2
-          sources {:defaults {"metric-group" "other" "permitted-user" "*"}
-                   :headers {"cpus" 20}
-                   :on-the-fly? nil ;; invalid value to check if it is ignored and generated in the fallback
+          sources {:headers {"cpus" 20}
+                   :on-the-fly? nil
+                   :profile->defaults {"" {"metric-group" "other" "permitted-user" "*"}} ;; invalid value to check if it is ignored and generated in the fallback
                    :service-description-template service-description-2
                    :token->token-data {test-token token-data-2}
                    :token-authentication-disabled false
@@ -843,7 +843,7 @@
                 :passthrough-headers passthrough-headers
                 :reference-type->entry {:token {:sources [(reference-tokens-entry test-token token-data-1)]}}
                 :service-authentication-disabled false
-                :service-description (merge (:defaults sources) expected-core-service-description)
+                :service-description (merge (get-in sources [:profile->defaults ""]) expected-core-service-description)
                 :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)
                 :service-preauthorized false
                 :source-tokens [(sd/source-tokens-entry test-token token-data-1)]
@@ -859,8 +859,8 @@
     (let [test-token "test-token"
           service-description-1 {"cmd" "ls" "cpus" 1 "mem" 32}
           service-description-2 {"run-as-user" "ru" "version" "foo"}
-          sources {:defaults {"permitted-user" "*"}
-                   :headers {}
+          sources {:headers {}
+                   :profile->defaults {"" {"permitted-user" "*"}}
                    :service-description-template (merge service-description-1 service-description-2)
                    :token->token-data {test-token service-description-1
                                        "token-2" service-description-2}
@@ -885,8 +885,8 @@
           token-data-2p {"last-update-time" 2000 "run-as-user" "rup" "version" "foo"}
           service-description-2p token-data-2p
           token-data-2 {"previous" token-data-2p "run-as-user" "ru" "version" "foo"}
-          sources {:defaults {"metric-group" "other" "permitted-user" "*"}
-                   :headers {}
+          sources {:headers {}
+                   :profile->defaults {"" {"metric-group" "other" "permitted-user" "*"}}
                    :service-description-template (merge service-description-1 service-description-2p)
                    :source-tokens [(sd/source-tokens-entry test-token-1 token-data-1)
                                    (sd/source-tokens-entry test-token-2 token-data-2)]
@@ -912,7 +912,7 @@
                 :reference-type->entry {:token {:sources [(reference-tokens-entry test-token-1 token-data-1)
                                                           (reference-tokens-entry test-token-2 token-data-2p)]}}
                 :service-authentication-disabled false
-                :service-description (merge (:defaults sources) expected-core-service-description)
+                :service-description (merge (get-in sources [:profile->defaults ""]) expected-core-service-description)
                 :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)
                 :service-preauthorized false
                 :source-tokens [(sd/source-tokens-entry test-token-1 token-data-1)
@@ -938,7 +938,7 @@
                   :reference-type->entry {:token {:sources [(reference-tokens-entry test-token-1 token-data-1p)
                                                             (reference-tokens-entry test-token-2 token-data-2p)]}}
                   :service-authentication-disabled false
-                  :service-description (merge (:defaults sources) expected-core-service-description)
+                  :service-description (merge (get-in sources [:profile->defaults ""]) expected-core-service-description)
                   :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)
                   :service-preauthorized false
                   :source-tokens [(sd/source-tokens-entry test-token-1 token-data-1p)

--- a/waiter/test/waiter/descriptor_test.clj
+++ b/waiter/test/waiter/descriptor_test.clj
@@ -477,7 +477,7 @@
 
   (deftest test-descriptor->previous-descriptor-no-token
     (let [sources {:headers {}
-                   :profile->defaults {"" {"permitted-user" "*"}}
+                   :profile->defaults {:default {"permitted-user" "*"}}
                    :service-description-template {"cmd" "ls" "cpus" 1 "mem" 32 "run-as-user" "ru" "version" "foo"}
                    :token->token-data {}
                    :token-authentication-disabled false
@@ -494,7 +494,7 @@
   (deftest test-descriptor->previous-descriptor-single-token-without-previous
     (let [service-description-1 {"cmd" "ls" "cpus" 1 "mem" 32 "run-as-user" "ru" "version" "foo"}
           sources {:headers {}
-                   :profile->defaults {"" {"permitted-user" "*"}}
+                   :profile->defaults {:default {"permitted-user" "*"}}
                    :service-description-template service-description-1
                    :token->token-data {"token-1" {"cmd" "ls" "cpus" 1 "mem" 32 "run-as-user" "ru" "version" "foo"}}
                    :token-authentication-disabled false
@@ -648,7 +648,7 @@
           token-data-2 {"cmd" "ls" "cpus" 2 "mem" 64 "previous" token-data-1 "run-as-user" "ru" "version" "foo2"}
           service-description-2 token-data-2
           sources {:headers {}
-                   :profile->defaults {"" {"metric-group" "other" "permitted-user" "*"}}
+                   :profile->defaults {:default {"metric-group" "other" "permitted-user" "*"}}
                    :service-description-template service-description-2
                    :token->token-data {test-token token-data-2}
                    :token-authentication-disabled false
@@ -668,7 +668,7 @@
               :passthrough-headers passthrough-headers
               :reference-type->entry {:token {:sources [(reference-tokens-entry test-token token-data-1)]}}
               :service-authentication-disabled false
-              :service-description (merge (get-in sources [:profile->defaults ""]) service-description-1)
+              :service-description (merge (get-in sources [:profile->defaults :default]) service-description-1)
               :service-id (sd/service-description->service-id service-id-prefix service-description-1)
               :service-preauthorized false
               :source-tokens [(sd/source-tokens-entry test-token token-data-1)]
@@ -689,7 +689,7 @@
           token-data-3 {"cmd" "ls" "cpus" 2 "mem" 64 "previous" token-data-2 "run-as-user" "ru" "version" "foo2"}
           service-description-3 token-data-3
           sources {:headers {}
-                   :profile->defaults {"" {"metric-group" "other" "permitted-user" "*"}}
+                   :profile->defaults {:default {"metric-group" "other" "permitted-user" "*"}}
                    :service-description-template service-description-3
                    :token->token-data {test-token token-data-3}
                    :token-authentication-disabled false
@@ -709,7 +709,7 @@
               :passthrough-headers passthrough-headers
               :reference-type->entry {:token {:sources [(reference-tokens-entry test-token token-data-1)]}}
               :service-authentication-disabled false
-              :service-description (merge (get-in sources [:profile->defaults ""]) service-description-1)
+              :service-description (merge (get-in sources [:profile->defaults :default]) service-description-1)
               :service-id (sd/service-description->service-id service-id-prefix service-description-1)
               :service-preauthorized false
               :source-tokens [(sd/source-tokens-entry test-token token-data-1)]
@@ -730,7 +730,7 @@
           token-data-3 {"cmd" "ls" "cpus" 2 "mem" 64 "previous" token-data-2 "run-as-user" "ru" "version" "foo2"}
           service-description-3 token-data-3
           sources {:headers {}
-                   :profile->defaults {"" {"metric-group" "other" "permitted-user" "*"}}
+                   :profile->defaults {:default {"metric-group" "other" "permitted-user" "*"}}
                    :service-description-template service-description-3
                    :token->token-data {test-token token-data-3}
                    :token-authentication-disabled false
@@ -760,7 +760,7 @@
               :passthrough-headers passthrough-headers
               :reference-type->entry {:token {:sources [(reference-tokens-entry test-token token-data-1)]}}
               :service-authentication-disabled false
-              :service-description (merge (get-in sources [:profile->defaults ""]) service-description-1)
+              :service-description (merge (get-in sources [:profile->defaults :default]) service-description-1)
               :service-id (sd/service-description->service-id service-id-prefix service-description-1)
               :service-preauthorized false
               :source-tokens [(sd/source-tokens-entry test-token token-data-1)]
@@ -781,7 +781,7 @@
           token-data-3 {"cmd" "ls-3" "cpus" 3 "mem" 128 "previous" token-data-2 "run-as-user" "ru" "version" "foo3"}
           service-description-3 token-data-2
           sources {:headers {}
-                   :profile->defaults {"" {"metric-group" "other" "permitted-user" "*"}}
+                   :profile->defaults {:default {"metric-group" "other" "permitted-user" "*"}}
                    :service-description-template service-description-3
                    :token->token-data {test-token token-data-3}
                    :token-authentication-disabled false
@@ -801,7 +801,7 @@
               :passthrough-headers passthrough-headers
               :reference-type->entry {:token {:sources [(reference-tokens-entry test-token token-data-1)]}}
               :service-authentication-disabled false
-              :service-description (merge (get-in sources [:profile->defaults ""]) service-description-1)
+              :service-description (merge (get-in sources [:profile->defaults :default]) service-description-1)
               :service-id (sd/service-description->service-id service-id-prefix service-description-1)
               :service-preauthorized false
               :source-tokens [(sd/source-tokens-entry test-token token-data-1)]
@@ -822,7 +822,7 @@
           service-description-2 token-data-2
           sources {:headers {"cpus" 20}
                    :on-the-fly? nil
-                   :profile->defaults {"" {"metric-group" "other" "permitted-user" "*"}} ;; invalid value to check if it is ignored and generated in the fallback
+                   :profile->defaults {:default {"metric-group" "other" "permitted-user" "*"}} ;; invalid value to check if it is ignored and generated in the fallback
                    :service-description-template service-description-2
                    :token->token-data {test-token token-data-2}
                    :token-authentication-disabled false
@@ -843,7 +843,7 @@
                 :passthrough-headers passthrough-headers
                 :reference-type->entry {:token {:sources [(reference-tokens-entry test-token token-data-1)]}}
                 :service-authentication-disabled false
-                :service-description (merge (get-in sources [:profile->defaults ""]) expected-core-service-description)
+                :service-description (merge (get-in sources [:profile->defaults :default]) expected-core-service-description)
                 :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)
                 :service-preauthorized false
                 :source-tokens [(sd/source-tokens-entry test-token token-data-1)]
@@ -860,7 +860,7 @@
           service-description-1 {"cmd" "ls" "cpus" 1 "mem" 32}
           service-description-2 {"run-as-user" "ru" "version" "foo"}
           sources {:headers {}
-                   :profile->defaults {"" {"permitted-user" "*"}}
+                   :profile->defaults {:default {"permitted-user" "*"}}
                    :service-description-template (merge service-description-1 service-description-2)
                    :token->token-data {test-token service-description-1
                                        "token-2" service-description-2}
@@ -886,7 +886,7 @@
           service-description-2p token-data-2p
           token-data-2 {"previous" token-data-2p "run-as-user" "ru" "version" "foo"}
           sources {:headers {}
-                   :profile->defaults {"" {"metric-group" "other" "permitted-user" "*"}}
+                   :profile->defaults {:default {"metric-group" "other" "permitted-user" "*"}}
                    :service-description-template (merge service-description-1 service-description-2p)
                    :source-tokens [(sd/source-tokens-entry test-token-1 token-data-1)
                                    (sd/source-tokens-entry test-token-2 token-data-2)]
@@ -912,7 +912,7 @@
                 :reference-type->entry {:token {:sources [(reference-tokens-entry test-token-1 token-data-1)
                                                           (reference-tokens-entry test-token-2 token-data-2p)]}}
                 :service-authentication-disabled false
-                :service-description (merge (get-in sources [:profile->defaults ""]) expected-core-service-description)
+                :service-description (merge (get-in sources [:profile->defaults :default]) expected-core-service-description)
                 :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)
                 :service-preauthorized false
                 :source-tokens [(sd/source-tokens-entry test-token-1 token-data-1)
@@ -938,7 +938,7 @@
                   :reference-type->entry {:token {:sources [(reference-tokens-entry test-token-1 token-data-1p)
                                                             (reference-tokens-entry test-token-2 token-data-2p)]}}
                   :service-authentication-disabled false
-                  :service-description (merge (get-in sources [:profile->defaults ""]) expected-core-service-description)
+                  :service-description (merge (get-in sources [:profile->defaults :default]) expected-core-service-description)
                   :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)
                   :service-preauthorized false
                   :source-tokens [(sd/source-tokens-entry test-token-1 token-data-1p)

--- a/waiter/test/waiter/headers_test.clj
+++ b/waiter/test/waiter/headers_test.clj
@@ -92,7 +92,10 @@
     (is (= "h2c" (parse-header-value "x-waiter-backend-proto" "h2c"))))
 
   (testing "parse-header-value:backend-proto:h2"
-    (is (= "h2" (parse-header-value "x-waiter-backend-proto" "h2")))))
+    (is (= "h2" (parse-header-value "x-waiter-backend-proto" "h2"))))
+
+  (testing "parse-header-value:profile"
+    (is (= "webapp" (parse-header-value "x-waiter-profile" "webapp")))))
 
 (deftest test-contains-waiter-header
   (let [test-cases (list

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -244,7 +244,7 @@
     (with-redefs [kv/fetch (fn [in-kv-store token]
                              (is (= kv-store in-kv-store))
                              (create-token-data token))]
-      (let [profile->defaults {"" {"name" "default-name" "health-check-url" "/ping"}}
+      (let [profile->defaults {:default {"name" "default-name" "health-check-url" "/ping"}}
             token-defaults {"fallback-period-secs" 300}
             test-cases (list
                          {:name "prepare-service-description-sources:WITH Service Desc specific Waiter Headers except run-as-user"
@@ -263,8 +263,8 @@
                                                "cmd" "test-cmd"
                                                "version" "test-version"
                                                "run-as-user" test-user}
-                                     :profile->defaults {"" {"name" "default-name"
-                                                             "health-check-url" "/ping"}}
+                                     :profile->defaults {:default {"name" "default-name"
+                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-host"
                                                                     "version" "token"}
@@ -289,8 +289,8 @@
                                                "cmd" "test-cmd"
                                                "version" "test-version"
                                                "run-as-user" test-user}
-                                     :profile->defaults {"" {"name" "default-name"
-                                                             "health-check-url" "/ping"}}
+                                     :profile->defaults {:default {"name" "default-name"
+                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -313,8 +313,8 @@
                                                "cmd" "test-cmd"
                                                "version" "test-version"
                                                "run-as-user" test-user}
-                                     :profile->defaults {"" {"name" "default-name"
-                                                             "health-check-url" "/ping"}}
+                                     :profile->defaults {:default {"name" "default-name"
+                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-host"
                                                                     "version" "token"}
@@ -338,8 +338,8 @@
                                                "cmd" "test-cmd"
                                                "version" "test-version"
                                                "run-as-user" test-user}
-                                     :profile->defaults {"" {"name" "default-name"
-                                                             "health-check-url" "/ping"}}
+                                     :profile->defaults {:default {"name" "default-name"
+                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -353,8 +353,8 @@
                                                 "fee" "foe"}
                           :expected {:fallback-period-secs 300
                                      :headers {}
-                                     :profile->defaults {"" {"name" "default-name"
-                                                             "health-check-url" "/ping"}}
+                                     :profile->defaults {:default {"name" "default-name"
+                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-host"
                                                                     "version" "token"}
@@ -370,8 +370,8 @@
                           :passthrough-headers {"host" "test-host" "fee" "foe"}
                           :expected {:fallback-period-secs 300
                                      :headers {}
-                                     :profile->defaults {"" {"name" "default-name"
-                                                             "health-check-url" "/ping"}}
+                                     :profile->defaults {:default {"name" "default-name"
+                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-token"
                                                                     "version" "token"}
@@ -388,8 +388,8 @@
                                                 "fee" "foe"}
                           :expected {:fallback-period-secs 300
                                      :headers {}
-                                     :profile->defaults {"" {"name" "default-name"
-                                                             "health-check-url" "/ping"}}
+                                     :profile->defaults {:default {"name" "default-name"
+                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-token2"
                                                                     "version" "token"}
@@ -406,7 +406,7 @@
                           :passthrough-headers {"host" "test-host" "fee" "foe"}
                           :expected {:fallback-period-secs 300
                                      :headers {}
-                                     :profile->defaults {"" {"name" "default-name" "health-check-url" "/ping"}}
+                                     :profile->defaults {:default {"name" "default-name" "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "cpus" "1"
                                                                     "mem" "2"
@@ -426,8 +426,8 @@
                                                 "fee" "foe"}
                           :expected {:fallback-period-secs 300
                                      :headers {}
-                                     :profile->defaults {"" {"name" "default-name"
-                                                             "health-check-url" "/ping"}}
+                                     :profile->defaults {:default {"name" "default-name"
+                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-host"
                                                                     "version" "token"}
@@ -442,8 +442,8 @@
                                                 "fee" "foe"}
                           :expected {:fallback-period-secs 300
                                      :headers {}
-                                     :profile->defaults {"" {"name" "default-name"
-                                                             "health-check-url" "/ping"}}
+                                     :profile->defaults {:default {"name" "default-name"
+                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-host"
                                                                     "version" "token"}
@@ -458,8 +458,8 @@
                                                 "fee" "foe"}
                           :expected {:fallback-period-secs 300
                                      :headers {}
-                                     :profile->defaults {"" {"name" "default-name"
-                                                             "health-check-url" "/ping"}}
+                                     :profile->defaults {:default {"name" "default-name"
+                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-token-run"
                                                                     "run-as-user" "ruser"
@@ -475,8 +475,8 @@
                                                 "fee" "foe"}
                           :expected {:fallback-period-secs 600
                                      :headers {}
-                                     :profile->defaults {"" {"name" "default-name"
-                                                             "health-check-url" "/ping"}}
+                                     :profile->defaults {:default {"name" "default-name"
+                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-token-per-fall"
                                                                     "version" "token" "permitted-user" "puser"}
@@ -491,8 +491,8 @@
                                                 "fee" "foe"}
                           :expected {:fallback-period-secs 300
                                      :headers {}
-                                     :profile->defaults {"" {"name" "default-name"
-                                                             "health-check-url" "/ping"}}
+                                     :profile->defaults {:default {"name" "default-name"
+                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-token-per-run"
                                                                     "permitted-user" "puser"
@@ -509,8 +509,8 @@
                                                 "fee" "foe"}
                           :expected {:fallback-period-secs 300
                                      :headers {}
-                                     :profile->defaults {"" {"name" "default-name"
-                                                             "health-check-url" "/ping"}}
+                                     :profile->defaults {:default {"name" "default-name"
+                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "cpus" "1"
                                                                     "name" "test-cpus-token"
@@ -532,8 +532,8 @@
                                      :headers {"metadata" {"foo" "bar"
                                                            "baz" "quux"}
                                                "cpus" "1"}
-                                     :profile->defaults {"" {"name" "default-name"
-                                                             "health-check-url" "/ping"}}
+                                     :profile->defaults {:default {"name" "default-name"
+                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -549,8 +549,8 @@
                                      :headers {"env" {"BAZ" "quux"
                                                       "FOO_BAR" "bar"}
                                                "cpus" "1"}
-                                     :profile->defaults {"" {"name" "default-name"
-                                                             "health-check-url" "/ping"}}
+                                     :profile->defaults {:default {"name" "default-name"
+                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -564,8 +564,8 @@
                           :expected {:fallback-period-secs 300
                                      :headers {"param" {"BAR" "bar-value"
                                                         "FOO" "foo-value"}}
-                                     :profile->defaults {"" {"health-check-url" "/ping"
-                                                             "name" "default-name"}}
+                                     :profile->defaults {:default {"health-check-url" "/ping"
+                                                                   "name" "default-name"}}
                                      :service-description-template {"allowed-params" #{"BAR" "FOO"}
                                                                     "cmd" "token-user"
                                                                     "cpus" "1"
@@ -588,8 +588,8 @@
                                      :headers {"cpus" "20"
                                                "param" {"BAR" "bar-value"
                                                         "FOO" "foo-value"}}
-                                     :profile->defaults {"" {"health-check-url" "/ping"
-                                                             "name" "default-name"}}
+                                     :profile->defaults {:default {"health-check-url" "/ping"
+                                                                   "name" "default-name"}}
                                      :service-description-template {"allowed-params" #{"BAR" "FOO"}
                                                                     "cmd" "token-user"
                                                                     "cpus" "1"
@@ -611,8 +611,8 @@
                           :expected {:fallback-period-secs 300
                                      :headers {"param" {"BAR" "bar-value"
                                                         "FOO" "foo-value"}}
-                                     :profile->defaults {"" {"health-check-url" "/ping"
-                                                             "name" "default-name"}}
+                                     :profile->defaults {:default {"health-check-url" "/ping"
+                                                                   "name" "default-name"}}
                                      :service-description-template {"allowed-params" #{"BAR" "FOO"}
                                                                     "cmd" "token-user"
                                                                     "cpus" "1"
@@ -635,8 +635,8 @@
                                      :headers {"cpus" "1"
                                                "param" {"BAZ" "quux"
                                                         "FOO_BAR" "bar"}}
-                                     :profile->defaults {"" {"name" "default-name"
-                                                             "health-check-url" "/ping"}}
+                                     :profile->defaults {:default {"name" "default-name"
+                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -656,8 +656,8 @@
                                                       "FOO_BAR" "bar"}
                                                "param" {"BAZ" "quux"
                                                         "FOO_BAR" "bar"}}
-                                     :profile->defaults {"" {"name" "default-name"
-                                                             "health-check-url" "/ping"}}
+                                     :profile->defaults {:default {"name" "default-name"
+                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -677,8 +677,8 @@
                                                       "FOO_BAR" "bar1"}
                                                "param" {"BAZ" "quux"
                                                         "FOO_BAR" "bar2"}}
-                                     :profile->defaults {"" {"name" "default-name"
-                                                             "health-check-url" "/ping"}}
+                                     :profile->defaults {:default {"name" "default-name"
+                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -694,8 +694,8 @@
                                      :headers {"cpus" "1"
                                                "env" {"1" "quux"
                                                       "FOO-BAR" "bar"}}
-                                     :profile->defaults {"" {"name" "default-name"
-                                                             "health-check-url" "/ping"}}
+                                     :profile->defaults {:default {"name" "default-name"
+                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -719,7 +719,7 @@
   (let [kv-store (Object.)
         waiter-hostname "waiter-hostname.app.example.com"
         test-token "test-token-name"
-        profile->defaults {"" {"name" "default-name" "health-check-url" "/ping"}}
+        profile->defaults {:default {"name" "default-name" "health-check-url" "/ping"}}
         token-defaults {"fallback-period-secs" 300}]
     (testing "authentication-disabled token"
       (let [token-data {"authentication" "disabled"
@@ -814,7 +814,7 @@
 
 (deftest test-compute-service-description-on-the-fly?
   (let [defaults {"health-check-url" "/ping", "permitted-user" "bob"}
-        sources {:profile->defaults {"" defaults}
+        sources {:profile->defaults {:default defaults}
                  :service-description-template {"cmd" "token-cmd"}}
         compute-on-the-fly (fn compute-on-the-fly [waiter-headers]
                              (-> (compute-service-description-helper sources :waiter-headers waiter-headers)
@@ -828,7 +828,7 @@
 (deftest test-compute-service-description-source-tokens
   (let [defaults {"health-check-url" "/ping", "permitted-user" "bob"}
         source-tokens [:foo-bar]
-        sources {:profile->defaults {"" defaults}
+        sources {:profile->defaults {:default defaults}
                  :service-description-template {"cmd" "token-cmd"}
                  :source-tokens source-tokens}
         compute-source-tokens (fn compute-source-tokens [waiter-headers]
@@ -843,14 +843,14 @@
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"
               "permitted-user" "bob"}
-             (service-description {:profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}
+             (service-description {:profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"}}))))
 
     (testing "only token from host without permitted-user in defaults"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"}
-             (service-description {:profile->defaults {"" {"health-check-url" "/ping"}}
+             (service-description {:profile->defaults {:default {"health-check-url" "/ping"}}
                                    :service-description-template {"cmd" "token-cmd"}}))))
 
     (testing "only token from header without permitted-user"
@@ -858,8 +858,8 @@
               "health-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "current-request-user"}
-             (service-description {:profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}
+             (service-description {:profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"}}
                                   :waiter-headers {"x-waiter-token" "value-does-not-matter"}))))
 
@@ -868,8 +868,8 @@
               "health-check-url" "/ping"
               "permitted-user" "token-user"
               "run-as-user" "token-user"}
-             (service-description {:profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}
+             (service-description {:profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "permitted-user" "token-user"
                                                                   "run-as-user" "token-user"}}
@@ -880,8 +880,8 @@
               "health-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "on-the-fly-ru"}
-             (service-description {:profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}
+             (service-description {:profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}
                                    :headers {"run-as-user" "on-the-fly-ru"}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "permitted-user" "token-user"
@@ -892,7 +892,7 @@
     (testing "only token from host with defaults missing permitted user"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"}
-             (service-description {:profile->defaults {"" {"health-check-url" "/ping"}}
+             (service-description {:profile->defaults {:default {"health-check-url" "/ping"}}
                                    :service-description-template {"cmd" "token-cmd"}}))))
 
     (testing "only token from header with defaults missing permitted user"
@@ -900,14 +900,14 @@
               "health-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "current-request-user"}
-             (service-description {:profile->defaults {"" {"health-check-url" "/ping"}}
+             (service-description {:profile->defaults {:default {"health-check-url" "/ping"}}
                                    :service-description-template {"cmd" "token-cmd"}}
                                   :waiter-headers {"x-waiter-token" "value-does-not-matter"}))))
 
     (testing "only token from host with dummy header"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"}
-             (service-description {:profile->defaults {"" {"health-check-url" "/ping"}}
+             (service-description {:profile->defaults {:default {"health-check-url" "/ping"}}
                                    :service-description-template {"cmd" "token-cmd"}}
                                   :waiter-headers {"x-waiter-dummy" "value-does-not-matter"}))))
 
@@ -917,8 +917,8 @@
               "permitted-user" "bob"
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"}
-                                   :profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}}))))
+                                   :profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}}))))
 
     (testing "token host with non-intersecting values"
       (is (= {"cmd" "token-cmd"
@@ -927,8 +927,8 @@
               "run-as-user" "current-request-user"
               "version" "on-the-fly-version"}
              (service-description {:headers {"version" "on-the-fly-version"}
-                                   :profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}
+                                   :profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"}}))))
 
     (testing "token header with non-intersecting values"
@@ -939,8 +939,8 @@
               "run-as-user" "current-request-user"
               "version" "on-the-fly-version"}
              (service-description {:headers {"version" "on-the-fly-version"}
-                                   :profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}
+                                   :profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "concurrency-level" 5}}))))
 
@@ -957,8 +957,8 @@
              (service-description {:headers {"param" {"VAR_1" "VALUE-1"
                                                       "VAR_2" "VALUE-2"}
                                              "version" "on-the-fly-version"}
-                                   :profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}
+                                   :profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}
                                    :service-description-template {"allowed-params" #{"VAR_1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                   "cmd" "token-cmd"
                                                                   "concurrency-level" 5
@@ -979,8 +979,8 @@
              (service-description {:headers {"param" {"VAR_3" "VALUE-3p"
                                                       "VAR_4" "VALUE-4p"}
                                              "version" "on-the-fly-version"}
-                                   :profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}
+                                   :profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}
                                    :service-description-template {"allowed-params" #{"VAR_1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                   "cmd" "token-cmd"
                                                                   "concurrency-level" 5
@@ -1002,8 +1002,8 @@
              (service-description {:headers {"param" {"VAR_2" "VALUE-2p"
                                                       "VAR_3" "VALUE-3p"}
                                              "version" "on-the-fly-version"}
-                                   :profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}
+                                   :profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}
                                    :service-description-template {"allowed-params" #{"VAR_1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                   "cmd" "token-cmd"
                                                                   "concurrency-level" 5
@@ -1022,8 +1022,8 @@
               "run-as-user" "test-user"}
              (service-description {:headers {"param" {"VAR_1" "VALUE-1"
                                                       "VAR_2" "VALUE-2"}}
-                                   :profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}
+                                   :profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}
                                    :service-description-template {"allowed-params" #{"VAR_1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                   "cmd" "token-cmd"
                                                                   "concurrency-level" 5
@@ -1042,8 +1042,8 @@
               "run-as-user" "test-user"}
              (service-description {:headers {"param" {"VAR_3" "VALUE-3p"
                                                       "VAR_4" "VALUE-4p"}}
-                                   :profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}
+                                   :profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}
                                    :service-description-template {"allowed-params" #{"VAR_1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                   "cmd" "token-cmd"
                                                                   "concurrency-level" 5
@@ -1063,8 +1063,8 @@
               "run-as-user" "test-user"}
              (service-description {:headers {"param" {"VAR_2" "VALUE-2p"
                                                       "VAR_3" "VALUE-3p"}}
-                                   :profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}
+                                   :profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}
                                    :service-description-template {"allowed-params" #{"VAR_1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                   "cmd" "token-cmd"
                                                                   "concurrency-level" 5
@@ -1080,8 +1080,8 @@
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "concurrency-level" 6}
-                                   :profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}
+                                   :profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"}}))))
 
     (testing "token header with intersecting values"
@@ -1090,8 +1090,8 @@
               "permitted-user" "bob"
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"}
-                                   :profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}
+                                   :profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"}}))))
 
     (testing "intersecting values with additional fields"
@@ -1103,8 +1103,8 @@
               "version" "on-the-fly-version"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "version" "on-the-fly-version"}
-                                   :profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}
+                                   :profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "name" "token-name"}}))))
 
@@ -1114,7 +1114,7 @@
               "permitted-user" "token-pu"
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"}
-                                   :profile->defaults {"" {"health-check-url" "/ping"}}
+                                   :profile->defaults {:default {"health-check-url" "/ping"}}
                                    :service-description-template {"permitted-user" "token-pu"}}))))
 
     (testing "permitted user from on-the-fly"
@@ -1124,7 +1124,7 @@
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "permitted-user" "on-the-fly-pu"}
-                                   :profile->defaults {"" {"health-check-url" "/ping"}}}))))
+                                   :profile->defaults {:default {"health-check-url" "/ping"}}}))))
 
     (testing "permitted user intersecting"
       (is (= {"cmd" "on-the-fly-cmd"
@@ -1133,7 +1133,7 @@
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "permitted-user" "on-the-fly-pu"}
-                                   :profile->defaults {"" {"health-check-url" "/ping"}}
+                                   :profile->defaults {:default {"health-check-url" "/ping"}}
                                    :service-description-template {"permitted-user" "token-pu"}}))))
 
     (testing "run as user and permitted user only in token"
@@ -1142,7 +1142,7 @@
               "permitted-user" "token-pu"
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"}
-                                   :profile->defaults {"" {"health-check-url" "/ping"}}
+                                   :profile->defaults {:default {"health-check-url" "/ping"}}
                                    :service-description-template {"run-as-user" "token-ru"
                                                                   "permitted-user" "token-pu"}}))))
 
@@ -1151,7 +1151,7 @@
               "health-check-url" "/ping"
               "permitted-user" "token-pu"
               "run-as-user" "token-ru"}
-             (service-description {:profile->defaults {"" {"health-check-url" "/ping"}}
+             (service-description {:profile->defaults {:default {"health-check-url" "/ping"}}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "run-as-user" "token-ru"
                                                                   "permitted-user" "token-pu"}}))))
@@ -1161,8 +1161,8 @@
               "health-check-url" "/ping"
               "permitted-user" "bob"
               "run-as-user" "token-ru"}
-             (service-description {:profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}
+             (service-description {:profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "run-as-user" "token-ru"}}))))
 
@@ -1173,8 +1173,8 @@
               "run-as-user" "on-the-fly-ru"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "run-as-user" "on-the-fly-ru"}
-                                   :profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}}
+                                   :profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}}
                                   :waiter-headers {"x-waiter-cmd" "on-the-fly-cmd"
                                                    "x-waiter-run-as-user" "on-the-fly-ru"}))))
 
@@ -1185,8 +1185,8 @@
               "run-as-user" "on-the-fly-ru"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "run-as-user" "on-the-fly-ru"}
-                                   :profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}
+                                   :profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}
                                    :service-description-template {"run-as-user" "token-ru"}}
                                   :waiter-headers {"x-waiter-cmd" "on-the-fly-cmd"
                                                    "x-waiter-run-as-user" "on-the-fly-ru"}))))
@@ -1197,8 +1197,8 @@
               "permitted-user" "current-request-user"
               "run-as-user" "chris"}
              (service-description {:headers {"run-as-user" "chris"}
-                                   :profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}
+                                   :profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "run-as-user" "alice"}}
                                   :waiter-headers {"x-waiter-run-as-user" "chris"}))))
@@ -1209,8 +1209,8 @@
               "permitted-user" "current-request-user"
               "run-as-user" "current-request-user"}
              (service-description {:headers {"run-as-user" "*"}
-                                   :profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}
+                                   :profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "run-as-user" "alice"}}
                                   :waiter-headers {"x-waiter-run-as-user" "*"}))))
@@ -1220,8 +1220,8 @@
               "health-check-url" "/ping"
               "permitted-user" "bob"}
              (service-description {:headers {}
-                                   :profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}
+                                   :profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "run-as-user" "*"}}
                                   :waiter-headers {}))))
@@ -1232,8 +1232,8 @@
               "permitted-user" "current-request-user"
               "run-as-user" "current-request-user"}
              (service-description {:headers {}
-                                   :profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}
+                                   :profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd", "run-as-user" "*"}}
                                   :waiter-headers {"x-waiter-token" "on-the-fly-token"}))))
 
@@ -1244,7 +1244,7 @@
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "run-as-user" "*"}
-                                   :profile->defaults {"" {"health-check-url" "/ping", "permitted-user" "bob"}}
+                                   :profile->defaults {:default {"health-check-url" "/ping", "permitted-user" "bob"}}
                                    :service-description-template {"run-as-user" "token-ru"}}
                                   :waiter-headers {"x-waiter-cmd" "on-the-fly-cmd"
                                                    "x-waiter-run-as-user" "*"}))))
@@ -1257,8 +1257,8 @@
              (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "permitted-user" "alice"
                                              "run-as-user" "*"}
-                                   :profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}
+                                   :profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}
                                    :service-description-template {"run-as-user" "token-ru"}}
                                   :waiter-headers {"x-waiter-cmd" "on-the-fly-cmd"
                                                    "x-waiter-permitted-user" "alice"
@@ -1270,7 +1270,7 @@
               "permitted-user" "current-request-user"
               "run-as-user" "header-user"}
              (service-description {:headers {"run-as-user" "header-user"}
-                                   :profile->defaults {"" {"health-check-url" "/ping"}}
+                                   :profile->defaults {:default {"health-check-url" "/ping"}}
                                    :service-description-template {"run-as-user" "*"
                                                                   "permitted-user" "*"
                                                                   "cmd" "token-cmd"}}
@@ -1294,9 +1294,9 @@
                    "scale-factor" 0.3)
                  (service-description {:headers {"cmd" "on-the-fly-cmd"
                                                  "run-as-user" "on-the-fly-ru"}
-                                       :profile->defaults {"" {"health-check-url" "/ping"
-                                                               "permitted-user" "bob"
-                                                               "scale-factor" 1}}}
+                                       :profile->defaults {:default {"health-check-url" "/ping"
+                                                                     "permitted-user" "bob"
+                                                                     "scale-factor" 1}}}
                                       :kv-store kv-store))))
 
         (testing "inactive"
@@ -1309,8 +1309,8 @@
                    "permitted-user" "bob")
                  (service-description {:headers {"cmd" "on-the-fly-cmd"
                                                  "run-as-user" "on-the-fly-ru"}
-                                       :profile->defaults {"" {"health-check-url" "/ping"
-                                                               "permitted-user" "bob"}}}
+                                       :profile->defaults {:default {"health-check-url" "/ping"
+                                                                     "permitted-user" "bob"}}}
                                       :kv-store kv-store))))))
 
     (testing "override token metadata from headers"
@@ -1320,8 +1320,8 @@
               "run-as-user" "current-request-user"
               "metadata" {"e" "f"}}
              (service-description {:headers {"metadata" {"e" "f"}}
-                                   :profile->defaults {"" {"health-check-url" "/ping"
-                                                           "permitted-user" "bob"}}
+                                   :profile->defaults {:default {"health-check-url" "/ping"
+                                                                 "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "metadata" {"a" "b", "c" "d"}}}))))
 
@@ -1331,7 +1331,7 @@
               "permitted-user" "current-request-user"
               "run-as-user" "current-request-user"
               "metadata" {"abc" "DEF"}}
-             (service-description {:profile->defaults {"" {"health-check-url" "/ping"}}
+             (service-description {:profile->defaults {:default {"health-check-url" "/ping"}}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "metadata" {"Abc" "DEF"}}}
                                   :waiter-headers {"x-waiter-token" "value-does-not-matter"}))))
@@ -1342,7 +1342,7 @@
               "run-as-user" "current-request-user"
               "metric-group" "token-mg"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"}
-                                   :profile->defaults {"" {"health-check-url" "/health"}}
+                                   :profile->defaults {:default {"health-check-url" "/health"}}
                                    :service-description-template {"metric-group" "token-mg"}}))))
 
     (testing "metric group from on-the-fly"
@@ -1352,7 +1352,7 @@
               "metric-group" "on-the-fly-mg"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "metric-group" "on-the-fly-mg"}
-                                   :profile->defaults {"" {"health-check-url" "/health"}}}))))
+                                   :profile->defaults {:default {"health-check-url" "/health"}}}))))
 
     (testing "metric group intersecting"
       (is (= {"cmd" "on-the-fly-cmd"
@@ -1361,7 +1361,7 @@
               "metric-group" "on-the-fly-mg"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "metric-group" "on-the-fly-mg"}
-                                   :profile->defaults {"" {"health-check-url" "/health"}}
+                                   :profile->defaults {:default {"health-check-url" "/health"}}
                                    :service-description-template {"metric-group" "token-mg"}}))))
 
     (testing "auto-populate run-as-user"
@@ -1370,7 +1370,7 @@
               "run-as-user" "current-request-user"
               "permitted-user" "current-request-user"
               "metric-group" "token-mg"}
-             (service-description {:profile->defaults {"" {"health-check-url" "/health"}}
+             (service-description {:profile->defaults {:default {"health-check-url" "/health"}}
                                    :service-description-template {"cmd" "some-cmd"
                                                                   "metric-group" "token-mg"}}
                                   :assoc-run-as-user-approved? (constantly true)))))
@@ -1379,13 +1379,13 @@
       (is (= {"cmd" "some-cmd"
               "health-check-url" "/health"
               "instance-expiry-mins" 0}
-             (service-description {:profile->defaults {"" {"health-check-url" "/health"}}
+             (service-description {:profile->defaults {:default {"health-check-url" "/health"}}
                                    :service-description-template {"cmd" "some-cmd"
                                                                   "instance-expiry-mins" 0}}))))
 
     (testing "profile parameter"
-      (let [profile->defaults {"" {"cmd" "default-cmd"
-                                   "health-check-url" "/ping"}
+      (let [profile->defaults {:default {"cmd" "default-cmd"
+                                         "health-check-url" "/ping"}
                                "webapp" {"cmd" "web-cmd"
                                          "health-check-url" "/status"}}]
         (testing "from token"
@@ -1448,7 +1448,7 @@
             result-descriptor))]
     (is (thrown? Exception
                  (run-compute-service-description {:headers {}
-                                                   :profile->defaults {"" {"health-check-url" "/ping"}}
+                                                   :profile->defaults {:default {"health-check-url" "/ping"}}
                                                    :service-description-template {"cmd" "test command"
                                                                                   "cpus" "one"
                                                                                   "mem" 200
@@ -1456,7 +1456,7 @@
                                                                                   "run-as-user" test-user}})))
     (is (thrown? Exception
                  (run-compute-service-description {:headers {}
-                                                   :profile->defaults {"" {"health-check-url" 1}}
+                                                   :profile->defaults {:default {"health-check-url" 1}}
                                                    :service-description-template {"cmd" "test command"
                                                                                   "cpus" 1
                                                                                   "mem" 200
@@ -1464,10 +1464,10 @@
                                                                                   "run-as-user" test-user}})))
     (is (thrown? Exception
                  (run-compute-service-description {:headers {}
-                                                   :profile->defaults {"" {"health-check-url" 1}}
+                                                   :profile->defaults {:default {"health-check-url" 1}}
                                                    :service-description-template {}})))
     (is (thrown? Exception
-                 (run-compute-service-description {:profile->defaults {"" {"health-check-url" "/health"}}
+                 (run-compute-service-description {:profile->defaults {:default {"health-check-url" "/health"}}
                                                    :service-description-template {"cmd" "cmd for missing run-as-user"
                                                                                   "cpus" 1
                                                                                   "mem" 200
@@ -1476,8 +1476,8 @@
     (testing "invalid allowed params - reserved"
       (is (thrown? Exception
                    (run-compute-service-description {:headers {}
-                                                     :profile->defaults {"" {"health-check-url" "/ping"
-                                                                             "permitted-user" "bob"}}
+                                                     :profile->defaults {:default {"health-check-url" "/ping"
+                                                                                   "permitted-user" "bob"}}
                                                      :service-description-template {"allowed-params" #{"HOME" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                                     "cmd" "token-cmd"
                                                                                     "cpus" 1
@@ -1488,8 +1488,8 @@
     (testing "invalid allowed params - bad naming"
       (is (thrown? Exception
                    (run-compute-service-description {:headers {}
-                                                     :profile->defaults {"" {"health-check-url" "/ping"
-                                                                             "permitted-user" "bob"}}
+                                                     :profile->defaults {:default {"health-check-url" "/ping"
+                                                                                   "permitted-user" "bob"}}
                                                      :service-description-template {"allowed-params" #{"VAR.1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                                     "cmd" "token-cmd"
                                                                                     "cpus" 1
@@ -1500,8 +1500,8 @@
     (testing "invalid allowed params - reserved and bad naming"
       (is (thrown? Exception
                    (run-compute-service-description {:headers {}
-                                                     :profile->defaults {"" {"health-check-url" "/ping"
-                                                                             "permitted-user" "bob"}}
+                                                     :profile->defaults {:default {"health-check-url" "/ping"
+                                                                                   "permitted-user" "bob"}}
                                                      :service-description-template {"allowed-params" #{"USER" "VAR.1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                                     "cmd" "token-cmd"
                                                                                     "cpus" 1
@@ -1514,8 +1514,8 @@
                    (run-compute-service-description {:headers {"param" {"VAR_1" "VALUE-1"
                                                                         "ANOTHER_VAR_2" "VALUE-2"}
                                                                "version" "on-the-fly-version"}
-                                                     :profile->defaults {"" {"health-check-url" "/ping"
-                                                                             "permitted-user" "bob"}}
+                                                     :profile->defaults {:default {"health-check-url" "/ping"
+                                                                                   "permitted-user" "bob"}}
                                                      :service-description-template {"allowed-params" #{"VAR_1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                                     "cmd" "token-cmd"
                                                                                     "concurrency-level" 5
@@ -1526,8 +1526,8 @@
                    (run-compute-service-description {:headers {"param" {"VAR_1" "VALUE-1"
                                                                         "VAR_2" "VALUE-2"}
                                                                "version" "on-the-fly-version"}
-                                                     :profile->defaults {"" {"health-check-url" "/ping"
-                                                                             "permitted-user" "bob"}}
+                                                     :profile->defaults {:default {"health-check-url" "/ping"
+                                                                                   "permitted-user" "bob"}}
                                                      :service-description-template {"allowed-params" #{}
                                                                                     "cmd" "token-cmd"
                                                                                     "concurrency-level" 5
@@ -1540,7 +1540,7 @@
                                       "run-as-user" test-user
                                       "version" "a1b2c3"}
             run-compute-service-description-helper (fn [service-description]
-                                                     (run-compute-service-description {:profile->defaults {"" {"health-check-url" "/health"}}
+                                                     (run-compute-service-description {:profile->defaults {:default {"health-check-url" "/health"}}
                                                                                        :service-description-template service-description}))]
         (is (thrown? Exception (run-compute-service-description-helper (assoc core-service-description "instance-expiry-mins" -1))))
         (is (run-compute-service-description-helper (assoc core-service-description "instance-expiry-mins" 0)))
@@ -1550,7 +1550,7 @@
   (letfn [(execute-test [service-description-template header-parameters]
             (let [{:keys [service-authentication-disabled service-preauthorized]}
                   (compute-service-description-helper {:headers header-parameters
-                                                       :profile->defaults {"" {}}
+                                                       :profile->defaults {:default {}}
                                                        :service-description-template service-description-template
                                                        :token-authentication-disabled (token-authentication-disabled? service-description-template)
                                                        :token-preauthorized (token-preauthorized? service-description-template)})]
@@ -1723,7 +1723,7 @@
 (deftest test-service-id->service-description
   (let [service-id "test-service-1"
         service-key (str "^SERVICE-ID#" service-id)
-        profile->defaults {"" {}}
+        profile->defaults {:default {}}
         fetch-service-description (fn [kv-store]
                                     (service-id->service-description kv-store service-id profile->defaults []
                                                                      :effective? false))]
@@ -1922,7 +1922,7 @@
                            "run-as-user" "default-run-as-user"}
         constraints-schema {(s/optional-key "cmd") (s/pred #(<= (count %) 100) (symbol "limit-100"))
                             s/Str s/Any}
-        profile->defaults {"" {"name" "default-name"}
+        profile->defaults {:default {"name" "default-name"}
                            "web-app" {"name" "web-app-name"}}
         config {:allow-missing-required-fields? false
                 :profile->defaults profile->defaults}]

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -244,7 +244,8 @@
     (with-redefs [kv/fetch (fn [in-kv-store token]
                              (is (= kv-store in-kv-store))
                              (create-token-data token))]
-      (let [profile->defaults {:default {"name" "default-name" "health-check-url" "/ping"}}
+      (let [service-description-defaults {"name" "default-name" "health-check-url" "/ping"}
+            profile->overrides {"webapp" {"concurrency-level" 120}}
             token-defaults {"fallback-period-secs" 300}
             test-cases (list
                          {:name "prepare-service-description-sources:WITH Service Desc specific Waiter Headers except run-as-user"
@@ -263,8 +264,6 @@
                                                "cmd" "test-cmd"
                                                "version" "test-version"
                                                "run-as-user" test-user}
-                                     :profile->defaults {:default {"name" "default-name"
-                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-host"
                                                                     "version" "token"}
@@ -289,8 +288,6 @@
                                                "cmd" "test-cmd"
                                                "version" "test-version"
                                                "run-as-user" test-user}
-                                     :profile->defaults {:default {"name" "default-name"
-                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -313,8 +310,6 @@
                                                "cmd" "test-cmd"
                                                "version" "test-version"
                                                "run-as-user" test-user}
-                                     :profile->defaults {:default {"name" "default-name"
-                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-host"
                                                                     "version" "token"}
@@ -338,8 +333,6 @@
                                                "cmd" "test-cmd"
                                                "version" "test-version"
                                                "run-as-user" test-user}
-                                     :profile->defaults {:default {"name" "default-name"
-                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -353,8 +346,6 @@
                                                 "fee" "foe"}
                           :expected {:fallback-period-secs 300
                                      :headers {}
-                                     :profile->defaults {:default {"name" "default-name"
-                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-host"
                                                                     "version" "token"}
@@ -370,8 +361,6 @@
                           :passthrough-headers {"host" "test-host" "fee" "foe"}
                           :expected {:fallback-period-secs 300
                                      :headers {}
-                                     :profile->defaults {:default {"name" "default-name"
-                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-token"
                                                                     "version" "token"}
@@ -388,8 +377,6 @@
                                                 "fee" "foe"}
                           :expected {:fallback-period-secs 300
                                      :headers {}
-                                     :profile->defaults {:default {"name" "default-name"
-                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-token2"
                                                                     "version" "token"}
@@ -406,7 +393,6 @@
                           :passthrough-headers {"host" "test-host" "fee" "foe"}
                           :expected {:fallback-period-secs 300
                                      :headers {}
-                                     :profile->defaults {:default {"name" "default-name" "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "cpus" "1"
                                                                     "mem" "2"
@@ -426,8 +412,6 @@
                                                 "fee" "foe"}
                           :expected {:fallback-period-secs 300
                                      :headers {}
-                                     :profile->defaults {:default {"name" "default-name"
-                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-host"
                                                                     "version" "token"}
@@ -442,8 +426,6 @@
                                                 "fee" "foe"}
                           :expected {:fallback-period-secs 300
                                      :headers {}
-                                     :profile->defaults {:default {"name" "default-name"
-                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-host"
                                                                     "version" "token"}
@@ -458,8 +440,6 @@
                                                 "fee" "foe"}
                           :expected {:fallback-period-secs 300
                                      :headers {}
-                                     :profile->defaults {:default {"name" "default-name"
-                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-token-run"
                                                                     "run-as-user" "ruser"
@@ -475,8 +455,6 @@
                                                 "fee" "foe"}
                           :expected {:fallback-period-secs 600
                                      :headers {}
-                                     :profile->defaults {:default {"name" "default-name"
-                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-token-per-fall"
                                                                     "version" "token" "permitted-user" "puser"}
@@ -491,8 +469,6 @@
                                                 "fee" "foe"}
                           :expected {:fallback-period-secs 300
                                      :headers {}
-                                     :profile->defaults {:default {"name" "default-name"
-                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-token-per-run"
                                                                     "permitted-user" "puser"
@@ -509,8 +485,6 @@
                                                 "fee" "foe"}
                           :expected {:fallback-period-secs 300
                                      :headers {}
-                                     :profile->defaults {:default {"name" "default-name"
-                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "cpus" "1"
                                                                     "name" "test-cpus-token"
@@ -532,8 +506,6 @@
                                      :headers {"metadata" {"foo" "bar"
                                                            "baz" "quux"}
                                                "cpus" "1"}
-                                     :profile->defaults {:default {"name" "default-name"
-                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -549,8 +521,6 @@
                                      :headers {"env" {"BAZ" "quux"
                                                       "FOO_BAR" "bar"}
                                                "cpus" "1"}
-                                     :profile->defaults {:default {"name" "default-name"
-                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -564,8 +534,6 @@
                           :expected {:fallback-period-secs 300
                                      :headers {"param" {"BAR" "bar-value"
                                                         "FOO" "foo-value"}}
-                                     :profile->defaults {:default {"health-check-url" "/ping"
-                                                                   "name" "default-name"}}
                                      :service-description-template {"allowed-params" #{"BAR" "FOO"}
                                                                     "cmd" "token-user"
                                                                     "cpus" "1"
@@ -588,8 +556,6 @@
                                      :headers {"cpus" "20"
                                                "param" {"BAR" "bar-value"
                                                         "FOO" "foo-value"}}
-                                     :profile->defaults {:default {"health-check-url" "/ping"
-                                                                   "name" "default-name"}}
                                      :service-description-template {"allowed-params" #{"BAR" "FOO"}
                                                                     "cmd" "token-user"
                                                                     "cpus" "1"
@@ -611,8 +577,6 @@
                           :expected {:fallback-period-secs 300
                                      :headers {"param" {"BAR" "bar-value"
                                                         "FOO" "foo-value"}}
-                                     :profile->defaults {:default {"health-check-url" "/ping"
-                                                                   "name" "default-name"}}
                                      :service-description-template {"allowed-params" #{"BAR" "FOO"}
                                                                     "cmd" "token-user"
                                                                     "cpus" "1"
@@ -635,8 +599,6 @@
                                      :headers {"cpus" "1"
                                                "param" {"BAZ" "quux"
                                                         "FOO_BAR" "bar"}}
-                                     :profile->defaults {:default {"name" "default-name"
-                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -656,8 +618,6 @@
                                                       "FOO_BAR" "bar"}
                                                "param" {"BAZ" "quux"
                                                         "FOO_BAR" "bar"}}
-                                     :profile->defaults {:default {"name" "default-name"
-                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -677,8 +637,6 @@
                                                       "FOO_BAR" "bar1"}
                                                "param" {"BAZ" "quux"
                                                         "FOO_BAR" "bar2"}}
-                                     :profile->defaults {:default {"name" "default-name"
-                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -694,8 +652,6 @@
                                      :headers {"cpus" "1"
                                                "env" {"1" "quux"
                                                       "FOO-BAR" "bar"}}
-                                     :profile->defaults {:default {"name" "default-name"
-                                                                   "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -708,7 +664,10 @@
             (let [actual (prepare-service-description-sources
                            {:passthrough-headers passthrough-headers
                             :waiter-headers waiter-headers}
-                           kv-store waiter-hostnames profile->defaults token-defaults)]
+                           kv-store waiter-hostnames service-description-defaults profile->overrides token-defaults)
+                  expected (merge {:profile->overrides profile->overrides
+                                   :service-description-defaults service-description-defaults}
+                                  expected)]
               (when (not= expected actual)
                 (println name)
                 (println "Expected: " (into (sorted-map) expected))
@@ -719,7 +678,8 @@
   (let [kv-store (Object.)
         waiter-hostname "waiter-hostname.app.example.com"
         test-token "test-token-name"
-        profile->defaults {:default {"name" "default-name" "health-check-url" "/ping"}}
+        service-description-defaults {"name" "default-name" "health-check-url" "/ping"}
+        profile->overrides {"webapp" {"concurrency-level" 120}}
         token-defaults {"fallback-period-secs" 300}]
     (testing "authentication-disabled token"
       (let [token-data {"authentication" "disabled"
@@ -741,10 +701,11 @@
                 actual (prepare-service-description-sources
                          {:waiter-headers waiter-headers
                           :passthrough-headers passthrough-headers}
-                         kv-store waiter-hostname profile->defaults token-defaults)
+                         kv-store waiter-hostname service-description-defaults profile->overrides token-defaults)
                 expected {:fallback-period-secs 300
                           :headers {}
-                          :profile->defaults profile->defaults
+                          :profile->overrides profile->overrides
+                          :service-description-defaults service-description-defaults
                           :service-description-template (select-keys token-data service-parameter-keys)
                           :source-tokens [(source-tokens-entry test-token token-data)]
                           :token->token-data {test-token token-data}
@@ -773,10 +734,11 @@
                 actual (prepare-service-description-sources
                          {:waiter-headers waiter-headers
                           :passthrough-headers passthrough-headers}
-                         kv-store waiter-hostname profile->defaults token-defaults)
+                         kv-store waiter-hostname service-description-defaults profile->overrides token-defaults)
                 expected {:fallback-period-secs 300
                           :headers {}
-                          :profile->defaults profile->defaults
+                          :profile->overrides profile->overrides
+                          :service-description-defaults service-description-defaults
                           :service-description-template (select-keys token-data service-parameter-keys)
                           :source-tokens [(source-tokens-entry test-token token-data)]
                           :token->token-data {test-token token-data}
@@ -814,11 +776,11 @@
 
 (deftest test-compute-service-description-on-the-fly?
   (let [defaults {"health-check-url" "/ping", "permitted-user" "bob"}
-        sources {:profile->defaults {:default defaults}
+        sources {:profile->overrides {:default defaults}
                  :service-description-template {"cmd" "token-cmd"}}
         compute-on-the-fly (fn compute-on-the-fly [waiter-headers]
                              (-> (compute-service-description-helper sources :waiter-headers waiter-headers)
-                                 :on-the-fly?))]
+                               :on-the-fly?))]
     (is (nil? (compute-on-the-fly {})))
     (is (nil? (compute-on-the-fly {"x-waiter-dummy" "value-does-not-matter"})))
     (is (nil? (compute-on-the-fly {"cmd" "on-the-fly-cmd", "run-as-user" "on-the-fly-ru"})))
@@ -828,12 +790,12 @@
 (deftest test-compute-service-description-source-tokens
   (let [defaults {"health-check-url" "/ping", "permitted-user" "bob"}
         source-tokens [:foo-bar]
-        sources {:profile->defaults {:default defaults}
+        sources {:profile->overrides {:default defaults}
                  :service-description-template {"cmd" "token-cmd"}
                  :source-tokens source-tokens}
         compute-source-tokens (fn compute-source-tokens [waiter-headers]
                                 (-> (compute-service-description-helper sources :waiter-headers waiter-headers)
-                                    :source-tokens))]
+                                  :source-tokens))]
     (is (= source-tokens (compute-source-tokens {})))))
 
 (deftest test-compute-service-description
@@ -843,14 +805,16 @@
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"
               "permitted-user" "bob"}
-             (service-description {:profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}
+             (service-description {:profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :service-description-template {"cmd" "token-cmd"}}))))
 
     (testing "only token from host without permitted-user in defaults"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"}
-             (service-description {:profile->defaults {:default {"health-check-url" "/ping"}}
+             (service-description {:profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"}
                                    :service-description-template {"cmd" "token-cmd"}}))))
 
     (testing "only token from header without permitted-user"
@@ -858,8 +822,9 @@
               "health-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "current-request-user"}
-             (service-description {:profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}
+             (service-description {:profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :service-description-template {"cmd" "token-cmd"}}
                                   :waiter-headers {"x-waiter-token" "value-does-not-matter"}))))
 
@@ -868,8 +833,9 @@
               "health-check-url" "/ping"
               "permitted-user" "token-user"
               "run-as-user" "token-user"}
-             (service-description {:profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}
+             (service-description {:profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "permitted-user" "token-user"
                                                                   "run-as-user" "token-user"}}
@@ -880,8 +846,9 @@
               "health-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "on-the-fly-ru"}
-             (service-description {:profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}
+             (service-description {:profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :headers {"run-as-user" "on-the-fly-ru"}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "permitted-user" "token-user"
@@ -892,7 +859,8 @@
     (testing "only token from host with defaults missing permitted user"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"}
-             (service-description {:profile->defaults {:default {"health-check-url" "/ping"}}
+             (service-description {:profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"}
                                    :service-description-template {"cmd" "token-cmd"}}))))
 
     (testing "only token from header with defaults missing permitted user"
@@ -900,14 +868,16 @@
               "health-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "current-request-user"}
-             (service-description {:profile->defaults {:default {"health-check-url" "/ping"}}
+             (service-description {:profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"}
                                    :service-description-template {"cmd" "token-cmd"}}
                                   :waiter-headers {"x-waiter-token" "value-does-not-matter"}))))
 
     (testing "only token from host with dummy header"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"}
-             (service-description {:profile->defaults {:default {"health-check-url" "/ping"}}
+             (service-description {:profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"}
                                    :service-description-template {"cmd" "token-cmd"}}
                                   :waiter-headers {"x-waiter-dummy" "value-does-not-matter"}))))
 
@@ -917,8 +887,9 @@
               "permitted-user" "bob"
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"}
-                                   :profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}}))))
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}}))))
 
     (testing "token host with non-intersecting values"
       (is (= {"cmd" "token-cmd"
@@ -927,8 +898,9 @@
               "run-as-user" "current-request-user"
               "version" "on-the-fly-version"}
              (service-description {:headers {"version" "on-the-fly-version"}
-                                   :profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :service-description-template {"cmd" "token-cmd"}}))))
 
     (testing "token header with non-intersecting values"
@@ -939,8 +911,9 @@
               "run-as-user" "current-request-user"
               "version" "on-the-fly-version"}
              (service-description {:headers {"version" "on-the-fly-version"}
-                                   :profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "concurrency-level" 5}}))))
 
@@ -957,8 +930,9 @@
              (service-description {:headers {"param" {"VAR_1" "VALUE-1"
                                                       "VAR_2" "VALUE-2"}
                                              "version" "on-the-fly-version"}
-                                   :profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :service-description-template {"allowed-params" #{"VAR_1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                   "cmd" "token-cmd"
                                                                   "concurrency-level" 5
@@ -979,8 +953,9 @@
              (service-description {:headers {"param" {"VAR_3" "VALUE-3p"
                                                       "VAR_4" "VALUE-4p"}
                                              "version" "on-the-fly-version"}
-                                   :profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :service-description-template {"allowed-params" #{"VAR_1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                   "cmd" "token-cmd"
                                                                   "concurrency-level" 5
@@ -1002,8 +977,9 @@
              (service-description {:headers {"param" {"VAR_2" "VALUE-2p"
                                                       "VAR_3" "VALUE-3p"}
                                              "version" "on-the-fly-version"}
-                                   :profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :service-description-template {"allowed-params" #{"VAR_1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                   "cmd" "token-cmd"
                                                                   "concurrency-level" 5
@@ -1022,8 +998,9 @@
               "run-as-user" "test-user"}
              (service-description {:headers {"param" {"VAR_1" "VALUE-1"
                                                       "VAR_2" "VALUE-2"}}
-                                   :profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :service-description-template {"allowed-params" #{"VAR_1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                   "cmd" "token-cmd"
                                                                   "concurrency-level" 5
@@ -1042,8 +1019,9 @@
               "run-as-user" "test-user"}
              (service-description {:headers {"param" {"VAR_3" "VALUE-3p"
                                                       "VAR_4" "VALUE-4p"}}
-                                   :profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :service-description-template {"allowed-params" #{"VAR_1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                   "cmd" "token-cmd"
                                                                   "concurrency-level" 5
@@ -1063,8 +1041,9 @@
               "run-as-user" "test-user"}
              (service-description {:headers {"param" {"VAR_2" "VALUE-2p"
                                                       "VAR_3" "VALUE-3p"}}
-                                   :profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :service-description-template {"allowed-params" #{"VAR_1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                   "cmd" "token-cmd"
                                                                   "concurrency-level" 5
@@ -1080,8 +1059,9 @@
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "concurrency-level" 6}
-                                   :profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :service-description-template {"cmd" "token-cmd"}}))))
 
     (testing "token header with intersecting values"
@@ -1090,8 +1070,9 @@
               "permitted-user" "bob"
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"}
-                                   :profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :service-description-template {"cmd" "token-cmd"}}))))
 
     (testing "intersecting values with additional fields"
@@ -1103,8 +1084,9 @@
               "version" "on-the-fly-version"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "version" "on-the-fly-version"}
-                                   :profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "name" "token-name"}}))))
 
@@ -1114,7 +1096,8 @@
               "permitted-user" "token-pu"
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"}
-                                   :profile->defaults {:default {"health-check-url" "/ping"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"}
                                    :service-description-template {"permitted-user" "token-pu"}}))))
 
     (testing "permitted user from on-the-fly"
@@ -1124,7 +1107,8 @@
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "permitted-user" "on-the-fly-pu"}
-                                   :profile->defaults {:default {"health-check-url" "/ping"}}}))))
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"}}))))
 
     (testing "permitted user intersecting"
       (is (= {"cmd" "on-the-fly-cmd"
@@ -1133,7 +1117,8 @@
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "permitted-user" "on-the-fly-pu"}
-                                   :profile->defaults {:default {"health-check-url" "/ping"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"}
                                    :service-description-template {"permitted-user" "token-pu"}}))))
 
     (testing "run as user and permitted user only in token"
@@ -1142,7 +1127,8 @@
               "permitted-user" "token-pu"
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"}
-                                   :profile->defaults {:default {"health-check-url" "/ping"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"}
                                    :service-description-template {"run-as-user" "token-ru"
                                                                   "permitted-user" "token-pu"}}))))
 
@@ -1151,7 +1137,8 @@
               "health-check-url" "/ping"
               "permitted-user" "token-pu"
               "run-as-user" "token-ru"}
-             (service-description {:profile->defaults {:default {"health-check-url" "/ping"}}
+             (service-description {:profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "run-as-user" "token-ru"
                                                                   "permitted-user" "token-pu"}}))))
@@ -1161,8 +1148,9 @@
               "health-check-url" "/ping"
               "permitted-user" "bob"
               "run-as-user" "token-ru"}
-             (service-description {:profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}
+             (service-description {:profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "run-as-user" "token-ru"}}))))
 
@@ -1173,8 +1161,9 @@
               "run-as-user" "on-the-fly-ru"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "run-as-user" "on-the-fly-ru"}
-                                   :profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}}
                                   :waiter-headers {"x-waiter-cmd" "on-the-fly-cmd"
                                                    "x-waiter-run-as-user" "on-the-fly-ru"}))))
 
@@ -1185,8 +1174,9 @@
               "run-as-user" "on-the-fly-ru"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "run-as-user" "on-the-fly-ru"}
-                                   :profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :service-description-template {"run-as-user" "token-ru"}}
                                   :waiter-headers {"x-waiter-cmd" "on-the-fly-cmd"
                                                    "x-waiter-run-as-user" "on-the-fly-ru"}))))
@@ -1197,8 +1187,9 @@
               "permitted-user" "current-request-user"
               "run-as-user" "chris"}
              (service-description {:headers {"run-as-user" "chris"}
-                                   :profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "run-as-user" "alice"}}
                                   :waiter-headers {"x-waiter-run-as-user" "chris"}))))
@@ -1209,8 +1200,9 @@
               "permitted-user" "current-request-user"
               "run-as-user" "current-request-user"}
              (service-description {:headers {"run-as-user" "*"}
-                                   :profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "run-as-user" "alice"}}
                                   :waiter-headers {"x-waiter-run-as-user" "*"}))))
@@ -1220,8 +1212,9 @@
               "health-check-url" "/ping"
               "permitted-user" "bob"}
              (service-description {:headers {}
-                                   :profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "run-as-user" "*"}}
                                   :waiter-headers {}))))
@@ -1232,8 +1225,9 @@
               "permitted-user" "current-request-user"
               "run-as-user" "current-request-user"}
              (service-description {:headers {}
-                                   :profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :service-description-template {"cmd" "token-cmd", "run-as-user" "*"}}
                                   :waiter-headers {"x-waiter-token" "on-the-fly-token"}))))
 
@@ -1244,7 +1238,9 @@
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "run-as-user" "*"}
-                                   :profile->defaults {:default {"health-check-url" "/ping", "permitted-user" "bob"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :service-description-template {"run-as-user" "token-ru"}}
                                   :waiter-headers {"x-waiter-cmd" "on-the-fly-cmd"
                                                    "x-waiter-run-as-user" "*"}))))
@@ -1257,8 +1253,9 @@
              (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "permitted-user" "alice"
                                              "run-as-user" "*"}
-                                   :profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :service-description-template {"run-as-user" "token-ru"}}
                                   :waiter-headers {"x-waiter-cmd" "on-the-fly-cmd"
                                                    "x-waiter-permitted-user" "alice"
@@ -1270,7 +1267,8 @@
               "permitted-user" "current-request-user"
               "run-as-user" "header-user"}
              (service-description {:headers {"run-as-user" "header-user"}
-                                   :profile->defaults {:default {"health-check-url" "/ping"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"}
                                    :service-description-template {"run-as-user" "*"
                                                                   "permitted-user" "*"
                                                                   "cmd" "token-cmd"}}
@@ -1294,9 +1292,10 @@
                    "scale-factor" 0.3)
                  (service-description {:headers {"cmd" "on-the-fly-cmd"
                                                  "run-as-user" "on-the-fly-ru"}
-                                       :profile->defaults {:default {"health-check-url" "/ping"
-                                                                     "permitted-user" "bob"
-                                                                     "scale-factor" 1}}}
+                                       :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                       :service-description-defaults {"health-check-url" "/ping"
+                                                                      "permitted-user" "bob"
+                                                                      "scale-factor" 1}}
                                       :kv-store kv-store))))
 
         (testing "inactive"
@@ -1309,8 +1308,9 @@
                    "permitted-user" "bob")
                  (service-description {:headers {"cmd" "on-the-fly-cmd"
                                                  "run-as-user" "on-the-fly-ru"}
-                                       :profile->defaults {:default {"health-check-url" "/ping"
-                                                                     "permitted-user" "bob"}}}
+                                       :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                       :service-description-defaults {"health-check-url" "/ping"
+                                                                      "permitted-user" "bob"}}
                                       :kv-store kv-store))))))
 
     (testing "override token metadata from headers"
@@ -1320,8 +1320,9 @@
               "run-as-user" "current-request-user"
               "metadata" {"e" "f"}}
              (service-description {:headers {"metadata" {"e" "f"}}
-                                   :profile->defaults {:default {"health-check-url" "/ping"
-                                                                 "permitted-user" "bob"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"
+                                                                  "permitted-user" "bob"}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "metadata" {"a" "b", "c" "d"}}}))))
 
@@ -1331,7 +1332,8 @@
               "permitted-user" "current-request-user"
               "run-as-user" "current-request-user"
               "metadata" {"abc" "DEF"}}
-             (service-description {:profile->defaults {:default {"health-check-url" "/ping"}}
+             (service-description {:profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/ping"}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "metadata" {"Abc" "DEF"}}}
                                   :waiter-headers {"x-waiter-token" "value-does-not-matter"}))))
@@ -1342,7 +1344,8 @@
               "run-as-user" "current-request-user"
               "metric-group" "token-mg"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"}
-                                   :profile->defaults {:default {"health-check-url" "/health"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/health"}
                                    :service-description-template {"metric-group" "token-mg"}}))))
 
     (testing "metric group from on-the-fly"
@@ -1352,7 +1355,8 @@
               "metric-group" "on-the-fly-mg"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "metric-group" "on-the-fly-mg"}
-                                   :profile->defaults {:default {"health-check-url" "/health"}}}))))
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/health"}}))))
 
     (testing "metric group intersecting"
       (is (= {"cmd" "on-the-fly-cmd"
@@ -1361,7 +1365,8 @@
               "metric-group" "on-the-fly-mg"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "metric-group" "on-the-fly-mg"}
-                                   :profile->defaults {:default {"health-check-url" "/health"}}
+                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/health"}
                                    :service-description-template {"metric-group" "token-mg"}}))))
 
     (testing "auto-populate run-as-user"
@@ -1370,7 +1375,8 @@
               "run-as-user" "current-request-user"
               "permitted-user" "current-request-user"
               "metric-group" "token-mg"}
-             (service-description {:profile->defaults {:default {"health-check-url" "/health"}}
+             (service-description {:profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/health"}
                                    :service-description-template {"cmd" "some-cmd"
                                                                   "metric-group" "token-mg"}}
                                   :assoc-run-as-user-approved? (constantly true)))))
@@ -1379,52 +1385,57 @@
       (is (= {"cmd" "some-cmd"
               "health-check-url" "/health"
               "instance-expiry-mins" 0}
-             (service-description {:profile->defaults {:default {"health-check-url" "/health"}}
+             (service-description {:profile->overrides {"webapp" {"concurrency-level" 120}}
+                                   :service-description-defaults {"health-check-url" "/health"}
                                    :service-description-template {"cmd" "some-cmd"
                                                                   "instance-expiry-mins" 0}}))))
 
     (testing "profile parameter"
-      (let [profile->defaults {:default {"cmd" "default-cmd"
-                                         "health-check-url" "/ping"}
-                               "webapp" {"cmd" "web-cmd"
-                                         "health-check-url" "/status"}}]
+      (let [service-description-defaults {"cmd" "default-cmd"
+                                          "health-check-url" "/ping"}
+            profile->overrides {"webapp" {"cmd" "web-cmd"}}]
         (testing "from token"
           (is (= {"cmd" "web-cmd"
-                  "health-check-url" "/status"
+                  "health-check-url" "/ping"
                   "profile" "webapp"}
                  (service-description {:headers {}
-                                       :profile->defaults profile->defaults
+                                       :profile->overrides profile->overrides
+                                       :service-description-defaults service-description-defaults
                                        :service-description-template {"profile" "webapp"}})))
           (is (= {"cmd" "token-cmd"
-                  "health-check-url" "/status"
+                  "health-check-url" "/ping"
                   "profile" "webapp"}
                  (service-description {:headers {}
-                                       :profile->defaults profile->defaults
+                                       :profile->overrides profile->overrides
+                                       :service-description-defaults service-description-defaults
                                        :service-description-template {"cmd" "token-cmd"
                                                                       "profile" "webapp"}})))
           (is (= {"cmd" "on-the-fly-cmd"
-                  "health-check-url" "/status"
+                  "health-check-url" "/ping"
                   "profile" "webapp"
                   "run-as-user" "current-request-user"}
                  (service-description {:headers {"cmd" "on-the-fly-cmd"}
-                                       :profile->defaults profile->defaults
+                                       :profile->overrides profile->overrides
+                                       :service-description-defaults service-description-defaults
                                        :service-description-template {"cmd" "token-cmd"
                                                                       "profile" "webapp"}}))))
 
         (testing "from on-the-fly"
           (is (= {"cmd" "web-cmd"
-                  "health-check-url" "/status"
+                  "health-check-url" "/ping"
                   "profile" "webapp"
                   "run-as-user" "current-request-user"}
                  (service-description {:headers {"profile" "webapp"}
-                                       :profile->defaults profile->defaults})))
+                                       :profile->overrides profile->overrides
+                                       :service-description-defaults service-description-defaults})))
           (is (= {"cmd" "on-the-fly-cmd"
-                  "health-check-url" "/status"
+                  "health-check-url" "/ping"
                   "profile" "webapp"
                   "run-as-user" "current-request-user"}
                  (service-description {:headers {"cmd" "on-the-fly-cmd"
                                                  "profile" "webapp"}
-                                       :profile->defaults profile->defaults}))))))))
+                                       :profile->overrides profile->overrides
+                                       :service-description-defaults service-description-defaults}))))))))
 
 (deftest test-compute-service-description-error-scenarios
   (let [kv-store (kv/->LocalKeyValueStore (atom {}))
@@ -1448,7 +1459,8 @@
             result-descriptor))]
     (is (thrown? Exception
                  (run-compute-service-description {:headers {}
-                                                   :profile->defaults {:default {"health-check-url" "/ping"}}
+                                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                                   :service-description-defaults {"health-check-url" "/ping"}
                                                    :service-description-template {"cmd" "test command"
                                                                                   "cpus" "one"
                                                                                   "mem" 200
@@ -1456,7 +1468,8 @@
                                                                                   "run-as-user" test-user}})))
     (is (thrown? Exception
                  (run-compute-service-description {:headers {}
-                                                   :profile->defaults {:default {"health-check-url" 1}}
+                                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                                   :service-description-defaults {"health-check-url" 1}
                                                    :service-description-template {"cmd" "test command"
                                                                                   "cpus" 1
                                                                                   "mem" 200
@@ -1464,10 +1477,12 @@
                                                                                   "run-as-user" test-user}})))
     (is (thrown? Exception
                  (run-compute-service-description {:headers {}
-                                                   :profile->defaults {:default {"health-check-url" 1}}
+                                                   :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                                   :service-description-defaults {"health-check-url" 1}
                                                    :service-description-template {}})))
     (is (thrown? Exception
-                 (run-compute-service-description {:profile->defaults {:default {"health-check-url" "/health"}}
+                 (run-compute-service-description {:profile->overrides {"webapp" {"concurrency-level" 120}}
+                                                   :service-description-defaults {"health-check-url" "/health"}
                                                    :service-description-template {"cmd" "cmd for missing run-as-user"
                                                                                   "cpus" 1
                                                                                   "mem" 200
@@ -1476,8 +1491,9 @@
     (testing "invalid allowed params - reserved"
       (is (thrown? Exception
                    (run-compute-service-description {:headers {}
-                                                     :profile->defaults {:default {"health-check-url" "/ping"
-                                                                                   "permitted-user" "bob"}}
+                                                     :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                                     :service-description-defaults {"health-check-url" "/ping"
+                                                                                    "permitted-user" "bob"}
                                                      :service-description-template {"allowed-params" #{"HOME" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                                     "cmd" "token-cmd"
                                                                                     "cpus" 1
@@ -1488,8 +1504,9 @@
     (testing "invalid allowed params - bad naming"
       (is (thrown? Exception
                    (run-compute-service-description {:headers {}
-                                                     :profile->defaults {:default {"health-check-url" "/ping"
-                                                                                   "permitted-user" "bob"}}
+                                                     :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                                     :service-description-defaults {"health-check-url" "/ping"
+                                                                                    "permitted-user" "bob"}
                                                      :service-description-template {"allowed-params" #{"VAR.1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                                     "cmd" "token-cmd"
                                                                                     "cpus" 1
@@ -1500,8 +1517,9 @@
     (testing "invalid allowed params - reserved and bad naming"
       (is (thrown? Exception
                    (run-compute-service-description {:headers {}
-                                                     :profile->defaults {:default {"health-check-url" "/ping"
-                                                                                   "permitted-user" "bob"}}
+                                                     :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                                     :service-description-defaults {"health-check-url" "/ping"
+                                                                                    "permitted-user" "bob"}
                                                      :service-description-template {"allowed-params" #{"USER" "VAR.1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                                     "cmd" "token-cmd"
                                                                                     "cpus" 1
@@ -1514,8 +1532,9 @@
                    (run-compute-service-description {:headers {"param" {"VAR_1" "VALUE-1"
                                                                         "ANOTHER_VAR_2" "VALUE-2"}
                                                                "version" "on-the-fly-version"}
-                                                     :profile->defaults {:default {"health-check-url" "/ping"
-                                                                                   "permitted-user" "bob"}}
+                                                     :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                                     :service-description-defaults {"health-check-url" "/ping"
+                                                                                    "permitted-user" "bob"}
                                                      :service-description-template {"allowed-params" #{"VAR_1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                                     "cmd" "token-cmd"
                                                                                     "concurrency-level" 5
@@ -1526,8 +1545,9 @@
                    (run-compute-service-description {:headers {"param" {"VAR_1" "VALUE-1"
                                                                         "VAR_2" "VALUE-2"}
                                                                "version" "on-the-fly-version"}
-                                                     :profile->defaults {:default {"health-check-url" "/ping"
-                                                                                   "permitted-user" "bob"}}
+                                                     :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                                     :service-description-defaults {"health-check-url" "/ping"
+                                                                                    "permitted-user" "bob"}
                                                      :service-description-template {"allowed-params" #{}
                                                                                     "cmd" "token-cmd"
                                                                                     "concurrency-level" 5
@@ -1540,7 +1560,8 @@
                                       "run-as-user" test-user
                                       "version" "a1b2c3"}
             run-compute-service-description-helper (fn [service-description]
-                                                     (run-compute-service-description {:profile->defaults {:default {"health-check-url" "/health"}}
+                                                     (run-compute-service-description {:profile->overrides {"webapp" {"concurrency-level" 120}}
+                                                                                       :service-description-defaults {"health-check-url" "/healthy"}
                                                                                        :service-description-template service-description}))]
         (is (thrown? Exception (run-compute-service-description-helper (assoc core-service-description "instance-expiry-mins" -1))))
         (is (run-compute-service-description-helper (assoc core-service-description "instance-expiry-mins" 0)))
@@ -1550,7 +1571,8 @@
   (letfn [(execute-test [service-description-template header-parameters]
             (let [{:keys [service-authentication-disabled service-preauthorized]}
                   (compute-service-description-helper {:headers header-parameters
-                                                       :profile->defaults {:default {}}
+                                                       :profile->overrides {"webapp" {"concurrency-level" 120}}
+                                                       :service-description-defaults {}
                                                        :service-description-template service-description-template
                                                        :token-authentication-disabled (token-authentication-disabled? service-description-template)
                                                        :token-preauthorized (token-preauthorized? service-description-template)})]
@@ -1637,8 +1659,8 @@
           (is (= service-parameter-template service-description-template-2))
           (is (= (select-keys in-service-description service-description-keys) service-parameter-template))
           (is (= (-> in-service-description
-                     (assoc "previous" {})
-                     (select-keys token-metadata-keys))
+                   (assoc "previous" {})
+                   (select-keys token-metadata-keys))
                  token-metadata))))
 
       (testing "test:deleted:token->service-description-2"
@@ -1723,10 +1745,13 @@
 (deftest test-service-id->service-description
   (let [service-id "test-service-1"
         service-key (str "^SERVICE-ID#" service-id)
-        profile->defaults {:default {}}
-        fetch-service-description (fn [kv-store]
-                                    (service-id->service-description kv-store service-id profile->defaults []
-                                                                     :effective? false))]
+        fetch-service-description (fn [kv-store & {:keys [effective? profile->overrides service-description-defaults]
+                                                   :or {effective? false
+                                                        profile->overrides {"webapp" {"concurrency-level" 120}}
+                                                        service-description-defaults {}}}]
+                                    (service-id->service-description
+                                      kv-store service-id service-description-defaults profile->overrides []
+                                      :effective? effective?))]
 
     (testing "no data available"
       (let [kv-store (kv/->LocalKeyValueStore (atom {}))]
@@ -1740,6 +1765,28 @@
         (is (nil? (kv/fetch kv-store service-key)))
         (kv/store kv-store service-key service-description)
         (is (= service-description (fetch-service-description kv-store)))
+        (is (= service-description (kv/fetch kv-store service-key)))))
+
+    (testing "data with profile"
+      (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+            service-description {"cmd" "tc" "cpus" 1 "mem" 200 "profile" "webapp" "version" "a1b2c3"}
+            profile->overrides {"webapp" {"concurrency-level" 120}}
+            service-description-defaults {"metric-group" "webapp"}]
+        (is (nil? (kv/fetch kv-store service-key)))
+        (kv/store kv-store service-key service-description)
+        (is (= service-description
+               (fetch-service-description
+                 kv-store
+                 :profile->overrides profile->overrides
+                 :service-description-defaults service-description-defaults)))
+        (is (= (merge service-description
+                      service-description-defaults
+                      (get profile->overrides "webapp"))
+               (fetch-service-description
+                 kv-store
+                 :effective? true
+                 :profile->overrides profile->overrides
+                 :service-description-defaults service-description-defaults)))
         (is (= service-description (kv/fetch kv-store service-key)))))
 
     (testing "cached empty data"
@@ -1922,10 +1969,9 @@
                            "run-as-user" "default-run-as-user"}
         constraints-schema {(s/optional-key "cmd") (s/pred #(<= (count %) 100) (symbol "limit-100"))
                             s/Str s/Any}
-        profile->defaults {:default {"name" "default-name"}
-                           "web-app" {"name" "web-app-name"}}
+        profile->overrides {"web-app" {"name" "web-app-name"}}
         config {:allow-missing-required-fields? false
-                :profile->defaults profile->defaults}]
+                :profile->overrides profile->overrides}]
     (is (nil? (validate-schema valid-description constraints-schema config)))
 
     (testing (str "testing empty cmd")
@@ -1979,7 +2025,7 @@
         constraints-schema config "Unsupported profile: web-service, supported profile(s) are web-app")
 
       (let [config {:allow-missing-required-fields? false
-                    :profile->defaults (dissoc profile->defaults "web-app")}]
+                    :profile->overrides (dissoc profile->overrides "web-app")}]
         (run-validate-schema-test
           (assoc valid-description "profile" 1234)
           constraints-schema config (str "profile must be a non-empty string, there are no supported profiles"))
@@ -2196,7 +2242,7 @@
       (is (thrown? Exception #"Cannot use run-as-requester with a specific namespace"
                    (validate builder
                              (assoc basic-service-description
-                                    "namespace" "some-user")
+                               "namespace" "some-user")
                              validation-settings))))
 
     (testing "validate-service-description-namespace-some-user"
@@ -2207,7 +2253,7 @@
       (is (thrown? Exception #"Service namespace must either be omitted or match the run-as-user"
                    (validate builder
                              (assoc basic-service-description
-                                    "namespace" "some-other-user")
+                               "namespace" "some-other-user")
                              validation-settings))))))
 
 (deftest test-retrieve-most-recently-modified-token

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -244,7 +244,7 @@
     (with-redefs [kv/fetch (fn [in-kv-store token]
                              (is (= kv-store in-kv-store))
                              (create-token-data token))]
-      (let [service-description-defaults {"name" "default-name" "health-check-url" "/ping"}
+      (let [profile->defaults {"" {"name" "default-name" "health-check-url" "/ping"}}
             token-defaults {"fallback-period-secs" 300}
             test-cases (list
                          {:name "prepare-service-description-sources:WITH Service Desc specific Waiter Headers except run-as-user"
@@ -257,14 +257,14 @@
                                            "x-waiter-version" "test-version"}
                           :passthrough-headers {"host" "test-host"
                                                 "fee" "foe"}
-                          :expected {:defaults {"name" "default-name"
-                                                "health-check-url" "/ping"}
-                                     :fallback-period-secs 300
+                          :expected {:fallback-period-secs 300
                                      :headers {"cpus" 1
                                                "mem" 1024
                                                "cmd" "test-cmd"
                                                "version" "test-version"
                                                "run-as-user" test-user}
+                                     :profile->defaults {"" {"name" "default-name"
+                                                             "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-host"
                                                                     "version" "token"}
@@ -283,14 +283,14 @@
                                            "x-waiter-version" "test-version"}
                           :passthrough-headers {"host" waiter-hostname
                                                 "fee" "foe"}
-                          :expected {:defaults {"name" "default-name"
-                                                "health-check-url" "/ping"}
-                                     :fallback-period-secs 300
+                          :expected {:fallback-period-secs 300
                                      :headers {"cpus" 1
                                                "mem" 1024
                                                "cmd" "test-cmd"
                                                "version" "test-version"
                                                "run-as-user" test-user}
+                                     :profile->defaults {"" {"name" "default-name"
+                                                             "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -307,14 +307,14 @@
                                            "x-waiter-version" "test-version"}
                           :passthrough-headers {"host" "test-host"
                                                 "fee" "foe"}
-                          :expected {:defaults {"name" "default-name"
-                                                "health-check-url" "/ping"}
-                                     :fallback-period-secs 300
+                          :expected {:fallback-period-secs 300
                                      :headers {"cpus" 1
                                                "mem" 1024
                                                "cmd" "test-cmd"
                                                "version" "test-version"
                                                "run-as-user" test-user}
+                                     :profile->defaults {"" {"name" "default-name"
+                                                             "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-host"
                                                                     "version" "token"}
@@ -332,14 +332,14 @@
                                            "x-waiter-source" "serv-desc"
                                            "x-waiter-version" "test-version"}
                           :passthrough-headers {"host" "test-host-no-token" "fee" "foe"}
-                          :expected {:defaults {"name" "default-name"
-                                                "health-check-url" "/ping"}
-                                     :fallback-period-secs 300
+                          :expected {:fallback-period-secs 300
                                      :headers {"cpus" 1
                                                "mem" 1024
                                                "cmd" "test-cmd"
                                                "version" "test-version"
                                                "run-as-user" test-user}
+                                     :profile->defaults {"" {"name" "default-name"
+                                                             "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -351,10 +351,10 @@
                                            "x-waiter-source" "serv-desc"}
                           :passthrough-headers {"host" "test-host"
                                                 "fee" "foe"}
-                          :expected {:defaults {"name" "default-name"
-                                                "health-check-url" "/ping"}
-                                     :fallback-period-secs 300
+                          :expected {:fallback-period-secs 300
                                      :headers {}
+                                     :profile->defaults {"" {"name" "default-name"
+                                                             "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-host"
                                                                     "version" "token"}
@@ -368,10 +368,10 @@
                                            "x-waiter-source" "serv-desc"
                                            "x-waiter-token" "test-token"}
                           :passthrough-headers {"host" "test-host" "fee" "foe"}
-                          :expected {:defaults {"name" "default-name"
-                                                "health-check-url" "/ping"}
-                                     :fallback-period-secs 300
+                          :expected {:fallback-period-secs 300
                                      :headers {}
+                                     :profile->defaults {"" {"name" "default-name"
+                                                             "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-token"
                                                                     "version" "token"}
@@ -386,10 +386,10 @@
                                            "x-waiter-token" "test-token,test-token2"}
                           :passthrough-headers {"host" "test-host"
                                                 "fee" "foe"}
-                          :expected {:defaults {"name" "default-name"
-                                                "health-check-url" "/ping"}
-                                     :fallback-period-secs 300
+                          :expected {:fallback-period-secs 300
                                      :headers {}
+                                     :profile->defaults {"" {"name" "default-name"
+                                                             "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-token2"
                                                                     "version" "token"}
@@ -404,9 +404,9 @@
                                            "x-waiter-source" "serv-desc"
                                            "x-waiter-token" "test-token,test-token2,test-cpus-token,test-mem-token"}
                           :passthrough-headers {"host" "test-host" "fee" "foe"}
-                          :expected {:defaults {"name" "default-name" "health-check-url" "/ping"}
-                                     :fallback-period-secs 300
+                          :expected {:fallback-period-secs 300
                                      :headers {}
+                                     :profile->defaults {"" {"name" "default-name" "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "cpus" "1"
                                                                     "mem" "2"
@@ -424,10 +424,10 @@
                           :waiter-headers {}
                           :passthrough-headers {"host" "test-host"
                                                 "fee" "foe"}
-                          :expected {:defaults {"name" "default-name"
-                                                "health-check-url" "/ping"}
-                                     :fallback-period-secs 300
+                          :expected {:fallback-period-secs 300
                                      :headers {}
+                                     :profile->defaults {"" {"name" "default-name"
+                                                             "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-host"
                                                                     "version" "token"}
@@ -440,10 +440,10 @@
                           :waiter-headers {}
                           :passthrough-headers {"host" "test-host:1234"
                                                 "fee" "foe"}
-                          :expected {:defaults {"name" "default-name"
-                                                "health-check-url" "/ping"}
-                                     :fallback-period-secs 300
+                          :expected {:fallback-period-secs 300
                                      :headers {}
+                                     :profile->defaults {"" {"name" "default-name"
+                                                             "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-host"
                                                                     "version" "token"}
@@ -456,10 +456,10 @@
                           :waiter-headers {"x-waiter-token" "test-token-run"}
                           :passthrough-headers {"host" "test-host:1234"
                                                 "fee" "foe"}
-                          :expected {:defaults {"name" "default-name"
-                                                "health-check-url" "/ping"}
-                                     :fallback-period-secs 300
+                          :expected {:fallback-period-secs 300
                                      :headers {}
+                                     :profile->defaults {"" {"name" "default-name"
+                                                             "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-token-run"
                                                                     "run-as-user" "ruser"
@@ -473,10 +473,10 @@
                           :waiter-headers {"x-waiter-token" "test-token-per-fall"}
                           :passthrough-headers {"host" "test-host:1234"
                                                 "fee" "foe"}
-                          :expected {:defaults {"name" "default-name"
-                                                "health-check-url" "/ping"}
-                                     :fallback-period-secs 600
+                          :expected {:fallback-period-secs 600
                                      :headers {}
+                                     :profile->defaults {"" {"name" "default-name"
+                                                             "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-token-per-fall"
                                                                     "version" "token" "permitted-user" "puser"}
@@ -489,10 +489,10 @@
                           :waiter-headers {"x-waiter-token" "test-token-per-run"}
                           :passthrough-headers {"host" "test-host:1234"
                                                 "fee" "foe"}
-                          :expected {:defaults {"name" "default-name"
-                                                "health-check-url" "/ping"}
-                                     :fallback-period-secs 300
+                          :expected {:fallback-period-secs 300
                                      :headers {}
+                                     :profile->defaults {"" {"name" "default-name"
+                                                             "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "name" "test-token-per-run"
                                                                     "permitted-user" "puser"
@@ -507,10 +507,10 @@
                           :waiter-headers {"x-waiter-token" "test-token-per-run,test-cpus-token"}
                           :passthrough-headers {"host" "test-host:1234"
                                                 "fee" "foe"}
-                          :expected {:defaults {"name" "default-name"
-                                                "health-check-url" "/ping"}
-                                     :fallback-period-secs 300
+                          :expected {:fallback-period-secs 300
                                      :headers {}
+                                     :profile->defaults {"" {"name" "default-name"
+                                                             "health-check-url" "/ping"}}
                                      :service-description-template {"cmd" "token-user"
                                                                     "cpus" "1"
                                                                     "name" "test-cpus-token"
@@ -528,12 +528,12 @@
                                            "x-waiter-metadata-baz" "quux"
                                            "x-waiter-metadata-foo" "bar"}
                           :passthrough-headers {}
-                          :expected {:defaults {"name" "default-name"
-                                                "health-check-url" "/ping"}
-                                     :fallback-period-secs 300
+                          :expected {:fallback-period-secs 300
                                      :headers {"metadata" {"foo" "bar"
                                                            "baz" "quux"}
                                                "cpus" "1"}
+                                     :profile->defaults {"" {"name" "default-name"
+                                                             "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -545,12 +545,12 @@
                                            "x-waiter-env-baz" "quux"
                                            "x-waiter-env-foo_bar" "bar"}
                           :passthrough-headers {}
-                          :expected {:defaults {"name" "default-name"
-                                                "health-check-url" "/ping"}
-                                     :fallback-period-secs 300
+                          :expected {:fallback-period-secs 300
                                      :headers {"env" {"BAZ" "quux"
                                                       "FOO_BAR" "bar"}
                                                "cpus" "1"}
+                                     :profile->defaults {"" {"name" "default-name"
+                                                             "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -561,11 +561,11 @@
                           :waiter-headers {"x-waiter-param-bar" "bar-value"
                                            "x-waiter-param-foo" "foo-value"}
                           :passthrough-headers {"host" "test-host-allowed-cpus-mem-per-run:1234"}
-                          :expected {:defaults {"health-check-url" "/ping"
-                                                "name" "default-name"}
-                                     :fallback-period-secs 300
+                          :expected {:fallback-period-secs 300
                                      :headers {"param" {"BAR" "bar-value"
                                                         "FOO" "foo-value"}}
+                                     :profile->defaults {"" {"health-check-url" "/ping"
+                                                             "name" "default-name"}}
                                      :service-description-template {"allowed-params" #{"BAR" "FOO"}
                                                                     "cmd" "token-user"
                                                                     "cpus" "1"
@@ -584,12 +584,12 @@
                                            "x-waiter-param-bar" "bar-value"
                                            "x-waiter-param-foo" "foo-value"}
                           :passthrough-headers {"host" "test-host-allowed-cpus-mem-per-run:1234"}
-                          :expected {:defaults {"health-check-url" "/ping"
-                                                "name" "default-name"}
-                                     :fallback-period-secs 300
+                          :expected {:fallback-period-secs 300
                                      :headers {"cpus" "20"
                                                "param" {"BAR" "bar-value"
                                                         "FOO" "foo-value"}}
+                                     :profile->defaults {"" {"health-check-url" "/ping"
+                                                             "name" "default-name"}}
                                      :service-description-template {"allowed-params" #{"BAR" "FOO"}
                                                                     "cmd" "token-user"
                                                                     "cpus" "1"
@@ -608,11 +608,11 @@
                                            "x-waiter-param-foo" "foo-value"
                                            "x-waiter-token" "test-host-allowed-cpus-mem-per-run"}
                           :passthrough-headers {}
-                          :expected {:defaults {"health-check-url" "/ping"
-                                                "name" "default-name"}
-                                     :fallback-period-secs 300
+                          :expected {:fallback-period-secs 300
                                      :headers {"param" {"BAR" "bar-value"
                                                         "FOO" "foo-value"}}
+                                     :profile->defaults {"" {"health-check-url" "/ping"
+                                                             "name" "default-name"}}
                                      :service-description-template {"allowed-params" #{"BAR" "FOO"}
                                                                     "cmd" "token-user"
                                                                     "cpus" "1"
@@ -631,12 +631,12 @@
                                            "x-waiter-param-baz" "quux"
                                            "x-waiter-param-foo_bar" "bar"}
                           :passthrough-headers {}
-                          :expected {:defaults {"name" "default-name"
-                                                "health-check-url" "/ping"}
-                                     :fallback-period-secs 300
+                          :expected {:fallback-period-secs 300
                                      :headers {"cpus" "1"
                                                "param" {"BAZ" "quux"
                                                         "FOO_BAR" "bar"}}
+                                     :profile->defaults {"" {"name" "default-name"
+                                                             "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -650,14 +650,14 @@
                                            "x-waiter-param-baz" "quux"
                                            "x-waiter-param-foo_bar" "bar"}
                           :passthrough-headers {}
-                          :expected {:defaults {"name" "default-name"
-                                                "health-check-url" "/ping"}
-                                     :fallback-period-secs 300
+                          :expected {:fallback-period-secs 300
                                      :headers {"cpus" "1"
                                                "env" {"BAZ" "quux"
                                                       "FOO_BAR" "bar"}
                                                "param" {"BAZ" "quux"
                                                         "FOO_BAR" "bar"}}
+                                     :profile->defaults {"" {"name" "default-name"
+                                                             "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -671,14 +671,14 @@
                                            "x-waiter-param-baz" "quux"
                                            "x-waiter-param-foo_bar" "bar2"}
                           :passthrough-headers {}
-                          :expected {:defaults {"name" "default-name"
-                                                "health-check-url" "/ping"}
-                                     :fallback-period-secs 300
+                          :expected {:fallback-period-secs 300
                                      :headers {"cpus" "1"
                                                "env" {"BAZ" "quux"
                                                       "FOO_BAR" "bar1"}
                                                "param" {"BAZ" "quux"
                                                         "FOO_BAR" "bar2"}}
+                                     :profile->defaults {"" {"name" "default-name"
+                                                             "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -690,12 +690,12 @@
                                            "x-waiter-env-1" "quux"
                                            "x-waiter-env-foo-bar" "bar"}
                           :passthrough-headers {}
-                          :expected {:defaults {"name" "default-name"
-                                                "health-check-url" "/ping"}
-                                     :fallback-period-secs 300
+                          :expected {:fallback-period-secs 300
                                      :headers {"cpus" "1"
                                                "env" {"1" "quux"
                                                       "FOO-BAR" "bar"}}
+                                     :profile->defaults {"" {"name" "default-name"
+                                                             "health-check-url" "/ping"}}
                                      :service-description-template {},
                                      :source-tokens []
                                      :token->token-data {},
@@ -708,7 +708,7 @@
             (let [actual (prepare-service-description-sources
                            {:passthrough-headers passthrough-headers
                             :waiter-headers waiter-headers}
-                           kv-store waiter-hostnames service-description-defaults token-defaults)]
+                           kv-store waiter-hostnames profile->defaults token-defaults)]
               (when (not= expected actual)
                 (println name)
                 (println "Expected: " (into (sorted-map) expected))
@@ -719,7 +719,7 @@
   (let [kv-store (Object.)
         waiter-hostname "waiter-hostname.app.example.com"
         test-token "test-token-name"
-        service-description-defaults {"name" "default-name" "health-check-url" "/ping"}
+        profile->defaults {"" {"name" "default-name" "health-check-url" "/ping"}}
         token-defaults {"fallback-period-secs" 300}]
     (testing "authentication-disabled token"
       (let [token-data {"authentication" "disabled"
@@ -741,10 +741,10 @@
                 actual (prepare-service-description-sources
                          {:waiter-headers waiter-headers
                           :passthrough-headers passthrough-headers}
-                         kv-store waiter-hostname service-description-defaults token-defaults)
-                expected {:defaults service-description-defaults
-                          :fallback-period-secs 300
+                         kv-store waiter-hostname profile->defaults token-defaults)
+                expected {:fallback-period-secs 300
                           :headers {}
+                          :profile->defaults profile->defaults
                           :service-description-template (select-keys token-data service-parameter-keys)
                           :source-tokens [(source-tokens-entry test-token token-data)]
                           :token->token-data {test-token token-data}
@@ -773,10 +773,10 @@
                 actual (prepare-service-description-sources
                          {:waiter-headers waiter-headers
                           :passthrough-headers passthrough-headers}
-                         kv-store waiter-hostname service-description-defaults token-defaults)
-                expected {:defaults service-description-defaults
-                          :fallback-period-secs 300
+                         kv-store waiter-hostname profile->defaults token-defaults)
+                expected {:fallback-period-secs 300
                           :headers {}
+                          :profile->defaults profile->defaults
                           :service-description-template (select-keys token-data service-parameter-keys)
                           :source-tokens [(source-tokens-entry test-token token-data)]
                           :token->token-data {test-token token-data}
@@ -814,7 +814,8 @@
 
 (deftest test-compute-service-description-on-the-fly?
   (let [defaults {"health-check-url" "/ping", "permitted-user" "bob"}
-        sources {:defaults defaults :service-description-template {"cmd" "token-cmd"}}
+        sources {:profile->defaults {"" defaults}
+                 :service-description-template {"cmd" "token-cmd"}}
         compute-on-the-fly (fn compute-on-the-fly [waiter-headers]
                              (-> (compute-service-description-helper sources :waiter-headers waiter-headers)
                                  :on-the-fly?))]
@@ -827,7 +828,7 @@
 (deftest test-compute-service-description-source-tokens
   (let [defaults {"health-check-url" "/ping", "permitted-user" "bob"}
         source-tokens [:foo-bar]
-        sources {:defaults defaults
+        sources {:profile->defaults {"" defaults}
                  :service-description-template {"cmd" "token-cmd"}
                  :source-tokens source-tokens}
         compute-source-tokens (fn compute-source-tokens [waiter-headers]
@@ -842,14 +843,14 @@
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"
               "permitted-user" "bob"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
+             (service-description {:profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"}}))))
 
     (testing "only token from host without permitted-user in defaults"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"}
-             (service-description {:defaults {"health-check-url" "/ping"}
+             (service-description {:profile->defaults {"" {"health-check-url" "/ping"}}
                                    :service-description-template {"cmd" "token-cmd"}}))))
 
     (testing "only token from header without permitted-user"
@@ -857,8 +858,8 @@
               "health-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "current-request-user"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
+             (service-description {:profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"}}
                                   :waiter-headers {"x-waiter-token" "value-does-not-matter"}))))
 
@@ -867,8 +868,8 @@
               "health-check-url" "/ping"
               "permitted-user" "token-user"
               "run-as-user" "token-user"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
+             (service-description {:profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "permitted-user" "token-user"
                                                                   "run-as-user" "token-user"}}
@@ -879,8 +880,8 @@
               "health-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "on-the-fly-ru"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
+             (service-description {:profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}
                                    :headers {"run-as-user" "on-the-fly-ru"}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "permitted-user" "token-user"
@@ -891,7 +892,7 @@
     (testing "only token from host with defaults missing permitted user"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"}
-             (service-description {:defaults {"health-check-url" "/ping"}
+             (service-description {:profile->defaults {"" {"health-check-url" "/ping"}}
                                    :service-description-template {"cmd" "token-cmd"}}))))
 
     (testing "only token from header with defaults missing permitted user"
@@ -899,14 +900,14 @@
               "health-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "current-request-user"}
-             (service-description {:defaults {"health-check-url" "/ping"}
+             (service-description {:profile->defaults {"" {"health-check-url" "/ping"}}
                                    :service-description-template {"cmd" "token-cmd"}}
                                   :waiter-headers {"x-waiter-token" "value-does-not-matter"}))))
 
     (testing "only token from host with dummy header"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"}
-             (service-description {:defaults {"health-check-url" "/ping"}
+             (service-description {:profile->defaults {"" {"health-check-url" "/ping"}}
                                    :service-description-template {"cmd" "token-cmd"}}
                                   :waiter-headers {"x-waiter-dummy" "value-does-not-matter"}))))
 
@@ -915,9 +916,9 @@
               "health-check-url" "/ping"
               "permitted-user" "bob"
               "run-as-user" "current-request-user"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
-                                   :headers {"cmd" "on-the-fly-cmd"}}))))
+             (service-description {:headers {"cmd" "on-the-fly-cmd"}
+                                   :profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}}))))
 
     (testing "token host with non-intersecting values"
       (is (= {"cmd" "token-cmd"
@@ -925,9 +926,9 @@
               "permitted-user" "bob"
               "run-as-user" "current-request-user"
               "version" "on-the-fly-version"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
-                                   :headers {"version" "on-the-fly-version"}
+             (service-description {:headers {"version" "on-the-fly-version"}
+                                   :profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"}}))))
 
     (testing "token header with non-intersecting values"
@@ -937,9 +938,9 @@
               "permitted-user" "bob"
               "run-as-user" "current-request-user"
               "version" "on-the-fly-version"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
-                                   :headers {"version" "on-the-fly-version"}
+             (service-description {:headers {"version" "on-the-fly-version"}
+                                   :profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "concurrency-level" 5}}))))
 
@@ -953,11 +954,11 @@
               "permitted-user" "bob"
               "run-as-user" "current-request-user"
               "version" "on-the-fly-version"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
-                                   :headers {"param" {"VAR_1" "VALUE-1"
+             (service-description {:headers {"param" {"VAR_1" "VALUE-1"
                                                       "VAR_2" "VALUE-2"}
                                              "version" "on-the-fly-version"}
+                                   :profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}
                                    :service-description-template {"allowed-params" #{"VAR_1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                   "cmd" "token-cmd"
                                                                   "concurrency-level" 5
@@ -975,11 +976,11 @@
               "permitted-user" "bob"
               "run-as-user" "current-request-user"
               "version" "on-the-fly-version"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
-                                   :headers {"param" {"VAR_3" "VALUE-3p"
+             (service-description {:headers {"param" {"VAR_3" "VALUE-3p"
                                                       "VAR_4" "VALUE-4p"}
                                              "version" "on-the-fly-version"}
+                                   :profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}
                                    :service-description-template {"allowed-params" #{"VAR_1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                   "cmd" "token-cmd"
                                                                   "concurrency-level" 5
@@ -998,11 +999,11 @@
               "permitted-user" "bob"
               "run-as-user" "current-request-user"
               "version" "on-the-fly-version"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
-                                   :headers {"param" {"VAR_2" "VALUE-2p"
+             (service-description {:headers {"param" {"VAR_2" "VALUE-2p"
                                                       "VAR_3" "VALUE-3p"}
                                              "version" "on-the-fly-version"}
+                                   :profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}
                                    :service-description-template {"allowed-params" #{"VAR_1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                   "cmd" "token-cmd"
                                                                   "concurrency-level" 5
@@ -1019,10 +1020,10 @@
               "health-check-url" "/ping"
               "permitted-user" "bob"
               "run-as-user" "test-user"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
-                                   :headers {"param" {"VAR_1" "VALUE-1"
+             (service-description {:headers {"param" {"VAR_1" "VALUE-1"
                                                       "VAR_2" "VALUE-2"}}
+                                   :profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}
                                    :service-description-template {"allowed-params" #{"VAR_1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                   "cmd" "token-cmd"
                                                                   "concurrency-level" 5
@@ -1039,10 +1040,10 @@
               "health-check-url" "/ping"
               "permitted-user" "bob"
               "run-as-user" "test-user"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
-                                   :headers {"param" {"VAR_3" "VALUE-3p"
+             (service-description {:headers {"param" {"VAR_3" "VALUE-3p"
                                                       "VAR_4" "VALUE-4p"}}
+                                   :profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}
                                    :service-description-template {"allowed-params" #{"VAR_1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                   "cmd" "token-cmd"
                                                                   "concurrency-level" 5
@@ -1060,10 +1061,10 @@
               "health-check-url" "/ping"
               "permitted-user" "bob"
               "run-as-user" "test-user"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
-                                   :headers {"param" {"VAR_2" "VALUE-2p"
+             (service-description {:headers {"param" {"VAR_2" "VALUE-2p"
                                                       "VAR_3" "VALUE-3p"}}
+                                   :profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}
                                    :service-description-template {"allowed-params" #{"VAR_1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                   "cmd" "token-cmd"
                                                                   "concurrency-level" 5
@@ -1077,10 +1078,10 @@
               "health-check-url" "/ping"
               "permitted-user" "bob"
               "run-as-user" "current-request-user"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
-                                   :headers {"cmd" "on-the-fly-cmd"
+             (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "concurrency-level" 6}
+                                   :profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"}}))))
 
     (testing "token header with intersecting values"
@@ -1088,9 +1089,9 @@
               "health-check-url" "/ping"
               "permitted-user" "bob"
               "run-as-user" "current-request-user"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
-                                   :headers {"cmd" "on-the-fly-cmd"}
+             (service-description {:headers {"cmd" "on-the-fly-cmd"}
+                                   :profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"}}))))
 
     (testing "intersecting values with additional fields"
@@ -1100,10 +1101,10 @@
               "permitted-user" "bob"
               "run-as-user" "current-request-user"
               "version" "on-the-fly-version"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
-                                   :headers {"cmd" "on-the-fly-cmd"
+             (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "version" "on-the-fly-version"}
+                                   :profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "name" "token-name"}}))))
 
@@ -1112,8 +1113,8 @@
               "health-check-url" "/ping"
               "permitted-user" "token-pu"
               "run-as-user" "current-request-user"}
-             (service-description {:defaults {"health-check-url" "/ping"}
-                                   :headers {"cmd" "on-the-fly-cmd"}
+             (service-description {:headers {"cmd" "on-the-fly-cmd"}
+                                   :profile->defaults {"" {"health-check-url" "/ping"}}
                                    :service-description-template {"permitted-user" "token-pu"}}))))
 
     (testing "permitted user from on-the-fly"
@@ -1121,18 +1122,18 @@
               "health-check-url" "/ping"
               "permitted-user" "on-the-fly-pu"
               "run-as-user" "current-request-user"}
-             (service-description {:defaults {"health-check-url" "/ping"}
-                                   :headers {"cmd" "on-the-fly-cmd"
-                                             "permitted-user" "on-the-fly-pu"}}))))
+             (service-description {:headers {"cmd" "on-the-fly-cmd"
+                                             "permitted-user" "on-the-fly-pu"}
+                                   :profile->defaults {"" {"health-check-url" "/ping"}}}))))
 
     (testing "permitted user intersecting"
       (is (= {"cmd" "on-the-fly-cmd"
               "health-check-url" "/ping"
               "permitted-user" "on-the-fly-pu"
               "run-as-user" "current-request-user"}
-             (service-description {:defaults {"health-check-url" "/ping"}
-                                   :headers {"cmd" "on-the-fly-cmd"
+             (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "permitted-user" "on-the-fly-pu"}
+                                   :profile->defaults {"" {"health-check-url" "/ping"}}
                                    :service-description-template {"permitted-user" "token-pu"}}))))
 
     (testing "run as user and permitted user only in token"
@@ -1140,8 +1141,8 @@
               "health-check-url" "/ping"
               "permitted-user" "token-pu"
               "run-as-user" "current-request-user"}
-             (service-description {:defaults {"health-check-url" "/ping"}
-                                   :headers {"cmd" "on-the-fly-cmd"}
+             (service-description {:headers {"cmd" "on-the-fly-cmd"}
+                                   :profile->defaults {"" {"health-check-url" "/ping"}}
                                    :service-description-template {"run-as-user" "token-ru"
                                                                   "permitted-user" "token-pu"}}))))
 
@@ -1150,7 +1151,7 @@
               "health-check-url" "/ping"
               "permitted-user" "token-pu"
               "run-as-user" "token-ru"}
-             (service-description {:defaults {"health-check-url" "/ping"}
+             (service-description {:profile->defaults {"" {"health-check-url" "/ping"}}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "run-as-user" "token-ru"
                                                                   "permitted-user" "token-pu"}}))))
@@ -1160,8 +1161,8 @@
               "health-check-url" "/ping"
               "permitted-user" "bob"
               "run-as-user" "token-ru"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
+             (service-description {:profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "run-as-user" "token-ru"}}))))
 
@@ -1170,10 +1171,10 @@
               "health-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "on-the-fly-ru"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
-                                   :headers {"cmd" "on-the-fly-cmd"
-                                             "run-as-user" "on-the-fly-ru"}}
+             (service-description {:headers {"cmd" "on-the-fly-cmd"
+                                             "run-as-user" "on-the-fly-ru"}
+                                   :profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}}
                                   :waiter-headers {"x-waiter-cmd" "on-the-fly-cmd"
                                                    "x-waiter-run-as-user" "on-the-fly-ru"}))))
 
@@ -1182,10 +1183,10 @@
               "health-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "on-the-fly-ru"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
-                                   :headers {"cmd" "on-the-fly-cmd"
+             (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "run-as-user" "on-the-fly-ru"}
+                                   :profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}
                                    :service-description-template {"run-as-user" "token-ru"}}
                                   :waiter-headers {"x-waiter-cmd" "on-the-fly-cmd"
                                                    "x-waiter-run-as-user" "on-the-fly-ru"}))))
@@ -1195,9 +1196,9 @@
               "health-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "chris"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
-                                   :headers {"run-as-user" "chris"}
+             (service-description {:headers {"run-as-user" "chris"}
+                                   :profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "run-as-user" "alice"}}
                                   :waiter-headers {"x-waiter-run-as-user" "chris"}))))
@@ -1207,9 +1208,9 @@
               "health-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "current-request-user"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
-                                   :headers {"run-as-user" "*"}
+             (service-description {:headers {"run-as-user" "*"}
+                                   :profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "run-as-user" "alice"}}
                                   :waiter-headers {"x-waiter-run-as-user" "*"}))))
@@ -1218,9 +1219,9 @@
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"
               "permitted-user" "bob"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
-                                   :headers {}
+             (service-description {:headers {}
+                                   :profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "run-as-user" "*"}}
                                   :waiter-headers {}))))
@@ -1230,9 +1231,9 @@
               "health-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "current-request-user"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
-                                   :headers {}
+             (service-description {:headers {}
+                                   :profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd", "run-as-user" "*"}}
                                   :waiter-headers {"x-waiter-token" "on-the-fly-token"}))))
 
@@ -1241,9 +1242,9 @@
               "health-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "current-request-user"}
-             (service-description {:defaults {"health-check-url" "/ping", "permitted-user" "bob"}
-                                   :headers {"cmd" "on-the-fly-cmd"
+             (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "run-as-user" "*"}
+                                   :profile->defaults {"" {"health-check-url" "/ping", "permitted-user" "bob"}}
                                    :service-description-template {"run-as-user" "token-ru"}}
                                   :waiter-headers {"x-waiter-cmd" "on-the-fly-cmd"
                                                    "x-waiter-run-as-user" "*"}))))
@@ -1253,11 +1254,11 @@
               "health-check-url" "/ping"
               "permitted-user" "alice"
               "run-as-user" "current-request-user"}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
-                                   :headers {"cmd" "on-the-fly-cmd"
+             (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "permitted-user" "alice"
                                              "run-as-user" "*"}
+                                   :profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}
                                    :service-description-template {"run-as-user" "token-ru"}}
                                   :waiter-headers {"x-waiter-cmd" "on-the-fly-cmd"
                                                    "x-waiter-permitted-user" "alice"
@@ -1268,8 +1269,8 @@
               "health-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "header-user"}
-             (service-description {:defaults {"health-check-url" "/ping"}
-                                   :headers {"run-as-user" "header-user"}
+             (service-description {:headers {"run-as-user" "header-user"}
+                                   :profile->defaults {"" {"health-check-url" "/ping"}}
                                    :service-description-template {"run-as-user" "*"
                                                                   "permitted-user" "*"
                                                                   "cmd" "token-cmd"}}
@@ -1291,11 +1292,11 @@
                    "health-check-url" "/ping"
                    "permitted-user" "bob"
                    "scale-factor" 0.3)
-                 (service-description {:defaults {"health-check-url" "/ping"
-                                                  "permitted-user" "bob"
-                                                  "scale-factor" 1}
-                                       :headers {"cmd" "on-the-fly-cmd"
-                                                 "run-as-user" "on-the-fly-ru"}}
+                 (service-description {:headers {"cmd" "on-the-fly-cmd"
+                                                 "run-as-user" "on-the-fly-ru"}
+                                       :profile->defaults {"" {"health-check-url" "/ping"
+                                                               "permitted-user" "bob"
+                                                               "scale-factor" 1}}}
                                       :kv-store kv-store))))
 
         (testing "inactive"
@@ -1306,10 +1307,10 @@
           (is (= (assoc basic-service-description
                    "health-check-url" "/ping"
                    "permitted-user" "bob")
-                 (service-description {:defaults {"health-check-url" "/ping"
-                                                  "permitted-user" "bob"}
-                                       :headers {"cmd" "on-the-fly-cmd"
-                                                 "run-as-user" "on-the-fly-ru"}}
+                 (service-description {:headers {"cmd" "on-the-fly-cmd"
+                                                 "run-as-user" "on-the-fly-ru"}
+                                       :profile->defaults {"" {"health-check-url" "/ping"
+                                                               "permitted-user" "bob"}}}
                                       :kv-store kv-store))))))
 
     (testing "override token metadata from headers"
@@ -1318,9 +1319,9 @@
               "permitted-user" "bob"
               "run-as-user" "current-request-user"
               "metadata" {"e" "f"}}
-             (service-description {:defaults {"health-check-url" "/ping"
-                                              "permitted-user" "bob"}
-                                   :headers {"metadata" {"e" "f"}}
+             (service-description {:headers {"metadata" {"e" "f"}}
+                                   :profile->defaults {"" {"health-check-url" "/ping"
+                                                           "permitted-user" "bob"}}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "metadata" {"a" "b", "c" "d"}}}))))
 
@@ -1330,7 +1331,7 @@
               "permitted-user" "current-request-user"
               "run-as-user" "current-request-user"
               "metadata" {"abc" "DEF"}}
-             (service-description {:defaults {"health-check-url" "/ping"}
+             (service-description {:profile->defaults {"" {"health-check-url" "/ping"}}
                                    :service-description-template {"cmd" "token-cmd"
                                                                   "metadata" {"Abc" "DEF"}}}
                                   :waiter-headers {"x-waiter-token" "value-does-not-matter"}))))
@@ -1340,8 +1341,8 @@
               "health-check-url" "/health"
               "run-as-user" "current-request-user"
               "metric-group" "token-mg"}
-             (service-description {:defaults {"health-check-url" "/health"}
-                                   :headers {"cmd" "on-the-fly-cmd"}
+             (service-description {:headers {"cmd" "on-the-fly-cmd"}
+                                   :profile->defaults {"" {"health-check-url" "/health"}}
                                    :service-description-template {"metric-group" "token-mg"}}))))
 
     (testing "metric group from on-the-fly"
@@ -1349,18 +1350,18 @@
               "health-check-url" "/health"
               "run-as-user" "current-request-user"
               "metric-group" "on-the-fly-mg"}
-             (service-description {:defaults {"health-check-url" "/health"}
-                                   :headers {"cmd" "on-the-fly-cmd"
-                                             "metric-group" "on-the-fly-mg"}}))))
+             (service-description {:headers {"cmd" "on-the-fly-cmd"
+                                             "metric-group" "on-the-fly-mg"}
+                                   :profile->defaults {"" {"health-check-url" "/health"}}}))))
 
     (testing "metric group intersecting"
       (is (= {"cmd" "on-the-fly-cmd"
               "health-check-url" "/health"
               "run-as-user" "current-request-user"
               "metric-group" "on-the-fly-mg"}
-             (service-description {:defaults {"health-check-url" "/health"}
-                                   :headers {"cmd" "on-the-fly-cmd"
+             (service-description {:headers {"cmd" "on-the-fly-cmd"
                                              "metric-group" "on-the-fly-mg"}
+                                   :profile->defaults {"" {"health-check-url" "/health"}}
                                    :service-description-template {"metric-group" "token-mg"}}))))
 
     (testing "auto-populate run-as-user"
@@ -1369,7 +1370,7 @@
               "run-as-user" "current-request-user"
               "permitted-user" "current-request-user"
               "metric-group" "token-mg"}
-             (service-description {:defaults {"health-check-url" "/health"}
+             (service-description {:profile->defaults {"" {"health-check-url" "/health"}}
                                    :service-description-template {"cmd" "some-cmd"
                                                                   "metric-group" "token-mg"}}
                                   :assoc-run-as-user-approved? (constantly true)))))
@@ -1378,9 +1379,52 @@
       (is (= {"cmd" "some-cmd"
               "health-check-url" "/health"
               "instance-expiry-mins" 0}
-             (service-description {:defaults {"health-check-url" "/health"}
+             (service-description {:profile->defaults {"" {"health-check-url" "/health"}}
                                    :service-description-template {"cmd" "some-cmd"
-                                                                  "instance-expiry-mins" 0}}))))))
+                                                                  "instance-expiry-mins" 0}}))))
+
+    (testing "profile parameter"
+      (let [profile->defaults {"" {"cmd" "default-cmd"
+                                   "health-check-url" "/ping"}
+                               "webapp" {"cmd" "web-cmd"
+                                         "health-check-url" "/status"}}]
+        (testing "from token"
+          (is (= {"cmd" "web-cmd"
+                  "health-check-url" "/status"
+                  "profile" "webapp"}
+                 (service-description {:headers {}
+                                       :profile->defaults profile->defaults
+                                       :service-description-template {"profile" "webapp"}})))
+          (is (= {"cmd" "token-cmd"
+                  "health-check-url" "/status"
+                  "profile" "webapp"}
+                 (service-description {:headers {}
+                                       :profile->defaults profile->defaults
+                                       :service-description-template {"cmd" "token-cmd"
+                                                                      "profile" "webapp"}})))
+          (is (= {"cmd" "on-the-fly-cmd"
+                  "health-check-url" "/status"
+                  "profile" "webapp"
+                  "run-as-user" "current-request-user"}
+                 (service-description {:headers {"cmd" "on-the-fly-cmd"}
+                                       :profile->defaults profile->defaults
+                                       :service-description-template {"cmd" "token-cmd"
+                                                                      "profile" "webapp"}}))))
+
+        (testing "from on-the-fly"
+          (is (= {"cmd" "web-cmd"
+                  "health-check-url" "/status"
+                  "profile" "webapp"
+                  "run-as-user" "current-request-user"}
+                 (service-description {:headers {"profile" "webapp"}
+                                       :profile->defaults profile->defaults})))
+          (is (= {"cmd" "on-the-fly-cmd"
+                  "health-check-url" "/status"
+                  "profile" "webapp"
+                  "run-as-user" "current-request-user"}
+                 (service-description {:headers {"cmd" "on-the-fly-cmd"
+                                                 "profile" "webapp"}
+                                       :profile->defaults profile->defaults}))))))))
 
 (deftest test-compute-service-description-error-scenarios
   (let [kv-store (kv/->LocalKeyValueStore (atom {}))
@@ -1393,37 +1437,37 @@
         assoc-run-as-user-approved? (constantly false)
         service-description-builder (create-default-service-description-builder {})
         run-compute-service-description
-        (fn run-compute-service-description [descriptor]
+        (fn run-compute-service-description [sources]
           (let [result-descriptor
                 (compute-service-description
-                  descriptor waiter-headers passthrough-headers component->previous-descriptor-fns kv-store service-id-prefix
+                  sources waiter-headers passthrough-headers component->previous-descriptor-fns kv-store service-id-prefix
                   test-user metric-group-mappings assoc-run-as-user-approved? service-description-builder)
                 result-errors (validate-service-description kv-store service-description-builder result-descriptor)]
             (when result-errors
               (throw result-errors))
             result-descriptor))]
     (is (thrown? Exception
-                 (run-compute-service-description {:defaults {"health-check-url" "/ping"}
-                                                   :headers {}
+                 (run-compute-service-description {:headers {}
+                                                   :profile->defaults {"" {"health-check-url" "/ping"}}
                                                    :service-description-template {"cmd" "test command"
                                                                                   "cpus" "one"
                                                                                   "mem" 200
                                                                                   "version" "a1b2c3"
                                                                                   "run-as-user" test-user}})))
     (is (thrown? Exception
-                 (run-compute-service-description {:defaults {"health-check-url" 1}
-                                                   :headers {}
+                 (run-compute-service-description {:headers {}
+                                                   :profile->defaults {"" {"health-check-url" 1}}
                                                    :service-description-template {"cmd" "test command"
                                                                                   "cpus" 1
                                                                                   "mem" 200
                                                                                   "version" "a1b2c3"
                                                                                   "run-as-user" test-user}})))
     (is (thrown? Exception
-                 (run-compute-service-description {:defaults {"health-check-url" 1}
-                                                   :headers {}
+                 (run-compute-service-description {:headers {}
+                                                   :profile->defaults {"" {"health-check-url" 1}}
                                                    :service-description-template {}})))
     (is (thrown? Exception
-                 (run-compute-service-description {:defaults {"health-check-url" "/health"}
+                 (run-compute-service-description {:profile->defaults {"" {"health-check-url" "/health"}}
                                                    :service-description-template {"cmd" "cmd for missing run-as-user"
                                                                                   "cpus" 1
                                                                                   "mem" 200
@@ -1431,9 +1475,9 @@
 
     (testing "invalid allowed params - reserved"
       (is (thrown? Exception
-                   (run-compute-service-description {:defaults {"health-check-url" "/ping"
-                                                                "permitted-user" "bob"}
-                                                     :headers {}
+                   (run-compute-service-description {:headers {}
+                                                     :profile->defaults {"" {"health-check-url" "/ping"
+                                                                             "permitted-user" "bob"}}
                                                      :service-description-template {"allowed-params" #{"HOME" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                                     "cmd" "token-cmd"
                                                                                     "cpus" 1
@@ -1443,9 +1487,9 @@
 
     (testing "invalid allowed params - bad naming"
       (is (thrown? Exception
-                   (run-compute-service-description {:defaults {"health-check-url" "/ping"
-                                                                "permitted-user" "bob"}
-                                                     :headers {}
+                   (run-compute-service-description {:headers {}
+                                                     :profile->defaults {"" {"health-check-url" "/ping"
+                                                                             "permitted-user" "bob"}}
                                                      :service-description-template {"allowed-params" #{"VAR.1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                                     "cmd" "token-cmd"
                                                                                     "cpus" 1
@@ -1455,9 +1499,9 @@
 
     (testing "invalid allowed params - reserved and bad naming"
       (is (thrown? Exception
-                   (run-compute-service-description {:defaults {"health-check-url" "/ping"
-                                                                "permitted-user" "bob"}
-                                                     :headers {}
+                   (run-compute-service-description {:headers {}
+                                                     :profile->defaults {"" {"health-check-url" "/ping"
+                                                                             "permitted-user" "bob"}}
                                                      :service-description-template {"allowed-params" #{"USER" "VAR.1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                                     "cmd" "token-cmd"
                                                                                     "cpus" 1
@@ -1467,11 +1511,11 @@
 
     (testing "token + disallowed param header - on-the-fly"
       (is (thrown? Exception
-                   (run-compute-service-description {:defaults {"health-check-url" "/ping"
-                                                                "permitted-user" "bob"}
-                                                     :headers {"param" {"VAR_1" "VALUE-1"
+                   (run-compute-service-description {:headers {"param" {"VAR_1" "VALUE-1"
                                                                         "ANOTHER_VAR_2" "VALUE-2"}
                                                                "version" "on-the-fly-version"}
+                                                     :profile->defaults {"" {"health-check-url" "/ping"
+                                                                             "permitted-user" "bob"}}
                                                      :service-description-template {"allowed-params" #{"VAR_1" "VAR_2" "VAR_3" "VAR_4" "VAR_5"}
                                                                                     "cmd" "token-cmd"
                                                                                     "concurrency-level" 5
@@ -1479,11 +1523,11 @@
 
     (testing "token + no allowed params - on-the-fly"
       (is (thrown? Exception
-                   (run-compute-service-description {:defaults {"health-check-url" "/ping"
-                                                                "permitted-user" "bob"}
-                                                     :headers {"param" {"VAR_1" "VALUE-1"
+                   (run-compute-service-description {:headers {"param" {"VAR_1" "VALUE-1"
                                                                         "VAR_2" "VALUE-2"}
                                                                "version" "on-the-fly-version"}
+                                                     :profile->defaults {"" {"health-check-url" "/ping"
+                                                                             "permitted-user" "bob"}}
                                                      :service-description-template {"allowed-params" #{}
                                                                                     "cmd" "token-cmd"
                                                                                     "concurrency-level" 5
@@ -1496,7 +1540,7 @@
                                       "run-as-user" test-user
                                       "version" "a1b2c3"}
             run-compute-service-description-helper (fn [service-description]
-                                                     (run-compute-service-description {:defaults {"health-check-url" "/health"}
+                                                     (run-compute-service-description {:profile->defaults {"" {"health-check-url" "/health"}}
                                                                                        :service-description-template service-description}))]
         (is (thrown? Exception (run-compute-service-description-helper (assoc core-service-description "instance-expiry-mins" -1))))
         (is (run-compute-service-description-helper (assoc core-service-description "instance-expiry-mins" 0)))
@@ -1506,6 +1550,7 @@
   (letfn [(execute-test [service-description-template header-parameters]
             (let [{:keys [service-authentication-disabled service-preauthorized]}
                   (compute-service-description-helper {:headers header-parameters
+                                                       :profile->defaults {"" {}}
                                                        :service-description-template service-description-template
                                                        :token-authentication-disabled (token-authentication-disabled? service-description-template)
                                                        :token-preauthorized (token-preauthorized? service-description-template)})]
@@ -1678,8 +1723,10 @@
 (deftest test-service-id->service-description
   (let [service-id "test-service-1"
         service-key (str "^SERVICE-ID#" service-id)
+        profile->defaults {"" {}}
         fetch-service-description (fn [kv-store]
-                                    (service-id->service-description kv-store service-id {} [] :effective? false))]
+                                    (service-id->service-description kv-store service-id profile->defaults []
+                                                                     :effective? false))]
 
     (testing "no data available"
       (let [kv-store (kv/->LocalKeyValueStore (atom {}))]
@@ -1875,7 +1922,10 @@
                            "run-as-user" "default-run-as-user"}
         constraints-schema {(s/optional-key "cmd") (s/pred #(<= (count %) 100) (symbol "limit-100"))
                             s/Str s/Any}
-        config {:allow-missing-required-fields? false}]
+        profile->defaults {"" {"name" "default-name"}
+                           "web-app" {"name" "web-app-name"}}
+        config {:allow-missing-required-fields? false
+                :profile->defaults profile->defaults}]
     (is (nil? (validate-schema valid-description constraints-schema config)))
 
     (testing (str "testing empty cmd")
@@ -1918,7 +1968,24 @@
     (testing (str "testing invalid metric-group")
       (run-validate-schema-test
         (assoc valid-description "metric-group" (str/join "" (repeat 100 "m")))
-        constraints-schema config "The metric-group must be be between 2 and 32 characters"))))
+        constraints-schema config "The metric-group must be be between 2 and 32 characters"))
+
+    (testing (str "testing invalid profile")
+      (run-validate-schema-test
+        (assoc valid-description "profile" 1234)
+        constraints-schema config (str "profile must be a non-empty string, supported profile(s) are web-app"))
+      (run-validate-schema-test
+        (assoc valid-description "profile" "web-service")
+        constraints-schema config "Unsupported profile: web-service, supported profile(s) are web-app")
+
+      (let [config {:allow-missing-required-fields? false
+                    :profile->defaults (dissoc profile->defaults "web-app")}]
+        (run-validate-schema-test
+          (assoc valid-description "profile" 1234)
+          constraints-schema config (str "profile must be a non-empty string, there are no supported profiles"))
+        (run-validate-schema-test
+          (assoc valid-description "profile" "web-service")
+          constraints-schema config "Unsupported profile: web-service, there are no supported profiles")))))
 
 (deftest test-service-description-schema
   (testing "Service description schema"


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for the `profile` parameter

## Why are we making these changes?

Adding support for the `profile` parameter to allow different defaults for different applications.

### Notes
- profiles can override the default service parameters
- user-specified profiles must be non-empty strings and supported in the Waiter config
- services which do not specify profiles are treated internally in code to have specified a profile with an empty string
