### PR TITLE
avoids using apply max in favor of reduce max

### DIFF
--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -1169,7 +1169,7 @@
       :token->token-data
       (pc/map-vals (fn [{:strs [last-update-time]}] (or last-update-time 0)))
       vals
-      (apply max))
+      (reduce max))
     0))
 
 (defn service-id->service-description


### PR DESCRIPTION
## Changes proposed in this PR

- avoids using apply max in favor of reduce max

## Why are we making these changes?

`apply` uses reflection which we've found to be slow in the past.
