### PR TITLE
adds support for async requests in http-utils

### DIFF
--- a/waiter/test/waiter/util/http_utils_test.clj
+++ b/waiter/test/waiter/util/http_utils_test.clj
@@ -71,7 +71,9 @@
           (http-request http-client "some-url")
           (is false "exception not thrown")
           (catch ExceptionInfo ex
-            (is (= {:body "{\"error\":\"response\"}" :status http-400-bad-request} (ex-data ex)))))))))
+            (is (= {:body {:error "response"}
+                    :status http-400-bad-request}
+                   (ex-data ex)))))))))
 
 (deftest test-backend-protocol->http-version
   (is (= "HTTP/2.0" (backend-protocol->http-version "h2")))


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for async requests in `http-utils`

## Why are we making these changes?

Allows making async request with the `http-utils` helper.


