### PR TITLE
includes health check response headers in the logs

### DIFF
--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -226,7 +226,7 @@
 
 (defn log-health-check-issues
   "Logs messages based on the type of error (if any) encountered by a health check"
-  [service-instance instance-health-check-url status error]
+  [service-instance instance-health-check-url {:keys [error headers status]}]
   (if error
     (let [error-map {:instance service-instance
                      :service instance-health-check-url}]
@@ -239,9 +239,10 @@
     (when-not (or (hu/status-2XX? status)
                   (= http-404-not-found status)
                   (= http-504-gateway-timeout status))
-      (log/info "unexpected status from health check" {:status status
+      (log/info "unexpected status from health check" {:headers headers
                                                        :instance service-instance
-                                                       :service instance-health-check-url}))))
+                                                       :service instance-health-check-url
+                                                       :status status}))))
 
 (defn service-description->health-check-protocol
   "Determines the protocol to use for health checks."
@@ -297,7 +298,7 @@
                                     (instance? EOFException error) :hangup-exception
                                     (instance? SocketTimeoutException error) :timeout-exception
                                     (instance? TimeoutException error) :timeout-exception)]
-                   (log-health-check-issues service-instance instance-health-check-url status error)
+                   (log-health-check-issues service-instance instance-health-check-url response)
                    (let [backend-protocol (hu/backend-protocol->http-version protocol)
                          backend-scheme (hu/backend-proto->scheme protocol)
                          request {:client-protocol backend-protocol

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -322,8 +322,8 @@
     (let [_ (log/debug "running health check against" instance)
           instance-health-check-url (scheduler/build-health-check-url
                                       instance health-check-proto health-check-port-index health-check-path)
-          {:keys [status error]} (async/<!! (http/get http-client instance-health-check-url))]
-      (scheduler/log-health-check-issues instance instance-health-check-url status error)
+          {:keys [status error] :as response} (async/<!! (http/get http-client instance-health-check-url))]
+      (scheduler/log-health-check-issues instance instance-health-check-url response)
       (and (not error) (hu/status-2XX? status)))
     false))
 


### PR DESCRIPTION
## Changes proposed in this PR

- includes health check response headers in the logs

## Why are we making these changes?

Having access to the response headers simplfies debugging the failed health check response.

Example logs:
```
2020-04-24 10:59:04,832 INFO  waiter.scheduler [async-dispatch-58] -  unexpected status from health check 
{:headers {server BaseHTTP/0.6 Python/3.7.2, date Fri, 24 Apr 2020 15:59:04 GMT, connection close, content-type text/plain, x-cid waiter-health-check-4f4b0cb0db2cf-22b5f451c10835f5, content-length 11}, 
 :instance #waiter.scheduler.ServiceInstance{:id w9091-whctttui1394926567971914-7e1c6e329d265d117c8a6d99dcb3e116.4f4adbf6e6fd0-1d52d58f1bdf5597, ...}, 
 :service http://127.0.0.4:10500/status, 
 :status 400}
```

