### PR TITLE
adds x-waiter-jwt header containing JWT access token to backend requests

### DIFF
--- a/waiter/integration/waiter/authentication_test.clj
+++ b/waiter/integration/waiter/authentication_test.clj
@@ -293,10 +293,10 @@
 
 (defn- validate-response
   [service-id access-token auth-method {:keys [body headers] :as response}]
-  (let [assertion-message (str {:access-token access-token
-                                :auth-method auth-method
+  (let [assertion-message (str {:auth-method auth-method
                                 :body body
                                 :headers headers
+                                :jwt-access-token access-token
                                 :service-id service-id})
         set-cookie (str (get headers "set-cookie"))]
     (assert-response-status response http-200-ok)

--- a/waiter/src/waiter/auth/authentication.clj
+++ b/waiter/src/waiter/auth/authentication.clj
@@ -53,7 +53,8 @@
 
 (defn- add-cached-auth
   [response password principal age-in-seconds auth-metadata]
-  (let [cookie-value [principal (tc/to-long (t/now)) auth-metadata]
+  (let [cookie-value (cond-> [principal (tc/to-long (t/now))]
+                       auth-metadata (conj auth-metadata))
         cookie-expiry (or age-in-seconds (-> 1 t/days t/in-seconds))]
     (cookie-support/add-encoded-cookie
       response password AUTH-COOKIE-NAME cookie-value cookie-expiry)))

--- a/waiter/src/waiter/auth/jwt.clj
+++ b/waiter/src/waiter/auth/jwt.clj
@@ -354,8 +354,8 @@
                                           key-id->jwk max-expiry-duration-ms realm request-scheme access-token)]
         (timers/stop timer-context)
         (counters/inc! (metrics/waiter-counter "core" "jwt" "validation" "success"))
-        {:access-token access-token
-         :claims claims})
+        {:claims claims
+         :jwt-access-token access-token})
       (catch Throwable throwable
         (timers/stop timer-context)
         (counters/inc! (metrics/waiter-counter "core" "jwt" "validation" "failed"))
@@ -394,10 +394,10 @@
           (make-401-response-updater request))
         ;; non-401 response avoids further downstream handler processing
         (utils/exception->response result-map-or-throwable request))
-      (let [{:keys [access-token claims]} result-map-or-throwable
+      (let [{:keys [claims jwt-access-token]} result-map-or-throwable
             {:keys [exp]} claims
             subject (subject-key claims)
-            auth-params-map (auth/build-auth-params-map :jwt subject {:access-token access-token})
+            auth-params-map (auth/build-auth-params-map :jwt subject {:jwt-access-token jwt-access-token})
             auth-cookie-age-in-seconds (- exp (current-time-secs))]
         (auth/handle-request-auth
           request-handler request auth-params-map password auth-cookie-age-in-seconds)))))

--- a/waiter/src/waiter/auth/kerberos.clj
+++ b/waiter/src/waiter/auth/kerberos.clj
@@ -33,7 +33,7 @@
   (try
     (let [{:keys [exit out err]} (shell/sh "krb5_prestash" "query" "host" host)]
       (if (zero? exit)
-        (set (map #(first (str/split % #"@" 2)) (str/split-lines out)))
+        (set (map #(utils/principal->username %) (str/split-lines out)))
         (do
           (log/error "Failed to reload prestash cache: " err)
           nil)))

--- a/waiter/src/waiter/auth/spnego.clj
+++ b/waiter/src/waiter/auth/spnego.clj
@@ -156,7 +156,8 @@
               (if-not error
                 (try
                   (if principal
-                    (let [response (auth/handle-request-auth request-handler request :spnego principal password)]
+                    (let [auth-params-map (auth/build-auth-params-map :spnego principal)
+                          response (auth/handle-request-auth request-handler request auth-params-map password)]
                       (log/debug "added cookies to response")
                       (if token
                         (if (map? response)

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1265,7 +1265,7 @@
                                                     [:settings waiter-principal]
                                                     [:state async-request-store-atom router-id user-agent-version]
                                                     populate-maintainer-chan!]
-                                             (let [auth-params-map (auth/auth-params-map :internal waiter-principal)
+                                             (let [auth-params-map (auth/build-auth-params-map :internal waiter-principal)
                                                    user-agent (str "waiter-async-status-check/" user-agent-version)]
                                                (fn post-process-async-request-response-wrapper
                                                  [response descriptor instance _

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -47,12 +47,6 @@
             [waiter.util.utils :as utils])
   (:import (java.io InputStream)))
 
-(defn make-auth-user-map
-  "Creates a map containing the username and principal from a request"
-  [request]
-  {:principal (:authorization/principal request)
-   :username (:authorization/user request)})
-
 (defn async-make-request-helper
   "Helper function that returns a function that can invoke make-request-fn."
   [http-clients instance-request-properties make-basic-auth-fn service-id->password-fn prepare-request-properties-fn make-request-fn]

--- a/waiter/src/waiter/headers.clj
+++ b/waiter/src/waiter/headers.clj
@@ -113,13 +113,12 @@
 (defn assoc-auth-headers
   "`assoc`s the x-waiter-auth-principal and x-waiter-authenticated-principal headers if the
    username and principal are non-nil, respectively."
-  ([headers principal]
-   (let [username (first (str/split principal #"@" 2))]
-     (assoc-auth-headers headers username principal)))
-  ([headers username principal]
-   (cond-> headers
-     username (assoc "x-waiter-auth-principal" username)
-     principal (assoc "x-waiter-authenticated-principal" principal))))
+  ([headers principal {:keys [access-token]}]
+   (let [username (utils/principal->username principal)]
+     (cond-> headers
+       username (assoc "x-waiter-auth-principal" username)
+       principal (assoc "x-waiter-authenticated-principal" principal)
+       access-token (assoc "x-waiter-jwt" access-token)))))
 
 (defn basic-auth-header
   "Constructs the basic auth header for the provided username and password."
@@ -135,4 +134,4 @@
   [waiter-username service-password request-principal]
   (assoc-auth-headers
     {"authorization" (basic-auth-header waiter-username service-password)}
-    request-principal))
+    request-principal nil))

--- a/waiter/src/waiter/headers.clj
+++ b/waiter/src/waiter/headers.clj
@@ -113,12 +113,12 @@
 (defn assoc-auth-headers
   "`assoc`s the x-waiter-auth-principal and x-waiter-authenticated-principal headers if the
    username and principal are non-nil, respectively."
-  ([headers principal {:keys [access-token]}]
+  ([headers principal {:keys [jwt-access-token]}]
    (let [username (utils/principal->username principal)]
      (cond-> headers
        username (assoc "x-waiter-auth-principal" username)
        principal (assoc "x-waiter-authenticated-principal" principal)
-       access-token (assoc "x-waiter-jwt" access-token)))))
+       jwt-access-token (assoc "x-waiter-jwt" jwt-access-token)))))
 
 (defn basic-auth-header
   "Constructs the basic auth header for the provided username and password."

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -55,7 +55,6 @@
 (defn make-auth-user-map
   "Creates a map containing the username and principal from a request"
   [{:keys [authorization/metadata authorization/principal]}]
-  ;; TODO creating this map is unnecessary, we can destructure from the request directly
   {:metadata metadata
    :principal principal})
 

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -637,3 +637,8 @@
   [data history-length history-key]
   (dissoc-in data (repeat history-length history-key)))
 
+(defn principal->username
+  "Extracts the user name from the provided principal by dropping the domain part."
+  [principal]
+  (when principal
+    (first (str/split principal #"@" 2))))

--- a/waiter/test/waiter/async_request_test.clj
+++ b/waiter/test/waiter/async_request_test.clj
@@ -299,7 +299,7 @@
         request-properties {:async-check-interval-ms 100 :async-request-max-status-checks 50 :async-request-timeout-ms 200}
         location (str "/location/" request-id)
         query-string "a=b&c=d|e"
-        auth-params-map (auth/auth-params-map :internal "waiter@example.com")
+        auth-params-map (auth/build-auth-params-map :internal "waiter@example.com")
         make-http-request-fn (fn [in-instance in-request end-route metric-group backend-proto]
                                (is (= instance in-instance))
                                (is (contains? in-request :request-id))
@@ -368,7 +368,7 @@
         sanitized-check-interval-ms (sanitize-check-interval async-request-timeout-ms async-check-interval-ms async-request-max-status-checks)
         location (str "/location/" request-id)
         query-string "a=b&c=d|e"
-        auth-params-map (auth/auth-params-map :internal "waiter@example.com")
+        auth-params-map (auth/build-auth-params-map :internal "waiter@example.com")
         make-http-request-fn (fn [in-instance in-request end-route metric-group backend-proto]
                                (is (= instance in-instance))
                                (is (contains? in-request :request-id))

--- a/waiter/test/waiter/auth/authenticator_test.clj
+++ b/waiter/test/waiter/auth/authenticator_test.clj
@@ -55,14 +55,14 @@
         one-day-in-millis (-> 1 t/days t/in-millis)]
     (is (true? (decoded-auth-valid? ["test-principal" now-ms])))
     (is (true? (decoded-auth-valid? ["test-principal" (-> now-ms (- one-day-in-millis) (+ 1000))])))
-    (is (true? (decoded-auth-valid? ["test-principal" now-ms {:access-token "a.b.c"}])))
+    (is (true? (decoded-auth-valid? ["test-principal" now-ms {:jwt-access-token "a.b.c"}])))
     (is (false? (decoded-auth-valid? ["test-principal" (- now-ms one-day-in-millis 1000)])))
     (is (false? (decoded-auth-valid? ["test-principal" "invalid-string-time"])))
     (is (false? (decoded-auth-valid? [(rand-int 10000) "invalid-string-time"])))
     (is (false? (decoded-auth-valid? [])))
     (is (false? (decoded-auth-valid? ["test-principal"])))
     (is (false? (decoded-auth-valid? ["test-principal" now-ms now-ms])))
-    (is (false? (decoded-auth-valid? ["test-principal" now-ms {:access-token "a.b.c"} now-ms])))))
+    (is (false? (decoded-auth-valid? ["test-principal" now-ms {:jwt-access-token "a.b.c"} now-ms])))))
 
 (deftest test-auth-cookie-handler
   (let [request-handler (fn [{:keys [authorization/principal authorization/user]}]
@@ -82,9 +82,9 @@
                  (auth-cookie-handler {:headers {"cookie" "x-waiter-auth=test-auth-cookie"}})))))
 
       (with-redefs [decode-auth-cookie (constantly [auth-principal (+ (System/currentTimeMillis) 60000)
-                                                    {:access-token "test.access.token"}])]
+                                                    {:jwt-access-token "test.access.token"}])]
         (let [auth-cookie-handler (wrap-auth-cookie-handler password request-handler)]
-          (is (= {:authorization/metadata {:access-token "test.access.token"}
+          (is (= {:authorization/metadata {:jwt-access-token "test.access.token"}
                   :authorization/method :cookie
                   :authorization/principal auth-principal
                   :authorization/user auth-user

--- a/waiter/test/waiter/auth/authenticator_test.clj
+++ b/waiter/test/waiter/auth/authenticator_test.clj
@@ -55,11 +55,14 @@
         one-day-in-millis (-> 1 t/days t/in-millis)]
     (is (true? (decoded-auth-valid? ["test-principal" now-ms])))
     (is (true? (decoded-auth-valid? ["test-principal" (-> now-ms (- one-day-in-millis) (+ 1000))])))
+    (is (true? (decoded-auth-valid? ["test-principal" now-ms {:access-token "a.b.c"}])))
     (is (false? (decoded-auth-valid? ["test-principal" (- now-ms one-day-in-millis 1000)])))
     (is (false? (decoded-auth-valid? ["test-principal" "invalid-string-time"])))
     (is (false? (decoded-auth-valid? [(rand-int 10000) "invalid-string-time"])))
+    (is (false? (decoded-auth-valid? [])))
     (is (false? (decoded-auth-valid? ["test-principal"])))
-    (is (false? (decoded-auth-valid? [])))))
+    (is (false? (decoded-auth-valid? ["test-principal" now-ms now-ms])))
+    (is (false? (decoded-auth-valid? ["test-principal" now-ms {:access-token "a.b.c"} now-ms])))))
 
 (deftest test-auth-cookie-handler
   (let [request-handler (fn [{:keys [authorization/principal authorization/user]}]
@@ -73,6 +76,16 @@
       (with-redefs [decode-auth-cookie (constantly [auth-principal (+ (System/currentTimeMillis) 60000)])]
         (let [auth-cookie-handler (wrap-auth-cookie-handler password request-handler)]
           (is (= {:authorization/method :cookie
+                  :authorization/principal auth-principal
+                  :authorization/user auth-user
+                  :body {:principal auth-principal :user auth-user}}
+                 (auth-cookie-handler {:headers {"cookie" "x-waiter-auth=test-auth-cookie"}})))))
+
+      (with-redefs [decode-auth-cookie (constantly [auth-principal (+ (System/currentTimeMillis) 60000)
+                                                    {:access-token "test.access.token"}])]
+        (let [auth-cookie-handler (wrap-auth-cookie-handler password request-handler)]
+          (is (= {:authorization/metadata {:access-token "test.access.token"}
+                  :authorization/method :cookie
                   :authorization/principal auth-principal
                   :authorization/user auth-user
                   :body {:principal auth-principal :user auth-user}}

--- a/waiter/test/waiter/auth/jwt_test.clj
+++ b/waiter/test/waiter/auth/jwt_test.clj
@@ -493,7 +493,7 @@
                       t/now (constantly (tc/from-long (* current-time 1000)))]
           (is (= (assoc request
                    :auth-cookie-age-in-seconds expiry-interval-secs
-                   :auth-params-map (auth/build-auth-params-map :jwt principal {:access-token access-token})
+                   :auth-params-map (auth/build-auth-params-map :jwt principal {:jwt-access-token access-token})
                    :password password
                    :principal principal
                    :source ::request-handler)

--- a/waiter/test/waiter/auth/jwt_test.clj
+++ b/waiter/test/waiter/auth/jwt_test.clj
@@ -459,7 +459,8 @@
     (testing "success scenario - non 401"
       (let [request-handler (fn [request] (assoc request :source ::request-handler))
             realm "www.test-realm.com"
-            request {:headers {"authorization" "Bearer foo.bar.baz"
+            access-token "foo.bar.baz"
+            request {:headers {"authorization" (str "Bearer " access-token)
                                "host" realm}
                      :request-id (rand-int 10000)
                      :scheme :test-scheme}
@@ -482,17 +483,17 @@
                                               (is (= "foo.bar.baz" in-access-token))
                                               (is (= keys in-keys))
                                               payload)
-                      auth/handle-request-auth (fn [request-handler request principal auth-params-map password auth-cookie-age-in-seconds]
+                      auth/handle-request-auth (fn [request-handler request auth-params-map password auth-cookie-age-in-seconds]
                                                  (-> request
                                                    (assoc :auth-cookie-age-in-seconds auth-cookie-age-in-seconds
                                                           :auth-params-map auth-params-map
                                                           :password password
-                                                          :principal principal)
+                                                          :principal (:authorization/principal auth-params-map))
                                                    request-handler))
                       t/now (constantly (tc/from-long (* current-time 1000)))]
           (is (= (assoc request
                    :auth-cookie-age-in-seconds expiry-interval-secs
-                   :auth-params-map (auth/auth-params-map :jwt principal)
+                   :auth-params-map (auth/build-auth-params-map :jwt principal {:access-token access-token})
                    :password password
                    :principal principal
                    :source ::request-handler)

--- a/waiter/test/waiter/auth/saml_test.clj
+++ b/waiter/test/waiter/auth/saml_test.clj
@@ -119,7 +119,7 @@
                   :authorization/user "my-user"
                   :body ""
                   :headers {"location" "redirect-url"
-                            "set-cookie" "x-waiter-auth=%5B%22my%2Duser%40domain%22+1557792000000%5D;Max-Age=86400;Path=/;HttpOnly=true"}
+                            "set-cookie" "x-waiter-auth=%5B%22my%2Duser%40domain%22+1557792000000+nil%5D;Max-Age=86400;Path=/;HttpOnly=true"}
                   :status http-303-see-other}
                  (saml-auth-redirect-handler saml-authenticator dummy-request'))))))
     (testing "has saml-auth-data no expiry"
@@ -139,7 +139,7 @@
                   :authorization/user "my-user"
                   :body ""
                   :headers {"location" "redirect-url"
-                            "set-cookie" "x-waiter-auth=%5B%22my%2Duser%40domain%22+1557792000000%5D;Max-Age=86400;Path=/;HttpOnly=true"}
+                            "set-cookie" "x-waiter-auth=%5B%22my%2Duser%40domain%22+1557792000000+nil%5D;Max-Age=86400;Path=/;HttpOnly=true"}
                   :status http-303-see-other}
                  (saml-auth-redirect-handler saml-authenticator dummy-request'))))))
     (testing "has saml-auth-data short expiry"
@@ -159,7 +159,7 @@
                   :authorization/user "my-user"
                   :body ""
                   :headers {"location" "redirect-url"
-                            "set-cookie" "x-waiter-auth=%5B%22my%2Duser%40domain%22+1557792000000%5D;Max-Age=3600;Path=/;HttpOnly=true"}
+                            "set-cookie" "x-waiter-auth=%5B%22my%2Duser%40domain%22+1557792000000+nil%5D;Max-Age=3600;Path=/;HttpOnly=true"}
                   :status http-303-see-other}
                  (saml-auth-redirect-handler saml-authenticator dummy-request'))))))))
 

--- a/waiter/test/waiter/auth/saml_test.clj
+++ b/waiter/test/waiter/auth/saml_test.clj
@@ -119,7 +119,7 @@
                   :authorization/user "my-user"
                   :body ""
                   :headers {"location" "redirect-url"
-                            "set-cookie" "x-waiter-auth=%5B%22my%2Duser%40domain%22+1557792000000+nil%5D;Max-Age=86400;Path=/;HttpOnly=true"}
+                            "set-cookie" "x-waiter-auth=%5B%22my%2Duser%40domain%22+1557792000000%5D;Max-Age=86400;Path=/;HttpOnly=true"}
                   :status http-303-see-other}
                  (saml-auth-redirect-handler saml-authenticator dummy-request'))))))
     (testing "has saml-auth-data no expiry"
@@ -139,7 +139,7 @@
                   :authorization/user "my-user"
                   :body ""
                   :headers {"location" "redirect-url"
-                            "set-cookie" "x-waiter-auth=%5B%22my%2Duser%40domain%22+1557792000000+nil%5D;Max-Age=86400;Path=/;HttpOnly=true"}
+                            "set-cookie" "x-waiter-auth=%5B%22my%2Duser%40domain%22+1557792000000%5D;Max-Age=86400;Path=/;HttpOnly=true"}
                   :status http-303-see-other}
                  (saml-auth-redirect-handler saml-authenticator dummy-request'))))))
     (testing "has saml-auth-data short expiry"
@@ -159,7 +159,7 @@
                   :authorization/user "my-user"
                   :body ""
                   :headers {"location" "redirect-url"
-                            "set-cookie" "x-waiter-auth=%5B%22my%2Duser%40domain%22+1557792000000+nil%5D;Max-Age=3600;Path=/;HttpOnly=true"}
+                            "set-cookie" "x-waiter-auth=%5B%22my%2Duser%40domain%22+1557792000000%5D;Max-Age=3600;Path=/;HttpOnly=true"}
                   :status http-303-see-other}
                  (saml-auth-redirect-handler saml-authenticator dummy-request'))))))))
 


### PR DESCRIPTION
## Changes proposed in this PR

- adds x-waiter-jwt header containing JWT access token to backend requests

## Why are we making these changes?

The JWT access token should be available to the backend in case it wants to perform its own authorization.


