### PR TITLE
excludes token parameters while comparing service description from profile test

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -96,8 +96,10 @@
                   (str {:base-service-description base-service-description
                         :service-description new-service-description
                         :service-id new-service-id}))
-              (is (= (merge service-description-defaults profile-config-defaults
-                            base-service-description {:profile (name profile)})
+              (is (= (merge service-description-defaults
+                            (select-keys profile-config-defaults (map keyword sd/service-parameter-keys))
+                            base-service-description
+                            {:profile (name profile)})
                      effective-service-description)
                   (str {:profile-config-defaults profile-config-defaults
                         :service-description effective-service-description


### PR DESCRIPTION

## Changes proposed in this PR

- excludes token parameters while comparing service description from profile test




