### PR TITLE
introduces constants for the various status codes

### DIFF
--- a/waiter/integration/waiter/async_request_integration_test.clj
+++ b/waiter/integration/waiter/async_request_integration_test.clj
@@ -19,6 +19,7 @@
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [plumbing.core :as pc]
+            [waiter.status-codes :refer :all]
             [waiter.util.client-tools :refer :all]))
 
 (deftest ^:parallel ^:integration-fast test-202-response-without-location-header
@@ -32,7 +33,7 @@
           (make-request-with-debug-info async-request-headers
                                         #(make-kitchen-request waiter-url % :method :get :path "/async/request"))
           status-location (get (pc/map-keys str/lower-case headers) "location")]
-      (assert-response-status response 202)
+      (assert-response-status response http-202-accepted)
       (is (str/blank? status-location))
       (with-service-cleanup
         service-id
@@ -88,7 +89,7 @@
           {:keys [cookies request-headers response service-id status-location]}
           (make-async-request waiter-url (-> processing-time-secs t/seconds t/in-millis))
           async-request-cid (get-in response [:headers "x-cid"] "")]
-      (assert-response-status response 202)
+      (assert-response-status response http-202-accepted)
       (is (not (str/blank? status-location)))
       (is (str/starts-with? (str status-location) "/waiter-async/status/") (str status-location))
       (log/info async-request-cid "status-location:" status-location)
@@ -109,20 +110,20 @@
           (testing "validating-status"
             (doseq [router (seq routers)]
               (let [{:keys [response result-location]} (async-status router status-location cookies)]
-                (assert-response-status response 200)
+                (assert-response-status response http-200-ok)
                 (is (nil? result-location)))))
 
           ;; wait for async request to complete processing
           (wait-for
             #(let [router-entry (rand-nth (seq routers))
                    {:keys [response result-location]} (async-status router-entry status-location cookies)]
-               (and result-location (= 303 (:status response))))
+               (and result-location (= http-303-see-other (:status response))))
             :interval 1 :timeout (inc processing-time-secs))
 
           (testing "validate-complete-status"
             (doseq [router-entry (seq routers)]
               (let [{:keys [response result-location]} (async-status router-entry status-location cookies)]
-                (assert-response-status response 303)
+                (assert-response-status response http-303-see-other)
                 (is result-location))))
 
           (testing "validate-303-does-not-reset-in-flight-request-counters"
@@ -142,7 +143,7 @@
               (is (str/includes? (str result-location) service-id) (str result-location))
               (log/info "validating async result from router" router-id "at" endpoint-url)
               (let [{:keys [body] :as response} (make-request endpoint-url result-location :headers request-headers :cookies cookies)]
-                (assert-response-status response 200)
+                (assert-response-status response http-200-ok)
                 ;; kitchen response includes the original CID
                 (is (str/includes? (str body) async-request-cid) (str body))))))
 
@@ -161,17 +162,17 @@
     (let [processing-time-ms 15000
           {:keys [cookies response service-id status-location]}
           (make-async-request waiter-url processing-time-ms)]
-      (assert-response-status response 202)
+      (assert-response-status response http-202-accepted)
       (is (not (str/blank? status-location)))
       (is (str/starts-with? (str status-location) "/waiter-async/status/") (str status-location))
       (with-service-cleanup
         service-id
         (let [routers (routers waiter-url)]
           (let [response (cancel-async-request waiter-url status-location true cookies)]
-            (assert-response-status response 204))
+            (assert-response-status response http-204-no-content))
           (doseq [router (seq routers)]
             (let [{:keys [response result-location]} (async-status router status-location cookies)]
-              (assert-response-status response 410)
+              (assert-response-status response http-410-gone)
               (is (nil? result-location)))))))))
 
 (deftest ^:parallel ^:integration-fast test-cancel-unsupported-async-request
@@ -179,16 +180,16 @@
     (let [processing-time-ms 15000
           {:keys [cookies response service-id status-location]}
           (make-async-request waiter-url processing-time-ms)]
-      (assert-response-status response 202)
+      (assert-response-status response http-202-accepted)
       (is (not (str/blank? status-location)))
       (with-service-cleanup
         service-id
         (let [routers (routers waiter-url)]
           (let [response (cancel-async-request waiter-url status-location false cookies)]
-            (assert-response-status response 405))
+            (assert-response-status response http-405-method-not-allowed))
           (doseq [router (seq routers)]
             (let [{:keys [response]} (async-status router status-location cookies)]
-              (assert-response-status response 200))))))))
+              (assert-response-status response http-200-ok))))))))
 
 ; Marked explicit because it's flaky. Disabled tests are documented and will be fixed
 (deftest ^:parallel ^:integration-slow ^:resource-heavy ^:explicit test-multiple-async-requests
@@ -218,7 +219,7 @@
                             :verbose true)
           status-locations (for [{:keys [headers] :as response} async-responses]
                              (let [status-location (get (pc/map-keys str/lower-case headers) "location")]
-                               (assert-response-status response 202)
+                               (assert-response-status response http-202-accepted)
                                (is (not (str/blank? status-location)))
                                status-location))]
 
@@ -241,7 +242,7 @@
                                                               :cookies cookies
                                                               :headers kitchen-delete-headers
                                                               :method :delete)]
-                (assert-response-status response 200)
+                (assert-response-status response http-200-ok)
                 (is (str/includes? body "Deleted request-id")))))
           (Thread/sleep inter-router-metrics-interval-ms) ;; allow routers to sync metrics
           (let [{:keys [async outstanding] :as request-counts}
@@ -255,7 +256,7 @@
           (fn []
             (every? (fn [status-location]
                       (let [{:keys [status]} (make-request waiter-url status-location :cookies cookies)]
-                        (not= 200 status)))
+                        (not= http-200-ok status)))
                     status-locations))
           :interval 5, :timeout 70)
 
@@ -264,12 +265,12 @@
             (doseq [status-location status-locations]
               (let [[router-id endpoint-url] (rand-nth (seq routers))
                     {:keys [result-location response]} (async-status [router-id endpoint-url] status-location cookies)]
-                (when (not= 410 (:status response))
+                (when (not= http-410-gone (:status response))
                   (is (str/starts-with? (str result-location) "/waiter-async/result/") (str result-location))
                   (is (str/includes? (str result-location) service-id) (str result-location))
                   (log/info "validating async result via router" router-id "at" endpoint-url)
                   (let [response (make-request endpoint-url result-location :cookies cookies :method :get)]
-                    (assert-response-status response 200))))))
+                    (assert-response-status response http-200-ok))))))
 
           (testing "validate-completed-request-counters"
             (Thread/sleep inter-router-metrics-interval-ms) ;; allow routers to sync metrics

--- a/waiter/integration/waiter/autoscaling_test.clj
+++ b/waiter/integration/waiter/autoscaling_test.clj
@@ -17,6 +17,7 @@
   (:require [clj-time.core :as t]
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
+            [waiter.status-codes :refer :all]
             [waiter.util.client-tools :refer :all]
             [waiter.util.utils :as utils]))
 
@@ -157,7 +158,7 @@
           {:keys [cookies instance-id service-id] :as response}
           (make-request-with-debug-info extra-headers #(make-kitchen-request waiter-url %))
           extra-headers (assoc extra-headers :x-kitchen-delay-ms (-> 10 t/seconds t/in-millis))]
-      (assert-response-status response 200)
+      (assert-response-status response http-200-ok)
       (log/info "service-id:" service-id)
       (with-service-cleanup
         service-id
@@ -179,7 +180,7 @@
                           :service-id service-id
                           :verbose true)]
           (log/info "made" (count responses) "requests")
-          (is (every? #(= 200 (:status %)) responses))
+          (is (every? #(= http-200-ok (:status %)) responses))
           (is (contains? @response-instance-ids-atom instance-id)
               (str {:all-instances @response-instance-ids-atom :instance-id instance-id}))
           (is (> (count @response-instance-ids-atom) 1)

--- a/waiter/integration/waiter/busy_instance_test.clj
+++ b/waiter/integration/waiter/busy_instance_test.clj
@@ -17,6 +17,7 @@
   (:require [clojure.string :as str]
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
+            [waiter.status-codes :refer :all]
             [waiter.util.client-tools :refer :all]
             [waiter.util.utils :as utils]))
 
@@ -97,10 +98,10 @@
           (is (= num-requests (count @responses)))
           (log/info "response statuses:" (map :status @responses))
           (log/info "response bodies:" (map :body @responses))
-          (let [responses-with-503 (filter #(= 503 (:status %)) @responses)]
-            (is (not (empty? responses-with-503)))
-            (is (< (count responses-with-503) num-requests))
+          (let [responses-with-http-503-service-unavailable (filter #(= http-503-service-unavailable (:status %)) @responses)]
+            (is (not (empty? responses-with-http-503-service-unavailable)))
+            (is (< (count responses-with-http-503-service-unavailable) num-requests))
             (is (every? (fn [{body :body}]
                           (every? #(str/includes? (str body) (str %))
                                   ["Max queue length exceeded" service-id]))
-                        responses-with-503))))))))
+                        responses-with-http-503-service-unavailable))))))))

