### PR TITLE
account for token edits while GC-ing services

### DIFF
--- a/waiter/integration/waiter/new_app_test.clj
+++ b/waiter/integration/waiter/new_app_test.clj
@@ -57,9 +57,11 @@
       (with-service-cleanup
         service-id
         (log/debug "Waiting for" service-id "to show up...")
-        (is (wait-for #(= 1 (num-instances waiter-url service-id)) :interval 1))
+        (is (wait-for #(= 1 (num-instances waiter-url service-id)) :interval 1)
+            (str service-id " instance wasn't created"))
         (log/debug "Waiting for" service-id "to go away...")
-        (is (wait-for #(= 0 (num-instances waiter-url service-id)) :interval 10))))))
+        (is (wait-for #(= 0 (num-instances waiter-url service-id)) :interval 10)
+            (str service-id " instance wasn't removed"))))))
 
 (deftest ^:parallel ^:integration-fast test-default-grace-period
   (testing-using-waiter-url

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -1261,7 +1261,7 @@
   "Computes the time when a given service should be GC-ed.
    If the service has GC disabled (by configuring idle-timeout-mins=0), nil is returned.
    If the service is active or was created by on-the-fly, the GC time is calculated using
-   the service's idle-timeout-mins and the time of the service's most recent request.
+   the service's idle-timeout-mins and the most recent completion time of the service's requests.
    Else, the GC time is the sum of the fallback period seconds and the stale service timeout."
   [service-id->service-description-fn service-id->references-fn token->token-parameters reference-type->stale-fn
    attach-token-defaults-fn service-id last-modified-time]

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -2461,6 +2461,19 @@
                  service-id->service-description-fn service-id->references-fn token->token-data reference-type->stale-fn
                  attach-token-defaults-fn (str service-id "s0") last-modified-time)))))
 
