### PR TITLE
avoids using apply while dissoc-ing multiple keys

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1661,7 +1661,7 @@
                             :version "1"}]
       (doseq [[profile {:keys [defaults]}] (seq profile-config)]
         (let [token (rand-name)
-              token-description (-> (apply dissoc base-description (keys defaults))
+              token-description (-> (utils/remove-keys base-description (keys defaults))
                                   (assoc :profile (name profile) :token token))
               register-response (post-token waiter-url token-description)]
           (try

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -484,7 +484,7 @@
                                                                  (log/error e "error in deleting:" service))))
                                                            apps-to-gc)
                             apps-failed-to-delete (apply disj (set apps-to-gc) apps-successfully-gced)
-                            service->state'' (apply dissoc service->state' apps-successfully-gced)]
+                            service->state'' (utils/remove-keys service->state' apps-successfully-gced)]
                         (when (or (not= (set (keys service->state'')) (set (keys service->raw-data)))
                                   (not= (set (keys service->state'')) (set (keys service->state))))
                           (log/info "state has" (count service->state'') "active services, received"

--- a/waiter/src/waiter/headers.clj
+++ b/waiter/src/waiter/headers.clj
@@ -107,8 +107,8 @@
         connection-headers (map str/trim (str/split (str connection) #","))]
     (cond-> (dissoc headers "connection" "keep-alive" "proxy-authenticate" "proxy-authorization"
                     "trailers" "transfer-encoding" "upgrade")
-      (seq force-remove-headers) (as-> $ (apply dissoc $ force-remove-headers))
-      (seq connection-headers) (as-> $ (apply dissoc $ connection-headers)))))
+      (seq force-remove-headers) (utils/remove-keys force-remove-headers)
+      (seq connection-headers) (utils/remove-keys connection-headers))))
 
 (defn assoc-auth-headers
   "`assoc`s the x-waiter-auth-principal and x-waiter-authenticated-principal headers if the

--- a/waiter/src/waiter/interstitial.clj
+++ b/waiter/src/waiter/interstitial.clj
@@ -27,7 +27,8 @@
             [plumbing.core :as pc]
             [waiter.metrics :as metrics]
             [waiter.status-codes :refer :all]
-            [waiter.util.async-utils :as au]))
+            [waiter.util.async-utils :as au]
+            [waiter.util.utils :as utils]))
 
 (defn- service-id->interstitial-promise
   "Returns the promise mapped against a service-id.
@@ -86,7 +87,7 @@
          (fn [{:keys [service-id->interstitial-promise] :as interstitial-state}]
            (->> service-ids
                 (filter #(some-> % service-id->interstitial-promise realized?))
-                (apply dissoc service-id->interstitial-promise)
+                (utils/remove-keys service-id->interstitial-promise)
                 (assoc interstitial-state :service-id->interstitial-promise))))
   (->> @interstitial-state-atom
        :service-id->interstitial-promise

--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -98,7 +98,9 @@
   (let [redacted-request-fields-string (get-in response [:descriptor :service-description "env" "WAITER_CONFIG_REDACTED_REQUEST_FIELDS"])
         redacted-request-fields (when-not (str/blank? redacted-request-fields-string)
                                   (map keyword (str/split redacted-request-fields-string #",")))]
-    (log (apply dissoc (merge (request->context request) (response->context response)) redacted-request-fields))))
+    (-> (merge (request->context request) (response->context response))
+      (utils/remove-keys redacted-request-fields)
+      (log))))
 
 (defn wrap-log
   "Wraps a handler logging data from requests and responses."

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -962,7 +962,7 @@
       service-description
       (let [key-regex (re-pattern (str "^" key-name "-"))
             renamed-env-map (pc/map-keys #(str/upper-case (str/replace % key-regex "")) env-map)
-            sanitized-service-description (apply dissoc service-description env-keys)]
+            sanitized-service-description (utils/remove-keys service-description env-keys)]
         (assoc sanitized-service-description key-name renamed-env-map)))))
 
 (defn- parse-metadata-headers
@@ -974,7 +974,7 @@
     (if (empty? metadata-map)
       service-description
       (let [renamed-metadata-map (pc/map-keys #(str/replace % #"^metadata-" "") metadata-map)
-            sanitized-service-description (apply dissoc service-description metadata-keys)]
+            sanitized-service-description (utils/remove-keys service-description metadata-keys)]
         (assoc sanitized-service-description "metadata" renamed-metadata-map)))))
 
 (defn- waiter-headers->service-parameters

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -391,6 +391,12 @@
       m)
     (dissoc m k)))
 
