### PR TITLE
Removed old waiter-cluster label from kubernetes.clj and kubernetes-t…

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -837,10 +837,6 @@
                   ;; https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
                   :annotations {:waiter/service-id service-id}
                   :labels {:app k8s-name
-                           ;; TODO - remove waiter-cluster
-                           ;; after waiter/cluster is exclusively in use
-                           ;; (see GitHub issue #721)
-                           :waiter-cluster cluster-name
                            :waiter/cluster cluster-name
                            :waiter/service-hash service-hash
                            :waiter/user run-as-user}
@@ -848,12 +844,10 @@
                   :namespace (or namespace default-namespace)}
        :spec {:replicas min-instances
               :selector {:matchLabels {:app k8s-name
-                                       :waiter-cluster cluster-name
                                        :waiter/user run-as-user}}
               :template {:metadata {:annotations {:waiter/port-count (str ports)
                                                   :waiter/service-id service-id}
                                     :labels {:app k8s-name
-                                             :waiter-cluster cluster-name
                                              :waiter/cluster cluster-name
                                              :waiter/service-hash service-hash
                                              :waiter/user run-as-user}}

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -1047,7 +1047,7 @@
       {:query-fn global-pods-state-query
        :resource-key :service-id->pod-id->pod
        :resource-name "Pods"
-       :resource-url (str api-server-url "/api/v1/pods?labelSelector=waiter-cluster=" cluster-name)
+       :resource-url (str api-server-url "/api/v1/pods?labelSelector=waiter%2Fcluster=" cluster-name)
        :metadata-key :pods-metadata
        :update-fn (fn pods-watch-update [{pod :object update-type :type}]
                     (let [now (t/now)
@@ -1091,7 +1091,7 @@
        :resource-key :service-id->service
        :resource-name "ReplicaSets"
        :resource-url (str api-server-url "/apis/" replicaset-api-version
-                          "/replicasets?labelSelector=waiter-cluster="
+                          "/replicasets?labelSelector=waiter%2Fcluster="
                           cluster-name)
        :metadata-key :rs-metadata
        :update-fn (fn rs-watch-update [{rs :object update-type :type}]

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -288,13 +288,11 @@
            :items [{:metadata {:name "test-app-1234"
                                :namespace "myself"
                                :labels {:app "test-app-1234"
-                                        :waiter-cluster "waiter"
                                         :waiter/cluster "waiter"
                                         :waiter/service-hash "test-app-1234"}
                                :annotations {:waiter/service-id "test-app-1234"}}
                     :spec {:replicas 2
                            :selector {:matchLabels {:app "test-app-1234"
-                                                    :waiter-cluster "waiter"
                                                     :waiter/cluster "waiter"}}}
                     :status {:replicas 2
                              :readyReplicas 2
@@ -302,13 +300,11 @@
                    {:metadata {:name "test-app-6789"
                                :namespace "myself"
                                :labels {:app "test-app-6789"
-                                        :waiter-cluster "waiter"
                                         :waiter/cluster "waiter"
                                         :waiter/service-hash "test-app-6789"}
                                :annotations {:waiter/service-id "test-app-6789"}}
                     :spec {:replicas 3
                            :selector {:matchLabels {:app "test-app-6789"
-                                                    :waiter-cluster "waiter"
                                                     :waiter/cluster "waiter"}}}
                     :status {:replicas 3
                              :readyReplicas 1
@@ -327,13 +323,11 @@
            :items [{:metadata {:name "test-app-abcd"
                                :namespace "myself"
                                :labels {:app "test-app-abcd"
-                                        :waiter-cluster "waiter"
                                         :waiter/cluster "waiter"
                                         :waiter/service-hash "test-app-abcd"}
                                :annotations {:waiter/service-id "test-app-abcd"}}
                     :spec {:replicas 2
                            :selector {:matchLabels {:app "test-app-abcd"
-                                                    :waiter-cluster "waiter"
                                                     :waiter/cluster "waiter"}}}
                     :status {:replicas 2
                              :readyReplicas 2
@@ -342,13 +336,11 @@
                    {:metadata {:name "test-app-wxyz"
                                :namespace "myself"
                                :labels {:app "test-app-wxyz"
-                                        :waiter-cluster "waiter"
                                         :waiter/cluster "waiter"
                                         :waiter/service-hash "test-app-wxyz"}
                                :annotations {:waiter/service-id "test-app-wxyz"}}
                     :spec {:replicas 3
                            :selector {:matchLabels {:app "test-app-wxyz"
-                                                    :waiter-cluster "waiter"
                                                     :waiter/cluster "waiter"}}}
                     :status {:replicas 3
                              :readyReplicas 1
@@ -368,13 +360,11 @@
            :items [{:metadata {:name "test-app-4321"
                                :namespace "myself"
                                :labels {:app "test-app-4321"
-                                        :waiter-cluster "waiter"
                                         :waiter/cluster "waiter"
                                         :waiter/service-hash "test-app-4321"}
                                :annotations {:waiter/service-id "test-app-4321"}}
                     :spec {:replicas 3
                            :selector {:matchLabels {:app "test-app-4321"
-                                                    :waiter-cluster "waiter"
                                                     :waiter/cluster "waiter"}}}
                     :status {:replicas 3
                              :readyReplicas 1
@@ -390,13 +380,11 @@
            :items [{:metadata {:name "test-app-9999"
                                :namespace "myself"
                                :labels {:app "test-app-9999"
-                                        :waiter-cluster "waiter"
                                         :waiter/cluster "waiter"
                                         :waiter/service-hash "test-app-9999"}
                                :annotations {:waiter/service-id "test-app-9999"}}
                     :spec {:replicas 0
                            :selector {:matchLabels {:app "test-app-9999"
-                                                    :waiter-cluster "waiter"
                                                     :waiter/cluster "waiter"}}}
                     :status {:replicas 0
                              :readyReplicas 0
@@ -422,7 +410,6 @@
          :items [{:metadata {:name "test-app-1234"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :waiter-cluster "waiter"
                                       :waiter/cluster "waiter"
                                       :waiter/user "myself"
                                       :waiter/service-hash "test-app-1234"}
@@ -434,7 +421,6 @@
                  {:metadata {:name "test-app-6789"
                              :namespace "myself"
                              :labels {:app "test-app-6789"
-                                      :waiter-cluster "waiter"
                                       :waiter/cluster "waiter"
                                       :waiter/service-hash "test-app-6789"}
                              :annotations {:waiter/service-id "test-app-6789"}}
@@ -450,7 +436,6 @@
          :items [{:metadata {:name "test-app-1234-abcd0"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :waiter-cluster "waiter"
                                       :waiter/cluster "waiter"
                                       :waiter/service-hash "test-app-1234"
                                       :waiter/user "myself"}
@@ -467,7 +452,6 @@
                  {:metadata {:name "test-app-1234-abcd1"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :waiter-cluster "waiter"
                                       :waiter/cluster "waiter"
                                       :waiter/service-hash "test-app-1234"
                                       :waiter/user "myself"}
@@ -484,7 +468,6 @@
                  {:metadata {:name "test-app-1234-abcd2"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :waiter-cluster "waiter"
                                       :waiter/cluster "waiter"
                                       :waiter/user "myself"
                                       :waiter/service-hash "test-app-1234"}
@@ -500,7 +483,6 @@
                  {:metadata {:name "test-app-6789-abcd1"
                              :namespace "myself"
                              :labels {:app "test-app-6789"
-                                      :waiter-cluster "waiter"
                                       :waiter/cluster "waiter"
                                       :waiter/user "myself"
                                       :waiter/service-hash "test-app-6789"}
@@ -515,7 +497,6 @@
                  {:metadata {:name "test-app-6789-abcd2"
                              :namespace "myself"
                              :labels {:app "test-app-6789"
-                                      :waiter-cluster "waiter"
                                       :waiter/cluster "waiter"
                                       :waiter/user "myself"
                                       :waiter/service-hash "test-app-6789"}
@@ -532,7 +513,6 @@
                  {:metadata {:name "test-app-6789-abcd3"
                              :namespace "myself"
                              :labels {:app "test-app-6789"
-                                      :waiter-cluster "waiter"
                                       :waiter/cluster "waiter"
                                       :waiter/user "myself"
                                       :waiter/service-hash "test-app-6789"}
@@ -651,7 +631,6 @@
                              :items [{:metadata {:name service-id
                                                  :namespace "myself"
                                                  :labels {:app service-id
-                                                          :waiter-cluster "waiter"
                                                           :waiter/cluster "waiter"
                                                           :waiter/service-hash service-id}
                                                  :annotations {:waiter/service-id service-id}}
@@ -720,13 +699,11 @@
          :items [{:metadata {:name service-id
                              :namespace "myself"
                              :labels {:app service-id
-                                      :waiter-cluster "waiter"
                                       :waiter/cluster "waiter"
                                       :waiter/service-hash service-id}
                              :annotations {:waiter/service-id service-id}}
                   :spec {:replicas 2
                          :selector {:matchLabels {:app service-id
-                                                  :waiter-cluster "waiter"
                                                   :waiter/cluster "waiter"}}}
                   :status {:replicas 2
                            :readyReplicas 2
@@ -1072,13 +1049,11 @@
          :items [{:metadata {:name "test-app-1234"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :waiter-cluster "waiter"
                                       :waiter/cluster "waiter"
                                       :waiter/service-hash "test-app-1234"}
                              :annotations {:waiter/service-id "test-app-1234"}}
                   :spec {:replicas 2
                          :selector {:matchLabels {:app "test-app-1234"
-                                                  :waiter-cluster "waiter"
                                                   :waiter/cluster "waiter"}}}
                   :status {:replicas 2
                            :readyReplicas 1
@@ -1089,14 +1064,12 @@
           :object {:metadata {:name "test-app-1234"
                               :namespace "myself"
                               :labels {:app "test-app-1234"
-                                       :waiter-cluster "waiter"
                                        :waiter/cluster "waiter"
                                        :waiter/service-hash "test-app-1234"}
                               :annotations {:waiter/service-id "test-app-1234"}
                               :resourceVersion "1001"}
                    :spec {:replicas 2
                           :selector {:matchLabels {:app "test-app-1234"
-                                                   :waiter-cluster "waiter"
                                                    :waiter/cluster "waiter"}}}
                    :status {:replicas 2
                             :readyReplicas 2
@@ -1105,14 +1078,12 @@
           :object {:metadata {:name "test-app-1234"
                               :namespace "myself"
                               :labels {:app "test-app-1234"
-                                       :waiter-cluster "waiter"
                                        :waiter/cluster "waiter"
                                        :waiter/service-hash "test-app-1234"}
                               :annotations {:waiter/service-id "test-app-1234"}
                               :resourceVersion "1002"}
                    :spec {:replicas 3
                           :selector {:matchLabels {:app "test-app-1234"
-                                                   :waiter-cluster "waiter"
                                                    :waiter/cluster "waiter"}}}
                    :status {:replicas 3
                             :readyReplicas 2
@@ -1121,14 +1092,12 @@
           :object {:metadata {:name "test-app-1234"
                               :namespace "myself"
                               :labels {:app "test-app-1234"
-                                       :waiter-cluster "waiter"
                                        :waiter/cluster "waiter"
                                        :waiter/service-hash "test-app-1234"}
                               :annotations {:waiter/service-id "test-app-1234"}
                               :resourceVersion "1003"}
                    :spec {:replicas 2
                           :selector {:matchLabels {:app "test-app-1234"
-                                                   :waiter-cluster "waiter"
                                                    :waiter/cluster "waiter"}}}
                    :status {:replicas 2
                             :readyReplicas 1
@@ -1141,7 +1110,6 @@
          :items [{:metadata {:name "test-app-1234-abcd1"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :waiter-cluster "waiter"
                                       :waiter/cluster "waiter"
                                       :waiter/service-hash "test-app-1234"}
                              :annotations {:waiter/port-count "1"
@@ -1156,7 +1124,6 @@
                  {:metadata {:name "test-app-1234-abcd2"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :waiter-cluster "waiter"
                                       :waiter/cluster "waiter"
                                       :waiter/service-hash "test-app-1234"}
                              :annotations {:waiter/port-count "1"
@@ -1172,7 +1139,6 @@
           :object {:metadata {:name "test-app-1234-abcd2"
                               :namespace "myself"
                               :labels {:app "test-app-1234"
-                                       :waiter-cluster "waiter"
                                        :waiter/cluster "waiter"
                                        :waiter/service-hash "test-app-1234"}
                               :annotations {:waiter/port-count "1"
@@ -1188,7 +1154,6 @@
           :object {:metadata {:name "test-app-1234-abcd3"
                               :namespace "myself"
                               :labels {:app "test-app-1234"
-                                       :waiter-cluster "waiter"
                                        :waiter/cluster "waiter"
                                        :waiter/service-hash "test-app-1234"}
                               :annotations {:waiter/port-count "1"
@@ -1324,13 +1289,11 @@
          :items [{:metadata {:name "test-app-1234"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :waiter-cluster "waiter"
                                       :waiter/cluster "waiter"
                                       :waiter/service-hash "test-app-1234"}
                              :annotations {:waiter/service-id "test-app-1234"}}
                   :spec {:replicas 2
                          :selector {:matchLabels {:app "test-app-1234"
-                                                  :waiter-cluster "waiter"
                                                   :waiter/cluster "waiter"}}}
                   :status {:replicas 2
                            :readyReplicas 1
@@ -1341,14 +1304,12 @@
           :object {:metadata {:name "test-app-1234"
                               :namespace "myself"
                               :labels {:app "test-app-1234"
-                                       :waiter-cluster "waiter"
                                        :waiter/cluster "waiter"
                                        :waiter/service-hash "test-app-1234"}
                               :annotations {:waiter/service-id "test-app-1234"}
                               :resourceVersion "1001"}
                    :spec {:replicas 2
                           :selector {:matchLabels {:app "test-app-1234"
-                                                   :waiter-cluster "waiter"
                                                    :waiter/cluster "waiter"}}}
                    :status {:replicas 2
                             :readyReplicas 2
@@ -1357,14 +1318,12 @@
           :object {:metadata {:name "test-app-1234"
                               :namespace "myself"
                               :labels {:app "test-app-1234"
-                                       :waiter-cluster "waiter"
                                        :waiter/cluster "waiter"
                                        :waiter/service-hash "test-app-1234"}
                               :annotations {:waiter/service-id "test-app-1234"}
                               :resourceVersion "1002"}
                    :spec {:replicas 3
                           :selector {:matchLabels {:app "test-app-1234"
-                                                   :waiter-cluster "waiter"
                                                    :waiter/cluster "waiter"}}}
                    :status {:replicas 3
                             :readyReplicas 2
@@ -1373,14 +1332,12 @@
           :object {:metadata {:name "test-app-1234"
                               :namespace "myself"
                               :labels {:app "test-app-1234"
-                                       :waiter-cluster "waiter"
                                        :waiter/cluster "waiter"
                                        :waiter/service-hash "test-app-1234"}
                               :annotations {:waiter/service-id "test-app-1234"}
                               :resourceVersion "1004"}
                    :spec {:replicas 2
                           :selector {:matchLabels {:app "test-app-1234"
-                                                   :waiter-cluster "waiter"
                                                    :waiter/cluster "waiter"}}}
                    :status {:replicas 2
                             :readyReplicas 1
@@ -1393,7 +1350,6 @@
          :items [{:metadata {:name "test-app-1234-abcd1"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :waiter-cluster "waiter"
                                       :waiter/cluster "waiter"
                                       :waiter/service-hash "test-app-1234"}
                              :annotations {:waiter/port-count "1"
@@ -1407,7 +1363,6 @@
                  {:metadata {:name "test-app-1234-abcd2"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :waiter-cluster "waiter"
                                       :waiter/cluster "waiter"
                                       :waiter/service-hash "test-app-1234"}
                              :annotations {:waiter/port-count "1"
@@ -1425,7 +1380,6 @@
          :items [{:metadata {:name "test-app-1234-abcd1"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :waiter-cluster "waiter"
                                       :waiter/cluster "waiter"
                                       :waiter/service-hash "test-app-1234"}
                              :annotations {:waiter/port-count "1"
@@ -1439,7 +1393,6 @@
                  {:metadata {:name "test-app-1234-abcd2"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :waiter-cluster "waiter"
                                       :waiter/cluster "waiter"
                                       :waiter/service-hash "test-app-1234"}
                              :annotations {:waiter/port-count "1"
@@ -1453,7 +1406,6 @@
                  {:metadata {:name "test-app-1234-abcd3"
                              :namespace "myself"
                              :labels {:app "test-app-1234"
-                                      :waiter-cluster "waiter"
                                       :waiter/cluster "waiter"
                                       :waiter/service-hash "test-app-1234"}
                              :annotations {:waiter/port-count "1"
@@ -1470,7 +1422,6 @@
           :object {:metadata {:name "test-app-1234-abcd2"
                               :namespace "myself"
                               :labels {:app "test-app-1234"
-                                       :waiter-cluster "waiter"
                                        :waiter/cluster "waiter"
                                        :waiter/service-hash "test-app-1234"}
                               :annotations {:waiter/port-count "1"
@@ -1486,7 +1437,6 @@
           :object {:metadata {:name "test-app-1234-abcd3"
                               :namespace "myself"
                               :labels {:app "test-app-1234"
-                                       :waiter-cluster "waiter"
                                        :waiter/cluster "waiter"
                                        :waiter/service-hash "test-app-1234"}
                               :annotations {:waiter/port-count "1"
@@ -1681,7 +1631,6 @@
         pod {:metadata {:name "test-app-1234-abcd1"
                         :namespace "myself"
                         :labels {:app "test-app-1234"
-                                 :waiter-cluster "waiter"
                                  :waiter/cluster "waiter"
                                  :waiter/service-hash "test-app-1234"}
                         :annotations {:waiter/port-count "1"


### PR DESCRIPTION
## Changes proposed in this PR

- Removing old waiter-cluster label as per #721 

## Why are we making these changes?

- Because we're confident that all objects without waiter/cluster have been already deleted or replaced.
