### PR TITLE
adds metric group for the services created in the gRPC integration tests

### DIFF
--- a/waiter/integration/waiter/grpc_test.clj
+++ b/waiter/integration/waiter/grpc_test.clj
@@ -67,6 +67,7 @@
        "max-instances" 1
        "min-instances" 1
        "mem" 512
+       "metric-group" "waiter_test"
        "name" (rand-name)
        "ports" 2
        "version" "version-does-not-matter"})))


### PR DESCRIPTION
## Changes proposed in this PR

- adds metric group for the services created in the gRPC integration tests

## Why are we making these changes?

Makes it easy to identify services created by the integration tests.


