### PR TITLE
Refactor CLI to support plugin overrides from wrapper

### DIFF
--- a/cli/waiter/__main__.py
+++ b/cli/waiter/__main__.py
@@ -9,12 +9,12 @@ from waiter.cli import run
 from waiter.util import print_error
 
 
-def main(args=None):
+def main(args=None, plugins={}):
     if args is None:
         args = sys.argv[1:]
 
     try:
-        result = run(args)
+        result = run(args, plugins)
         sys.exit(result)
     except Exception as e:
         logging.exception('exception when running with %s' % args)

--- a/cli/waiter/cli.py
+++ b/cli/waiter/cli.py
@@ -71,7 +71,7 @@ def load_target_clusters(config_map, url=None, cluster=None):
     return clusters
 
 
-def run(args):
+def run(args, plugins):
     """
     Main entrypoint to the Waiter CLI. Loads configuration files,
     processes global command line arguments, and calls other command line 
@@ -93,13 +93,15 @@ def run(args):
 
     args = parser.parse_args()
     args = vars(args)
-    logging.debug('args: %s' % args)
+    logging.debug('args: %s', args)
     args.pop('verbose')
 
     action = args.pop('action')
     config_path = args.pop('config')
     cluster = args.pop('cluster')
     url = args.pop('url')
+
+    logging.debug('plugins: %s', plugins)
 
     if action is None:
         parser.print_help()
@@ -109,7 +111,7 @@ def run(args):
             metrics.initialize(config_map)
             metrics.inc(f'command.{action}.runs')
             clusters = load_target_clusters(config_map, url, cluster)
-            http_util.configure(config_map)
+            http_util.configure(config_map, plugins)
             args = {k: v for k, v in args.items() if v is not None}
             result = actions[action]['run-function'](clusters, args, config_path)
             logging.debug(f'result: {result}')

--- a/cli/waiter/configuration.py
+++ b/cli/waiter/configuration.py
@@ -17,9 +17,7 @@ ADDITIONAL_CONFIG_PATHS = ['.waiter.json',
 
 DEFAULT_CONFIG = {'http': {'retries': 2,
                            'connect-timeout': 3.05,
-                           'read-timeout': 20,
-                           'modules': {'session-module': 'requests',
-                                       'adapters-module': 'requests.adapters'}},
+                           'read-timeout': 20},
                   'metrics': {'disabled': True,
                               'max-retries': 2,
                               'timeout': 0.15}}

--- a/cli/waiter/version.py
+++ b/cli/waiter/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.8.3-dev'
+VERSION = '1.0.0'

--- a/cli/waiter/version.py
+++ b/cli/waiter/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.0.0'
+VERSION = '1.0.1-dev'


### PR DESCRIPTION
## Changes proposed in this PR

- Add an optional `plugins` argument to `main`. This will be the new (and only) way to configure site-wide plugins rather than using the config file.
- Refactor http modules loading logic to read from the `plugins` map that was passed to `main`. The `.waiter.json` config file is no longer consulted for `module` entries.
- Bumps major version to 1 (breaking change with config)

## Why are we making these changes?

Making site-wide changes to plugged-in logic is difficult/impossible if various users have old plugin overrides copied in `.waiter.json` files in home and working directories. The new `plugins` argument to `main` allows the `waiter` package maintainer to manage all side-specific changes centrally and not worry about stale configuration files.

Users that still want custom behavior can create their own wrapper that invokes either the site-specific wrapper's `main` or bypasses it to use the vanilla `main`.