### PR TITLE
allows specifying components to include in scheduler state

### DIFF
--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -15,7 +15,10 @@
     (when (using-k8s? waiter-url)
       (let [cookies (all-cookies waiter-url)
             router-url (-> waiter-url routers first val)
-            {:keys [body] :as response} (make-request router-url "/state/scheduler" :method :get :cookies cookies)
+            {:keys [body] :as response} (make-request router-url "/state/scheduler"
+                                                      :cookies cookies
+                                                      :method :get
+                                                      :query-params {"include" ["components" "watch-state"]})
             _ (assert-response-status response 200)
             body-json (-> body str try-parse-json)
             watch-state-json (get-watch-state body-json)
@@ -28,7 +31,10 @@
                                    #(make-kitchen-request waiter-url % :path "/hello"))]
         (with-service-cleanup
           service-id
-          (let [{:keys [body] :as response} (make-request router-url "/state/scheduler" :method :get :cookies cookies)
+          (let [{:keys [body] :as response} (make-request router-url "/state/scheduler"
+                                                          :cookies cookies
+                                                          :method :get
+                                                          :query-params {"include" ["components" "watch-state"]})
                 _ (assert-response-status response 200)
                 body-json (-> body str try-parse-json)
                 watch-state-json (get-watch-state body-json)
@@ -176,7 +182,10 @@
                       error)))
     (with-service-cleanup
       service-id
-      (let [{:keys [body] :as response} (make-request router-url "/state/scheduler" :method :get :cookies cookies)
+      (let [{:keys [body] :as response} (make-request router-url "/state/scheduler"
+                                                      :cookies cookies
+                                                      :method :get
+                                                      :query-params {"include" ["components" "watch-state"]})
             _ (assert-response-status response 200)
             body-json (-> body str try-parse-json)
             watch-state-json (get-watch-state body-json)

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -764,7 +764,9 @@
 (defn get-scheduler-state
   "Outputs the scheduler state."
   [router-id scheduler request]
-  (get-function-state #(scheduler/state scheduler) router-id request))
+  (let [{:strs [include]} (-> request ru/query-params-request :query-params)
+        include-flags (if (string? include) #{include} (set include))]
+    (get-function-state #(scheduler/state scheduler include-flags) router-id request)))
 
 (defn get-statsd-state
   "Outputs the statsd state."

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -118,7 +118,7 @@
   (service-id->state [this ^String service-id]
     "Retrieves the state the scheduler is maintaining for the given service-id.")
 
-  (state [this]
+  (state [this include-flags]
     "Returns the global (i.e. non-service-specific) state the scheduler is maintaining")
 
   (validate-service [this ^String service-id]

--- a/waiter/src/waiter/scheduler/composite.clj
+++ b/waiter/src/waiter/scheduler/composite.clj
@@ -101,7 +101,7 @@
 
   (state [_ include-flags]
     (cond-> {:supported-include-params ["aggregator" "components"]
-             :type "CompositeScheduler"}
+             :type "Composite"}
       (contains? include-flags "aggregator")
       (assoc :aggregator (query-aggregator-state-fn))
       (contains? include-flags "components")

--- a/waiter/src/waiter/scheduler/composite.clj
+++ b/waiter/src/waiter/scheduler/composite.clj
@@ -99,9 +99,13 @@
         service-id->scheduler
         (scheduler/service-id->state service-id)))
 
-  (state [_]
-    {:aggregator (query-aggregator-state-fn)
-     :components (pc/map-vals scheduler/state scheduler-id->scheduler)})
+  (state [_ include-flags]
+    (cond-> {:supported-include-params ["aggregator" "components"]
+             :type "CompositeScheduler"}
+      (contains? include-flags "aggregator")
+      (assoc :aggregator (query-aggregator-state-fn))
+      (contains? include-flags "components")
+      (assoc :components (pc/map-vals #(scheduler/state % include-flags) scheduler-id->scheduler))))
 
   (validate-service [_ service-id]
     (-> service-id

--- a/waiter/src/waiter/scheduler/composite.clj
+++ b/waiter/src/waiter/scheduler/composite.clj
@@ -101,7 +101,7 @@
 
   (state [_ include-flags]
     (cond-> {:supported-include-params ["aggregator" "components"]
-             :type "Composite"}
+             :type "CompositeScheduler"}
       (contains? include-flags "aggregator")
       (assoc :aggregator (query-aggregator-state-fn))
       (contains? include-flags "components")

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -492,7 +492,7 @@
 
   (state [_ include-flags]
     (cond-> {:supported-include-params ["authorizer" "failed-instances" "syncer"]
-             :type "CookScheduler"}
+             :type "Cook"}
       (and authorizer (contains? include-flags "authorizer"))
       (assoc :authorizer (authz/state authorizer))
       (contains? include-flags "failed-instances")

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -491,12 +491,12 @@
      :syncer (retrieve-syncer-state-fn service-id)})
 
   (state [_ include-flags]
-    (cond-> {:supported-include-params ["authorizer" "failed-instances" "syncer"]
+    (cond-> {:supported-include-params ["authorizer" "service-id->failed-instances" "syncer"]
              :type "Cook"}
       (and authorizer (contains? include-flags "authorizer"))
       (assoc :authorizer (authz/state authorizer))
-      (contains? include-flags "failed-instances")
-      (assoc :service-id->failed-instances-transient-store @service-id->failed-instances-transient-store)
+      (contains? include-flags "service-id->failed-instances")
+      (assoc :service-id->failed-instances @service-id->failed-instances-transient-store)
       (contains? include-flags "syncer")
       (assoc :syncer (retrieve-syncer-state-fn))))
 

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -492,7 +492,7 @@
 
   (state [_ include-flags]
     (cond-> {:supported-include-params ["authorizer" "service-id->failed-instances" "syncer"]
-             :type "Cook"}
+             :type "CookScheduler"}
       (and authorizer (contains? include-flags "authorizer"))
       (assoc :authorizer (authz/state authorizer))
       (contains? include-flags "service-id->failed-instances")

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -490,10 +490,15 @@
     {:failed-instances (service-id->failed-instances service-id->failed-instances-transient-store service-id)
      :syncer (retrieve-syncer-state-fn service-id)})
 
-  (state [_]
-    {:authorizer (when authorizer (authz/state authorizer))
-     :service-id->failed-instances-transient-store @service-id->failed-instances-transient-store
-     :syncer (retrieve-syncer-state-fn)})
+  (state [_ include-flags]
+    (cond-> {:supported-include-params ["authorizer" "failed-instances" "syncer"]
+             :type "CookScheduler"}
+      (and authorizer (contains? include-flags "authorizer"))
+      (assoc :authorizer (authz/state authorizer))
+      (contains? include-flags "failed-instances")
+      (assoc :service-id->failed-instances-transient-store @service-id->failed-instances-transient-store)
+      (contains? include-flags "syncer")
+      (assoc :syncer (retrieve-syncer-state-fn))))
 
   (validate-service [_ service-id]
     (let [{:strs [run-as-user image]} (service-id->service-description-fn service-id)]

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -740,7 +740,7 @@
 
   (state [_ include-flags]
     (cond-> {:supported-include-params ["auth-token-renewer" "authorizer" "failed-instances" "syncer" "watch-state"]
-             :type "KubernetesScheduler"}
+             :type "Kubernetes"}
       (contains? include-flags "auth-token-renewer")
       (assoc :auth-token-renewer (retrieve-auth-token-state-fn))
       (and authorizer (contains? include-flags "authorizer"))

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -739,13 +739,14 @@
      :syncer (retrieve-syncer-state-fn service-id)})
 
   (state [_ include-flags]
-    (cond-> {:supported-include-params ["auth-token-renewer" "authorizer" "failed-instances" "syncer" "watch-state"]
+    (cond-> {:supported-include-params ["auth-token-renewer" "authorizer" "service-id->failed-instances"
+                                        "syncer" "watch-state"]
              :type "Kubernetes"}
       (contains? include-flags "auth-token-renewer")
       (assoc :auth-token-renewer (retrieve-auth-token-state-fn))
       (and authorizer (contains? include-flags "authorizer"))
       (assoc :authorizer (authz/state authorizer))
-      (contains? include-flags "failed-instances")
+      (contains? include-flags "service-id->failed-instances")
       (assoc :service-id->failed-instances @service-id->failed-instances-transient-store)
       (contains? include-flags "syncer")
       (assoc :syncer (retrieve-syncer-state-fn))

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -741,7 +741,7 @@
   (state [_ include-flags]
     (cond-> {:supported-include-params ["auth-token-renewer" "authorizer" "service-id->failed-instances"
                                         "syncer" "watch-state"]
-             :type "Kubernetes"}
+             :type "KubernetesScheduler"}
       (contains? include-flags "auth-token-renewer")
       (assoc :auth-token-renewer (retrieve-auth-token-state-fn))
       (and authorizer (contains? include-flags "authorizer"))

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -738,12 +738,19 @@
     {:failed-instances (vals (get @service-id->failed-instances-transient-store service-id))
      :syncer (retrieve-syncer-state-fn service-id)})
 
-  (state [_]
-    {:auth-token-renewer (retrieve-auth-token-state-fn)
-     :authorizer (when authorizer (authz/state authorizer))
-     :service-id->failed-instances @service-id->failed-instances-transient-store
-     :syncer (retrieve-syncer-state-fn)
-     :watch-state @watch-state})
+  (state [_ include-flags]
+    (cond-> {:supported-include-params ["auth-token-renewer" "authorizer" "failed-instances" "syncer" "watch-state"]
+             :type "KubernetesScheduler"}
+      (contains? include-flags "auth-token-renewer")
+      (assoc :auth-token-renewer (retrieve-auth-token-state-fn))
+      (and authorizer (contains? include-flags "authorizer"))
+      (assoc :authorizer (authz/state authorizer))
+      (contains? include-flags "failed-instances")
+      (assoc :service-id->failed-instances @service-id->failed-instances-transient-store)
+      (contains? include-flags "syncer")
+      (assoc :syncer (retrieve-syncer-state-fn))
+      (contains? include-flags "watch-state")
+      (assoc :watch-state @watch-state)))
 
   (validate-service [this service-id]
     (let [{:strs [run-as-user]} (retrieve-service-description this service-id)]

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -463,7 +463,7 @@
   (state [_ include-flags]
     (cond-> {:supported-include-params ["authorizer" "service-id->failed-instances" "service-id->kill-info"
                                         "service-id->out-of-sync-state" "syncer"]
-             :type "Marathon"}
+             :type "MarathonScheduler"}
       (and authorizer (contains? include-flags "authorizer"))
       (assoc :authorizer (authz/state authorizer))
       (contains? include-flags "service-id->failed-instances")

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -460,12 +460,19 @@
      :out-of-sync-state (get @service-id->out-of-sync-state-store service-id)
      :syncer (retrieve-syncer-state-fn service-id)})
 
-  (state [_]
-    {:authorizer (when authorizer (authz/state authorizer))
-     :service-id->failed-instances-transient-store @service-id->failed-instances-transient-store
-     :service-id->kill-info-store @service-id->kill-info-store
-     :service-id->out-of-sync-state-store @service-id->out-of-sync-state-store
-     :syncer (retrieve-syncer-state-fn)})
+  (state [_ include-flags]
+    (cond-> {:supported-include-params ["authorizer" "failed-instances" "killed-instances" "out-of-sync" "syncer"]
+             :type "MarathonScheduler"}
+      (and authorizer (contains? include-flags "authorizer"))
+      (assoc :authorizer (authz/state authorizer))
+      (contains? include-flags "failed-instances")
+      (assoc :service-id->failed-instances-transient-store @service-id->failed-instances-transient-store)
+      (contains? include-flags "killed-instances")
+      (assoc :service-id->kill-info-store @service-id->kill-info-store)
+      (contains? include-flags "out-of-sync")
+      (assoc :service-id->out-of-sync-state-store @service-id->out-of-sync-state-store)
+      (contains? include-flags "syncer")
+      (assoc :syncer (retrieve-syncer-state-fn))))
 
   (validate-service [_ service-id]
     (let [{:strs [run-as-user]} (service-id->service-description-fn service-id)]

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -461,16 +461,17 @@
      :syncer (retrieve-syncer-state-fn service-id)})
 
   (state [_ include-flags]
-    (cond-> {:supported-include-params ["authorizer" "failed-instances" "killed-instances" "out-of-sync" "syncer"]
+    (cond-> {:supported-include-params ["authorizer" "service-id->failed-instances" "service-id->kill-info"
+                                        "service-id->out-of-sync-state" "syncer"]
              :type "Marathon"}
       (and authorizer (contains? include-flags "authorizer"))
       (assoc :authorizer (authz/state authorizer))
-      (contains? include-flags "failed-instances")
-      (assoc :service-id->failed-instances-transient-store @service-id->failed-instances-transient-store)
-      (contains? include-flags "killed-instances")
-      (assoc :service-id->kill-info-store @service-id->kill-info-store)
-      (contains? include-flags "out-of-sync")
-      (assoc :service-id->out-of-sync-state-store @service-id->out-of-sync-state-store)
+      (contains? include-flags "service-id->failed-instances")
+      (assoc :service-id->failed-instances @service-id->failed-instances-transient-store)
+      (contains? include-flags "service-id->kill-info")
+      (assoc :service-id->kill-info @service-id->kill-info-store)
+      (contains? include-flags "service-id->out-of-sync-state")
+      (assoc :service-id->out-of-sync-state @service-id->out-of-sync-state-store)
       (contains? include-flags "syncer")
       (assoc :syncer (retrieve-syncer-state-fn))))
 

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -462,7 +462,7 @@
 
   (state [_ include-flags]
     (cond-> {:supported-include-params ["authorizer" "failed-instances" "killed-instances" "out-of-sync" "syncer"]
-             :type "MarathonScheduler"}
+             :type "Marathon"}
       (and authorizer (contains? include-flags "authorizer"))
       (assoc :authorizer (authz/state authorizer))
       (contains? include-flags "failed-instances")

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -687,12 +687,12 @@
       :syncer (retrieve-syncer-state-fn service-id)))
 
   (state [_ include-flags]
-    (cond-> {:supported-include-params ["port-reservation" "services" "syncer"]
+    (cond-> {:supported-include-params ["id->service" "port->reservation" "syncer"]
              :type "Shell"}
-      (contains? include-flags "port-reservation")
-      (assoc :port->reservation @port->reservation-atom)
-      (contains? include-flags "services")
+      (contains? include-flags "id->service")
       (assoc :id->service @id->service-agent)
+      (contains? include-flags "port->reservation")
+      (assoc :port->reservation @port->reservation-atom)
       (contains? include-flags "syncer")
       (assoc :syncer (retrieve-syncer-state-fn))))
 

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -686,10 +686,15 @@
     (assoc (get @id->service-agent service-id)
       :syncer (retrieve-syncer-state-fn service-id)))
 
-  (state [_]
-    {:id->service @id->service-agent
-     :port->reservation @port->reservation-atom
-     :syncer (retrieve-syncer-state-fn)})
+  (state [_ include-flags]
+    (cond-> {:supported-include-params ["port-reservation" "services" "syncer"]
+             :type "ShellScheduler"}
+      (contains? include-flags "port-reservation")
+      (assoc :port->reservation @port->reservation-atom)
+      (contains? include-flags "services")
+      (assoc :id->service @id->service-agent)
+      (contains? include-flags "syncer")
+      (assoc :syncer (retrieve-syncer-state-fn))))
 
   (validate-service [_ service-id]
     (let [{:strs [image]} (service-id->service-description-fn service-id)]

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -688,7 +688,7 @@
 
   (state [_ include-flags]
     (cond-> {:supported-include-params ["id->service" "port->reservation" "syncer"]
-             :type "Shell"}
+             :type "ShellScheduler"}
       (contains? include-flags "id->service")
       (assoc :id->service @id->service-agent)
       (contains? include-flags "port->reservation")

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -688,7 +688,7 @@
 
   (state [_ include-flags]
     (cond-> {:supported-include-params ["port-reservation" "services" "syncer"]
-             :type "ShellScheduler"}
+             :type "Shell"}
       (contains? include-flags "port-reservation")
       (assoc :port->reservation @port->reservation-atom)
       (contains? include-flags "services")

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -1008,11 +1008,11 @@
 (deftest test-get-scheduler-state
   (let [router-id "test-router-id"
         scheduler (reify scheduler/ServiceScheduler
-                    (state [_]
+                    (state [_ _]
                       {:scheduler "state"}))
         test-fn (wrap-handler-json-response get-scheduler-state)]
     (testing "successful response"
-      (let [state (walk/stringify-keys (scheduler/state scheduler))
+      (let [state (walk/stringify-keys (scheduler/state scheduler #{}))
             {:keys [body status]} (test-fn router-id scheduler {})]
         (is (= 200 status))
         (is (= (json/read-str body) {"router-id" router-id, "state" state}))))))

--- a/waiter/test/waiter/scheduler/composite_test.clj
+++ b/waiter/test/waiter/scheduler/composite_test.clj
@@ -365,7 +365,7 @@
                   :components {"ipsum" {:operation :scheduler-state :scheduler-name "ipsum"}
                                "lorem" {:operation :scheduler-state :scheduler-name "lorem"}}
                   :supported-include-params ["aggregator" "components"]
-                  :type "CompositeScheduler"}
+                  :type "Composite"}
                  (scheduler/state composite-scheduler #{"aggregator" "components"}))))))
 
     (async/close! component-channel)

--- a/waiter/test/waiter/scheduler/composite_test.clj
+++ b/waiter/test/waiter/scheduler/composite_test.clj
@@ -365,7 +365,7 @@
                   :components {"ipsum" {:operation :scheduler-state :scheduler-name "ipsum"}
                                "lorem" {:operation :scheduler-state :scheduler-name "lorem"}}
                   :supported-include-params ["aggregator" "components"]
-                  :type "Composite"}
+                  :type "CompositeScheduler"}
                  (scheduler/state composite-scheduler #{"aggregator" "components"}))))))
 
     (async/close! component-channel)

--- a/waiter/test/waiter/scheduler/composite_test.clj
+++ b/waiter/test/waiter/scheduler/composite_test.clj
@@ -80,7 +80,7 @@
   (service-id->state [_ service-id]
     {:identifier service-id :operation :service-state :scheduler-name scheduler-name})
 
-  (state [_]
+  (state [_ _]
     {:operation :scheduler-state :scheduler-name scheduler-name}))
 
 (deftest test-service-id->scheduler
@@ -363,8 +363,10 @@
                                :scheduler-id->sync-time {}
                                :scheduler-id->type->messages {}}
                   :components {"ipsum" {:operation :scheduler-state :scheduler-name "ipsum"}
-                               "lorem" {:operation :scheduler-state :scheduler-name "lorem"}}}
-                 (scheduler/state composite-scheduler))))))
+                               "lorem" {:operation :scheduler-state :scheduler-name "lorem"}}
+                  :supported-include-params ["aggregator" "components"]
+                  :type "CompositeScheduler"}
+                 (scheduler/state composite-scheduler #{"aggregator" "components"}))))))
 
     (async/close! component-channel)
     (async/close! scheduler-state-chan)))

--- a/waiter/test/waiter/scheduler/cook_test.clj
+++ b/waiter/test/waiter/scheduler/cook_test.clj
@@ -862,20 +862,20 @@
     (is (= {:failed-instances [:failed-instances]
             :syncer {:last-update-time :time}}
            (scheduler/service-id->state cook-scheduler service-id)))
-    (is (= {:supported-include-params ["authorizer" "failed-instances" "syncer"]
+    (is (= {:supported-include-params ["authorizer" "service-id->failed-instances" "syncer"]
             :type "Cook"}
            (scheduler/state cook-scheduler #{})))
-    (is (= {:supported-include-params ["authorizer" "failed-instances" "syncer"]
+    (is (= {:supported-include-params ["authorizer" "service-id->failed-instances" "syncer"]
             :syncer {:last-update-time :time
                      :service-id->health-check-context {}}
             :type "Cook"}
            (scheduler/state cook-scheduler #{"syncer"})))
-    (is (= {:service-id->failed-instances-transient-store {"service-id" [:failed-instances]}
-            :supported-include-params ["authorizer" "failed-instances" "syncer"]
+    (is (= {:service-id->failed-instances {"service-id" [:failed-instances]}
+            :supported-include-params ["authorizer" "service-id->failed-instances" "syncer"]
             :syncer {:last-update-time :time
                      :service-id->health-check-context {}}
             :type "Cook"}
-           (scheduler/state cook-scheduler #{"authorizer" "failed-instances" "syncer"})))))
+           (scheduler/state cook-scheduler #{"authorizer" "service-id->failed-instances" "syncer"})))))
 
 (deftest test-cook-scheduler
   (testing "Creating a CookScheduler"

--- a/waiter/test/waiter/scheduler/cook_test.clj
+++ b/waiter/test/waiter/scheduler/cook_test.clj
@@ -863,18 +863,18 @@
             :syncer {:last-update-time :time}}
            (scheduler/service-id->state cook-scheduler service-id)))
     (is (= {:supported-include-params ["authorizer" "service-id->failed-instances" "syncer"]
-            :type "Cook"}
+            :type "CookScheduler"}
            (scheduler/state cook-scheduler #{})))
     (is (= {:supported-include-params ["authorizer" "service-id->failed-instances" "syncer"]
             :syncer {:last-update-time :time
                      :service-id->health-check-context {}}
-            :type "Cook"}
+            :type "CookScheduler"}
            (scheduler/state cook-scheduler #{"syncer"})))
     (is (= {:service-id->failed-instances {"service-id" [:failed-instances]}
             :supported-include-params ["authorizer" "service-id->failed-instances" "syncer"]
             :syncer {:last-update-time :time
                      :service-id->health-check-context {}}
-            :type "Cook"}
+            :type "CookScheduler"}
            (scheduler/state cook-scheduler #{"authorizer" "service-id->failed-instances" "syncer"})))))
 
 (deftest test-cook-scheduler

--- a/waiter/test/waiter/scheduler/cook_test.clj
+++ b/waiter/test/waiter/scheduler/cook_test.clj
@@ -863,18 +863,18 @@
             :syncer {:last-update-time :time}}
            (scheduler/service-id->state cook-scheduler service-id)))
     (is (= {:supported-include-params ["authorizer" "failed-instances" "syncer"]
-            :type "CookScheduler"}
+            :type "Cook"}
            (scheduler/state cook-scheduler #{})))
     (is (= {:supported-include-params ["authorizer" "failed-instances" "syncer"]
             :syncer {:last-update-time :time
                      :service-id->health-check-context {}}
-            :type "CookScheduler"}
+            :type "Cook"}
            (scheduler/state cook-scheduler #{"syncer"})))
     (is (= {:service-id->failed-instances-transient-store {"service-id" [:failed-instances]}
             :supported-include-params ["authorizer" "failed-instances" "syncer"]
             :syncer {:last-update-time :time
                      :service-id->health-check-context {}}
-            :type "CookScheduler"}
+            :type "Cook"}
            (scheduler/state cook-scheduler #{"authorizer" "failed-instances" "syncer"})))))
 
 (deftest test-cook-scheduler

--- a/waiter/test/waiter/scheduler/cook_test.clj
+++ b/waiter/test/waiter/scheduler/cook_test.clj
@@ -862,11 +862,20 @@
     (is (= {:failed-instances [:failed-instances]
             :syncer {:last-update-time :time}}
            (scheduler/service-id->state cook-scheduler service-id)))
-    (is (= {:authorizer nil
-            :service-id->failed-instances-transient-store {"service-id" [:failed-instances]}
+    (is (= {:supported-include-params ["authorizer" "failed-instances" "syncer"]
+            :type "CookScheduler"}
+           (scheduler/state cook-scheduler #{})))
+    (is (= {:supported-include-params ["authorizer" "failed-instances" "syncer"]
             :syncer {:last-update-time :time
-                     :service-id->health-check-context {}}}
-           (scheduler/state cook-scheduler)))))
+                     :service-id->health-check-context {}}
+            :type "CookScheduler"}
+           (scheduler/state cook-scheduler #{"syncer"})))
+    (is (= {:service-id->failed-instances-transient-store {"service-id" [:failed-instances]}
+            :supported-include-params ["authorizer" "failed-instances" "syncer"]
+            :syncer {:last-update-time :time
+                     :service-id->health-check-context {}}
+            :type "CookScheduler"}
+           (scheduler/state cook-scheduler #{"authorizer" "failed-instances" "syncer"})))))
 
 (deftest test-cook-scheduler
   (testing "Creating a CookScheduler"


### PR DESCRIPTION
## Changes proposed in this PR

- allows specifying components to include in scheduler state

## Why are we making these changes?

Reduces the amount of scheduler state that is transmitted and rendered when only certain components are of interest.


