### PR TITLE
allows token parameters in profile defaults

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -690,8 +690,8 @@
  ;; In the example below:
  ;; - the 'webapp' profile overrides the default configuration defined in :service-description-defaults
  ;;   by increasing the concurrency-level and changing the load balancing scheme to random
- :profile-config {"webapp" {:service-parameters {"concurrency-level" 120
-                                                 "load-balancing" "random"}}}
+ :profile-config {"webapp" {:defaults {"concurrency-level" 120
+                                       "load-balancing" "random"}}}
 
  :service-description-builder-config {
                                       ;; :kind :default invokes the DefaultServiceDescriptionBuilder

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -74,16 +74,17 @@
               (str "Number of profiles in config and API output do not match!"
                    {:profile-config profile-config
                     :profile-list profile-list}))
-          (doseq [[profile {:keys [service-parameters]}] profile-config]
-            (let [profile-defaults (->> profile-list
-                                     (filter #(= (name profile) (:name %)))
-                                     first
-                                     :defaults)
-                  _ (is (= service-parameters profile-defaults)
+          (doseq [[profile {:keys [defaults]}] profile-config]
+            (let [profile-config-defaults defaults
+                  profile-api-defaults (->> profile-list
+                                         (filter #(= (name profile) (:name %)))
+                                         first
+                                         :defaults)
+                  _ (is (= profile-config-defaults profile-api-defaults)
                         (str "Profile configuration and API output do not match!"
                              {:profile profile
-                              :profile-defaults profile-defaults
-                              :service-parameters service-parameters}))
+                              :profile-api-defaults profile-api-defaults
+                              :profile-config-defaults profile-config-defaults}))
                   new-request-headers (assoc request-headers "x-waiter-profile" (name profile))
                   new-service-id (retrieve-service-id waiter-url new-request-headers)
                   service-settings (service-settings waiter-url new-service-id
@@ -95,12 +96,12 @@
                   (str {:base-service-description base-service-description
                         :service-description new-service-description
                         :service-id new-service-id}))
-              (is (= (merge service-description-defaults service-parameters
+              (is (= (merge service-description-defaults profile-config-defaults
                             base-service-description {:profile (name profile)})
                      effective-service-description)
-                  (str {:service-description effective-service-description
-                        :service-id new-service-id
-                        :service-parameters service-parameters}))
+                  (str {:profile-config-defaults profile-config-defaults
+                        :service-description effective-service-description
+                        :service-id new-service-id}))
               (is (not= service-id new-service-id)
                   (str {:profile profile :request-headers request-headers}))))))
 

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1658,9 +1658,9 @@
                             :permitted-user "*"
                             :run-as-user (retrieve-username)
                             :version "1"}]
-      (doseq [[profile {:keys [service-parameters]}] (seq profile-config)]
+      (doseq [[profile {:keys [defaults]}] (seq profile-config)]
         (let [token (rand-name)
-              token-description (-> (apply dissoc base-description (keys service-parameters))
+              token-description (-> (apply dissoc base-description (keys defaults))
                                   (assoc :profile (name profile) :token token))
               register-response (post-token waiter-url token-description)]
           (try

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -917,6 +917,10 @@
                                  (fn async-trigger-terminate-fn [target-router-id service-id request-id]
                                    (async-req/async-trigger-terminate
                                      async-request-terminate-fn make-inter-router-requests-sync-fn router-id target-router-id service-id request-id)))
+   :attach-token-defaults-fn (pc/fnk [[:settings [:token-config token-defaults]]
+                                      [:state profile->defaults]]
+                               (fn attach-token-defaults-fn [token-parameters]
+                                 (sd/attach-token-defaults token-parameters token-defaults profile->defaults)))
    :authentication-method-wrapper-fn (pc/fnk [[:state authenticator jwt-authenticator passwords]]
                                        (fn authentication-method-wrapper [request-handler]
                                          (let [auth-handler (auth/wrap-auth-handler authenticator request-handler)
@@ -1003,16 +1007,17 @@
    :refresh-service-descriptions-fn (pc/fnk [[:state kv-store]]
                                       (fn refresh-service-descriptions-fn [service-ids]
                                         (sd/refresh-service-descriptions kv-store service-ids)))
-   :request->descriptor-fn (pc/fnk [[:settings [:token-config history-length token-defaults]]
+   :request->descriptor-fn (pc/fnk [[:settings [:token-config history-length]]
                                     [:state fallback-state-atom kv-store service-description-builder
                                      service-id-prefix waiter-hostnames]
-                                    assoc-run-as-user-approved? can-run-as?-fn store-reference-fn store-source-tokens-fn]
+                                    assoc-run-as-user-approved? attach-token-defaults-fn can-run-as?-fn
+                                    store-reference-fn store-source-tokens-fn]
                              (fn request->descriptor-fn [request]
                                (let [{:keys [latest-descriptor] :as result}
                                      (descriptor/request->descriptor
-                                       assoc-run-as-user-approved? can-run-as?-fn fallback-state-atom kv-store
-                                       history-length service-description-builder service-id-prefix token-defaults
-                                       waiter-hostnames request)
+                                       assoc-run-as-user-approved? can-run-as?-fn attach-token-defaults-fn
+                                       fallback-state-atom kv-store history-length service-description-builder
+                                       service-id-prefix waiter-hostnames request)
                                      {:keys [reference-type->entry service-id source-tokens]} latest-descriptor]
                                  (when (seq source-tokens)
                                    (store-source-tokens-fn service-id source-tokens))
@@ -1029,16 +1034,15 @@
    :service-description->service-id (pc/fnk [[:state service-id-prefix]]
                                       (fn service-description->service-id [service-description]
                                         (sd/service-description->service-id service-id-prefix service-description)))
-   :service-id->idle-timeout (pc/fnk [[:settings [:token-config token-defaults]]
-                                      [:state service-description-builder]
-                                      service-id->service-description-fn service-id->references-fn
-                                      token->token-hash token->token-metadata]
+   :service-id->idle-timeout (pc/fnk [[:state service-description-builder]
+                                      attach-token-defaults-fn service-id->service-description-fn service-id->references-fn
+                                      token->token-hash token->token-parameters]
                                (let [context {:token->token-hash token->token-hash}
                                      reference-type->stale-fn (sd/retrieve-reference-type->stale-fn service-description-builder context)]
                                  (fn service-id->idle-timeout [service-id]
                                    (sd/service-id->idle-timeout
-                                     service-id->service-description-fn service-id->references-fn token->token-metadata
-                                     reference-type->stale-fn token-defaults service-id))))
+                                     service-id->service-description-fn service-id->references-fn token->token-parameters
+                                     reference-type->stale-fn attach-token-defaults-fn service-id))))
    :service-id->password-fn (pc/fnk [[:scheduler service-id->password-fn*]]
                               service-id->password-fn*)
    :service-id->references-fn (pc/fnk [[:state kv-store]]
@@ -1093,6 +1097,9 @@
    :token->token-metadata (pc/fnk [[:state kv-store]]
                             (fn token->token-metadata [token]
                               (sd/token->token-metadata kv-store token :error-on-missing false)))
+   :token->token-parameters (pc/fnk [[:state kv-store]]
+                              (fn token->token-parameters [token]
+                                (sd/token->token-parameters kv-store token :error-on-missing false)))
    :validate-service-description-fn (pc/fnk [[:settings service-description-defaults]
                                              [:state authenticator service-description-builder]]
                                       (let [authentication-providers (into #{"disabled" "standard"} (auth/get-authentication-providers authenticator))
@@ -1113,8 +1120,8 @@
    :websocket-request-auth-cookie-attacher (pc/fnk [[:state passwords router-id]]
                                              (fn websocket-request-auth-cookie-attacher [request]
                                                (ws/inter-router-request-middleware router-id (first passwords) request)))
-   :websocket-request-acceptor (pc/fnk [[:settings [:token-config token-defaults]]
-                                        [:state kv-store passwords server-name waiter-hostnames]]
+   :websocket-request-acceptor (pc/fnk [[:state kv-store passwords server-name waiter-hostnames]
+                                        attach-token-defaults-fn]
                                  (fn websocket-request-acceptor [^ServletUpgradeRequest request ^ServletUpgradeResponse response]
                                    (let [request-headers (->> (.getHeaders request)
                                                            (pc/map-vals #(str/join "," %))
@@ -1133,7 +1140,8 @@
                                                   :uri (some-> request .getRequestURI .getPath)})
                                        (.setHeader response "server" server-name)
                                        (.setHeader response "x-cid" correlation-id)
-                                       (let [waiter-discovery (sd/discover-service-parameters kv-store token-defaults waiter-hostnames request-headers)]
+                                       (let [waiter-discovery (sd/discover-service-parameters
+                                                                kv-store attach-token-defaults-fn waiter-hostnames request-headers)]
                                          (process-authentication-parameter
                                            waiter-discovery
                                            (fn [status message]
@@ -1839,11 +1847,12 @@
                                    (fn inner-wrap-secure-request-fn [{:keys [uri] :as request}]
                                      (log/debug "secure request received at" uri)
                                      (handler request))))))
-   :wrap-service-discovery-fn (pc/fnk [[:settings [:token-config token-defaults]]
+   :wrap-service-discovery-fn (pc/fnk [[:routines attach-token-defaults-fn]
                                        [:state kv-store waiter-hostnames]]
                                 (fn wrap-service-discovery-fn
                                   [handler]
                                   (fn [{:keys [headers] :as request}]
                                     ;; TODO optimization opportunity to avoid this re-computation later in the chain
-                                    (let [discovered-parameters (sd/discover-service-parameters kv-store token-defaults waiter-hostnames headers)]
+                                    (let [discovered-parameters (sd/discover-service-parameters
+                                                                  kv-store attach-token-defaults-fn waiter-hostnames headers)]
                                       (handler (assoc request :waiter-discovery discovered-parameters))))))})

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -720,7 +720,7 @@
                             ;; validate the profile's service parameters
                             (sd/validate-schema defaults max-constraints-schema initial-profile->defaults
                                                 {:allow-missing-required-fields? true})
-                            ;; validate the profile's service parameters
+                            ;; validate the profile's token parameters
                             (token/validate-token-parameters defaults)
                             defaults)))
    :query-service-maintainer-chan (pc/fnk [] (au/latest-chan)) ; TODO move to service-chan-maintainer

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -707,9 +707,21 @@
                           (name profile)
                           (let [max-constraints-schema (sd/extract-max-constraints-schema service-description-constraints)
                                 initial-profile->defaults {}]
+                            ;; validate the profile's entries
+                            (when-let [unsupported-keys (-> defaults
+                                                          keys
+                                                          set
+                                                          (set/difference sd/token-user-editable-keys)
+                                                          seq)]
+                              (throw (ex-info "Profile has unsupported entries in defaults"
+                                              {:name profile
+                                               :profile-defaults defaults
+                                               :unsupported-keys unsupported-keys})))
                             ;; validate the profile's service parameters
                             (sd/validate-schema defaults max-constraints-schema initial-profile->defaults
                                                 {:allow-missing-required-fields? true})
+                            ;; validate the profile's service parameters
+                            (token/validate-token-parameters defaults)
                             defaults)))
    :query-service-maintainer-chan (pc/fnk [] (au/latest-chan)) ; TODO move to service-chan-maintainer
    :router-metrics-agent (pc/fnk [router-id] (metrics-sync/new-router-metrics-agent router-id {}))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -703,14 +703,14 @@
                       processed-passwords (mapv #(vector :cached %) passwords)]
                   processed-passwords))
    :profile->defaults (pc/fnk [[:settings profile-config service-description-constraints]]
-                        (pc/for-map [[profile {:keys [service-parameters]}] profile-config]
+                        (pc/for-map [[profile {:keys [defaults]}] profile-config]
                           (name profile)
                           (let [max-constraints-schema (sd/extract-max-constraints-schema service-description-constraints)
                                 initial-profile->defaults {}]
                             ;; validate the profile's service parameters
-                            (sd/validate-schema service-parameters max-constraints-schema initial-profile->defaults
+                            (sd/validate-schema defaults max-constraints-schema initial-profile->defaults
                                                 {:allow-missing-required-fields? true})
-                            service-parameters)))
+                            defaults)))
    :query-service-maintainer-chan (pc/fnk [] (au/latest-chan)) ; TODO move to service-chan-maintainer
    :router-metrics-agent (pc/fnk [router-id] (metrics-sync/new-router-metrics-agent router-id {}))
    :router-id (pc/fnk [[:settings router-id-prefix]]

--- a/waiter/src/waiter/cors.clj
+++ b/waiter/src/waiter/cors.clj
@@ -55,10 +55,11 @@
   "Preflight request handling middleware.
   This middleware needs to precede any authentication middleware since CORS preflight
   requests do not support authentication."
-  [handler cors-validator max-age kv-store token-defaults waiter-hostnames]
+  [handler cors-validator max-age kv-store attach-token-defaults-fn waiter-hostnames]
   (fn wrap-cors-preflight-fn [{:keys [headers] :as request}]
     (if (preflight-request? request)
-      (let [discovered-parameters (sd/discover-service-parameters kv-store token-defaults waiter-hostnames headers)]
+      (let [discovered-parameters (sd/discover-service-parameters
+                                    kv-store attach-token-defaults-fn waiter-hostnames headers)]
         (counters/inc! (metrics/waiter-counter "requests" "cors-preflight"))
         (let [{:keys [headers request-method]} request
               {:strs [origin]} headers]

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -224,7 +224,8 @@
 
 (defn- compute-token-source-previous-descriptor
   "Computes the previous descriptor using token sources."
-  [token-defaults build-service-description-and-id {:keys [component->previous-descriptor-fns sources] :as descriptor}]
+  [attach-token-defaults-fn build-service-description-and-id
+   {:keys [component->previous-descriptor-fns sources] :as descriptor}]
   (when-let [token-sequence (-> sources :token-sequence seq)]
     (let [{:keys [token->token-data]} sources
           previous-token (->> token->token-data
@@ -233,7 +234,7 @@
           previous-token-data (get-in token->token-data [previous-token "previous"])]
       (when (seq previous-token-data)
         (let [new-sources (->> (assoc token->token-data previous-token previous-token-data)
-                            (sd/compute-service-description-template-from-tokens token-defaults token-sequence)
+                            (sd/compute-service-description-template-from-tokens attach-token-defaults-fn token-sequence)
                             (merge sources))
               token-previous-descriptor-fns (get component->previous-descriptor-fns :token)]
           (-> (select-keys descriptor [:passthrough-headers :waiter-headers])
@@ -245,20 +246,20 @@
   "Attaches the helper functions map to retrieve previous descriptor using tokens into the
    [:component->previous-descriptor-fns :token] key in the provided descriptor.
    The map contains the following keys: :retrieve-last-update-time and :retrieve-previous-descriptor"
-  [descriptor token-defaults build-service-description-and-id]
+  [descriptor attach-token-defaults-fn build-service-description-and-id]
   (cond-> descriptor
     (-> descriptor :sources :token-sequence seq)
     (assoc-in [:component->previous-descriptor-fns :token]
               {:retrieve-last-update-time sd/retrieve-most-recently-modified-token-update-time
                :retrieve-previous-descriptor (fn retrieve-most-recent-token-update-descriptor [descriptor]
                                                (compute-token-source-previous-descriptor
-                                                 token-defaults build-service-description-and-id descriptor))})))
+                                                 attach-token-defaults-fn build-service-description-and-id descriptor))})))
 
 (defn compute-descriptor
   "Creates the service descriptor from the request.
    The result map contains the following elements:
    {:keys [waiter-headers passthrough-headers sources service-id service-description core-service-description suspended-state]}"
-  [token-defaults service-id-prefix kv-store waiter-hostnames request service-description-builder
+  [attach-token-defaults-fn service-id-prefix kv-store waiter-hostnames request service-description-builder
    assoc-run-as-user-approved?]
   (let [current-request-user (get request :authorization/user)
         build-service-description-and-id-helper (sd/make-build-service-description-and-id-helper
@@ -266,8 +267,8 @@
                                                   service-description-builder assoc-run-as-user-approved?)
         descriptor
         (-> (headers/split-headers (:headers request))
-          (sd/merge-service-description-sources kv-store waiter-hostnames token-defaults)
-          (attach-token-fallback-source token-defaults build-service-description-and-id-helper)
+          (sd/merge-service-description-sources kv-store waiter-hostnames attach-token-defaults-fn)
+          (attach-token-fallback-source attach-token-defaults-fn build-service-description-and-id-helper)
           (build-service-description-and-id-helper true))]
     (when-let [throwable (sd/validate-service-description kv-store service-description-builder descriptor)]
       (throw throwable))
@@ -302,15 +303,15 @@
   (defn request->descriptor
     "Extract the service descriptor from a request.
      It also performs the necessary authorization."
-    [assoc-run-as-user-approved? can-run-as? fallback-state-atom kv-store search-history-length
-     service-description-builder service-id-prefix token-defaults waiter-hostnames
+    [assoc-run-as-user-approved? can-run-as? attach-token-defaults-fn fallback-state-atom kv-store 
+     search-history-length service-description-builder service-id-prefix waiter-hostnames
      {:keys [request-time] :as request}]
     (timers/start-stop-time!
       request->descriptor-timer
       (let [auth-user (:authorization/user request)
             service-approved? (fn service-approved? [service-id] (assoc-run-as-user-approved? request service-id))
             latest-descriptor (compute-descriptor
-                                token-defaults service-id-prefix kv-store waiter-hostnames request
+                                attach-token-defaults-fn service-id-prefix kv-store waiter-hostnames request
                                 service-description-builder service-approved?)
             descriptor->previous-descriptor
             (fn descriptor->previous-descriptor-fn

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -101,15 +101,15 @@
    :scheduler core/scheduler
    :settings (pc/fnk dummy-symbol-for-fnk-schema-logic :- settings/settings-schema [] settings)
    :state core/state
-   :http-server (pc/fnk [[:routines generate-log-url-fn waiter-request?-fn websocket-request-acceptor]
-                         [:settings cors-config host port server-options support-info [:token-config token-defaults] websocket-config]
+   :http-server (pc/fnk [[:routines attach-token-defaults-fn generate-log-url-fn waiter-request?-fn websocket-request-acceptor]
+                         [:settings cors-config host port server-options support-info websocket-config]
                          [:state cors-validator kv-store router-id server-name waiter-hostnames]
                          handlers] ; Insist that all systems are running before we start server
                   (let [options (merge (cond-> server-options
                                          (:ssl-port server-options) (assoc :ssl? true))
                                        websocket-config
                                        {:ring-handler (-> (core/ring-handler-factory waiter-request?-fn handlers)
-                                                        (cors/wrap-cors-preflight cors-validator (:max-age cors-config) kv-store token-defaults waiter-hostnames)
+                                                        (cors/wrap-cors-preflight cors-validator (:max-age cors-config) kv-store attach-token-defaults-fn waiter-hostnames)
                                                         core/wrap-error-handling
                                                         (core/wrap-debug generate-log-url-fn)
                                                         (core/attach-waiter-api-middleware waiter-request?-fn)

--- a/waiter/src/waiter/schema.clj
+++ b/waiter/src/waiter/schema.clj
@@ -136,4 +136,4 @@
 
 (def profile-definition
   "Validator for profile parameters."
-  {(s/required-key :service-parameters) {non-empty-string s/Any}})
+  {(s/required-key :defaults) {non-empty-string s/Any}})

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -1599,7 +1599,7 @@
           (is (= 400 status))
           (is (not (str/includes? body "clojure")))
           (is (str/includes? (str details) "fallback-period-secs") body)
-          (is (str/includes? message "User metadata validation failed") body)))
+          (is (str/includes? message "Validation failed for user metadata on token") body)))
 
       (testing "post:new-user-metadata:fallback-period-secs-limit-exceeded"
         (let [kv-store (kv/->LocalKeyValueStore (atom {}))
@@ -1617,7 +1617,7 @@
           (is (= 400 status))
           (is (not (str/includes? body "clojure")))
           (is (str/includes? (str details) "fallback-period-secs") body)
-          (is (str/includes? message "User metadata validation failed") body)))
+          (is (str/includes? message "Validation failed for user metadata on token") body)))
 
       (testing "post:new-service-description:token-limit-reached"
         (let [kv-store (kv/->LocalKeyValueStore (atom {}))
@@ -1696,7 +1696,7 @@
           (is (str/includes? (str details) "origin-regex\\\" (throws? (is-a-valid-regular-expression?") body)
           (is (str/includes? (str details) "methods\\\" [(not (is-an-http-method?") body)
           (is (str/includes? (str details) "target-schemes\\\" disallowed-key") body)
-          (is (str/includes? message "User metadata validation failed") body)))
+          (is (str/includes? message "Validation failed for user metadata on token") body)))
 
       (testing "post:new-service-description-cors-rules-2"
         (let [kv-store (kv/->LocalKeyValueStore (atom {}))
@@ -1720,7 +1720,7 @@
           (is (str/includes? (str details) "origin-regex\\\" (throws? (is-a-valid-regular-expression?") body)
           (is (str/includes? (str details) "methods\\\" (not (not-empty []") body)
           (is (str/includes? (str details) "target-schemes\\\" disallowed-key") body)
-          (is (str/includes? message "User metadata validation failed") body)))
+          (is (str/includes? message "Validation failed for user metadata on token") body)))
 
       (testing "post:new-service-description-cors-rules-2"
         (let [kv-store (kv/->LocalKeyValueStore (atom {}))
@@ -1739,7 +1739,7 @@
               {{:strs [details message]} "waiter-error"} (json/read-str body)]
           (is (= 400 status))
           (is (str/includes? (str details) "cors-rules\\\" (not (sequential?") body)
-          (is (str/includes? message "User metadata validation failed") body))))))
+          (is (str/includes? message "Validation failed for user metadata on token") body))))))
 
 (deftest test-store-service-description
   (let [kv-store (kv/->LocalKeyValueStore (atom {}))


### PR DESCRIPTION
## Changes proposed in this PR

- renames service-parameters to defaults
- allows token parameters in profile defaults

## Why are we making these changes?

Allow configuring token parameters in profiles.

### Example logs:

Error message during startup when profile has unsupported keys:
```
2020-04-16 01:56:49,065 ERROR waiter.main [main] -  encountered exception starting waiter
clojure.lang.ExceptionInfo: Profile has unsupported entries in defaults {:name "webapp", :profile-defaults {"concurrency-level" 120, "cpus" 1, "load-balancing" "random", "foo" "bar"}, :unsupported-keys ("foo")}
        at waiter.core$fn__47420$fnk47418_positional__47421.invoke(core.clj:716)
```
