### PR TITLE
uses http2-hpack from jetty 9.4.28.v20200408 in jet

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -45,7 +45,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20191230_163338-g0dabe28"
+                 [twosigma/jet "0.7.10-20200504_104810-g200ef43"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]


### PR DESCRIPTION
## twosigma/jet changes
- https://github.com/twosigma/jet/pull/45

## Changes proposed in this PR
- use jet which uses `http2-hpack` from Jetty version `9.4.28.v20200408`

## Why are we making these changes?

gRPC python requests do not work due to a bug in the old http2 field encoding for the te trailer that places duplicate TE:trailers header in the request:
https://github.com/eclipse/jetty.project/blob/jetty-9.4.20.v20190813/jetty-http2/http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackEncoder.java#L191-L205

Proxying requests for gRPC-Python now works (using the [helloworld example from grpc-python on GitHub](https://github.com/grpc/grpc/blob/master/examples/python/helloworld/greeter_server_with_reflection.py) modified with a web-server for the health check):
```
$ curl -s -X GET 'http://grpc.localtest.me:9091/token' | jq -S .
{
  "backend-proto": "h2c",
  "cmd": "/github-projects/grpc/examples/python/helloworld/greeter_server_with_reflection.py",
  "cmd-type": "shell",
  ...
}
```

```
$ grpc_cli call grpc.localtest.me:9091 helloworld.Greeter.SayHello 'name: "Shams"' 
connecting to grpc.localtest.me:9091
Received initial metadata from server:
set-cookie : x-waiter-auth=TlBZA...;Max-Age=86400;Path=/;HttpOnly=true
x-cid : 74107194c16e-57266572bc296950
message: "Hello, Shams!"

Rpc succeeded with OK status
```

```
$ grep "74107194c16e-57266572bc296950" log/waiter.log 
2020-05-04 06:32:23,402 INFO  waiter.core [qtp245667796-187] - [CID=74107194c16e-57266572bc296950] request received: {:internal-protocol HTTP/2.0, :request-id 741071943ae1-3fe21ad5b1a261c1-http, :remote-addr 127.0.0.1, :client-protocol HTTP/2.0, :headers {te trailers, grpc-accept-encoding identity,deflate,gzip, host grpc.localtest.me:9091, content-type application/grpc, accept-encoding identity,gzip, user-agent grpc-c++/1.28.1 grpc-c/9.0.0 (osx; chttp2; galactic), x-cid 74107194c16e-57266572bc296950}, :content-length nil, :content-type application/grpc, :character-encoding nil, :uri /helloworld.Greeter/SayHello, :query-string nil, :router-id r9091-73d4c17aa24b-4ec684a184b8dbd, :scheme :http, :request-method :post}
2020-05-04 06:32:23,404 INFO  waiter.process-request [async-dispatch-41] - [CID=74107194c16e-57266572bc296950] suggested instance: w9091-w202005011550-f6fb3f7acbd9bf9e27fe7d6bab5fea59.740cd7845f14-721299e9e9a37528 127.0.0.5 10500
2020-05-04 06:32:23,404 INFO  waiter.process-request [qtp245667796-193] - [CID=74107194c16e-57266572bc296950] streamed 12 bytes from request input stream
2020-05-04 06:32:23,409 INFO  waiter.process-request [async-dispatch-24] - [CID=74107194c16e-57266572bc296950] 20 bytes streamed in response
2020-05-04 06:32:23,410 INFO  waiter.process-request [async-dispatch-24] - [CID=74107194c16e-57266572bc296950] done processing request :success
2020-05-04 06:32:23,410 INFO  waiter.process-request [async-dispatch-53] - [CID=74107194c16e-57266572bc296950] response trailers: {grpc-status 0, grpc-message }
```