### PR TITLE
adds support for last-update-time string in admin token update

### DIFF
--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1204,12 +1204,13 @@ class WaiterCliTest(util.WaiterTest):
     def test_show_service_current(self):
         token_name_1 = self.token_name()
         token_name_2 = self.token_name()
+        iso_8601_time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
         custom_fields = {
             'owner': getpass.getuser(),
             'cluster': 'test_show_service_current',
             'root': 'test_show_service_current',
             'last-update-user': getpass.getuser(),
-            'last-update-time': datetime.datetime.utcnow().isoformat()
+            'last-update-time': iso_8601_time
         }
         token_definition = util.minimal_service_description(**custom_fields)
 

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -510,14 +510,14 @@
     ; Store the token
     (let [{:strs [last-update-time] :as new-token-metadata}
           (merge {"cluster" (calculate-cluster cluster-calculator request)
-                                     "last-update-time" (.getMillis ^DateTime (clock))
-                                     "last-update-user" authenticated-user
-                                     "owner" owner
-                                     "root" (or (get existing-token-metadata "root") token-root)}
-                                    new-token-metadata)
+                  "last-update-time" (.getMillis ^DateTime (clock))
+                  "last-update-user" authenticated-user
+                  "owner" owner
+                  "root" (or (get existing-token-metadata "root") token-root)}
+                 new-token-metadata)
           new-token-metadata (cond-> new-token-metadata
                                (string? last-update-time)
-                               (assoc "last-update-time" (parse-last-update-time last-update-time)))
+                               (update "last-update-time" parse-last-update-time))
           new-user-editable-token-data (-> (merge new-service-parameter-template new-token-metadata)
                                            (select-keys sd/token-user-editable-keys))
           existing-token-description (sd/token->token-description kv-store token :include-deleted false)


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for last-update-time string in admin token update

## Why are we making these changes?

Maintain consistency between token output json and input accepted during token update.

