### PR TITLE
Require pytest<=5.3.5

### DIFF
--- a/cli/integration/requirements.txt
+++ b/cli/integration/requirements.txt
@@ -1,5 +1,5 @@
 pip==9.0.1; python_version >= '3.6'
-pytest>=4.3.0
+pytest>=4.3.0,<=5.3.5
 pytest-xdist>=1.20.1
 pyyaml>=3.13
 requests>=2.20.0


### PR DESCRIPTION
## Changes proposed in this PR

Require pytest<=5.3.5 for CLI integration tests.

## Why are we making these changes?

We hit the same issue in our metrics fixture as described here:
https://github.com/okken/pytest-check/issues/34