+(defn remove-keys
+  "Returns a map with any key in ks dissoc-ed from m.
+   Provides an alternate to (apply dissoc m ks)."
+  [m ks]
+  (reduce dissoc m ks))
+
 (defn sleep
   "Helper function that wraps sleep call to java.lang.Thread"
   [time]

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -414,7 +414,7 @@
           (is (= http-200-ok status))
           (is (= "application/json" (get headers "content-type")))
           (is (not (str/includes? body "last-update-time")))
-          (doseq [key (keys (apply dissoc (select-keys service-description-1 sd/service-parameter-keys) json-keys))]
+          (doseq [key (keys (utils/remove-keys (select-keys service-description-1 sd/service-parameter-keys) json-keys))]
             (is (str/includes? body (str (get service-description-1 key)))))
           (doseq [key json-keys]
             (is (str/includes? body (utils/clj->json (get service-description-1 key)))))))
@@ -430,7 +430,7 @@
           (is (= http-200-ok status))
           (is (= "application/json" (get headers "content-type")))
           (is (not (str/includes? body "last-update-time")))
-          (doseq [key (keys (apply dissoc (select-keys service-description-1 sd/service-parameter-keys) json-keys))]
+          (doseq [key (keys (utils/remove-keys (select-keys service-description-1 sd/service-parameter-keys) json-keys))]
             (is (str/includes? body (str (get service-description-1 key)))))
           (doseq [key json-keys]
             (is (str/includes? body (utils/clj->json (get service-description-1 key)))))))

--- a/waiter/test/waiter/util/utils_test.clj
+++ b/waiter/test/waiter/util/utils_test.clj
@@ -673,3 +673,32 @@
         (is (= (assoc standard-response :add-grpc-headers-and-trailers true)
                (attach-grpc-status standard-response {} {:client-protocol "HTTP/2.0"
                                                          :headers {"content-type" "application/grpc"}})))))))
+
+(deftest test-remove-keys
+  (is (nil? (remove-keys nil nil)))
+  (is (nil? (remove-keys nil [])))
+  (is (nil? (remove-keys nil [:a])))
+  (is (nil? (remove-keys nil [:a :b])))
+
+  (is (= {} (remove-keys {} nil)))
+  (is (= {} (remove-keys {} [])))
+  (is (= {} (remove-keys {} [:a])))
+  (is (= {} (remove-keys {} [:a :b])))
+
+  (is (= {:a 1} (remove-keys {:a 1} nil)))
+  (is (= {:a 1} (remove-keys {:a 1} [])))
+  (is (= {} (remove-keys {:a 1} [:a])))
+  (is (= {} (remove-keys {:a 1} [:a :b])))
+
+  (is (= {:a 1 :b 2} (remove-keys {:a 1 :b 2} nil)))
+  (is (= {:a 1 :b 2} (remove-keys {:a 1 :b 2} [])))
+  (is (= {:b 2} (remove-keys {:a 1 :b 2} [:a])))
+  (is (= {} (remove-keys {:a 1 :b 2} [:a :b])))
+  (is (= {} (remove-keys {:a 1 :b 2} [:a :b :c])))
+  (is (= {} (remove-keys {:a 1 :b 2} [:a :b :c :d])))
+
+  (is (= {:b 2 :c 3} (remove-keys {:b 2 :c 3} nil)))
+  (is (= {:b 2 :c 3} (remove-keys {:b 2 :c 3} [])))
+  (is (= {:b 2 :c 3} (remove-keys {:b 2 :c 3} [:a])))
+  (is (= {:b 2 :c 3} (remove-keys {:b 2 :c 3} [:a :d :e :f :g])))
+  (is (= {:c 3} (remove-keys {:b 2 :c 3} [:a :b]))))


### PR DESCRIPTION
## Changes proposed in this PR

- avoids using apply while dissoc-ing multiple keys

## Why are we making these changes?

Avoid `apply` which we've found to be slow in the past.


### Some microbenchmarks:

`utils/remove-keys` out-performs `apply dissoc` by at least `1.4X`

#### Small map with some keys removed

```
(let [sd {"allowed-params" #{}
          "authentication" "standard"
          "backend-proto" "http"
          "blacklist-on-503" true
          "concurrency-level" 1
          "distribution-scheme" "balanced"
          "env" {"FOO" "bar"
                 "BAZ" "qux"}
          "expired-instance-restart-rate" 0.1}
      ks ["expired-instance-restart-rate" "idle-timeout-mins" "ports" "cmd" "mem"]]
  (println "utils/remove-keys:")
  (quick-bench (utils/remove-keys sd ks))
  (println "apply dissoc:")
  (quick-bench (apply dissoc sd ks)))
utils/remove-keys:
Evaluation count : 1465824 in 6 samples of 244304 calls.
             Execution time mean : 401.382182 ns
    Execution time std-deviation : 16.727978 ns
   Execution time lower quantile : 382.239046 ns ( 2.5%)
   Execution time upper quantile : 422.727039 ns (97.5%)
                   Overhead used : 14.346622 ns
apply dissoc:
Evaluation count : 838158 in 6 samples of 139693 calls.
             Execution time mean : 746.221191 ns
    Execution time std-deviation : 31.314759 ns
   Execution time lower quantile : 700.410321 ns ( 2.5%)
   Execution time upper quantile : 775.346473 ns (97.5%)
                   Overhead used : 14.346622 ns
```