--- a/waiter/integration/waiter/content_encoding_test.clj
+++ b/waiter/integration/waiter/content_encoding_test.clj
@@ -19,6 +19,7 @@
             [clojure.data.json :as json]
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
+            [waiter.status-codes :refer :all]
             [waiter.util.client-tools :refer :all])
   (:import (java.io EOFException InputStreamReader)
            (org.apache.http ConnectionClosedException)))
@@ -38,7 +39,7 @@
                             :x-kitchen-response-size response-size
                             :x-waiter-debug true)
               {:keys [headers] :as response} (make-request waiter-url "/gzip" :headers req-headers)]
-          (assert-response-status response 200)
+          (assert-response-status response http-200-ok)
           (is (= (get headers "content-type") "text/plain") (str headers))
           (is (= (get headers "content-encoding") "gzip") (str headers))
           ;; ideally (is (= (get headers "transfer-encoding") "chunked") (str headers))
@@ -47,7 +48,7 @@
           (let [{:keys [body] :as response}
                 (make-request waiter-url "/gzip" :headers req-headers :decompress-body true :verbose true)
                 body-length (count (bytes (byte-array (map (comp byte int) (str body)))))]
-            (assert-response-status response 200)
+            (assert-response-status response http-200-ok)
             (is (= response-size body-length))))))))
 
 (deftest ^:parallel ^:integration-fast test-support-failed-chunked-gzip-response
@@ -84,7 +85,7 @@
                             :x-kitchen-response-size response-size
                             :x-waiter-debug true)
               {:keys [headers] :as response} (make-request waiter-url "/gzip" :headers req-headers :verbose true)]
-          (assert-response-status response 200)
+          (assert-response-status response http-200-ok)
           (is (= (get headers "content-type") "text/plain") (str headers))
           (is (= (get headers "content-encoding") "gzip") (str headers))
           (is (nil? (get headers "transfer-encoding")) (str headers))
@@ -93,7 +94,7 @@
           (let [{:keys [body] :as response}
                 (make-request waiter-url "/gzip" :headers req-headers :decompress-body true :verbose true)
                 body-length (count (bytes (byte-array (map (comp byte int) (str body)))))]
-            (assert-response-status response 200)
+            (assert-response-status response http-200-ok)
             (is (= response-size body-length))))))))
 
 (deftest ^:parallel ^:integration-fast test-support-failed-gzip-response
@@ -127,7 +128,7 @@
                             :x-waiter-debug true)
               {:keys [body headers] :as response} (make-request waiter-url "/chunked" :headers req-headers :verbose true)
               body-length (count (bytes (byte-array (map (comp byte int) (str body)))))]
-          (assert-response-status response 200)
+          (assert-response-status response http-200-ok)
           (is (== 100000 body-length))
           (is (= (get headers "content-type") "text/plain") (str headers))
           (is (nil? (get headers "content-encoding")) (str headers))
@@ -147,7 +148,7 @@
                             :x-waiter-debug true)
               {:keys [body headers] :as response} (make-request waiter-url "/chunked" :headers req-headers :verbose true)
               body-length (count (bytes (byte-array (map (comp byte int) (str body)))))]
-          (assert-response-status response 200)
+          (assert-response-status response http-200-ok)
           (is (< body-length 100000))
           (is (= (get headers "content-type") "text/plain") (str headers))
           (is (nil? (get headers "content-encoding")) (str headers))
@@ -168,7 +169,7 @@
                               :x-waiter-debug true)
                 {:keys [body headers] :as response} (make-request waiter-url "/unchunked" :headers req-headers :verbose true)
                 body-length (count (bytes (byte-array (map (comp byte int) (str body)))))]
-            (assert-response-status response 200)
+            (assert-response-status response http-200-ok)
             (is (== 100000 body-length))
             (is (= (get headers "content-type") "text/plain") (str headers))
             (is (nil? (get headers "content-encoding")) (str headers))

--- a/waiter/integration/waiter/cookie_support_integration_test.clj
+++ b/waiter/integration/waiter/cookie_support_integration_test.clj
@@ -16,6 +16,7 @@
 (ns waiter.cookie-support-integration-test
   (:require [clojure.data.json :as json]
             [clojure.test :refer :all]
+            [waiter.status-codes :refer :all]
             [waiter.util.client-tools :refer :all]))
 
 (deftest ^:parallel ^:integration-fast test-cookie-support
@@ -54,10 +55,10 @@
       (testing "no cookies sent to backend (x-waiter-auth removed)"
         (let [{:keys [cookies service-id] :as response}
               (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))]
-          (assert-response-status response 200)
+          (assert-response-status response http-200-ok)
           (with-service-cleanup
             service-id
             (let [{:keys [body] :as response} (make-kitchen-request waiter-url headers :cookies cookies :path "/request-info")
-                  _ (assert-response-status response 200)
+                  _ (assert-response-status response http-200-ok)
                   {:strs [headers]} (json/read-str (str body))]
               (is (empty? (get headers "cookie"))))))))))

--- a/waiter/integration/waiter/deployment_errors_test.clj
+++ b/waiter/integration/waiter/deployment_errors_test.clj
@@ -18,6 +18,7 @@
             [clojure.string :as str]
             [clojure.test :refer :all]
             [plumbing.core :as pc]