+    (testing "service created with missing token parameters"
+      (let [token->token-data {"t1" {"cpus" 1 "last-update-time" (tc/to-long t1000)}}
+            service-id->references-fn (fn [in-service-id]
+                                        (is (= in-service-id (str service-id "s1")))
+                                        #{{:token {:sources [{:token "t-miss" :version "t-miss.old"}]}}})
+            token->token-data (token->token-data-factory token->token-data)]
+        (is (= (-> (tc/from-long 0)
+                 (t/plus (t/seconds fallback-period-secs))
+                 (t/plus (t/minutes stale-timeout-mins)))
+               (service->gc-time
+                 service-id->service-description-fn service-id->references-fn token->token-data reference-type->stale-fn
+                 attach-token-defaults-fn (str service-id "s1") last-modified-time)))))
+
     (testing "service with single token is active"
       (let [token->token-data {"t1" {"cpus" 1 "last-update-time" (tc/to-long t1000)}}
             service-id->references-fn (fn [in-service-id]

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -2439,7 +2439,7 @@
         service-id->service-description-fn (fn [in-service-id]
                                              (is (str/starts-with? in-service-id service-id))
                                              {"idle-timeout-mins" idle-timeout-mins})
-        token->token-hash (fn [in-token] (str in-token ".hash1"))
+        token->token-hash (fn [in-token] (str in-token ".latest"))
         reference-type->stale-fn {:token #(service-token-references-stale? token->token-hash (:sources %))}
         token->token-data-factory (fn [token->token-data]
                                     (fn [in-token]
@@ -2465,7 +2465,7 @@
       (let [token->token-data {"t1" {"cpus" 1 "last-update-time" (tc/to-long t1000)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s1")))
-                                        #{{:token {:sources [{:token "t1" :version "t1.hash1"}]}}})
+                                        #{{:token {:sources [{:token "t1" :version "t1.latest"}]}}})
             token->token-data (token->token-data-factory token->token-data)]
         (is (= (t/plus last-modified-time (t/minutes idle-timeout-mins))
                (service->gc-time
@@ -2492,7 +2492,7 @@
                                "t2" {"mem" 2048 "last-update-time" (tc/to-long t2000)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s3")))
-                                        #{{:token {:sources [{:token "t1" :version "t1.hash1"} {:token "t2" :version "t2.hash1"}]}}})
+                                        #{{:token {:sources [{:token "t1" :version "t1.latest"} {:token "t2" :version "t2.latest"}]}}})
             token->token-data (token->token-data-factory token->token-data)]
         (is (= (t/plus last-modified-time (t/minutes idle-timeout-mins))
                (service->gc-time
@@ -2519,7 +2519,7 @@
                                     "t2" {"mem" 2048 "last-update-time" (tc/to-long t2000)}}}]]
         (let [service-id->references-fn (fn [in-service-id]
                                           (is (= in-service-id (str service-id "s4")))
-                                          #{{:token {:sources [{:token "t1" :version "t1.hash0"}]}}})
+                                          #{{:token {:sources [{:token "t1" :version "t1.old"}]}}})
               token->token-data (token->token-data-factory token->token-data)]
           (is (= (-> t1000
                    (t/plus (t/seconds expected-fallback-period-secs))
@@ -2529,7 +2529,7 @@
                    attach-token-defaults-fn (str service-id "s4") last-modified-time))))
         (let [service-id->references-fn (fn [in-service-id]
                                           (is (= in-service-id (str service-id "s5")))
-                                          #{{:token {:sources [{:token "t2" :version "t2.hash0"}]}}})
+                                          #{{:token {:sources [{:token "t2" :version "t2.old"}]}}})
               token->token-data (token->token-data-factory token->token-data)]
           (is (= (-> t2000
                    (t/plus (t/seconds fallback-period-secs))
@@ -2543,7 +2543,7 @@
                                "t2" {"mem" 2048 "last-update-time" (tc/to-long t2000)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s5")))
-                                        #{{:token {:sources [{:token "t1" :version "t1.hash0"}]}}
+                                        #{{:token {:sources [{:token "t1" :version "t1.old"}]}}
                                           {}})
             token->token-data (token->token-data-factory token->token-data)]
         (is (= (t/plus last-modified-time (t/minutes idle-timeout-mins))
@@ -2556,7 +2556,7 @@
                                "t2" {"mem" 2048 "last-update-time" (tc/to-long t2000)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s6")))
-                                        #{{:token {:sources [{:token "t1" :version "t1.hash1"} {:token "t2" :version "t2.hash0"}]}}})
+                                        #{{:token {:sources [{:token "t1" :version "t1.latest"} {:token "t2" :version "t2.old"}]}}})
             token->token-data (token->token-data-factory token->token-data)]
         (is (= (t/plus last-modified-time (t/minutes idle-timeout-mins))
                (service->gc-time
@@ -2570,9 +2570,9 @@
                                "t3" {"cmd" "tc" "fallback-period-secs" 900 "last-update-time" (tc/to-long t3000)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s7")))
-                                        #{{:token {:sources [{:token "t1" :version "t1.hash1"}
-                                                             {:token "t2" :version "t2.hash0"}
-                                                             {:token "t3" :version "t3.hash0"}]}}})
+                                        #{{:token {:sources [{:token "t1" :version "t1.latest"}
+                                                             {:token "t2" :version "t2.old"}
+                                                             {:token "t3" :version "t3.old"}]}}})
             token->token-data (token->token-data-factory token->token-data)]
         (is (= (t/plus last-modified-time (t/minutes idle-timeout-mins))
                (service->gc-time
@@ -2584,9 +2584,9 @@
                                "t3" {"cmd" "tc" "fallback-period-secs" 900 "last-update-time" (tc/to-long t3000)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s7")))
-                                        #{{:token {:sources [{:token "t1" :version "t1.hash0"}
-                                                             {:token "t2" :version "t2.hash0"}
-                                                             {:token "t3" :version "t3.hash1"}]}}})
+                                        #{{:token {:sources [{:token "t1" :version "t1.old"}
+                                                             {:token "t2" :version "t2.old"}
+                                                             {:token "t3" :version "t3.latest"}]}}})
             token->token-data (token->token-data-factory token->token-data)]
         (is (= (t/plus last-modified-time (t/minutes idle-timeout-mins))
                (service->gc-time
@@ -2600,9 +2600,9 @@
                                "t3" {"cmd" "tc" "fallback-period-secs" 900 "last-update-time" (tc/to-long t3000)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s8")))
-                                        #{{:token {:sources [{:token "t1" :version "t1.hash0"}
-                                                             {:token "t2" :version "t2.hash0"}
-                                                             {:token "t3" :version "t3.hash0"}]}}})
+                                        #{{:token {:sources [{:token "t1" :version "t1.old"}
+                                                             {:token "t2" :version "t2.old"}
+                                                             {:token "t3" :version "t3.old"}]}}})
             token->token-data (token->token-data-factory token->token-data)]
         (is (= (t/plus t4000 (t/minutes (-> 900 t/seconds t/in-minutes (+ stale-timeout-mins))))
                (service->gc-time
@@ -2617,8 +2617,8 @@
                                "t4" {"fallback-period-secs" 1200 "stale-timeout-mins" (+ stale-timeout-mins 15)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s9")))
-                                        #{{:token {:sources [{:token "t1" :version "t1.hash1"} {:token "t2" :version "t2.hash0"}]}}
-                                          {:token {:sources [{:token "t3" :version "t3.hash0"} {:token "t4" :version "t4.hash0"}]}}})
+                                        #{{:token {:sources [{:token "t1" :version "t1.latest"} {:token "t2" :version "t2.old"}]}}
+                                          {:token {:sources [{:token "t3" :version "t3.old"} {:token "t4" :version "t4.old"}]}}})
             token->token-data (token->token-data-factory token->token-data)]
         (is (= (t/plus last-modified-time (t/minutes idle-timeout-mins))
                (service->gc-time
@@ -2633,8 +2633,8 @@
                                "t4" {"fallback-period-secs" 1200 "stale-timeout-mins" (+ stale-timeout-mins 15)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s10")))
-                                        #{{:token {:sources [{:token "t1" :version "t1.hash1"} {:token "t2" :version "t2.hash1"}]}}
-                                          {:token {:sources [{:token "t3" :version "t3.hash1"} {:token "t4" :version "t4.hash1"}]}}})
+                                        #{{:token {:sources [{:token "t1" :version "t1.latest"} {:token "t2" :version "t2.latest"}]}}
+                                          {:token {:sources [{:token "t3" :version "t3.latest"} {:token "t4" :version "t4.latest"}]}}})
             token->token-data (token->token-data-factory token->token-data)]
         (is (= (t/plus last-modified-time (t/minutes idle-timeout-mins))
                (service->gc-time
@@ -2649,8 +2649,8 @@
                                "t4" {"fallback-period-secs" 1200 "stale-timeout-mins" (+ stale-timeout-mins 15)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s11")))
-                                        #{{:token {:sources [{:token "t1" :version "t1.hash1"} {:token "t2" :version "t2.hash1"}]}}
-                                          {:token {:sources [{:token "t3" :version "t3.hash0"} {:token "t4" :version "t4.hash0"}]}}})
+                                        #{{:token {:sources [{:token "t1" :version "t1.latest"} {:token "t2" :version "t2.latest"}]}}
+                                          {:token {:sources [{:token "t3" :version "t3.old"} {:token "t4" :version "t4.old"}]}}})
             token->token-data (token->token-data-factory token->token-data)]
         (is (= (t/plus last-modified-time (t/minutes idle-timeout-mins))
                (service->gc-time
@@ -2665,8 +2665,8 @@
                                "t4" {"fallback-period-secs" 1200 "last-update-time" (tc/to-long t4000) "stale-timeout-mins" (+ stale-timeout-mins 15)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s12")))
-                                        #{{:token {:sources [{:token "t1" :version "t1.hash0"} {:token "t2" :version "t2.hash0"}]}}
-                                          {:token {:sources [{:token "t3" :version "t3.hash0"} {:token "t4" :version "t4.hash0"}]}}})
+                                        #{{:token {:sources [{:token "t1" :version "t1.old"} {:token "t2" :version "t2.old"}]}}
+                                          {:token {:sources [{:token "t3" :version "t3.old"} {:token "t4" :version "t4.old"}]}}})
             token->token-data (token->token-data-factory token->token-data)]
         (is (= (t/plus
                  t4000
@@ -2685,7 +2685,7 @@
                                                  {"idle-timeout-mins" idle-timeout-mins})
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s1")))
-                                        #{{:token {:sources [{:token "t1" :version "t1.hash1"}]}}})
+                                        #{{:token {:sources [{:token "t1" :version "t1.latest"}]}}})
             token->token-data (token->token-data-factory token->token-data)]
         (is (nil?
               (service->gc-time

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -2596,7 +2596,7 @@
     (testing "service outdated on every token and fallback and timeout configured on all tokens"
       (let [stale-timeout-mins 45
             token->token-data {"t1" {"cpus" 123 "fallback-period-secs" 300 "last-update-time" (tc/to-long t1000)}
-                               "t2" {"cmd" "tc" "fallback-period-secs" 600 "last-update-time" (tc/to-long t2000) "stale-timeout-mins" stale-timeout-mins}
+                               "t2" {"cmd" "tc" "fallback-period-secs" 600 "last-update-time" (tc/to-long t4000) "stale-timeout-mins" stale-timeout-mins}
                                "t3" {"cmd" "tc" "fallback-period-secs" 900 "last-update-time" (tc/to-long t3000)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s8")))
@@ -2604,7 +2604,7 @@
                                                              {:token "t2" :version "t2.hash0"}
                                                              {:token "t3" :version "t3.hash0"}]}}})
             token->token-data (token->token-data-factory token->token-data)]
-        (is (= (t/plus t3000 (t/minutes (-> 900 t/seconds t/in-minutes (+ stale-timeout-mins))))
+        (is (= (t/plus t4000 (t/minutes (-> 900 t/seconds t/in-minutes (+ stale-timeout-mins))))
                (service->gc-time
                  service-id->service-description-fn service-id->references-fn token->token-data reference-type->stale-fn
                  attach-token-defaults-fn (str service-id "s8") last-modified-time)))))

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -14,7 +14,8 @@
 ;; limitations under the License.
 ;;
 (ns waiter.service-description-test
-  (:require [clj-time.core :as t]
+  (:require [clj-time.coerce :as tc]
+            [clj-time.core :as t]
             [clojure.set :as set]
             [clojure.string :as str]
             [clojure.test :refer :all]
@@ -2413,7 +2414,7 @@
     (kv/store kv-store token token-data)
     (is (= (token-data->token-hash token-data) (token->token-hash kv-store token)))))
 
-(deftest test-service-id->idle-timeout
+(deftest test-service->gc-time
   (let [fallback-period-secs 150
         profile-fallback-period-secs 100
         idle-timeout-mins 25
@@ -2442,197 +2443,254 @@
         reference-type->stale-fn {:token #(service-token-references-stale? token->token-hash (:sources %))}
         token->token-data-factory (fn [token->token-data]
                                     (fn [in-token]
-                                      (get token->token-data in-token)))]
+                                      (get token->token-data in-token)))
+        t1000 (tc/from-long 1000)
+        t2000 (tc/from-long 2000)
+        t3000 (tc/from-long 3000)
+        t4000 (tc/from-long 4000)
+        last-modified-time (tc/from-long 5000)]
+
+    (testing "service created without token"
+      (let [token->token-data {"t1" {"cpus" 1 "last-update-time" (tc/to-long t1000)}}
+            service-id->references-fn (fn [in-service-id]
+                                        (is (= in-service-id (str service-id "s0")))
+                                        #{})
+            token->token-data (token->token-data-factory token->token-data)]
+        (is (= (t/plus last-modified-time (t/minutes stale-timeout-mins))
+               (service->gc-time
+                 service-id->service-description-fn service-id->references-fn token->token-data reference-type->stale-fn
+                 attach-token-defaults-fn (str service-id "s0") last-modified-time)))))
 
     (testing "service with single token is active"
-      (let [token->token-data {"t1" {"cpus" 1}}
+      (let [token->token-data {"t1" {"cpus" 1 "last-update-time" (tc/to-long t1000)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s1")))
                                         #{{:token {:sources [{:token "t1" :version "t1.hash1"}]}}})
             token->token-data (token->token-data-factory token->token-data)]
-        (is (= idle-timeout-mins
-               (service-id->idle-timeout
+        (is (= (t/plus last-modified-time (t/minutes idle-timeout-mins))
+               (service->gc-time
                  service-id->service-description-fn service-id->references-fn token->token-data reference-type->stale-fn
-                 attach-token-defaults-fn (str service-id "s1"))))))
+                 attach-token-defaults-fn (str service-id "s1") last-modified-time)))))
 
     (testing "direct access service is active"
       (doseq [token->token-data
-              [{"t1" {"cpus" 1}}
-               {"t1" {"cpus" 1 "profile" "webapp1"}}
-               {"t1" {"cpus" 1 "profile" "webapp2"}}
-               {"t1" {"cpus" 1 "profile" "webapp3"}}]]
+              [{"t1" {"cpus" 1 "last-update-time" (tc/to-long t1000)}}
+               {"t1" {"cpus" 1 "last-update-time" (tc/to-long t1000) "profile" "webapp1"}}
+               {"t1" {"cpus" 1 "last-update-time" (tc/to-long t1000) "profile" "webapp2"}}
+               {"t1" {"cpus" 1 "last-update-time" (tc/to-long t1000) "profile" "webapp3"}}]]
         (let [service-id->references-fn (fn [in-service-id]
                                           (is (= in-service-id (str service-id "s2")))
                                           #{{}})
               token->token-data (token->token-data-factory token->token-data)]
-          (is (= idle-timeout-mins
-                 (service-id->idle-timeout
+          (is (= (t/plus last-modified-time (t/minutes idle-timeout-mins))
+                 (service->gc-time
                    service-id->service-description-fn service-id->references-fn token->token-data reference-type->stale-fn
-                   attach-token-defaults-fn (str service-id "s2")))))))
+                   attach-token-defaults-fn (str service-id "s2") last-modified-time))))))
 
     (testing "service with multiple tokens is active"
-      (let [token->token-data {"t1" {"cpus" 1}
-                               "t2" {"mem" 2048}}
+      (let [token->token-data {"t1" {"cpus" 1 "last-update-time" (tc/to-long t1000)}
+                               "t2" {"mem" 2048 "last-update-time" (tc/to-long t2000)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s3")))
                                         #{{:token {:sources [{:token "t1" :version "t1.hash1"} {:token "t2" :version "t2.hash1"}]}}})
             token->token-data (token->token-data-factory token->token-data)]
-        (is (= idle-timeout-mins
-               (service-id->idle-timeout
+        (is (= (t/plus last-modified-time (t/minutes idle-timeout-mins))
+               (service->gc-time
                  service-id->service-description-fn service-id->references-fn token->token-data reference-type->stale-fn
-                 attach-token-defaults-fn (str service-id "s3"))))))
+                 attach-token-defaults-fn (str service-id "s3") last-modified-time)))))
 
     (testing "service outdated but fallback not configured"
       (doseq [{:keys [expected-fallback-period-secs expected-stale-timeout-mins token->token-data]}
               [{:expected-fallback-period-secs fallback-period-secs
                 :expected-stale-timeout-mins stale-timeout-mins
-                :token->token-data {"t1" {"cpus" 1}
-                                    "t2" {"mem" 2048}}}
+                :token->token-data {"t1" {"cpus" 1 "last-update-time" (tc/to-long t1000)}
+                                    "t2" {"mem" 2048 "last-update-time" (tc/to-long t2000)}}}
                {:expected-fallback-period-secs profile-fallback-period-secs
                 :expected-stale-timeout-mins profile-stale-timeout-mins
-                :token->token-data {"t1" {"cpus" 1 "profile" "webapp1"}
-                                    "t2" {"mem" 2048}}}
+                :token->token-data {"t1" {"cpus" 1 "last-update-time" (tc/to-long t1000) "profile" "webapp1"}
+                                    "t2" {"mem" 2048 "last-update-time" (tc/to-long t2000)}}}
                {:expected-fallback-period-secs fallback-period-secs
                 :expected-stale-timeout-mins profile-stale-timeout-mins
-                :token->token-data {"t1" {"cpus" 1 "profile" "webapp2"}
-                                    "t2" {"mem" 2048}}}
+                :token->token-data {"t1" {"cpus" 1 "last-update-time" (tc/to-long t1000) "profile" "webapp2"}
+                                    "t2" {"mem" 2048 "last-update-time" (tc/to-long t2000)}}}
                {:expected-fallback-period-secs profile-fallback-period-secs
                 :expected-stale-timeout-mins stale-timeout-mins
-                :token->token-data {"t1" {"cpus" 1 "profile" "webapp3"}
-                                    "t2" {"mem" 2048}}}]]
+                :token->token-data {"t1" {"cpus" 1 "last-update-time" (tc/to-long t1000) "profile" "webapp3"}
+                                    "t2" {"mem" 2048 "last-update-time" (tc/to-long t2000)}}}]]
         (let [service-id->references-fn (fn [in-service-id]
                                           (is (= in-service-id (str service-id "s4")))
                                           #{{:token {:sources [{:token "t1" :version "t1.hash0"}]}}})
               token->token-data (token->token-data-factory token->token-data)]
-          (is (= (-> (+ expected-fallback-period-secs (dec (-> 1 t/minutes t/in-seconds)))
-                   t/seconds
-                   t/in-minutes
-                   (+ expected-stale-timeout-mins))
-                 (service-id->idle-timeout
+          (is (= (-> t1000
+                   (t/plus (t/seconds expected-fallback-period-secs))
+                   (t/plus (t/minutes expected-stale-timeout-mins)))
+                 (service->gc-time
                    service-id->service-description-fn service-id->references-fn token->token-data reference-type->stale-fn
-                   attach-token-defaults-fn (str service-id "s4")))))))
+                   attach-token-defaults-fn (str service-id "s4") last-modified-time))))
+        (let [service-id->references-fn (fn [in-service-id]
+                                          (is (= in-service-id (str service-id "s5")))
+                                          #{{:token {:sources [{:token "t2" :version "t2.hash0"}]}}})
+              token->token-data (token->token-data-factory token->token-data)]
+          (is (= (-> t2000
+                   (t/plus (t/seconds fallback-period-secs))
+                   (t/plus (t/minutes stale-timeout-mins)))
+                 (service->gc-time
+                   service-id->service-description-fn service-id->references-fn token->token-data reference-type->stale-fn
+                   attach-token-defaults-fn (str service-id "s5") last-modified-time))))))
 
     (testing "service outdated with tokens but direct access possible"
-      (let [token->token-data {"t1" {"cpus" 1}
-                               "t2" {"mem" 2048}}
+      (let [token->token-data {"t1" {"cpus" 1 "last-update-time" (tc/to-long t1000)}
+                               "t2" {"mem" 2048 "last-update-time" (tc/to-long t2000)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s5")))
                                         #{{:token {:sources [{:token "t1" :version "t1.hash0"}]}}
                                           {}})
             token->token-data (token->token-data-factory token->token-data)]
-        (is (= idle-timeout-mins
-               (service-id->idle-timeout
+        (is (= (t/plus last-modified-time (t/minutes idle-timeout-mins))
+               (service->gc-time
                  service-id->service-description-fn service-id->references-fn token->token-data reference-type->stale-fn
-                 attach-token-defaults-fn (str service-id "s5"))))))
+                 attach-token-defaults-fn (str service-id "s5") last-modified-time)))))
 
     (testing "service outdated and fallback configured on one token"
-      (let [token->token-data {"t1" {"cpus" 1 "fallback-period-secs" 300}
-                               "t2" {"mem" 2048}}
+      (let [token->token-data {"t1" {"cpus" 1 "last-update-time" (tc/to-long t1000) "fallback-period-secs" 300}
+                               "t2" {"mem" 2048 "last-update-time" (tc/to-long t2000)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s6")))
                                         #{{:token {:sources [{:token "t1" :version "t1.hash1"} {:token "t2" :version "t2.hash0"}]}}})
             token->token-data (token->token-data-factory token->token-data)]
-        (is (= idle-timeout-mins
-               (service-id->idle-timeout
+        (is (= (t/plus last-modified-time (t/minutes idle-timeout-mins))
+               (service->gc-time
                  service-id->service-description-fn service-id->references-fn token->token-data reference-type->stale-fn
-                 attach-token-defaults-fn (str service-id "s6"))))))
+                 attach-token-defaults-fn (str service-id "s6") last-modified-time)))))
 
     (testing "service outdated on some tokens and fallback and timeout configured on all tokens"
       (let [stale-timeout-mins 45
-            token->token-data {"t1" {"cpus" 123 "fallback-period-secs" 300}
-                               "t2" {"cmd" "tc" "fallback-period-secs" 600 "stale-timeout-mins" stale-timeout-mins}
-                               "t3" {"cmd" "tc" "fallback-period-secs" 900}}
+            token->token-data {"t1" {"cpus" 123 "fallback-period-secs" 300 "last-update-time" (tc/to-long t1000)}
+                               "t2" {"cmd" "tc" "fallback-period-secs" 600 "last-update-time" (tc/to-long t2000) "stale-timeout-mins" stale-timeout-mins}
+                               "t3" {"cmd" "tc" "fallback-period-secs" 900 "last-update-time" (tc/to-long t3000)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s7")))
                                         #{{:token {:sources [{:token "t1" :version "t1.hash1"}
                                                              {:token "t2" :version "t2.hash0"}
                                                              {:token "t3" :version "t3.hash0"}]}}})
             token->token-data (token->token-data-factory token->token-data)]
-        (is (= idle-timeout-mins
-               (service-id->idle-timeout
+        (is (= (t/plus last-modified-time (t/minutes idle-timeout-mins))
+               (service->gc-time
                  service-id->service-description-fn service-id->references-fn token->token-data reference-type->stale-fn
-                 attach-token-defaults-fn (str service-id "s7"))))))
+                 attach-token-defaults-fn (str service-id "s7") last-modified-time))))
+      (let [stale-timeout-mins 45
+            token->token-data {"t1" {"cpus" 123 "fallback-period-secs" 300 "last-update-time" (tc/to-long t1000)}
+                               "t2" {"cmd" "tc" "fallback-period-secs" 600 "last-update-time" (tc/to-long t2000) "stale-timeout-mins" stale-timeout-mins}
+                               "t3" {"cmd" "tc" "fallback-period-secs" 900 "last-update-time" (tc/to-long t3000)}}
+            service-id->references-fn (fn [in-service-id]
+                                        (is (= in-service-id (str service-id "s7")))
+                                        #{{:token {:sources [{:token "t1" :version "t1.hash0"}
+                                                             {:token "t2" :version "t2.hash0"}
+                                                             {:token "t3" :version "t3.hash1"}]}}})
+            token->token-data (token->token-data-factory token->token-data)]
+        (is (= (t/plus last-modified-time (t/minutes idle-timeout-mins))
+               (service->gc-time
+                 service-id->service-description-fn service-id->references-fn token->token-data reference-type->stale-fn
+                 attach-token-defaults-fn (str service-id "s7") last-modified-time)))))
 
     (testing "service outdated on every token and fallback and timeout configured on all tokens"
       (let [stale-timeout-mins 45
-            token->token-data {"t1" {"cpus" 123 "fallback-period-secs" 300}
-                               "t2" {"cmd" "tc" "fallback-period-secs" 600 "stale-timeout-mins" stale-timeout-mins}
-                               "t3" {"cmd" "tc" "fallback-period-secs" 900}}
+            token->token-data {"t1" {"cpus" 123 "fallback-period-secs" 300 "last-update-time" (tc/to-long t1000)}
+                               "t2" {"cmd" "tc" "fallback-period-secs" 600 "last-update-time" (tc/to-long t2000) "stale-timeout-mins" stale-timeout-mins}
+                               "t3" {"cmd" "tc" "fallback-period-secs" 900 "last-update-time" (tc/to-long t3000)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s8")))
                                         #{{:token {:sources [{:token "t1" :version "t1.hash0"}
                                                              {:token "t2" :version "t2.hash0"}
                                                              {:token "t3" :version "t3.hash0"}]}}})
             token->token-data (token->token-data-factory token->token-data)]
