### PR TITLE
removes use of PyInstaller to build the CLI

### DIFF
--- a/cli/bin/ci/setup.sh
+++ b/cli/bin/ci/setup.sh
@@ -20,8 +20,3 @@ fi
 
 pip install -e .
 pip install -r integration/requirements.txt
-
-# Make sure that pyinstaller can successfully build the cli
-pip install pyinstaller
-pyinstaller --clean --onefile --name waiter waiter/__main__.py
-./dist/waiter


### PR DESCRIPTION
## Changes proposed in this PR

- removes use of PyInstaller to build the CLI

## Why are we making these changes?

We no longer use PyInstaller to build the CLI executable.


