### PR TITLE
moves common arguments to service description builder fields

### DIFF
--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -258,16 +258,15 @@
   "Creates the service descriptor from the request.
    The result map contains the following elements:
    {:keys [waiter-headers passthrough-headers sources service-id service-description core-service-description suspended-state]}"
-  [service-description-defaults profile->overrides token-defaults service-id-prefix kv-store waiter-hostnames request
-   metric-group-mappings service-description-builder assoc-run-as-user-approved?]
+  [token-defaults service-id-prefix kv-store waiter-hostnames request metric-group-mappings service-description-builder
+   assoc-run-as-user-approved?]
   (let [current-request-user (get request :authorization/user)
         build-service-description-and-id-helper (sd/make-build-service-description-and-id-helper
                                                   kv-store service-id-prefix current-request-user metric-group-mappings
                                                   service-description-builder assoc-run-as-user-approved?)
         descriptor
         (-> (headers/split-headers (:headers request))
-          (sd/merge-service-description-sources
-            kv-store waiter-hostnames service-description-defaults profile->overrides token-defaults)
+          (sd/merge-service-description-sources kv-store waiter-hostnames token-defaults)
           (attach-token-fallback-source token-defaults build-service-description-and-id-helper)
           (build-service-description-and-id-helper true))]
     (when-let [throwable (sd/validate-service-description kv-store service-description-builder descriptor)]
@@ -304,15 +303,15 @@
     "Extract the service descriptor from a request.
      It also performs the necessary authorization."
     [assoc-run-as-user-approved? can-run-as? fallback-state-atom kv-store metric-group-mappings
-     search-history-length service-description-builder service-description-defaults profile->overrides
-     service-id-prefix token-defaults waiter-hostnames {:keys [request-time] :as request}]
+     search-history-length service-description-builder service-id-prefix token-defaults waiter-hostnames
+     {:keys [request-time] :as request}]
     (timers/start-stop-time!
       request->descriptor-timer
       (let [auth-user (:authorization/user request)
             service-approved? (fn service-approved? [service-id] (assoc-run-as-user-approved? request service-id))
             latest-descriptor (compute-descriptor
-                                service-description-defaults profile->overrides token-defaults service-id-prefix kv-store
-                                waiter-hostnames request metric-group-mappings service-description-builder service-approved?)
+                                token-defaults service-id-prefix kv-store waiter-hostnames request metric-group-mappings
+                                service-description-builder service-approved?)
             descriptor->previous-descriptor
             (fn descriptor->previous-descriptor-fn
               [descriptor]

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -1051,7 +1051,7 @@
                                   (and (str/starts-with? endpoint "token/")
                                        (str/ends-with? endpoint "/refresh")) {})
           validate-service-description-fn (fn validate-service-description-fn [service-description]
-                                            (sd/validate-schema service-description {s/Str s/Any} nil))
+                                            (sd/validate-schema service-description {s/Str s/Any} {} nil))
           token "test-token"
           token-root "test-token-root"
           waiter-hostname "waiter-hostname.app.example.com"


### PR DESCRIPTION
## Changes proposed in this PR

- moves common arguments to service description builder fields
  arguments include: `metric-group-mappings` `profile->overrides` `service-description-defaults`

## Why are we making these changes?

Refactoring to reduce tech-debt

