### PR TITLE
Enable service preauthorization and authentication to work with profiles

### DIFF
--- a/waiter/src/waiter/auth/jwt.clj
+++ b/waiter/src/waiter/auth/jwt.clj
@@ -370,7 +370,7 @@
              (or
                ;; service requests will enable JWT auth based on env variable or when absent, the allow-bearer-auth-services?
                (and (not waiter-api-call?)
-                    (= "true" (get-in request [:waiter-discovery :service-parameter-template "env" "USE_BEARER_AUTH"]
+                    (= "true" (get-in request [:waiter-discovery :service-description-template "env" "USE_BEARER_AUTH"]
                                       (str allow-bearer-auth-services?))))
                ;; waiter api requests will enable JWT auth based on allow-bearer-auth-api?
                (and waiter-api-call? allow-bearer-auth-api?)))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -923,6 +923,10 @@
                                  (fn async-trigger-terminate-fn [target-router-id service-id request-id]
                                    (async-req/async-trigger-terminate
                                      async-request-terminate-fn make-inter-router-requests-sync-fn router-id target-router-id service-id request-id)))
+   :attach-service-defaults-fn (pc/fnk [[:settings metric-group-mappings service-description-defaults]
+                                      [:state profile->defaults]]
+                               (fn attach-service-defaults-fn [service-description]
+                                 (sd/merge-defaults service-description service-description-defaults profile->defaults metric-group-mappings)))
    :attach-token-defaults-fn (pc/fnk [[:settings [:token-config token-defaults]]
                                       [:state profile->defaults]]
                                (fn attach-token-defaults-fn [token-parameters]
@@ -1016,12 +1020,13 @@
    :request->descriptor-fn (pc/fnk [[:settings [:token-config history-length]]
                                     [:state fallback-state-atom kv-store service-description-builder
                                      service-id-prefix waiter-hostnames]
-                                    assoc-run-as-user-approved? attach-token-defaults-fn can-run-as?-fn
-                                    store-reference-fn store-source-tokens-fn]
+                                    assoc-run-as-user-approved? attach-service-defaults-fn attach-token-defaults-fn
+                                    can-run-as?-fn store-reference-fn store-source-tokens-fn]
                              (fn request->descriptor-fn [request]
                                (let [{:keys [latest-descriptor] :as result}
                                      (descriptor/request->descriptor
-                                       assoc-run-as-user-approved? can-run-as?-fn attach-token-defaults-fn
+                                       assoc-run-as-user-approved? can-run-as?-fn
+                                       attach-service-defaults-fn attach-token-defaults-fn
                                        fallback-state-atom kv-store history-length service-description-builder
                                        service-id-prefix waiter-hostnames request)
                                      {:keys [reference-type->entry service-id source-tokens]} latest-descriptor]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -632,7 +632,8 @@
                            passwords]
                     (let [hostname (if (sequential? hostname) (first hostname) hostname)]
                       (utils/create-component authenticator-config
-                                              :context {:hostname hostname
+                                              :context {:default-authentication (get service-description-defaults "authentication")
+                                                        :hostname hostname
                                                         :password (first passwords)})))
    :clock (pc/fnk [] t/now)
    :cors-validator (pc/fnk [[:settings cors-config]]

--- a/waiter/src/waiter/cors.clj
+++ b/waiter/src/waiter/cors.clj
@@ -56,11 +56,10 @@
   "Preflight request handling middleware.
   This middleware needs to precede any authentication middleware since CORS preflight
   requests do not support authentication."
-  [handler cors-validator max-age kv-store attach-token-defaults-fn waiter-hostnames]
+  [handler cors-validator max-age discover-service-parameters-fn]
   (fn wrap-cors-preflight-fn [{:keys [headers] :as request}]
     (if (preflight-request? request)
-      (let [discovered-parameters (sd/discover-service-parameters
-                                    kv-store attach-token-defaults-fn waiter-hostnames headers)]
+      (let [discovered-parameters (discover-service-parameters-fn headers)]
         (counters/inc! (metrics/waiter-counter "requests" "cors-preflight"))
         (let [{:keys [headers request-method]} request
               {:strs [origin]} headers]

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -106,15 +106,16 @@
    :scheduler core/scheduler
    :settings (pc/fnk dummy-symbol-for-fnk-schema-logic :- settings/settings-schema [] settings)
    :state core/state
-   :http-server (pc/fnk [[:routines attach-token-defaults-fn generate-log-url-fn waiter-request?-fn websocket-request-acceptor]
+   :http-server (pc/fnk [[:routines discover-service-parameters-fn generate-log-url-fn waiter-request?-fn websocket-request-acceptor]
                          [:settings cors-config host port server-options support-info websocket-config]
-                         [:state cors-validator kv-store router-id server-name waiter-hostnames]
+                         [:state cors-validator router-id server-name]
                          handlers] ; Insist that all systems are running before we start server
                   (let [options (merge (cond-> server-options
                                          (:ssl-port server-options) (assoc :ssl? true))
                                        websocket-config
                                        {:ring-handler (-> (core/ring-handler-factory waiter-request?-fn handlers)
-                                                        (cors/wrap-cors-preflight cors-validator (:max-age cors-config) kv-store attach-token-defaults-fn waiter-hostnames)
+                                                        (cors/wrap-cors-preflight
+                                                          cors-validator (:max-age cors-config) discover-service-parameters-fn)
                                                         core/wrap-error-handling
                                                         (core/wrap-debug generate-log-url-fn)
                                                         (core/attach-waiter-api-middleware waiter-request?-fn)

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -888,9 +888,8 @@
           (if loop-token
             (let [token-data (token->token-data kv-store loop-token token-data-keys true false)]
               (recur (assoc loop-token->token-data loop-token token-data) remaining-tokens))
-            (let []
-              (compute-service-description-template-from-tokens
-                attach-service-defaults-fn attach-token-defaults-fn token-sequence loop-token->token-data)))))
+            (compute-service-description-template-from-tokens
+              attach-service-defaults-fn attach-token-defaults-fn token-sequence loop-token->token-data))))
 
       :else
       (compute-service-description-template-from-tokens attach-service-defaults-fn attach-token-defaults-fn [] {}))))

--- a/waiter/test/waiter/auth/composite_test.clj
+++ b/waiter/test/waiter/auth/composite_test.clj
@@ -49,7 +49,7 @@
 
 (defn dummy-composite-authenticator
   ([] (dummy-composite-authenticator valid-config))
-  ([config] (composite-authenticator config)))
+  ([config] (composite-authenticator (assoc config :default-authentication "standard"))))
 
 
 (def time-now

--- a/waiter/test/waiter/auth/composite_test.clj
+++ b/waiter/test/waiter/auth/composite_test.clj
@@ -48,10 +48,8 @@
    :default-authentication-provider "one-user"})
 
 (defn dummy-composite-authenticator
-  ([config]
-   (composite-authenticator (assoc config :default-authentication "standard")))
-  ([]
-   (dummy-composite-authenticator valid-config)))
+  ([] (dummy-composite-authenticator valid-config))
+  ([config] (composite-authenticator config)))
 
 
 (def time-now
@@ -78,7 +76,7 @@
 
 (defn- make-request
   [auth-type]
-  {:waiter-discovery {:service-parameter-template {"authentication" auth-type}}})
+  {:waiter-discovery {:service-description-template {"authentication" auth-type}}})
 
 (deftest auth-standard-auth-type
   (let [composite-authenticator (dummy-composite-authenticator)

--- a/waiter/test/waiter/auth/jwt_test.clj
+++ b/waiter/test/waiter/auth/jwt_test.clj
@@ -551,7 +551,7 @@
         issuer-constraints ["issuer"]
         attach-bearer-auth-env
         (fn attach-bearer-auth-env [request env-value]
-          (assoc-in request [:waiter-discovery :service-parameter-template "env" "USE_BEARER_AUTH"]
+          (assoc-in request [:waiter-discovery :service-description-template "env" "USE_BEARER_AUTH"]
                     (str env-value)))]
     (with-redefs [authenticate-request (fn [handler token-type in-issuer-constraints subject-key in-subject-regex in-algorithms
                                             keys password in-max-expiry-duration-ms request]

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -1105,10 +1105,18 @@
 
 (deftest test-wrap-auth-bypass
   (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+        service-description-defaults {"concurrency-level" 100
+                                      "health-check-url" "/status"}
+        metric-group-mappings []
         profile->defaults {"webapp" {"concurrency-level" 120
-                                     "fallback-period-secs" 100}}
+                                     "fallback-period-secs" 100}
+                           "service" {"authentication" "disabled"
+                                      "concurrency-level" 30
+                                      "fallback-period-secs" 90
+                                      "permitted-user" "*"}}
         token-defaults {"fallback-period-secs" 300
                         "https-redirect" false}
+        attach-service-defaults-fn #(sd/merge-defaults % service-description-defaults profile->defaults metric-group-mappings)
         attach-token-defaults-fn #(sd/attach-token-defaults % token-defaults profile->defaults)
         waiter-hostnames #{"www.waiter-router.com"}
         configuration {}
@@ -1116,7 +1124,7 @@
         handler-response (Object.)
         execute-request (fn execute-request-fn [{:keys [headers] :as in-request}]
                           (let [test-request (->> (sd/discover-service-parameters
-                                                    kv-store attach-token-defaults-fn waiter-hostnames headers)
+                                                    kv-store attach-service-defaults-fn attach-token-defaults-fn waiter-hostnames headers)
                                                (assoc in-request :waiter-discovery))
                                 request-handler-argument-atom (atom nil)
                                 test-request-handler (fn request-handler-fn [request]
@@ -1131,9 +1139,16 @@
     (kv/store kv-store "www.token-1p.com" {"cpu" 1
                                            "mem" 2048
                                            "profile" "webapp"})
+    (kv/store kv-store "www.token-1s.com" {"cpu" 1
+                                           "mem" 2048
+                                           "profile" "service"})
     (kv/store kv-store "www.token-2.com" {"authentication" "standard"
                                           "cpu" 1
                                           "mem" 2048})
+    (kv/store kv-store "www.token-2s.com" {"authentication" "standard"
+                                          "cpu" 1
+                                          "mem" 2048
+                                           "profile" "service"})
     (kv/store kv-store "www.token-3.com" {"authentication" "disabled"
                                           "cpu" 1
                                           "mem" 2048})
@@ -1150,7 +1165,7 @@
       (let [test-request {:headers {"host" "www.host.com"}}
             {:keys [handled-request response]} (execute-request test-request)]
         (is (= (assoc test-request :waiter-discovery {:passthrough-headers {"host" "www.host.com"}
-                                                      :service-parameter-template {}
+                                                      :service-description-template {}
                                                       :token "www.host.com"
                                                       :token-metadata token-defaults
                                                       :waiter-headers {}})
@@ -1161,7 +1176,7 @@
       (let [test-request {:headers {"host" "www.host.com" "x-waiter-run-as-user" "test-user"}}
             {:keys [handled-request response]} (execute-request test-request)]
         (is (= (assoc test-request :waiter-discovery {:passthrough-headers {"host" "www.host.com"}
-                                                      :service-parameter-template {}
+                                                      :service-description-template {}
                                                       :token "www.host.com"
                                                       :token-metadata token-defaults
                                                       :waiter-headers {"x-waiter-run-as-user" "test-user"}})
@@ -1172,7 +1187,10 @@
       (let [test-request {:headers {"host" "www.token-1.com"}}
             {:keys [handled-request response]} (execute-request test-request)]
         (is (= (assoc test-request :waiter-discovery {:passthrough-headers {"host" "www.token-1.com"}
-                                                      :service-parameter-template {"mem" 2048}
+                                                      :service-description-template {"concurrency-level" 100
+                                                                                     "health-check-url" "/status"
+                                                                                     "mem" 2048
+                                                                                     "metric-group" "other"}
                                                       :token "www.token-1.com"
                                                       :token-metadata (assoc token-defaults "owner" nil "previous" {})
                                                       :waiter-headers {}})
@@ -1182,12 +1200,36 @@
       (let [test-request {:headers {"host" "www.token-1p.com"}}
             {:keys [handled-request response]} (execute-request test-request)]
         (is (= (assoc test-request :waiter-discovery {:passthrough-headers {"host" "www.token-1p.com"}
-                                                      :service-parameter-template {"mem" 2048 "profile" "webapp"}
+                                                      :service-description-template {"concurrency-level" 120
+                                                                                     "health-check-url" "/status"
+                                                                                     "mem" 2048
+                                                                                     "metric-group" "other"
+                                                                                     "profile" "webapp"}
                                                       :token "www.token-1p.com"
                                                       :token-metadata (merge {"owner" nil "previous" {}}
                                                                              token-defaults
                                                                              (select-keys
                                                                                (get profile->defaults "webapp")
+                                                                               sd/user-metadata-keys))
+                                                      :waiter-headers {}})
+               handled-request))
+        (is (= handler-response response)))
+
+      (let [test-request {:headers {"host" "www.token-2s.com"}}
+            {:keys [handled-request response]} (execute-request test-request)]
+        (is (= (assoc test-request :waiter-discovery {:passthrough-headers {"host" "www.token-2s.com"}
+                                                      :service-description-template {"authentication" "standard"
+                                                                                     "concurrency-level" 30
+                                                                                     "health-check-url" "/status"
+                                                                                     "mem" 2048
+                                                                                     "metric-group" "other"
+                                                                                     "permitted-user" "*"
+                                                                                     "profile" "service"}
+                                                      :token "www.token-2s.com"
+                                                      :token-metadata (merge {"owner" nil "previous" {}}
+                                                                             token-defaults
+                                                                             (select-keys
+                                                                               (get profile->defaults "service")
                                                                                sd/user-metadata-keys))
                                                       :waiter-headers {}})
                handled-request))
@@ -1198,10 +1240,34 @@
             {:keys [handled-request response]} (execute-request test-request)]
         (is (= (assoc test-request :skip-authentication true
                                    :waiter-discovery {:passthrough-headers {"host" "www.token-3.com"}
-                                                      :service-parameter-template {"authentication" "disabled"
-                                                                                   "mem" 2048}
+                                                      :service-description-template {"authentication" "disabled"
+                                                                                     "concurrency-level" 100
+                                                                                     "health-check-url" "/status"
+                                                                                     "mem" 2048
+                                                                                     "metric-group" "other"}
                                                       :token "www.token-3.com"
                                                       :token-metadata (assoc token-defaults "owner" nil "previous" {})
+                                                      :waiter-headers {}})
+               handled-request))
+        (is (= handler-response response)))
+
+      (let [test-request {:headers {"host" "www.token-1s.com"}}
+            {:keys [handled-request response]} (execute-request test-request)]
+        (is (= (assoc test-request :skip-authentication true
+                                   :waiter-discovery {:passthrough-headers {"host" "www.token-1s.com"}
+                                                      :service-description-template {"authentication" "disabled"
+                                                                                     "concurrency-level" 30
+                                                                                     "health-check-url" "/status"
+                                                                                     "mem" 2048
+                                                                                     "metric-group" "other"
+                                                                                     "permitted-user" "*"
+                                                                                     "profile" "service"}
+                                                      :token "www.token-1s.com"
+                                                      :token-metadata (merge {"owner" nil "previous" {}}
+                                                                             token-defaults
+                                                                             (select-keys
+                                                                               (get profile->defaults "service")
+                                                                               sd/user-metadata-keys))
                                                       :waiter-headers {}})
                handled-request))
         (is (= handler-response response))))
@@ -1220,7 +1286,10 @@
                                     "x-waiter-token" "a-named-token-A"}}
             {:keys [handled-request response]} (execute-request test-request)]
         (is (= (assoc test-request :waiter-discovery {:passthrough-headers {"host" "www.service.com"}
-                                                      :service-parameter-template {"mem" 2048}
+                                                      :service-description-template {"concurrency-level" 100
+                                                                                     "health-check-url" "/status"
+                                                                                     "mem" 2048
+                                                                                     "metric-group" "other"}
                                                       :token "a-named-token-A"
                                                       :token-metadata (assoc token-defaults "owner" nil "previous" {})
                                                       :waiter-headers {"x-waiter-token" "a-named-token-A"}})
@@ -1243,8 +1312,11 @@
             {:keys [handled-request response]} (execute-request test-request)]
         (is (= (assoc test-request :skip-authentication true
                                    :waiter-discovery {:passthrough-headers {"host" "www.service.com"}
-                                                      :service-parameter-template {"authentication" "disabled"
-                                                                                   "mem" 2048}
+                                                      :service-description-template {"authentication" "disabled"
+                                                                                     "concurrency-level" 100
+                                                                                     "health-check-url" "/status"
+                                                                                     "mem" 2048
+                                                                                     "metric-group" "other"}
                                                       :token "a-named-token-B"
                                                       :token-metadata (assoc token-defaults "owner" nil "previous" {})
                                                       :waiter-headers {"x-waiter-token" "a-named-token-B"}})
@@ -1276,8 +1348,11 @@
                                     "x-waiter-token" "a-named-token-C"}}
             {:keys [handled-request response]} (execute-request test-request)]
         (is (= (assoc test-request :waiter-discovery {:passthrough-headers {"host" "www.service.com"}
-                                                      :service-parameter-template {"authentication" "standard"
-                                                                                   "mem" 2048}
+                                                      :service-description-template {"authentication" "standard"
+                                                                                     "concurrency-level" 100
+                                                                                     "health-check-url" "/status"
+                                                                                     "mem" 2048
+                                                                                     "metric-group" "other"}
                                                       :token "a-named-token-C"
                                                       :token-metadata (assoc token-defaults "owner" nil "previous" {})
                                                       :waiter-headers {"x-waiter-token" "a-named-token-C"}})
@@ -1308,8 +1383,11 @@
                                     "x-waiter-token" "a-named-token-C"}}
             {:keys [handled-request response]} (execute-request test-request)]
         (is (= (assoc test-request :waiter-discovery {:passthrough-headers {"host" "www.service.com"}
-                                                      :service-parameter-template {"authentication" "standard"
-                                                                                   "mem" 2048}
+                                                      :service-description-template {"authentication" "standard"
+                                                                                     "concurrency-level" 100
+                                                                                     "health-check-url" "/status"
+                                                                                     "mem" 2048
+                                                                                     "metric-group" "other"}
                                                       :token "a-named-token-C"
                                                       :token-metadata (assoc token-defaults "owner" nil "previous" {})
                                                       :waiter-headers {"x-waiter-run-as-user" "test-user"
@@ -1421,7 +1499,7 @@
         (let [test-request {:headers {"host" "token.localtest.me"}
                             :scheme :ws
                             :waiter-discovery {:passthrough-headers {}
-                                               :service-parameter-template {}
+                                               :service-description-template {}
                                                :token "token.localtest.me"
                                                :token-metadata {"https-redirect" true}
                                                :waiter-headers {}}}
@@ -1433,7 +1511,7 @@
         (let [test-request {:headers {"host" "token.localtest.me"}
                             :scheme :http
                             :waiter-discovery {:passthrough-headers {}
-                                               :service-parameter-template {}
+                                               :service-description-template {}
                                                :token "token.localtest.me"
                                                :token-metadata {"https-redirect" false}
                                                :waiter-headers {}}}
@@ -1447,7 +1525,7 @@
                             :request-method :get
                             :scheme :http
                             :waiter-discovery {:passthrough-headers {}
-                                               :service-parameter-template {}
+                                               :service-description-template {}
                                                :token "token.localtest.me"
                                                :token-metadata {"https-redirect" false}
                                                :waiter-headers {"x-waiter-https-redirect" true}}}
@@ -1459,7 +1537,7 @@
         (let [test-request {:headers {"host" "token.localtest.me"}
                             :scheme :https
                             :waiter-discovery {:passthrough-headers {}
-                                               :service-parameter-template {}
+                                               :service-description-template {}
                                                :token "token.localtest.me"
                                                :token-metadata {"https-redirect" false}
                                                :waiter-headers {}}}
@@ -1471,7 +1549,7 @@
         (let [test-request {:headers {"host" "token.localtest.me"}
                             :scheme :https
                             :waiter-discovery {:passthrough-headers {}
-                                               :service-parameter-template {}
+                                               :service-description-template {}
                                                :token "token.localtest.me"
                                                :token-metadata {"https-redirect" true}
                                                :waiter-headers {}}}
@@ -1484,7 +1562,7 @@
                                       "x-waiter-https-redirect" "false"}
                             :scheme :https
                             :waiter-discovery {:passthrough-headers {}
-                                               :service-parameter-template {"cpus" 1}
+                                               :service-description-template {"cpus" 1}
                                                :token "token.localtest.me"
                                                :token-metadata {"https-redirect" false}
                                                :waiter-headers {"x-waiter-https-redirect" false}}}
@@ -1497,7 +1575,7 @@
                                       "x-waiter-https-redirect" "true"}
                             :scheme :https
                             :waiter-discovery {:passthrough-headers {}
-                                               :service-parameter-template {"cpus" 1}
+                                               :service-description-template {"cpus" 1}
                                                :token "token.localtest.me"
                                                :token-metadata {"https-redirect" false}
                                                :waiter-headers {"x-waiter-https-redirect" true}}}
@@ -1510,7 +1588,7 @@
         (let [test-request {:headers {"host" "token.localtest.me:1234"}
                             :scheme :http
                             :waiter-discovery {:passthrough-headers {}
-                                               :service-parameter-template {}
+                                               :service-description-template {}
                                                :token "token.localtest.me"
                                                :token-metadata {"https-redirect" true}
                                                :waiter-headers {}}}
@@ -1528,7 +1606,7 @@
                             :request-method :get
                             :scheme :http
                             :waiter-discovery {:passthrough-headers {}
-                                               :service-parameter-template {}
+                                               :service-description-template {}
                                                :token "token.localtest.me"
                                                :token-metadata {"https-redirect" true}
                                                :waiter-headers {"x-waiter-https-redirect" false}}}

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -1134,31 +1134,31 @@
                             {:handled-request @request-handler-argument-atom
                              :response test-response}))]
 
-    (kv/store kv-store "www.token-1.com" {"cpu" 1
+    (kv/store kv-store "www.token-1.com" {"cpus" 1
                                           "mem" 2048})
-    (kv/store kv-store "www.token-1p.com" {"cpu" 1
+    (kv/store kv-store "www.token-1p.com" {"cpus" 1
                                            "mem" 2048
                                            "profile" "webapp"})
-    (kv/store kv-store "www.token-1s.com" {"cpu" 1
+    (kv/store kv-store "www.token-1s.com" {"cpus" 1
                                            "mem" 2048
                                            "profile" "service"})
     (kv/store kv-store "www.token-2.com" {"authentication" "standard"
-                                          "cpu" 1
+                                          "cpus" 1
                                           "mem" 2048})
     (kv/store kv-store "www.token-2s.com" {"authentication" "standard"
-                                          "cpu" 1
-                                          "mem" 2048
+                                           "cpus" 1
+                                           "mem" 2048
                                            "profile" "service"})
     (kv/store kv-store "www.token-3.com" {"authentication" "disabled"
-                                          "cpu" 1
+                                          "cpus" 1
                                           "mem" 2048})
-    (kv/store kv-store "a-named-token-A" {"cpu" 1
+    (kv/store kv-store "a-named-token-A" {"cpus" 1
                                           "mem" 2048})
     (kv/store kv-store "a-named-token-B" {"authentication" "disabled"
-                                          "cpu" 1
+                                          "cpus" 1
                                           "mem" 2048})
     (kv/store kv-store "a-named-token-C" {"authentication" "standard"
-                                          "cpu" 1
+                                          "cpus" 1
                                           "mem" 2048})
 
     (testing "request-without-non-existing-hostname-token"
@@ -1188,6 +1188,7 @@
             {:keys [handled-request response]} (execute-request test-request)]
         (is (= (assoc test-request :waiter-discovery {:passthrough-headers {"host" "www.token-1.com"}
                                                       :service-description-template {"concurrency-level" 100
+                                                                                     "cpus" 1
                                                                                      "health-check-url" "/status"
                                                                                      "mem" 2048
                                                                                      "metric-group" "other"}
@@ -1201,6 +1202,7 @@
             {:keys [handled-request response]} (execute-request test-request)]
         (is (= (assoc test-request :waiter-discovery {:passthrough-headers {"host" "www.token-1p.com"}
                                                       :service-description-template {"concurrency-level" 120
+                                                                                     "cpus" 1
                                                                                      "health-check-url" "/status"
                                                                                      "mem" 2048
                                                                                      "metric-group" "other"
@@ -1220,6 +1222,7 @@
         (is (= (assoc test-request :waiter-discovery {:passthrough-headers {"host" "www.token-2s.com"}
                                                       :service-description-template {"authentication" "standard"
                                                                                      "concurrency-level" 30
+                                                                                     "cpus" 1
                                                                                      "health-check-url" "/status"
                                                                                      "mem" 2048
                                                                                      "metric-group" "other"
@@ -1249,6 +1252,7 @@
         (is (= (assoc test-request :waiter-discovery {:passthrough-headers {"host" "www.token-2s.com"}
                                                       :service-description-template {"authentication" "standard"
                                                                                      "concurrency-level" 30
+                                                                                     "cpus" 1
                                                                                      "health-check-url" "/status"
                                                                                      "mem" 2048
                                                                                      "metric-group" "other"
@@ -1271,6 +1275,7 @@
                                    :waiter-discovery {:passthrough-headers {"host" "www.token-3.com"}
                                                       :service-description-template {"authentication" "disabled"
                                                                                      "concurrency-level" 100
+                                                                                     "cpus" 1
                                                                                      "health-check-url" "/status"
                                                                                      "mem" 2048
                                                                                      "metric-group" "other"}
@@ -1286,6 +1291,7 @@
                                    :waiter-discovery {:passthrough-headers {"host" "www.token-1s.com"}
                                                       :service-description-template {"authentication" "disabled"
                                                                                      "concurrency-level" 30
+                                                                                     "cpus" 1
                                                                                      "health-check-url" "/status"
                                                                                      "mem" 2048
                                                                                      "metric-group" "other"
@@ -1316,6 +1322,7 @@
             {:keys [handled-request response]} (execute-request test-request)]
         (is (= (assoc test-request :waiter-discovery {:passthrough-headers {"host" "www.service.com"}
                                                       :service-description-template {"concurrency-level" 100
+                                                                                     "cpus" 1
                                                                                      "health-check-url" "/status"
                                                                                      "mem" 2048
                                                                                      "metric-group" "other"}
@@ -1343,6 +1350,7 @@
                                    :waiter-discovery {:passthrough-headers {"host" "www.service.com"}
                                                       :service-description-template {"authentication" "disabled"
                                                                                      "concurrency-level" 100
+                                                                                     "cpus" 1
                                                                                      "health-check-url" "/status"
                                                                                      "mem" 2048
                                                                                      "metric-group" "other"}
@@ -1379,6 +1387,7 @@
         (is (= (assoc test-request :waiter-discovery {:passthrough-headers {"host" "www.service.com"}
                                                       :service-description-template {"authentication" "standard"
                                                                                      "concurrency-level" 100
+                                                                                     "cpus" 1
                                                                                      "health-check-url" "/status"
                                                                                      "mem" 2048
                                                                                      "metric-group" "other"}
@@ -1414,6 +1423,7 @@
         (is (= (assoc test-request :waiter-discovery {:passthrough-headers {"host" "www.service.com"}
                                                       :service-description-template {"authentication" "standard"
                                                                                      "concurrency-level" 100
+                                                                                     "cpus" 1
                                                                                      "health-check-url" "/status"
                                                                                      "mem" 2048
                                                                                      "metric-group" "other"}


### PR DESCRIPTION
## Changes proposed in this PR

- moves profile computation to merge-defaults
- adds support for token pre-authorization with profiles providing permitted-user field
- curry discover-service-parameters in routines
- adds profiles support in service discovery
- includes x-waiter headers in discovery service-description-parameters

## Why are we making these changes?

Allows service pre-authorization with tokens that use profiles.

