### PR TITLE
marks test_show_services_using_token as xfail 

### DIFF
--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1042,6 +1042,7 @@ class WaiterCliTest(util.WaiterTest):
             self.assertEqual(0, cp.returncode, cp.stderr)
             self.assertIn('Writing token JSON', cli.stdout(cp))
 
+    @pytest.mark.xfail
     def test_show_services_using_token(self):
         token_name = self.token_name()
         custom_fields = {


### PR DESCRIPTION
…as it is flaky in presence of failed instances

## Changes proposed in this PR

- marks test_show_services_using_token as xfail 