+            [waiter.status-codes :refer :all]
             [waiter.util.client-tools :refer :all]))
 
 (defn get-router->service-state
@@ -50,7 +51,7 @@
   `(let [response# ~response
          body# (:body response#)
          service-id# (response->service-id response#)]
-     (assert-response-status response# 503)
+     (assert-response-status response# http-503-service-unavailable)
      (is (str/includes? body# (deployment-error->str ~'waiter-url ~deployment-error))
          (formatted-service-state ~'waiter-url service-id#))
      (testing "status is reported as failing"

--- a/waiter/integration/waiter/grpc_test.clj
+++ b/waiter/integration/waiter/grpc_test.clj
@@ -22,6 +22,7 @@
             [clojure.walk :as walk]
             [plumbing.core :as pc]
             [waiter.correlation-id :as cid]
+            [waiter.status-codes :refer :all]
             [waiter.util.client-tools :refer :all])
   (:import (com.twosigma.waiter.courier
              CourierReply CourierSummary GrpcClient
@@ -92,7 +93,7 @@
          request-headers (assoc request-headers
                            "cookie" cookie-header
                            "x-waiter-timeout" "60000")]
-     (assert-response-status response 200)
+     (assert-response-status response http-200-ok)
      (log/info "ping cid:" (get headers "x-cid"))
      (log/info "service-id:" service-id)
      (is service-id)
@@ -103,7 +104,7 @@
        (is (= "received-response" (:result ping-response)) (str ping-response))
        (is (= "OK" (some-> ping-response :body)) (str ping-response))
        (is (str/starts-with? (str (some-> ping-response :headers :server)) "courier-health-check") (str ping-response))
-       (assert-response-status ping-response 200)
+       (assert-response-status ping-response http-200-ok)
        (is (true? (:exists? service-state)) (str service-state))
        (is (= service-id (:service-id service-state)) (str service-state))
        (is (contains? #{"Running" "Starting"} (:status service-state)) (str service-state)))
@@ -587,7 +588,7 @@
                                    "token" token)
                 _ (log/info "creating token:" token)
                 post-response (post-token waiter-url (walk/keywordize-keys token-parameters))
-                _ (assert-response-status post-response 200)
+                _ (assert-response-status post-response http-200-ok)
                 request-headers {"host" token
                                  "x-waiter-debug" true}
                 {:keys [h2c-port host service-id]} (start-courier-instance waiter-url request-headers)]

--- a/waiter/integration/waiter/instability_test.clj
+++ b/waiter/integration/waiter/instability_test.clj
@@ -15,6 +15,7 @@
 ;;
 (ns waiter.instability-test
   (:require [clojure.test :refer :all]
+            [waiter.status-codes :refer :all]
             [waiter.util.client-tools :refer :all]))
 
 (deftest ^:parallel ^:integration-fast ^:explicit test-oom-instability
@@ -24,6 +25,6 @@
           response (make-request-with-debug-info headers #(make-kitchen-request waiter-url % :path "/oom-instability"))]
       (wait-for #(= "not-enough-memory" ((((service-state waiter-url (response->service-id response))
                                             :state) :responder-state) :instability-issue)))
-      (assert-response-status response 502)
+      (assert-response-status response http-502-bad-gateway)
       (is (= "not-enough-memory" ((((service-state waiter-url (response->service-id response))
                                      :state) :responder-state) :instability-issue))))))

--- a/waiter/integration/waiter/latency_test.clj
+++ b/waiter/integration/waiter/latency_test.clj
@@ -17,6 +17,7 @@
   (:require [clojure.java.shell :as shell]
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
+            [waiter.status-codes :refer :all]
             [waiter.util.client-tools :refer :all]))
 
 (use-fixtures :once statsd-test-fixture)
@@ -92,7 +93,7 @@
             endpoint "/endpoint"
             _ (log/info (str "Making canary request..."))
             canary-response (make-request waiter-url endpoint :headers headers)
-            _ (assert-response-status canary-response 200)
+            _ (assert-response-status canary-response http-200-ok)
             service-id (retrieve-service-id waiter-url (:request-headers canary-response))
             run-apache-bench #(apache-bench waiter-url endpoint headers client-concurrency-level %)
             warm-up-requests (/ total-requests 10)

--- a/waiter/integration/waiter/metrics_output_test.clj
+++ b/waiter/integration/waiter/metrics_output_test.clj
@@ -18,6 +18,7 @@
             [clojure.tools.logging :as log]
             [schema.core :as s]
             [waiter.schema :as schema]
+            [waiter.status-codes :refer :all]
             [waiter.util.client-tools :refer :all]))
 
 (def quantile-metric-schema
@@ -217,7 +218,7 @@
       (with-service-cleanup
         service-id
         ; ensure the first request succeded before continuing with testing
-        (assert-response-status first-response 200)
+        (assert-response-status first-response http-200-ok)
         ; on each router, check that the launch-metrics are present and have sane values
         (doseq [[_ router-url] router->endpoint]
           (is (wait-for #(n-healthy-instances-observed? router-url cookies service-id instance-count)

--- a/waiter/integration/waiter/new_app_test.clj
+++ b/waiter/integration/waiter/new_app_test.clj
@@ -16,6 +16,7 @@
 (ns waiter.new-app-test
   (:require [clojure.test :refer :all]
             [clojure.tools.logging :as log]
+            [waiter.status-codes :refer :all]
             [waiter.util.client-tools :refer :all]
             [waiter.util.utils :as utils]))
 
@@ -28,7 +29,7 @@
           lorem-ipsum "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
           {:keys [body cookies router-id service-id] :as response}
           (make-request-with-debug-info headers #(make-kitchen-request waiter-url % :body lorem-ipsum))]
-      (assert-response-status response 200)
+      (assert-response-status response http-200-ok)
       (is (= lorem-ipsum body))
       (with-service-cleanup
         service-id
@@ -68,7 +69,7 @@
                         (dissoc :x-waiter-grace-period-secs))
             {:keys [service-id] :as response}
             (make-request-with-debug-info headers #(make-request waiter-url "/endpoint" :headers %))]
-        (assert-response-status response 200)
+        (assert-response-status response http-200-ok)
         (with-service-cleanup
           service-id
           (let [settings-json (waiter-settings waiter-url)

--- a/waiter/integration/waiter/proto_test.clj
+++ b/waiter/integration/waiter/proto_test.clj
@@ -16,6 +16,7 @@
 (ns waiter.proto-test
   (:require [clojure.data.json :as json]
             [clojure.test :refer :all]
+            [waiter.status-codes :refer :all]
             [waiter.util.client-tools :refer :all]
             [waiter.util.http-utils :as hu]))
 
@@ -27,7 +28,7 @@
          http-version# (hu/backend-protocol->http-version protocol#)
          kitchen-response-size# ~kitchen-response-size
          response# ~response]
-     (assert-response-status response# 200)
+     (assert-response-status response# http-200-ok)
      (is (= {:client-protocol http-version#
              :internal-protocol http-version#
              :response-size kitchen-response-size#}
@@ -56,7 +57,7 @@
         (make-request-with-debug-info request-headers #(make-shell-request waiter-url % :path "/request-info"))]
     (with-service-cleanup
       service-id
-      (assert-response-status response 200)
+      (assert-response-status response http-200-ok)
       (let [{:strs [x-nginx-client-proto x-nginx-client-scheme x-waiter-backend-proto]} headers]
         (is (= backend-proto-version x-nginx-client-proto))
         (is (= backend-scheme x-nginx-client-scheme))
@@ -146,7 +147,7 @@
                                                         :client http1-client
                                                         :query-params {"include" "request-info"})
               body-json (some-> body str json/read-str)]
-          (assert-response-status response 200)
+          (assert-response-status response http-200-ok)
           (is (= "HTTP/1.1" (retrieve-client-protocol body-json)) (str body-json))
           (is (= "HTTP/1.1" (retrieve-internal-protocol body-json)) (str body-json))
           (is (= "http" (retrieve-scheme body-json)) (str body-json))))
@@ -157,7 +158,7 @@
                                                           :client http2-client
                                                           :query-params {"include" "request-info"})
                 body-json (some-> body str json/read-str)]
-            (assert-response-status response 200)
+            (assert-response-status response http-200-ok)
             (is (= "HTTP/2.0" (retrieve-client-protocol body-json)) (str body-json))
             (is (= "HTTP/2.0" (retrieve-internal-protocol body-json)) (str body-json))
             (is (= "http" (retrieve-scheme body-json)) (str body-json)))))
@@ -169,7 +170,7 @@
                                                           :query-params {"include" "request-info"}
                                                           :scheme "https")
                 body-json (some-> body str json/read-str)]
-            (assert-response-status response 200)
+            (assert-response-status response http-200-ok)
             (is (= "HTTP/1.1" (retrieve-client-protocol body-json)) (str body-json))
             (is (= "HTTP/1.1" (retrieve-internal-protocol body-json)) (str body-json))
             (is (= "https" (retrieve-scheme body-json)) (str body-json))))
@@ -181,7 +182,7 @@
                                                             :query-params {"include" "request-info"}
                                                             :scheme "https")
                   body-json (some-> body str json/read-str)]
-              (assert-response-status response 200)
+              (assert-response-status response http-200-ok)
               (is (= "HTTP/2.0" (retrieve-client-protocol body-json)) (str body-json))
               (is (= "HTTP/2.0" (retrieve-internal-protocol body-json)) (str body-json))
               (is (= "https" (retrieve-scheme body-json)) (str body-json)))))))))

--- a/waiter/integration/waiter/reporters_integration_test.clj
+++ b/waiter/integration/waiter/reporters_integration_test.clj
@@ -15,13 +15,14 @@
 ;;
 (ns waiter.reporters-integration-test
   (:require [clojure.test :refer :all]
+            [waiter.status-codes :refer :all]
             [waiter.util.client-tools :refer :all]
             [waiter.util.date-utils :as du]))
 
 (defn- get-graphite-reporter-state
   [waiter-url cookies]
   (let [{:keys [body] :as response} (make-request waiter-url "/state/codahale-reporters" :method :get :cookies cookies)]
-    (assert-response-status response 200)
+    (assert-response-status response http-200-ok)
     (-> body str try-parse-json (get-in ["state" "graphite"]))))
 
 (defn- wait-for-period

--- a/waiter/integration/waiter/request_method_test.clj
+++ b/waiter/integration/waiter/request_method_test.clj
@@ -15,6 +15,7 @@
 ;;
 (ns waiter.request-method-test
   (:require [clojure.test :refer :all]
+            [waiter.status-codes :refer :all]
             [waiter.util.client-tools :refer :all]))
 
 (deftest ^:parallel ^:integration-fast test-request-method
@@ -23,7 +24,7 @@
           service-name (rand-name)
           headers {:x-waiter-name service-name, :x-kitchen-echo "true"}
           {:keys [service-id] :as response} (make-request-with-debug-info headers #(make-kitchen-request waiter-url %))]
-      (assert-response-status response 200)
+      (assert-response-status response http-200-ok)
       (with-service-cleanup
         service-id
         (is (= lorem-ipsum (:body (make-kitchen-request waiter-url headers :body lorem-ipsum :method :get))))

--- a/waiter/integration/waiter/response_headers_test.clj
+++ b/waiter/integration/waiter/response_headers_test.clj
@@ -16,6 +16,7 @@
 (ns waiter.response-headers-test
   (:require [clojure.string :as str]
             [clojure.test :refer :all]
+            [waiter.status-codes :refer :all]
             [waiter.util.client-tools :refer :all]))
 
 (defn- make-debug-kitchen-request
@@ -31,13 +32,13 @@
         service-id
         (testing "Basic response headers test using endpoint"
           (let [{:keys [headers] :as response} (make-kitchen-request waiter-url extra-headers :debug false)]
-            (assert-response-status response 200)
+            (assert-response-status response http-200-ok)
             (is (every? #(not (str/blank? (get headers %))) required-response-headers) (str "Response headers: " headers))
             (is (every? #(str/blank? (get headers %)) (retrieve-debug-response-headers waiter-url)) (str headers))))
 
         (testing "Router-Id in response headers test using endpoint"
           (let [{:keys [headers] :as response} (make-kitchen-request waiter-url extra-headers :debug true)]
-            (assert-response-status response 200)
+            (assert-response-status response http-200-ok)
             (is (every? #(not (str/blank? (get headers %)))
                         (concat required-response-headers (retrieve-debug-response-headers waiter-url)))
                 (str headers))))
@@ -46,7 +47,7 @@
           (let [test-cid "1234567890"
                 extra-headers (assoc extra-headers :x-cid test-cid)
                 {:keys [headers] :as response} (make-kitchen-request waiter-url extra-headers :debug false)]
-            (assert-response-status response 200)
+            (assert-response-status response http-200-ok)
             (is (= test-cid (get headers "x-cid")) (str headers))
             (is (every? #(not (str/blank? (get headers %))) required-response-headers) (str headers))
             (is (every? #(str/blank? (get headers %)) (retrieve-debug-response-headers waiter-url)) (str headers))))))))

--- a/waiter/integration/waiter/streaming_test.clj
+++ b/waiter/integration/waiter/streaming_test.clj
@@ -16,6 +16,7 @@
 (ns waiter.streaming-test
   (:require [clojure.test :refer :all]
             [clojure.tools.logging :as log]
+            [waiter.status-codes :refer :all]
             [waiter.util.client-tools :refer :all])
   (:import (java.net HttpURLConnection URL)))
 
@@ -33,7 +34,7 @@
           service-id (retrieve-service-id waiter-url request-headers)
           epsilon 0.01
           num-streaming-requests 50]
-      (assert-response-status canary-response 200)
+      (assert-response-status canary-response http-200-ok)
       (with-service-cleanup
         service-id
         (dotimes [n num-streaming-requests]
@@ -43,7 +44,7 @@
                           :content-type "application/octet-stream"
                           :x-cid request-cid)
                 {:keys [body] :as response} (make-kitchen-request waiter-url headers :body post-body :path "/streaming")]
-            (assert-response-status response 200)
+            (assert-response-status response http-200-ok)
             (is (.equals post-body body) (str response)))) ;; avoids printing the post-body when assertion fails
         ; wait to allow metrics to be aggregated
         (let [sleep-period (max (* 20 metrics-sync-interval-ms) 10000)]
@@ -80,7 +81,7 @@
           headers {:x-waiter-name (rand-name), :x-kitchen-echo true}
           {:keys [body service-id] :as response}
           (make-request-with-debug-info headers #(make-kitchen-request waiter-url % :body request-body))]
-      (assert-response-status response 200)
+      (assert-response-status response http-200-ok)
       (is (= (count request-body) (count body)))
       (delete-service waiter-url service-id))))
 

--- a/waiter/src/waiter/auth/authentication.clj
+++ b/waiter/src/waiter/auth/authentication.clj
@@ -20,6 +20,7 @@
             [clojure.tools.logging :as log]
             [waiter.cookie-support :as cookie-support]
             [waiter.middleware :as middleware]
+            [waiter.status-codes :refer :all]
             [waiter.util.utils :as utils]))
 
 (def ^:const AUTH-COOKIE-NAME "x-waiter-auth")
@@ -48,7 +49,7 @@
   Object
   (process-callback [this _]
     (throw (ex-info (str this " does not support authentication callbacks.")
-                    {:status 400}))))
+                    {:status http-400-bad-request}))))
 
 (defn- add-cached-auth
   [response password principal age-in-seconds]
@@ -159,13 +160,13 @@
             (handle-request-auth request-handler request :single-user run-as-user password)
             (= "unauthorized" auth-path)
             (utils/attach-waiter-source
-              {:headers {"www-authenticate" "SingleUser"} :status 401})
+              {:headers {"www-authenticate" "SingleUser"} :status http-401-unauthorized})
             (= "forbidden" auth-path)
             (utils/attach-waiter-source
-              {:headers {} :status 403})
+              {:headers {} :status http-403-forbidden})
             :else
             (utils/attach-waiter-source
-              {:headers {"x-waiter-single-user" (str "unknown operation: " auth-path)} :status 400})))))))
+              {:headers {"x-waiter-single-user" (str "unknown operation: " auth-path)} :status http-400-bad-request})))))))
 
 (defn one-user-authenticator
   "Factory function for creating single-user authenticator"

--- a/waiter/src/waiter/auth/composite.clj
+++ b/waiter/src/waiter/auth/composite.clj
@@ -17,6 +17,7 @@
   (:require [clojure.string :as str]
             [plumbing.core :as pc]
             [waiter.auth.authentication :as auth]
+            [waiter.status-codes :refer :all]
             [waiter.util.utils :as utils]))
 
 (defrecord CompositeAuthenticator [default-authentication provider-name->authenticator]
@@ -31,7 +32,7 @@
             (throw (ex-info (str "No authenticator found for " authentication " authentication.")
                             {:available-authenticators (keys provider-name->handler)
                              :request-authentication authentication
-                             :status 400})))))))
+                             :status http-400-bad-request})))))))
 
   auth/CompositeAuthenticator
   (get-authentication-providers [_]
@@ -44,7 +45,7 @@
       (throw (ex-info (str "Unknown authentication provider " authentication-provider)
                       {:available-authenticators (keys provider-name->authenticator)
                        :authentication-provider authentication-provider
-                       :status 400})))))
+                       :status http-400-bad-request})))))
 
 (defn- make-authenticator
   "Create an authenticator from an authentication-provider"

--- a/waiter/src/waiter/auth/kerberos.clj
+++ b/waiter/src/waiter/auth/kerberos.clj
@@ -23,6 +23,7 @@
             [waiter.authorization :as authz]
             [waiter.auth.spnego :as spnego]
             [waiter.metrics :as metrics]
+            [waiter.status-codes :refer :all]
             [waiter.util.utils :as utils])
   (:import (java.util.concurrent LinkedBlockingQueue ThreadPoolExecutor TimeUnit)))
 
@@ -100,7 +101,7 @@
         (throw (ex-info "No prestashed tickets available"
                         {:message (utils/message :prestashed-tickets-not-available)
                          :service-id service-id
-                         :status 403
+                         :status http-403-forbidden
                          :user run-as-user
                          :log-level :warn}))))))
 

--- a/waiter/src/waiter/cors.clj
+++ b/waiter/src/waiter/cors.clj
@@ -20,6 +20,7 @@
             [waiter.metrics :as metrics]
             [waiter.service-description :as sd]
             [waiter.schema :as schema]
+            [waiter.status-codes :refer :all]
             [waiter.util.ring-utils :as ru]
             [waiter.util.utils :as utils])
   (:import java.util.regex.Pattern))
@@ -64,7 +65,7 @@
         (let [{:keys [headers request-method]} request
               {:strs [origin]} headers]
           (when-not origin
-            (throw (ex-info "No origin provided" {:status 403})))
+            (throw (ex-info "No origin provided" {:status http-403-forbidden})))
           (let [{:keys [allowed? summary allowed-methods]}
                 (preflight-check cors-validator (assoc request :waiter-discovery discovered-parameters))]
             (when-not allowed?
@@ -72,11 +73,11 @@
               (throw (ex-info "Cross-origin request not allowed" {:cors-checks summary
                                                                   :origin origin
                                                                   :request-method request-method
-                                                                  :status 403
+                                                                  :status http-403-forbidden
                                                                   :log-level :warn})))
             (log/info "cors preflight request allowed" summary)
             (let [{:strs [access-control-request-headers]} headers]
-              {:status 200
+              {:status http-200-ok
                :headers {"access-control-allow-origin" origin
                          "access-control-allow-headers" access-control-request-headers
                          "access-control-allow-methods" (str/join ", " (or allowed-methods schema/http-methods))
@@ -114,7 +115,7 @@
                               {:cors-checks summary
                                :origin origin
                                :request-method request-method
-                               :status 403
+                               :status http-403-forbidden
                                :log-level :warn})))
             (log/info "cors request allowed" summary)
             (-> (handler request)

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -29,6 +29,7 @@
             [waiter.metrics :as metrics]
             [waiter.middleware :as middleware]
             [waiter.service-description :as sd]
+            [waiter.status-codes :refer :all]
             [waiter.token :as token]
             [waiter.util.async-utils :as au]
             [waiter.util.utils :as utils]))
@@ -85,7 +86,7 @@
                 location (str "/waiter-consent" uri (when-not (str/blank? query-string) (str "?" query-string)))]
             (counters/inc! (metrics/waiter-counter "auto-run-as-requester" "redirect"))
             (meters/mark! (metrics/waiter-meter "auto-run-as-requester" "redirect"))
-            {:headers {"location" location} :status 303})
+            {:headers {"location" location} :status http-303-see-other})
           (do
             ; For consistency with historical data, count errors looking up the descriptor as a "process error"
             (meters/mark! (metrics/waiter-meter "core" "process-errors"))
@@ -328,13 +329,13 @@
           (throw (ex-info "Authenticated user cannot run service"
                           {:authenticated-user auth-user
                            :run-as-user run-as-user
-                           :status 403
+                           :status http-403-forbidden
                            :log-level :warn})))
         (when-not (request-authorized? auth-user permitted-user)
           (throw (ex-info "This user isn't allowed to invoke this service"
                           {:authenticated-user auth-user
                            :service-description service-description
-                           :status 403
+                           :status http-403-forbidden
                            :log-level :warn})))
         {:descriptor descriptor
          :latest-descriptor latest-descriptor}))))

--- a/waiter/src/waiter/interstitial.clj
+++ b/waiter/src/waiter/interstitial.clj
@@ -26,6 +26,7 @@
             [metrics.meters :as meters]
             [plumbing.core :as pc]
             [waiter.metrics :as metrics]
+            [waiter.status-codes :refer :all]
             [waiter.util.async-utils :as au]))
 
 (defn- service-id->interstitial-promise
@@ -240,7 +241,7 @@
           (meters/mark! (metrics/waiter-meter "interstitial" "redirect"))
           {:headers {"location" location
                      "x-waiter-interstitial" "true"}
-           :status 303})))))
+           :status http-303-see-other})))))
 
 (let [interstitial-template-fn (template/fn [{:keys [target-url]}] (slurp (io/resource "web/interstitial.html")))]
   (defn render-interstitial-template
@@ -257,4 +258,4 @@
                         ;; the bypass interstitial should be the last query parameter
                         (request-time->interstitial-param-string request-time))]
     {:body (render-interstitial-template {:target-url target-url})
-     :status 200}))
+     :status http-200-ok }))

--- a/waiter/src/waiter/scaling.clj
+++ b/waiter/src/waiter/scaling.clj
@@ -26,6 +26,7 @@
             [waiter.metrics :as metrics]
             [waiter.scheduler :as scheduler]
             [waiter.service :as service]
+            [waiter.status-codes :refer :all]
             [waiter.util.async-utils :as au]
             [waiter.util.utils :as utils])
   (:import (org.joda.time DateTime)))
@@ -182,7 +183,7 @@
                                  scheduler populate-maintainer-chan! timeout-config service-id correlation-id 1
                                  scale-service-thread-pool response-chan))
             {:keys [instance-id status] :as kill-response} (or (async/poll! response-chan)
-                                                               {:message :no-instance-killed, :status 404})]
+                                                               {:message :no-instance-killed, :status http-404-not-found})]
         (if instance-killed?
           (cid/cinfo correlation-id "killed instance" instance-id)
           (cid/cinfo correlation-id "unable to kill instance" kill-response))
@@ -190,7 +191,7 @@
                                        :service-id service-id
                                        :source-router-id src-router-id
                                        :success instance-killed?}
-                                      :status (or status 500))
+                                      :status (or status http-500-internal-server-error))
             (update :headers assoc "x-cid" correlation-id))))))
 
 (defn compute-scale-amount-restricted-by-quanta

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -26,6 +26,7 @@
             [waiter.metrics :as metrics]
             [waiter.scheduler :as scheduler]
             [waiter.schema :as schema]
+            [waiter.status-codes :refer :all]
             [waiter.util.async-utils :as au]
             [waiter.util.cache-utils :as cu]
             [waiter.util.date-utils :as du]
@@ -396,7 +397,7 @@
         (str "service-exists?[" service-id "]")
         (some->> (service-id->service-description-fn service-id)
           (retrieve-jobs cook-api search-interval service-id)))
-      (catch [:status 404] _
+      (catch [:status http-404-not-found] _
         (log/warn "service-exists?: service" service-id "does not exist!"))))
 
   (create-service-if-new [this {:keys [service-id] :as descriptor}]

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -29,6 +29,7 @@
             [schema.core :as s]
             [waiter.metrics :as metrics]
             [waiter.scheduler :as scheduler]
+            [waiter.status-codes :refer :all]
             [waiter.util.async-utils :as au]
             [waiter.util.date-utils :as du]
             [waiter.util.http-utils :as hu]
@@ -323,7 +324,7 @@
                                       instance health-check-proto health-check-port-index health-check-path)
           {:keys [status error]} (async/<!! (http/get http-client instance-health-check-url))]
       (scheduler/log-health-check-issues instance instance-health-check-url status error)
-      (and (not error) (<= 200 status 299)))
+      (and (not error) (hu/status-2XX? status)))
     false))
 
 (defn- update-instance-health

--- a/waiter/src/waiter/state/maintainer.clj
+++ b/waiter/src/waiter/state/maintainer.clj
@@ -26,6 +26,7 @@
             [waiter.correlation-id :as cid]
             [waiter.metrics :as metrics]
             [waiter.scheduler :as scheduler]
+            [waiter.status-codes :refer :all]
             [waiter.util.async-utils :as au]
             [waiter.util.date-utils :as du]
             [waiter.util.utils :as utils]))
@@ -491,7 +492,7 @@
                              (and has-failed-instances? (no-instances-flagged-with? :has-connected)) :cannot-connect
                              (and has-failed-instances? (no-instances-flagged-with? :has-responded)) :health-check-timed-out
                              (and has-failed-instances? (all-instances-flagged-with? :never-passed-health-checks)) :invalid-health-check-response
-                             (and has-unhealthy-instances? (= first-unhealthy-status 401)) :health-check-requires-authentication)]
+                             (and has-unhealthy-instances? (= first-unhealthy-status http-401-unauthorized)) :health-check-requires-authentication)]
       (when deployment-error
         (log/debug "computed deployment error"
                    {:deployment-error deployment-error

--- a/waiter/src/waiter/status_codes.clj
+++ b/waiter/src/waiter/status_codes.clj
@@ -1,0 +1,80 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns waiter.status-codes
+  (:import (org.eclipse.jetty.http HttpStatus)
+           (org.eclipse.jetty.websocket.api StatusCode)))
+
+(def ^:const http-200-ok HttpStatus/OK_200)
+(def ^:const http-201-created HttpStatus/CREATED_201)
+(def ^:const http-202-accepted HttpStatus/ACCEPTED_202)
+(def ^:const http-204-no-content HttpStatus/NO_CONTENT_204)
+(def ^:const http-300-multiple-choices HttpStatus/MULTIPLE_CHOICES_300)
+(def ^:const http-301-moved-permanently HttpStatus/MOVED_PERMANENTLY_301)
+(def ^:const http-302-moved-temporarily HttpStatus/MOVED_TEMPORARILY_302)
+(def ^:const http-303-see-other HttpStatus/SEE_OTHER_303)
+(def ^:const http-307-temporary-redirect HttpStatus/TEMPORARY_REDIRECT_307)
+(def ^:const http-308-permanent-redirect HttpStatus/PERMANENT_REDIRECT_308)
+(def ^:const http-400-bad-request HttpStatus/BAD_REQUEST_400)
+(def ^:const http-401-unauthorized HttpStatus/UNAUTHORIZED_401)
+(def ^:const http-402-payment-required HttpStatus/PAYMENT_REQUIRED_402)
+(def ^:const http-403-forbidden HttpStatus/FORBIDDEN_403)
+(def ^:const http-404-not-found HttpStatus/NOT_FOUND_404)
+(def ^:const http-405-method-not-allowed HttpStatus/METHOD_NOT_ALLOWED_405)
+(def ^:const http-409-conflict HttpStatus/CONFLICT_409)
+(def ^:const http-410-gone HttpStatus/GONE_410)
+(def ^:const http-423-locked HttpStatus/LOCKED_423)
+(def ^:const http-429-too-many-requests HttpStatus/TOO_MANY_REQUESTS_429)
+(def ^:const http-500-internal-server-error HttpStatus/INTERNAL_SERVER_ERROR_500)
+(def ^:const http-501-not-implemented HttpStatus/NOT_IMPLEMENTED_501)
+(def ^:const http-502-bad-gateway HttpStatus/BAD_GATEWAY_502)
+(def ^:const http-503-service-unavailable HttpStatus/SERVICE_UNAVAILABLE_503)
+(def ^:const http-504-gateway-timeout HttpStatus/GATEWAY_TIMEOUT_504)
+
+(def ^:const websocket-1000-normal StatusCode/NORMAL)
+(def ^:const websocket-1001-shutdown StatusCode/SHUTDOWN)
+(def ^:const websocket-1002-protocol StatusCode/PROTOCOL)
+(def ^:const websocket-1003-bad-data StatusCode/BAD_DATA)
+(def ^:const websocket-1004-undefined StatusCode/UNDEFINED)
+(def ^:const websocket-1005-no-code StatusCode/NO_CODE)
+(def ^:const websocket-1006-abnormal StatusCode/ABNORMAL)
+(def ^:const websocket-1007-bad-payload StatusCode/BAD_PAYLOAD)
+(def ^:const websocket-1008-policy-violation StatusCode/POLICY_VIOLATION)
+(def ^:const websocket-1009-message-too-large StatusCode/MESSAGE_TOO_LARGE)
+(def ^:const websocket-1010-required-extension StatusCode/REQUIRED_EXTENSION)
+(def ^:const websocket-1011-server-error StatusCode/SERVER_ERROR)
+(def ^:const websocket-1012-service-restart StatusCode/SERVICE_RESTART)
+(def ^:const websocket-1013-try-again-later StatusCode/TRY_AGAIN_LATER)
+(def ^:const websocket-1014-invalid-upstream-response StatusCode/INVALID_UPSTREAM_RESPONSE)
+(def ^:const websocket-1015-failed-tls-handshake StatusCode/FAILED_TLS_HANDSHAKE)
+
+;; Constants from io.grpc.Status, we don't want to add a compile-time dependency on it
+(def ^:const grpc-0-ok 0)
+(def ^:const grpc-1-cancelled 1)
+(def ^:const grpc-2-unknown 2)
+(def ^:const grpc-3-invalid-argument 3)
+(def ^:const grpc-4-deadline-exceeded 4)
+(def ^:const grpc-5-not-found 5)
+(def ^:const grpc-6-already-exists 6)
+(def ^:const grpc-7-permission-denied 7)
+(def ^:const grpc-8-resource-exhausted 8)
+(def ^:const grpc-9-failed-precondition 9)
+(def ^:const grpc-10-aborted 10)
+(def ^:const grpc-11-out-of-range 11)
+(def ^:const grpc-12-unimplemented 12)
+(def ^:const grpc-13-internal 13)
+(def ^:const grpc-14-unavailable 14)
+(def ^:const grpc-15-data-loss 15)
+(def ^:const grpc-16-unauthenticated 16)

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -28,6 +28,7 @@
             [waiter.correlation-id :as cid]
             [waiter.mesos.marathon :as marathon]
             [waiter.statsd :as statsd]
+            [waiter.status-codes :refer :all]
             [waiter.util.date-utils :as du]
             [waiter.util.http-utils :as hu]
             [waiter.util.utils :as utils])
@@ -748,7 +749,7 @@
                                     ", target:" target-count))
         num-groups (cond
                      (> target-count 300) 6
-                     (> target-count 200) 5
+                     (> target-count 200 ) 5
                      (> target-count 100) 4
                      (> target-count 60) 3
                      :else 2)
@@ -818,7 +819,7 @@
                                :headers (assoc headers "host" token)
                                :method :delete
                                :query-params (if hard-delete {"hard-delete" true} {}))]
-    (assert-response-status response 200)))
+    (assert-response-status response http-200-ok )))
 
 (defn wait-for
   "Invoke predicate every interval (default 10) seconds until it returns true,

--- a/waiter/src/waiter/util/ring_utils.clj
+++ b/waiter/src/waiter/util/ring_utils.clj
@@ -18,6 +18,7 @@
             [clojure.data.json :as json]
             [ring.middleware.params :as ring-params]
             [ring.util.request :as ring-request]
+            [waiter.status-codes :refer :all]
             [waiter.util.async-utils :as au]))
 
 (defn update-response
@@ -33,7 +34,7 @@
   (try
     (assoc request :body (-> body slurp json/read-str))
     (catch Exception e
-      (throw (ex-info "Invalid JSON payload" {:status 400} e)))))
+      (throw (ex-info "Invalid JSON payload" {:status http-400-bad-request} e)))))
 
 (defn query-params-request
   "Like Ring's params-request, but doesn't try to pull params from the body."
@@ -45,7 +46,7 @@
   "Determines if a response is an error"
   [{:keys [status]}]
   (and status
-       (>= status 400)
+       (>= status http-400-bad-request)
        (<= status 599)))
 
 (defn attach-header

--- a/waiter/test/waiter/auth/kerberos_test.clj
+++ b/waiter/test/waiter/auth/kerberos_test.clj
@@ -19,6 +19,7 @@
             [clojure.string :as str]
             [clojure.test :refer :all]
             [waiter.auth.kerberos :refer :all]
+            [waiter.status-codes :refer :all]
             [waiter.util.utils :as utils])
   (:import (clojure.lang ExceptionInfo)
            (waiter.auth.kerberos KerberosAuthenticator)))
@@ -90,7 +91,7 @@
           (is false "Expected exception to be thrown")
           (catch ExceptionInfo e
             (let [{:keys [status message]} (ex-data e)]
-              (is (= 403 status))
+              (is (= http-403-forbidden status))
               (is (str/includes? message "Prestashed tickets")))))))
 
     (testing "queries on cache miss"

--- a/waiter/test/waiter/auth/saml_test.clj
+++ b/waiter/test/waiter/auth/saml_test.clj
@@ -21,6 +21,7 @@
             [taoensso.nippy :as nippy]
             [waiter.auth.authentication :as auth]
             [waiter.auth.saml :refer :all]
+            [waiter.status-codes :refer :all]
             [waiter.util.utils :as utils])
   (:import (java.io StringBufferInputStream)))
 
@@ -87,7 +88,7 @@
                                          (get-idp-redirect-original idp-url "saml-request" "relay-state"))]
           (is (= {:body ""
                   :headers {"Location" "https://idp-host/idp-endpoint?SAMLRequest=saml-request&RelayState=relay-state"}
-                  :status 302}
+                  :status http-302-moved-temporarily}
                  (wrapped-handler dummy-request))))))))
 
 (deftest test-auth-redirect-endpoint
@@ -119,7 +120,7 @@
                   :body ""
                   :headers {"location" "redirect-url"
                             "set-cookie" "x-waiter-auth=%5B%22my%2Duser%40domain%22+1557792000000%5D;Max-Age=86400;Path=/;HttpOnly=true"}
-                  :status 303}
+                  :status http-303-see-other}
                  (saml-auth-redirect-handler saml-authenticator dummy-request'))))))
     (testing "has saml-auth-data no expiry"
       (with-redefs [b64/decode identity
@@ -139,7 +140,7 @@
                   :body ""
                   :headers {"location" "redirect-url"
                             "set-cookie" "x-waiter-auth=%5B%22my%2Duser%40domain%22+1557792000000%5D;Max-Age=86400;Path=/;HttpOnly=true"}
-                  :status 303}
+                  :status http-303-see-other}
                  (saml-auth-redirect-handler saml-authenticator dummy-request'))))))
     (testing "has saml-auth-data short expiry"
       (with-redefs [b64/decode identity
@@ -159,7 +160,7 @@
                   :body ""
                   :headers {"location" "redirect-url"
                             "set-cookie" "x-waiter-auth=%5B%22my%2Duser%40domain%22+1557792000000%5D;Max-Age=3600;Path=/;HttpOnly=true"}
-                  :status 303}
+                  :status http-303-see-other}
                  (saml-auth-redirect-handler saml-authenticator dummy-request'))))))))
 
 (defn- saml-response-from-xml
@@ -181,7 +182,7 @@
                                         :saml-auth-data {:min-session-not-on-or-after expiry-time
                                                          :redirect-url "request-url"
                                                          :saml-principal "user1@example.com"}}
-                                 :status 200}]
+                                 :status http-200-ok}]
     (with-redefs [nippy/freeze (fn [data _] (.getBytes (str data)))
                   t/now (fn [] test-time)
                   render-authenticated-redirect-template identity

--- a/waiter/test/waiter/auth/spnego_test.clj
+++ b/waiter/test/waiter/auth/spnego_test.clj
@@ -17,6 +17,7 @@
   (:require [clojure.core.async :as async]
             [clojure.test :refer :all]
             [waiter.auth.spnego :refer :all]
+            [waiter.status-codes :refer :all]
             [waiter.util.utils :as utils]))
 
 (deftest test-decode-input-token
@@ -29,7 +30,7 @@
            (String. (decode-input-token {:headers {"authorization" encoded-token}}))))))
 
 (deftest test-require-gss
-  (let [ideal-response {:body "OK" :status 200}
+  (let [ideal-response {:body "OK" :status http-200-ok}
         request-handler (constantly ideal-response)
         thread-pool (Object.)
         max-queue-length 10
@@ -39,7 +40,7 @@
         standard-401-response {:body "Unauthorized"
                                :headers {"content-type" "text/plain"
                                          "www-authenticate" "Negotiate"}
-                               :status 401
+                               :status http-401-unauthorized
                                :waiter/response-source :waiter}]
 
     (with-redefs [utils/error-context->text-body #(-> % :message str)]
@@ -49,7 +50,7 @@
           (let [handler (require-gss request-handler thread-pool max-queue-length password)]
             (is (= {:body "Too many Kerberos authentication requests"
                     :headers {"content-type" "text/plain"}
-                    :status 503
+                    :status http-503-service-unavailable
                     :waiter/response-source :waiter}
                    (handler standard-request))))))
 

--- a/waiter/test/waiter/descriptor_test.clj
+++ b/waiter/test/waiter/descriptor_test.clj
@@ -23,6 +23,7 @@
             [waiter.descriptor :refer :all]
             [waiter.kv :as kv]
             [waiter.service-description :as sd]
+            [waiter.status-codes :refer :all]
             [waiter.token :as token]
             [waiter.util.async-utils :as au])
   (:import (clojure.lang ExceptionInfo)
@@ -31,7 +32,7 @@
 (deftest test-wrap-descriptor
   (let [latest-service-id "latest-service-id"
         fallback-service-id "fallback-service-id"
-        default-handler (fn [_] {:status 200})
+        default-handler (fn [_] {:status http-200-ok})
         latest-descriptor {:service-id latest-service-id}]
     (testing "latest-service-request"
       (let [request {:request-id (str "req-" (rand-int 1000))}
@@ -47,7 +48,7 @@
             fallback-state-atom (atom {:available-service-ids #{} :healthy-service-ids #{}})
             handler (wrap-descriptor default-handler request->descriptor-fn start-new-service-fn fallback-state-atom)
             response (handler request)]
-        (is (= {:descriptor descriptor :latest-service-id latest-service-id :status 200} response))
+        (is (= {:descriptor descriptor :latest-service-id latest-service-id :status http-200-ok} response))
         (is (= :no-service (deref started-service-id-promise 0 :no-service)))))
 
     (testing "fallback-with-latest-service-exists"
@@ -64,7 +65,7 @@
             fallback-state-atom (atom {:available-service-ids #{latest-service-id} :healthy-service-ids #{}})
             handler (wrap-descriptor default-handler request->descriptor-fn start-new-service-fn fallback-state-atom)
             response (handler request)]
-        (is (= {:descriptor descriptor :latest-service-id latest-service-id :status 200} response))
+        (is (= {:descriptor descriptor :latest-service-id latest-service-id :status http-200-ok} response))
         (is (= :no-service (deref started-service-id-promise 0 :no-service)))))
 
     (testing "fallback-with-latest-service-does-not-exist"
@@ -80,7 +81,7 @@
             fallback-state-atom (atom {:available-service-ids #{} :healthy-service-ids #{}})
             handler (wrap-descriptor default-handler request->descriptor-fn start-new-service-fn fallback-state-atom)
             response (handler request)]
-        (is (= {:descriptor descriptor :latest-service-id latest-service-id :status 200} response))
+        (is (= {:descriptor descriptor :latest-service-id latest-service-id :status http-200-ok} response))
         (is (= latest-service-id (deref started-service-id-promise 0 :no-service)))))))
 
 (deftest test-fallback-maintainer

--- a/waiter/test/waiter/middleware_test.clj
+++ b/waiter/test/waiter/middleware_test.clj
@@ -16,19 +16,20 @@
 (ns waiter.middleware-test
   (:require [clojure.core.async :as async]
             [clojure.test :refer :all]
-            [waiter.middleware :refer :all]))
+            [waiter.middleware :refer :all]
+            [waiter.status-codes :refer :all]))
 
 (deftest test-wrap-update
   (testing "sync"
     (let [handler (-> (fn [request]
                         (is (= :value (:key request)))
-                        {:status 200})
+                        {:status http-200-ok})
                       (wrap-assoc :key :value))]
       (is (= :value (-> {} handler :key)))))
   (testing "async"
     (let [handler (-> (fn [request]
                         (is (= :value (:key request)))
-                        (async/go {:status 200}))
+                        (async/go {:status http-200-ok}))
                       (wrap-assoc :key :value))]
       (is (= :value (-> {} handler async/<!! :key)))))
   (testing "sync w/ exception"

--- a/waiter/test/waiter/request_log_test.clj
+++ b/waiter/test/waiter/request_log_test.clj
@@ -16,7 +16,8 @@
 (ns waiter.request-log-test
   (:require [clj-time.core :as t]
             [clojure.test :refer :all]
-            [waiter.request-log :refer :all]))
+            [waiter.request-log :refer :all]
+            [waiter.status-codes :refer :all]))
 
 (deftest test-request->context
   (let [request {:client-protocol "HTTP/2.0"
@@ -81,13 +82,13 @@
                   :latest-service-id "latest-service-id"
                   :protocol "HTTP/2.0"
                   :request-type "test-request"
-                  :status 200
+                  :status http-200-ok
                   :waiter-api-call? false}]
     (is (= {:authentication-method "cookie"
             :backend-response-latency-ns 1000
             :backend-protocol "HTTP/2.0"
             :get-instance-latency-ns 500
-            :grpc-status "13"
+            :grpc-status (str grpc-13-internal)
             :handle-request-latency-ns 2000
             :instance-host "instance-host"
             :instance-id "instance-id"
@@ -107,7 +108,7 @@
             :service-id "service-id"
             :service-name "service-name"
             :service-version "service-version"
-            :status 200
+            :status http-200-ok
             :token "test-token1,test-token2"
             :waiter-api false
             :waiter-error-class "java.lang.Exception"}
@@ -146,7 +147,7 @@
                   :handle-request-latency-ns 2000
                   :headers {"content-length" "40"
                             "content-type" "application/xml"
-                            "grpc-status" "13"
+                            "grpc-status" (str grpc-13-internal)
                             "location" "/foo/bar"
                             "server" "foo-bar"}
                   :instance {:host "instance-host"
@@ -158,7 +159,7 @@
                   :latest-service-id "latest-service-id"
                   :protocol "HTTP/2.0"
                   :request-type "test-request"
-                  :status 200
+                  :status http-200-ok
                   :waiter-api-call? false}
         log-entries (atom [])]
     (with-redefs [log (fn [log-data]
@@ -184,7 +185,7 @@
                 :backend-response-latency-ns 1000
                 :backend-protocol "HTTP/2.0"
                 :get-instance-latency-ns 500
-                :grpc-status "13"
+                :grpc-status (str grpc-13-internal)
                 :handle-request-latency-ns 2000
                 :instance-host "instance-host"
                 :instance-id "instance-id"
@@ -203,7 +204,7 @@
                 :service-id "service-id"
                 :service-name "service-name"
                 :service-version "service-version"
-                :status 200
+                :status http-200-ok
                 :token "test-token1,test-token2"
                 :waiter-api false
                 :waiter-error-class "java.lang.Exception"}
@@ -213,7 +214,7 @@
   (let [log-entries (atom [])]
     (with-redefs [log (fn [log-data]
                         (swap! log-entries conj log-data))]
-      (let [handler (wrap-log (fn [_] {:status 200}))
+      (let [handler (wrap-log (fn [_] {:status http-200-ok}))
             request {:headers {"content-type" "text/plain"
                                "host" "host"
                                "x-cid" "123"}
@@ -232,5 +233,5 @@
                 :request-content-type "text/plain"
                 :request-id "abc"
                 :scheme "http"
-                :status 200}
+                :status http-200-ok}
                (dissoc log-entry :handle-request-latency-ns)))))))

--- a/waiter/test/waiter/scheduler/cook_test.clj
+++ b/waiter/test/waiter/scheduler/cook_test.clj
@@ -19,9 +19,10 @@
             [clojure.string :as str]
             [clojure.test :refer :all]
             [waiter.config :as config]
-            [waiter.scheduler.cook :refer :all]
             [waiter.mesos.mesos :as mesos]
             [waiter.scheduler :as scheduler]
+            [waiter.scheduler.cook :refer :all]
+            [waiter.status-codes :refer :all]
             [waiter.util.date-utils :as du]
             [waiter.util.http-utils :as hu]
             [waiter.util.utils :as utils])
@@ -693,7 +694,7 @@
         (is (= {:killed? true :message "Killed foo.1A" :result :killed :success true}
                (scheduler/kill-instance scheduler test-instance))))
 
-      (with-redefs [delete-jobs (fn [_ _] (throw (ex-info "Delete error" {:status 400})))]
+      (with-redefs [delete-jobs (fn [_ _] (throw (ex-info "Delete error" {:status http-400-bad-request})))]
         (is (= {:killed? false :message "Unable to kill foo.1A" :result :failed :success false}
                (scheduler/kill-instance scheduler test-instance))))
 
@@ -758,7 +759,7 @@
         (is (= {:message "Deleted foo" :result :deleted :success true}
                (scheduler/delete-service scheduler "foo"))))
 
-      (with-redefs [delete-jobs (fn [_ _] (throw (ex-info "Delete error" {:status 400})))]
+      (with-redefs [delete-jobs (fn [_ _] (throw (ex-info "Delete error" {:status http-400-bad-request})))]
         (is (= {:message "Unable to delete foo" :result :failed :success false}
                (scheduler/delete-service scheduler "foo"))))
 

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -25,6 +25,7 @@
             [waiter.config :as config]
             [waiter.scheduler :as scheduler]
             [waiter.scheduler.shell :refer :all]
+            [waiter.status-codes :refer :all]
             [waiter.util.date-utils :as du]
             [waiter.util.utils :as utils])
   (:import clojure.lang.ExceptionInfo
@@ -361,7 +362,7 @@
       (with-redefs [http/get (fn [_ _]
                                (swap! health-check-count-atom inc)
                                (let [c (async/chan)]
-                                 (async/go (async/>! c {:status 200}))
+                                 (async/go (async/>! c {:status http-200-ok}))
                                  c))]
         (let [instance (-> (scheduler/service-id->state scheduler "foo") :id->instance vals first)]
           ;; We force a health check to occur

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -23,6 +23,7 @@
             [waiter.authorization :as authz]
             [waiter.kv :as kv]
             [waiter.service-description :refer :all]
+            [waiter.status-codes :refer :all]
             [waiter.util.cache-utils :as cu])
   (:import (clojure.lang ExceptionInfo)
            (org.joda.time DateTime)))
@@ -2233,7 +2234,7 @@
           (catch ExceptionInfo ex
             (is (= {:friendly-error-message "cpus must be a positive number."
                     :issue {}
-                    :status 400
+                    :status http-400-bad-request
                     :type :service-description-error}
                    (select-keys (ex-data ex) [:friendly-error-message :issue :status :type])))))))
 
@@ -2245,7 +2246,7 @@
           (catch ExceptionInfo ex
             (is (= {:friendly-error-message (str "The following fields exceed their allowed limits: "
                                                  "cpus is 200 but the max allowed is 100")
-                    :status 400
+                    :status http-400-bad-request
                     :type :service-description-error}
                    (select-keys (ex-data ex) [:friendly-error-message :status :type])))))))
 
@@ -2258,7 +2259,7 @@
             (is (= {:friendly-error-message (str "The following fields exceed their allowed limits: "
                                                  "cpus is 200 but the max allowed is 100, "
                                                  "mem is 40960 but the max allowed is 32768")
-                    :status 400
+                    :status http-400-bad-request
                     :type :service-description-error}
                    (select-keys (ex-data ex) [:friendly-error-message :status :type])))))))
 

--- a/waiter/test/waiter/state/maintainer_test.clj
+++ b/waiter/test/waiter/state/maintainer_test.clj
@@ -23,6 +23,7 @@
             [digest]
             [plumbing.core :as pc]
             [waiter.state.maintainer :refer :all]
+            [waiter.status-codes :refer :all]
             [waiter.util.async-utils :as au]
             [waiter.util.date-utils :as du]))
 
@@ -627,16 +628,16 @@
         test-cases (list {:name "no-instances", :healthy-instances [], :unhealthy-instances [], :failed-instances [], :expected nil}
                          {:name "no-deployment-errors", :healthy-instances [:instance-one], :unhealthy-instances [], :failed-instances [], :expected nil}
                          {:name "healthy-and-unhealthy-instances", :healthy-instances [:instance-one],
-                          :unhealthy-instances [{:health-check-status 400 :started-at alive-started-at}], :failed-instances [], :expected nil}
+                          :unhealthy-instances [{:health-check-status http-400-bad-request :started-at alive-started-at}], :failed-instances [], :expected nil}
                          {:name "healthy-and-failed-instances", :healthy-instances [:instance-one],
                           :unhealthy-instances [], :failed-instances [{:message "Command exited with status" :exit-code 1}], :expected nil}
                          {:name "single-unhealthy-instance", :healthy-instances [],
-                          :unhealthy-instances [{:health-check-status 400 :started-at alive-started-at}], :failed-instances [], :expected nil}
+                          :unhealthy-instances [{:health-check-status http-400-bad-request :started-at alive-started-at}], :failed-instances [], :expected nil}
                          {:name "single-failed-instance", :healthy-instances [], :unhealthy-instances [],
                           :failed-instances [{:message "Command exited with status" :exit-code 1}], :expected nil}
                          {:name "multiple-different-unhealthy-instances", :healthy-instances [],
-                          :unhealthy-instances [{:health-check-status 400 :started-at alive-started-at}
-                                                {:health-check-status 401 :started-at alive-started-at}],
+                          :unhealthy-instances [{:health-check-status http-400-bad-request :started-at alive-started-at}
+                                                {:health-check-status http-401-unauthorized :started-at alive-started-at}],
                           :failed-instances [], :expected nil}
                          {:name "multiple-different-failed-instances", :healthy-instances [], :unhealthy-instances [],
                           :failed-instances [{:message "Command exited with status" :exit-code 1}
@@ -663,10 +664,10 @@
                                              {:message "Command exited with status" :exit-code 1}],
                           :expected :bad-startup-command}
                          {:name "health-check-requires-authentication", :healthy-instances [],
-                          :unhealthy-instances [{:health-check-status 401}], :failed-instances [],
+                          :unhealthy-instances [{:health-check-status http-401-unauthorized}], :failed-instances [],
                           :expected :health-check-requires-authentication}
                          {:name "unhealthy-and-failed-instances", :healthy-instances [],
-                          :unhealthy-instances [{:health-check-status 401}],
+                          :unhealthy-instances [{:health-check-status http-401-unauthorized}],
                           :failed-instances [{:message "Command exited with status" :exit-code 1}
                                              {:message "Command exited with status" :exit-code 1}],
                           :expected :bad-startup-command})]
@@ -1030,7 +1031,7 @@
       (is (= routers (:routers (async/<!! router-state-push-chan))))
 
       (let [start-time (t/now)
-            unhealthy-health-check-statuses [400 401 402]
+            unhealthy-health-check-statuses [http-400-bad-request http-401-unauthorized http-402-payment-required]
             unhealthy-instances-fn (fn [service-id index]
                                      (vec (map (fn [x] {:id (str service-id "." x "1")
                                                         :health-check-status (get unhealthy-health-check-statuses (mod index (count unhealthy-health-check-statuses)))

--- a/waiter/test/waiter/work_stealing_test.clj
+++ b/waiter/test/waiter/work_stealing_test.clj
@@ -18,6 +18,7 @@
             [clojure.data.json :as json]
             [clojure.test :refer :all]
             [clojure.walk :as walk]
+            [waiter.status-codes :refer :all]
             [waiter.test-helpers]
             [waiter.util.semaphore :as semaphore]
             [waiter.test-helpers :refer :all]
@@ -579,7 +580,7 @@
 
       (testing "2XX response - missing status"
         (let [offers-allowed-semaphore (semaphore/create-semaphore 10)
-              make-inter-router-requests-fn (make-inter-router-requests-fn-factory 200 {})]
+              make-inter-router-requests-fn (make-inter-router-requests-fn-factory http-200-ok {})]
           (start-work-stealing-balancer populate-maintainer-chan! reserve-timeout-ms offer-help-interval-ms offers-allowed-semaphore
                                         service-id->router-id->metrics make-inter-router-requests-fn router-id service-id)
           (is @offer-help-fn-atom)
@@ -591,7 +592,7 @@
 
       (testing "2XX response - success"
         (let [offers-allowed-semaphore (semaphore/create-semaphore 10)
-              make-inter-router-requests-fn (make-inter-router-requests-fn-factory 200 {:response-status "successful"})]
+              make-inter-router-requests-fn (make-inter-router-requests-fn-factory http-200-ok {:response-status "successful"})]
           (start-work-stealing-balancer populate-maintainer-chan! reserve-timeout-ms offer-help-interval-ms offers-allowed-semaphore
                                         service-id->router-id->metrics make-inter-router-requests-fn router-id service-id)
           (is @offer-help-fn-atom)
@@ -603,7 +604,7 @@
 
       (testing "2XX response - failure"
         (let [offers-allowed-semaphore (semaphore/create-semaphore 10)
-              make-inter-router-requests-fn (make-inter-router-requests-fn-factory 200 {:response-status "failure"})]
+              make-inter-router-requests-fn (make-inter-router-requests-fn-factory http-200-ok {:response-status "failure"})]
           (start-work-stealing-balancer populate-maintainer-chan! reserve-timeout-ms offer-help-interval-ms offers-allowed-semaphore
                                         service-id->router-id->metrics make-inter-router-requests-fn router-id service-id)
           (is @offer-help-fn-atom)
@@ -615,7 +616,7 @@
 
       (testing "4XX response - failure"
         (let [offers-allowed-semaphore (semaphore/create-semaphore 10)
-              make-inter-router-requests-fn (make-inter-router-requests-fn-factory 400 {:response-status "failure"})]
+              make-inter-router-requests-fn (make-inter-router-requests-fn-factory http-400-bad-request {:response-status "failure"})]
           (start-work-stealing-balancer populate-maintainer-chan! reserve-timeout-ms offer-help-interval-ms offers-allowed-semaphore
                                         service-id->router-id->metrics make-inter-router-requests-fn router-id service-id)
           (is @offer-help-fn-atom)
@@ -627,7 +628,7 @@
 
       (testing "5XX response - failure"
         (let [offers-allowed-semaphore (semaphore/create-semaphore 10)
-              make-inter-router-requests-fn (make-inter-router-requests-fn-factory 500 {:response-status "failure"})]
+              make-inter-router-requests-fn (make-inter-router-requests-fn-factory http-500-internal-server-error {:response-status "failure"})]
           (start-work-stealing-balancer populate-maintainer-chan! reserve-timeout-ms offer-help-interval-ms offers-allowed-semaphore
                                         service-id->router-id->metrics make-inter-router-requests-fn router-id service-id)
           (is @offer-help-fn-atom)


### PR DESCRIPTION
## Changes proposed in this PR

- refactors HTTP status codes into constants
- refactors WebSocket status codes into constants
- refactors gRPC status codes into constants

## Why are we making these changes?

Makes it easier to find uses of various status codes in Waiter clojure code.