-        (is (= (-> 900 t/seconds t/in-minutes (+ stale-timeout-mins))
-               (service-id->idle-timeout
+        (is (= (t/plus t3000 (t/minutes (-> 900 t/seconds t/in-minutes (+ stale-timeout-mins))))
+               (service->gc-time
                  service-id->service-description-fn service-id->references-fn token->token-data reference-type->stale-fn
-                 attach-token-defaults-fn (str service-id "s8"))))))
+                 attach-token-defaults-fn (str service-id "s8") last-modified-time)))))
 
     (testing "service using latest of one partial token among many"
       (let [stale-timeout-mins 45
-            token->token-data {"t1" {"cpus" 123 "fallback-period-secs" 300}
-                               "t2" {"cmd" "tc" "fallback-period-secs" 600 "stale-timeout-mins" stale-timeout-mins}
-                               "t3" {"cmd" "tc" "fallback-period-secs" 900}
+            token->token-data {"t1" {"cpus" 123 "fallback-period-secs" 300 "last-update-time" (tc/to-long t1000)}
+                               "t2" {"cmd" "tc" "fallback-period-secs" 600 "last-update-time" (tc/to-long t2000) "stale-timeout-mins" stale-timeout-mins}
+                               "t3" {"cmd" "tc" "fallback-period-secs" 900 "last-update-time" (tc/to-long t3000)}
                                "t4" {"fallback-period-secs" 1200 "stale-timeout-mins" (+ stale-timeout-mins 15)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s9")))
                                         #{{:token {:sources [{:token "t1" :version "t1.hash1"} {:token "t2" :version "t2.hash0"}]}}
                                           {:token {:sources [{:token "t3" :version "t3.hash0"} {:token "t4" :version "t4.hash0"}]}}})
             token->token-data (token->token-data-factory token->token-data)]
-        (is (= idle-timeout-mins
-               (service-id->idle-timeout
+        (is (= (t/plus last-modified-time (t/minutes idle-timeout-mins))
+               (service->gc-time
                  service-id->service-description-fn service-id->references-fn token->token-data reference-type->stale-fn
-                 attach-token-defaults-fn (str service-id "s9"))))))
+                 attach-token-defaults-fn (str service-id "s9") last-modified-time)))))
 
     (testing "service using latest versions of multiple tokens"
       (let [stale-timeout-mins 45
-            token->token-data {"t1" {"cpus" 123 "fallback-period-secs" 300}
-                               "t2" {"cmd" "tc" "fallback-period-secs" 600 "stale-timeout-mins" stale-timeout-mins}
-                               "t3" {"cmd" "tc" "fallback-period-secs" 900}
+            token->token-data {"t1" {"cpus" 123 "fallback-period-secs" 300 "last-update-time" (tc/to-long t1000)}
+                               "t2" {"cmd" "tc" "fallback-period-secs" 600 "last-update-time" (tc/to-long t2000) "stale-timeout-mins" stale-timeout-mins}
+                               "t3" {"cmd" "tc" "fallback-period-secs" 900 "last-update-time" (tc/to-long t3000)}
                                "t4" {"fallback-period-secs" 1200 "stale-timeout-mins" (+ stale-timeout-mins 15)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s10")))
                                         #{{:token {:sources [{:token "t1" :version "t1.hash1"} {:token "t2" :version "t2.hash1"}]}}
                                           {:token {:sources [{:token "t3" :version "t3.hash1"} {:token "t4" :version "t4.hash1"}]}}})
             token->token-data (token->token-data-factory token->token-data)]
-        (is (= idle-timeout-mins
-               (service-id->idle-timeout
+        (is (= (t/plus last-modified-time (t/minutes idle-timeout-mins))
+               (service->gc-time
                  service-id->service-description-fn service-id->references-fn token->token-data reference-type->stale-fn
-                 attach-token-defaults-fn (str service-id "s10"))))))
+                 attach-token-defaults-fn (str service-id "s10") last-modified-time)))))
 
     (testing "service using latest of one set of token entries"
       (let [stale-timeout-mins 45
-            token->token-data {"t1" {"cpus" 123 "fallback-period-secs" 300}
-                               "t2" {"cmd" "tc" "fallback-period-secs" 600 "stale-timeout-mins" stale-timeout-mins}
-                               "t3" {"cmd" "tc" "fallback-period-secs" 900}
+            token->token-data {"t1" {"cpus" 123 "fallback-period-secs" 300 "last-update-time" (tc/to-long t1000)}
+                               "t2" {"cmd" "tc" "fallback-period-secs" 600 "last-update-time" (tc/to-long t2000) "stale-timeout-mins" stale-timeout-mins}
+                               "t3" {"cmd" "tc" "fallback-period-secs" 900 "last-update-time" (tc/to-long t3000)}
                                "t4" {"fallback-period-secs" 1200 "stale-timeout-mins" (+ stale-timeout-mins 15)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s11")))
                                         #{{:token {:sources [{:token "t1" :version "t1.hash1"} {:token "t2" :version "t2.hash1"}]}}
                                           {:token {:sources [{:token "t3" :version "t3.hash0"} {:token "t4" :version "t4.hash0"}]}}})
             token->token-data (token->token-data-factory token->token-data)]
-        (is (= idle-timeout-mins
-               (service-id->idle-timeout
+        (is (= (t/plus last-modified-time (t/minutes idle-timeout-mins))
+               (service->gc-time
                  service-id->service-description-fn service-id->references-fn token->token-data reference-type->stale-fn
-                 attach-token-defaults-fn (str service-id "s11"))))))
+                 attach-token-defaults-fn (str service-id "s11") last-modified-time)))))
 
     (testing "service outdated and fallback and timeout configured on multiple source tokens"
       (let [stale-timeout-mins 45
-            token->token-data {"t1" {"cpus" 123 "fallback-period-secs" 300}
-                               "t2" {"cmd" "tc" "fallback-period-secs" 600 "stale-timeout-mins" stale-timeout-mins}
-                               "t3" {"cmd" "tc" "fallback-period-secs" 900}
-                               "t4" {"fallback-period-secs" 1200 "stale-timeout-mins" (+ stale-timeout-mins 15)}}
+            token->token-data {"t1" {"cpus" 123 "fallback-period-secs" 300 "last-update-time" (tc/to-long t1000)}
+                               "t2" {"cmd" "tc" "fallback-period-secs" 600 "last-update-time" (tc/to-long t2000) "stale-timeout-mins" stale-timeout-mins}
+                               "t3" {"cmd" "tc" "fallback-period-secs" 900 "last-update-time" (tc/to-long t3000)}
+                               "t4" {"fallback-period-secs" 1200 "last-update-time" (tc/to-long t4000) "stale-timeout-mins" (+ stale-timeout-mins 15)}}
             service-id->references-fn (fn [in-service-id]
                                         (is (= in-service-id (str service-id "s12")))
                                         #{{:token {:sources [{:token "t1" :version "t1.hash0"} {:token "t2" :version "t2.hash0"}]}}
                                           {:token {:sources [{:token "t3" :version "t3.hash0"} {:token "t4" :version "t4.hash0"}]}}})
             token->token-data (token->token-data-factory token->token-data)]
-        (is (= (max (-> 900 t/seconds t/in-minutes (+ stale-timeout-mins))
-                    (-> 1200 t/seconds t/in-minutes (+ stale-timeout-mins 15)))
-               (service-id->idle-timeout
+        (is (= (t/plus
+                 t4000
+                 (t/minutes
+                   (max (-> 900 t/seconds t/in-minutes (+ stale-timeout-mins))
+                        (-> 1200 t/seconds t/in-minutes (+ stale-timeout-mins 15)))))
+               (service->gc-time
                  service-id->service-description-fn service-id->references-fn token->token-data reference-type->stale-fn
-                 attach-token-defaults-fn (str service-id "s12"))))))))
+                 attach-token-defaults-fn (str service-id "s12") last-modified-time)))))
+
+    (testing "service with single token is stale but GC disabled"
+      (let [idle-timeout-mins 0
+            token->token-data {"t1" {"cpus" 1 "idle-timeout-mins" idle-timeout-mins "last-update-time" (tc/to-long t1000)}}
+            service-id->service-description-fn (fn [in-service-id]
+                                                 (is (str/starts-with? in-service-id service-id))
+                                                 {"idle-timeout-mins" idle-timeout-mins})
+            service-id->references-fn (fn [in-service-id]
+                                        (is (= in-service-id (str service-id "s1")))
+                                        #{{:token {:sources [{:token "t1" :version "t1.hash1"}]}}})
+            token->token-data (token->token-data-factory token->token-data)]
+        (is (nil?
+              (service->gc-time
+                service-id->service-description-fn service-id->references-fn token->token-data reference-type->stale-fn
+                attach-token-defaults-fn (str service-id "s1") last-modified-time)))))))
 
 (defn- synchronize-fn
   [lock f]


### PR DESCRIPTION
## Changes proposed in this PR

- account for token edits while GC-ing services

## Why are we making these changes?

We should avoid GC-ing services when there has been a recent token update to allow fallback to continue to function and avoid service downtime.


