### PR TITLE
adds API endpoint to list profiles

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -67,10 +67,24 @@
 
       (testing "explicitly specifying profile parameter resolves to different service"
         (let [{:keys [profile-config service-description-defaults]} (waiter-settings waiter-url)
+              profile-list (waiter-profiles waiter-url)
               request-headers (walk/stringify-keys request-headers)
               base-service-description (service-id->service-description waiter-url service-id)]
+          (is (= (count profile-config) (count profile-list))
+              (str "Number of profiles in config and API output do not match!"
+                   {:profile-config profile-config
+                    :profile-list profile-list}))
           (doseq [[profile {:keys [service-parameters]}] profile-config]
-            (let [new-request-headers (assoc request-headers "x-waiter-profile" (name profile))
+            (let [profile-overrides (->> profile-list
+                                      (filter #(= (name profile) (:name %)))
+                                      first
+                                      :overrides)
+                  _ (is (= service-parameters profile-overrides)
+                        (str "Profile configuration and API output do not match!"
+                             {:profile profile
+                              :profile-overrides profile-overrides
+                              :service-parameters service-parameters}))
+                  new-request-headers (assoc request-headers "x-waiter-profile" (name profile))
                   new-service-id (retrieve-service-id waiter-url new-request-headers)
                   service-settings (service-settings waiter-url new-service-id
                                                      :query-params {"effective-parameters" "true"})

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -75,14 +75,14 @@
                    {:profile-config profile-config
                     :profile-list profile-list}))
           (doseq [[profile {:keys [service-parameters]}] profile-config]
-            (let [profile-overrides (->> profile-list
-                                      (filter #(= (name profile) (:name %)))
-                                      first
-                                      :overrides)
-                  _ (is (= service-parameters profile-overrides)
+            (let [profile-defaults (->> profile-list
+                                     (filter #(= (name profile) (:name %)))
+                                     first
+                                     :defaults)
+                  _ (is (= service-parameters profile-defaults)
                         (str "Profile configuration and API output do not match!"
                              {:profile profile
-                              :profile-overrides profile-overrides
+                              :profile-defaults profile-defaults
                               :service-parameters service-parameters}))
                   new-request-headers (assoc request-headers "x-waiter-profile" (name profile))
                   new-service-id (retrieve-service-id waiter-url new-request-headers)

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -102,6 +102,7 @@
                      "favicon.ico" :favicon-handler-fn
                      "metrics" :metrics-request-handler-fn
                      "service-id" :service-id-handler-fn
+                     "profiles" :profile-list-handler-fn
                      "settings" :display-settings-handler-fn
                      "sim" :sim-request-handler
                      "state" [["" :state-all-handler-fn]
@@ -1455,6 +1456,11 @@
                                      wrap-auth-bypass-fn
                                      wrap-https-redirect-fn
                                      wrap-service-discovery-fn)))
+   :profile-list-handler-fn (pc/fnk [[:state profile->overrides]
+                                     wrap-secure-request-fn]
+                              (wrap-secure-request-fn
+                                (fn profile-list-handler-fn [request]
+                                  (handler/display-profiles-handler profile->overrides request))))
    :router-metrics-handler-fn (pc/fnk [[:routines crypt-helpers]
                                        [:settings [:metrics-config metrics-sync-interval-ms]]
                                        [:state router-metrics-agent]]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -991,17 +991,16 @@
    :refresh-service-descriptions-fn (pc/fnk [[:state kv-store]]
                                       (fn refresh-service-descriptions-fn [service-ids]
                                         (sd/refresh-service-descriptions kv-store service-ids)))
-   :request->descriptor-fn (pc/fnk [[:settings [:token-config history-length token-defaults]
-                                     metric-group-mappings]
+   :request->descriptor-fn (pc/fnk [[:settings [:token-config history-length token-defaults]]
                                     [:state fallback-state-atom kv-store service-description-builder
                                      service-id-prefix waiter-hostnames]
                                     assoc-run-as-user-approved? can-run-as?-fn store-reference-fn store-source-tokens-fn]
                              (fn request->descriptor-fn [request]
                                (let [{:keys [latest-descriptor] :as result}
                                      (descriptor/request->descriptor
-                                       assoc-run-as-user-approved? can-run-as?-fn fallback-state-atom kv-store metric-group-mappings
-                                       history-length service-description-builder service-id-prefix token-defaults waiter-hostnames
-                                       request)
+                                       assoc-run-as-user-approved? can-run-as?-fn fallback-state-atom kv-store
+                                       history-length service-description-builder service-id-prefix token-defaults
+                                       waiter-hostnames request)
                                      {:keys [reference-type->entry service-id source-tokens]} latest-descriptor]
                                  (when (seq source-tokens)
                                    (store-source-tokens-fn service-id source-tokens))

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -258,11 +258,11 @@
   "Creates the service descriptor from the request.
    The result map contains the following elements:
    {:keys [waiter-headers passthrough-headers sources service-id service-description core-service-description suspended-state]}"
-  [token-defaults service-id-prefix kv-store waiter-hostnames request metric-group-mappings service-description-builder
+  [token-defaults service-id-prefix kv-store waiter-hostnames request service-description-builder
    assoc-run-as-user-approved?]
   (let [current-request-user (get request :authorization/user)
         build-service-description-and-id-helper (sd/make-build-service-description-and-id-helper
-                                                  kv-store service-id-prefix current-request-user metric-group-mappings
+                                                  kv-store service-id-prefix current-request-user
                                                   service-description-builder assoc-run-as-user-approved?)
         descriptor
         (-> (headers/split-headers (:headers request))
@@ -302,15 +302,15 @@
   (defn request->descriptor
     "Extract the service descriptor from a request.
      It also performs the necessary authorization."
-    [assoc-run-as-user-approved? can-run-as? fallback-state-atom kv-store metric-group-mappings
-     search-history-length service-description-builder service-id-prefix token-defaults waiter-hostnames
+    [assoc-run-as-user-approved? can-run-as? fallback-state-atom kv-store search-history-length
+     service-description-builder service-id-prefix token-defaults waiter-hostnames
      {:keys [request-time] :as request}]
     (timers/start-stop-time!
       request->descriptor-timer
       (let [auth-user (:authorization/user request)
             service-approved? (fn service-approved? [service-id] (assoc-run-as-user-approved? request service-id))
             latest-descriptor (compute-descriptor
-                                token-defaults service-id-prefix kv-store waiter-hostnames request metric-group-mappings
+                                token-defaults service-id-prefix kv-store waiter-hostnames request
                                 service-description-builder service-approved?)
             descriptor->previous-descriptor
             (fn descriptor->previous-descriptor-fn

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -1012,9 +1012,9 @@
   [profile->overrides request]
   (try
     (utils/clj->json-response
-      (map (fn [[profile overrides]]
-             {:name profile
-              :overrides overrides})
+      (map (fn [[profile defaults]]
+             {:defaults defaults
+              :name profile})
            (seq profile->overrides)))
     (catch Throwable th
       (utils/exception->response th request))))

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -1006,3 +1006,15 @@
           utils/clj->json-response))
     (catch Throwable th
       (utils/exception->response th request))))
+
+(defn display-profiles-handler
+  "Responds with a list of profiles"
+  [profile->overrides request]
+  (try
+    (utils/clj->json-response
+      (map (fn [[profile overrides]]
+             {:name profile
+              :overrides overrides})
+           (seq profile->overrides)))
+    (catch Throwable th
+      (utils/exception->response th request))))

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -1009,12 +1009,12 @@
 
 (defn display-profiles-handler
   "Responds with a list of profiles"
-  [profile->overrides request]
+  [profile->defaults request]
   (try
     (utils/clj->json-response
       (map (fn [[profile defaults]]
              {:defaults defaults
               :name profile})
-           (seq profile->overrides)))
+           (seq profile->defaults)))
     (catch Throwable th
       (utils/exception->response th request))))

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -1082,7 +1082,7 @@
 (defn merge-service-description-and-id
   "Populates the descriptor with the service-description and service-id."
   [{:keys [component->previous-descriptor-fns passthrough-headers sources waiter-headers] :as descriptor}
-   kv-store service-id-prefix username metric-group-mappings service-description-builder assoc-run-as-user-approved?]
+   kv-store service-id-prefix username service-description-builder assoc-run-as-user-approved?]
   (->> (compute-service-description
          sources waiter-headers passthrough-headers component->previous-descriptor-fns kv-store service-id-prefix
          username assoc-run-as-user-approved? service-description-builder)
@@ -1090,7 +1090,7 @@
 
 (defn make-build-service-description-and-id-helper
   "Factory function to return the function used to complete creating a descriptor using the builder."
-  [kv-store service-id-prefix current-request-user metric-group-mappings service-description-builder
+  [kv-store service-id-prefix current-request-user service-description-builder
    assoc-run-as-user-approved?]
   (fn build-service-description-and-id-helper
     ;; If there is an error in attaching the service description or id and throw-exception? is false,
@@ -1098,7 +1098,7 @@
     [descriptor throw-exception?]
     (try
       (-> descriptor
-        (merge-service-description-and-id kv-store service-id-prefix current-request-user metric-group-mappings
+        (merge-service-description-and-id kv-store service-id-prefix current-request-user
                                           service-description-builder assoc-run-as-user-approved?)
         (merge-suspended kv-store))
       (catch Throwable ex

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -534,6 +534,11 @@
 (defn retrieve-kitchen-service-id [waiter-url waiter-headers & options]
   (pc/mapply retrieve-service-id waiter-url (merge (kitchen-request-headers) waiter-headers) options))
 
+(defn waiter-profiles [waiter-url & {:keys [cookies] :or {cookies []}}]
+  (let [profiles-result (make-request waiter-url "/profiles" :verbose true :cookies cookies)
+        profiles-json (try-parse-json (:body profiles-result))]
+    (walk/keywordize-keys profiles-json)))
+
 (defn waiter-settings [waiter-url & {:keys [cookies] :or {cookies []}}]
   (let [settings-result (make-request waiter-url "/settings" :verbose true :cookies cookies)
         settings-json (try-parse-json (:body settings-result))]

--- a/waiter/test/waiter/descriptor_test.clj
+++ b/waiter/test/waiter/descriptor_test.clj
@@ -240,7 +240,7 @@
         run-request->descriptor
         (fn run-request->descriptor
           [request &
-           {:keys [assoc-run-as-user-approved? can-run-as? fallback-state-atom kv-store metric-group-mappings profile->overrides
+           {:keys [assoc-run-as-user-approved? can-run-as? fallback-state-atom kv-store metric-group-mappings profile->defaults
                    search-history-length service-description-builder service-description-defaults service-id-prefix token-defaults
                    waiter-hostnames]
             :or {assoc-run-as-user-approved? (fn [_ _] false)
@@ -248,7 +248,7 @@
                  fallback-state-atom (atom {})
                  kv-store (kv/->LocalKeyValueStore (atom {}))
                  metric-group-mappings []
-                 profile->overrides {}
+                 profile->defaults {}
                  search-history-length default-search-history-length
                  service-description-defaults {}
                  service-id-prefix "service-prefix-"
@@ -257,7 +257,7 @@
           (let [service-description-builder (or service-description-builder
                                                 (sd/create-default-service-description-builder
                                                   {:metric-group-mappings metric-group-mappings
-                                                   :profile->overrides profile->overrides
+                                                   :profile->defaults profile->defaults
                                                    :service-description-defaults service-description-defaults}))]
             (request->descriptor
               assoc-run-as-user-approved? can-run-as? fallback-state-atom kv-store metric-group-mappings
@@ -474,12 +474,12 @@
       token-defaults {"fallback-period-secs" 300}
       username "test-user"
       metric-group-mappings []
-      profile->overrides {"webapp" {"concurrency-level" 120}}
+      profile->defaults {"webapp" {"concurrency-level" 120}}
       service-description-defaults {"metric-group" "other" "permitted-user" "*"}
       constraints {"cpus" {:max 100} "mem" {:max 1024}}
       builder (sd/create-default-service-description-builder {:constraints constraints
                                                               :metric-group-mappings metric-group-mappings
-                                                              :profile->overrides profile->overrides
+                                                              :profile->defaults profile->defaults
                                                               :service-description-defaults service-description-defaults})
       assoc-run-as-user-approved? (constantly false)
       build-service-description-and-id-helper (sd/make-build-service-description-and-id-helper
@@ -717,7 +717,7 @@
               :reference-type->entry {:token {:sources [(reference-tokens-entry test-token token-data-1)]}}
               :service-authentication-disabled false
               :service-description (merge service-description-defaults
-                                          (get profile->overrides "webapp")
+                                          (get profile->defaults "webapp")
                                           service-description-1)
               :service-id (sd/service-description->service-id service-id-prefix service-description-1)
               :service-preauthorized false

--- a/waiter/test/waiter/descriptor_test.clj
+++ b/waiter/test/waiter/descriptor_test.clj
@@ -260,9 +260,8 @@
                                                    :profile->defaults profile->defaults
                                                    :service-description-defaults service-description-defaults}))]
             (request->descriptor
-              assoc-run-as-user-approved? can-run-as? fallback-state-atom kv-store metric-group-mappings
-              search-history-length service-description-builder service-id-prefix token-defaults waiter-hostnames
-              request)))]
+              assoc-run-as-user-approved? can-run-as? fallback-state-atom kv-store search-history-length
+              service-description-builder service-id-prefix token-defaults waiter-hostnames request)))]
 
     (testing "missing user in request"
       (let [request {}
@@ -483,8 +482,7 @@
                                                               :service-description-defaults service-description-defaults})
       assoc-run-as-user-approved? (constantly false)
       build-service-description-and-id-helper (sd/make-build-service-description-and-id-helper
-                                                kv-store service-id-prefix username metric-group-mappings builder
-                                                assoc-run-as-user-approved?)]
+                                                kv-store service-id-prefix username builder assoc-run-as-user-approved?)]
 
   (deftest test-descriptor->previous-descriptor-no-token
     (let [sources {:headers {}


### PR DESCRIPTION
## Changes proposed in this PR

- adds API endpoint to list profiles

## Why are we making these changes?

Makes it easier to view the list of supported profiles per waiter cluster

<img width="322" alt="Screen Shot 2020-04-15 at 2 40 42 AM" src="https://user-images.githubusercontent.com/6611249/79311076-82b6e180-7ec2-11ea-94dc-963f90df7bbe.png">

