### PR TITLE
treat same content edits from users as successful token sync

### DIFF
--- a/token-syncer/src/token_syncer/commands/syncer.clj
+++ b/token-syncer/src/token_syncer/commands/syncer.clj
@@ -115,7 +115,10 @@
                        (not (get description "deleted"))
                        (= (apply dissoc latest-token-description system-metadata-keys)
                           (apply dissoc description system-metadata-keys)))
-                  {:code :skip/token-sync}
+                  (if (= latest-update-user cluster-update-user)
+                    {:code :success/skip-token-sync}
+                    {:code :error/token-sync
+                     :details {:message "token contents match, but were edited by different users"}})
 
                   ;; token user-specified content, last update user, and root different
                   (and (seq description)

--- a/token-syncer/test/token_syncer/commands/syncer_test.clj
+++ b/token-syncer/test/token_syncer/commands/syncer_test.clj
@@ -246,8 +246,8 @@
                                                :latest token-description}}}
                (sync-token-on-clusters waiter-api cluster-urls test-token token-description cluster-url->token-data)))))
 
-    (testing "sync cluster same parameters and owner but different root"
-      (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
+    (testing "sync cluster similar parameters and owner but different root"
+      (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com" "www.cluster-3.com"]
             test-token "test-token-1"
             token-description {"cpus" 1
                                "last-update-user" "john.doe"
@@ -256,14 +256,20 @@
                                "owner" "test-user-1"}
             token-description-1 (assoc token-description "root" "cluster-1")
             token-description-2 (assoc token-description "root" "cluster-2")
+            token-description-3 (assoc token-description "last-update-user" "jane.doe" "root" "cluster-3")
             cluster-url->token-data {"www.cluster-1.com" {:description token-description-1
                                                           :token-etag (str test-token-etag ".1")
                                                           :status 200}
                                      "www.cluster-2.com" {:description token-description-2
                                                           :token-etag (str test-token-etag ".2")
+                                                          :status 200}
+                                     "www.cluster-3.com" {:description token-description-3
+                                                          :token-etag (str test-token-etag ".3")
                                                           :status 200}}]
         (is (= {"www.cluster-1.com" {:code :success/token-match}
-                "www.cluster-2.com" {:code :skip/token-sync}}
+                "www.cluster-2.com" {:code :success/skip-token-sync}
+                "www.cluster-3.com" {:code :error/token-sync
+                                     :details {:message "token contents match, but were edited by different users"}}}
                (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 cluster-url->token-data)))))
 
     (testing "sync cluster same owner; soft-deleted on one; and different last-update-user and root"


### PR DESCRIPTION
## Changes proposed in this PR

- treat same content edits from users as successful token sync

## Why are we making these changes?

Reduce failure scenarios when token is already synced across clusters.