#### Larger map with **some** keys removed

```
(let [sd {"allowed-params" #{}
          "authentication" "standard"
          "backend-proto" "http"
          "blacklist-on-503" true
          "concurrency-level" 1
          "distribution-scheme" "balanced"
          "env" {"FOO" "bar"
                 "BAZ" "qux"}
          "expired-instance-restart-rate" 0.1
          "grace-period-secs" 30
          "health-check-authentication" "disabled"
          "health-check-interval-secs" 10
          "health-check-max-consecutive-failures" 5
          "health-check-port-index" 0
          "health-check-proto" nil
          "health-check-url" "/status"
          "idle-timeout-mins" 30
          "instance-expiry-mins" 7200
          "interstitial-secs" 0
          "jitter-threshold" 0.5
          "load-balancing" "oldest"
          "max-instances" 500
          "max-queue-length" 1000000
          "metadata" {}
          "min-instances" 1
          "permitted-user" "*"
          "ports" 1
          "restart-backoff-factor" 2
          "scale-down-factor" 0.001
          "scale-factor" 1
          "scale-up-factor" 0.1
          "run-as-user" "ruser"
          "cmd" "token-user"
          "cpus" "1"
          "mem" "2"
          "version" "token"}
      ks ["expired-instance-restart-rate" "idle-timeout-mins" "ports" "cmd" "mem"]]
  (println "utils/remove-keys:")
  (quick-bench (utils/remove-keys sd ks))
  (println "apply dissoc:")
  (quick-bench (apply dissoc sd ks)))
utils/remove-keys:
Evaluation count : 889776 in 6 samples of 148296 calls.
             Execution time mean : 860.103252 ns
    Execution time std-deviation : 17.541281 ns
   Execution time lower quantile : 836.727140 ns ( 2.5%)
   Execution time upper quantile : 880.339284 ns (97.5%)
                   Overhead used : 14.346622 ns
apply dissoc:
Evaluation count : 610884 in 6 samples of 101814 calls.
             Execution time mean : 1.201840 µs
    Execution time std-deviation : 45.667502 ns
   Execution time lower quantile : 1.138424 µs ( 2.5%)
   Execution time upper quantile : 1.252643 µs (97.5%)
                   Overhead used : 14.346622 ns

Found 2 outliers in 6 samples (33.3333 %)
	low-severe	 1 (16.6667 %)
	low-mild	 1 (16.6667 %)
 Variance from outliers : 13.8889 % Variance is moderately inflated by outliers
```
#### Larger map with **no** keys removed

```
(let [sd {"allowed-params" #{}
          "authentication" "standard"
          "backend-proto" "http"
          "blacklist-on-503" true
          "concurrency-level" 1
          "distribution-scheme" "balanced"
          "env" {"FOO" "bar"
                 "BAZ" "qux"}
          "expired-instance-restart-rate" 0.1
          "grace-period-secs" 30
          "health-check-authentication" "disabled"
          "health-check-interval-secs" 10
          "health-check-max-consecutive-failures" 5
          "health-check-port-index" 0
          "health-check-proto" nil
          "health-check-url" "/status"
          "idle-timeout-mins" 30
          "instance-expiry-mins" 7200
          "interstitial-secs" 0
          "jitter-threshold" 0.5
          "load-balancing" "oldest"
          "max-instances" 500
          "max-queue-length" 1000000
          "metadata" {}
          "min-instances" 1
          "permitted-user" "*"
          "ports" 1
          "restart-backoff-factor" 2
          "scale-down-factor" 0.001
          "scale-factor" 1
          "scale-up-factor" 0.1
          "run-as-user" "ruser"
          "cmd" "token-user"
          "cpus" "1"
          "mem" "2"
          "version" "token"}
      ks ["a" "b" "c" "d" "e" "f" "g"]]
  (println "utils/remove-keys:")
  (quick-bench (utils/remove-keys sd ks))
  (println "apply dissoc:")
  (quick-bench (apply dissoc sd ks)))
utils/remove-keys:
Evaluation count : 1197132 in 6 samples of 199522 calls.
             Execution time mean : 481.828228 ns
    Execution time std-deviation : 14.653613 ns
   Execution time lower quantile : 466.659441 ns ( 2.5%)
   Execution time upper quantile : 502.520557 ns (97.5%)
                   Overhead used : 14.346622 ns
apply dissoc:
Evaluation count : 698064 in 6 samples of 116344 calls.
             Execution time mean : 859.561868 ns
    Execution time std-deviation : 30.914949 ns
   Execution time lower quantile : 810.106048 ns ( 2.5%)
   Execution time upper quantile : 890.487069 ns (97.5%)
                   Overhead used : 14.346622 ns
```

