### PR TITLE
work-stealing changes: enable for specific services and configurable offer timeouts

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -824,7 +824,7 @@
                  :offer-help-interval-ms 100
 
                  ;; The duration (milliseconds) after which Waiter times out work-stealing offers:
-                 :offer-idle-timeout-ms 1800000
+                 :offer-idle-timeout-ms 900000
 
                  ;; The timeout (milliseconds) used internally by the
                  ;; Waiter router to reserve an instance for offering:

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -825,7 +825,10 @@
 
                  ;; The timeout (milliseconds) used internally by the
                  ;; Waiter router to reserve an instance for offering:
-                 :reserve-timeout-ms 1000}
+                 :reserve-timeout-ms 1000
+
+                 ;; The distribution schemes of services for which to enable work-stealing support:
+                 :supported-distribution-schemes #{"balanced" "simple"}}
 
  ; ---------- Metrics - StatsD ----------
 

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -823,6 +823,9 @@
                  ;; The interval (milliseconds) on which Waiter makes work-stealing offers:
                  :offer-help-interval-ms 100
 
+                 ;; The duration (milliseconds) after which Waiter times out work-stealing offers:
+                 :offer-idle-timeout-ms 1800000
+
                  ;; The timeout (milliseconds) used internally by the
                  ;; Waiter router to reserve an instance for offering:
                  :reserve-timeout-ms 1000

--- a/waiter/integration/waiter/work_stealing_integration_test.clj
+++ b/waiter/integration/waiter/work_stealing_integration_test.clj
@@ -20,69 +20,74 @@
 
 (deftest ^:parallel ^:integration-slow ^:resource-heavy test-work-stealing-load-balancing
   (testing-using-waiter-url
-    (let [request-fn (fn [router-url waiter-headers & {:keys [cookies] :or {cookies nil}}]
-                       (log/info "making kitchen request")
-                       (make-request-with-debug-info
-                         waiter-headers
-                         #(make-request router-url "/endpoint" :headers % :cookies cookies)))
-          max-instances 6
-          extra-headers (merge (kitchen-request-headers)
-                               {:x-waiter-name (rand-name)
-                                :x-waiter-max-instances max-instances
-                                :x-waiter-min-instances 1
-                                :x-waiter-scale-up-factor 0.999
-                                :x-waiter-scale-down-factor 0.001
-                                :x-waiter-work-stealing true})
-          {:keys [service-id]} (request-fn waiter-url extra-headers)
-          print-metrics (fn [service-id]
-                          (let [router-ids (keys (routers waiter-url))
-                                service-data (service-settings waiter-url service-id :query-params {"include" "metrics"})
-                                service-metrics (:metrics service-data)]
-                            (log/info "Aggregate process metrics:" (get-in service-metrics [:aggregate :timers :process]))
-                            (doseq [router-id router-ids]
-                              (log/info router-id " process metrics:" (get-in service-metrics [:routers (keyword router-id) :timers :process])))))]
+    (if (> (count (routers waiter-url)) 1)
+      (if-let [supported-distribution-schemes (seq (setting waiter-url [:work-stealing :supported-distribution-schemes]))]
+        (let [request-fn (fn [router-url waiter-headers & {:keys [cookies] :or {cookies nil}}]
+                           (log/info "making kitchen request")
+                           (make-request-with-debug-info
+                             waiter-headers
+                             #(make-request router-url "/endpoint" :headers % :cookies cookies)))
+              max-instances 6
+              extra-headers (merge (kitchen-request-headers)
+                                   {:x-waiter-distribution-scheme (first supported-distribution-schemes)
+                                    :x-waiter-name (rand-name)
+                                    :x-waiter-max-instances max-instances
+                                    :x-waiter-min-instances 1
+                                    :x-waiter-scale-up-factor 0.999
+                                    :x-waiter-scale-down-factor 0.001
+                                    :x-waiter-work-stealing true})
+              {:keys [service-id]} (request-fn waiter-url extra-headers)
+              print-metrics (fn [service-id]
+                              (let [router-ids (keys (routers waiter-url))
+                                    service-data (service-settings waiter-url service-id :query-params {"include" "metrics"})
+                                    service-metrics (:metrics service-data)]
+                                (log/info "Aggregate process metrics:" (get-in service-metrics [:aggregate :timers :process]))
+                                (doseq [router-id router-ids]
+                                  (log/info router-id " process metrics:" (get-in service-metrics [:routers (keyword router-id) :timers :process])))))]
 
-      ;; set up
-      (log/info "service-id:" service-id)
-      (with-service-cleanup
-        service-id
-        (parallelize-requests (+ max-instances 2) 2
-                              #(request-fn waiter-url (assoc extra-headers :x-kitchen-delay-ms 6000))
-                              :verbose true)
-        (log/info "num instances running" (num-instances waiter-url service-id))
-        (print-metrics service-id)
-        ;; actual test
-        (let [{:keys [cookies]} (make-request waiter-url "/waiter-auth")
-              router->endpoint (routers waiter-url)
-              router (-> router->endpoint (keys) (sort) (first))
-              router-url (get router->endpoint router)]
-          (when (= 1 (count router->endpoint))
-            (log/info "Assertions will be trivially true as only one router is running"))
-          (log/info "Forwarding all requests to router" router "at url" router-url)
-          (let [responses (parallelize-requests (* 4 max-instances)
-                                                1
-                                                #(request-fn router-url (assoc extra-headers :x-kitchen-delay-ms 16000)
-                                                             :cookies cookies)
-                                                :verbose true)
-                _ (log/debug "Num responses:" (count responses))
-                responses-map (reduce (fn [accum {:keys [instance-id]}]
-                                        (update-in accum [instance-id] (fnil inc 0)))
-                                      {} responses)]
+          ;; set up
+          (log/info "service-id:" service-id)
+          (with-service-cleanup
+            service-id
+            (parallelize-requests (+ max-instances 2) 2
+                                  #(request-fn waiter-url (assoc extra-headers :x-kitchen-delay-ms 6000))
+                                  :verbose true)
+            (log/info "num instances running" (num-instances waiter-url service-id))
             (print-metrics service-id)
-            (is (pos? (count responses-map))
-                "Error in receiving responses, a possible bug in parallelize-requests!")
-            (log/info (str "Response distribution:" responses-map))
-            (let [service-settings (service-settings waiter-url service-id :query-params {"include" "metrics"})
-                  num-instances (count (get-in service-settings [:instances :active-instances]))]
-              (log/info (str "Num instances:" num-instances))
-              (when (not= num-instances (count responses-map))
-                (log/info "Instances:" (get service-settings :instances)))
-              (is (<= num-instances (count responses-map))))
-            (is (every? (fn [[_ num-requests]] (pos? num-requests)) responses-map)
-                (str "Response distribution:" responses-map)))
+            ;; actual test
+            (let [{:keys [cookies]} (make-request waiter-url "/waiter-auth")
+                  router->endpoint (routers waiter-url)
+                  router (-> router->endpoint (keys) (sort) (first))
+                  router-url (get router->endpoint router)]
+              (when (= 1 (count router->endpoint))
+                (log/info "Assertions will be trivially true as only one router is running"))
+              (log/info "Forwarding all requests to router" router "at url" router-url)
+              (let [responses (parallelize-requests (* 4 max-instances)
+                                                    1
+                                                    #(request-fn router-url (assoc extra-headers :x-kitchen-delay-ms 16000)
+                                                                 :cookies cookies)
+                                                    :verbose true)
+                    _ (log/debug "Num responses:" (count responses))
+                    responses-map (reduce (fn [accum {:keys [instance-id]}]
+                                            (update-in accum [instance-id] (fnil inc 0)))
+                                          {} responses)]
+                (print-metrics service-id)
+                (is (pos? (count responses-map))
+                    "Error in receiving responses, a possible bug in parallelize-requests!")
+                (log/info (str "Response distribution:" responses-map))
+                (let [service-settings (service-settings waiter-url service-id :query-params {"include" "metrics"})
+                      num-instances (count (get-in service-settings [:instances :active-instances]))]
+                  (log/info (str "Num instances:" num-instances))
+                  (when (not= num-instances (count responses-map))
+                    (log/info "Instances:" (get service-settings :instances)))
+                  (is (<= num-instances (count responses-map))))
+                (is (every? (fn [[_ num-requests]] (pos? num-requests)) responses-map)
+                    (str "Response distribution:" responses-map)))
 
-          ;; check slot metrics
-          (let [metrics-routers (keys (get-in service-settings [:metrics :routers]))]
-            (doseq [router metrics-routers]
-              (let [slots-in-use (get-in service-settings [:metrics :routers router :counters :instance-counts :slots-in-use])]
-                (is (zero? slots-in-use) (str "Expected zero slots-in-use, but found " slots-in-use " in router " (name router)))))))))))
+              ;; check slot metrics
+              (let [metrics-routers (keys (get-in service-settings [:metrics :routers]))]
+                (doseq [router metrics-routers]
+                  (let [slots-in-use (get-in service-settings [:metrics :routers router :counters :instance-counts :slots-in-use])]
+                    (is (zero? slots-in-use) (str "Expected zero slots-in-use, but found " slots-in-use " in router " (name router)))))))))
+        (log/info "test-work-stealing-load-balancing skipped as no distribution scheme support enabled"))
+      (log/info "test-work-stealing-load-balancing skipped in single router scenario"))))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1090,7 +1090,8 @@
                              (scheduler/validate-service scheduler service-id)
                              (service/start-new-service
                                scheduler descriptor start-service-cache scheduler-interactions-thread-pool)))
-   :start-work-stealing-balancer-fn (pc/fnk [[:settings [:work-stealing offer-help-interval-ms reserve-timeout-ms]]
+   :start-work-stealing-balancer-fn (pc/fnk [[:settings [:work-stealing offer-help-interval-ms offer-idle-timeout-ms
+                                                         reserve-timeout-ms]]
                                              [:state offers-allowed-semaphore router-id]
                                              enable-work-stealing-support? make-inter-router-requests-async-fn router-metrics-helpers]
                                       (fn start-work-stealing-balancer [populate-maintainer-chan! service-id]
@@ -1100,7 +1101,7 @@
                                             (let [{:keys [service-id->router-id->metrics]} router-metrics-helpers]
                                               (work-stealing/start-work-stealing-balancer
                                                 populate-maintainer-chan! reserve-timeout-ms offer-help-interval-ms
-                                                offers-allowed-semaphore service-id->router-id->metrics
+                                                offer-idle-timeout-ms offers-allowed-semaphore service-id->router-id->metrics
                                                 make-inter-router-requests-async-fn router-id service-id))))))
    :stop-work-stealing-balancer-fn (pc/fnk []
                                      (fn stop-work-stealing-balancer [service-id {:keys [exit-chan]}]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -978,6 +978,11 @@
                                      (fn discover-service-parameters-fn [headers]
                                        (sd/discover-service-parameters
                                          kv-store attach-service-defaults-fn attach-token-defaults-fn waiter-hostnames headers)))
+   :enable-work-stealing-support? (pc/fnk [[:settings [:work-stealing supported-distribution-schemes]]
+                                           service-id->service-description-fn]
+                                    (fn enable-work-stealing-support? [service-id]
+                                      (let [{:strs [distribution-scheme]} (service-id->service-description-fn service-id)]
+                                        (contains? supported-distribution-schemes distribution-scheme))))
    :generate-log-url-fn (pc/fnk [prepend-waiter-url]
                           (partial handler/generate-log-url prepend-waiter-url))
    :list-tokens-fn (pc/fnk [[:curator curator]
@@ -1087,19 +1092,23 @@
                                scheduler descriptor start-service-cache scheduler-interactions-thread-pool)))
    :start-work-stealing-balancer-fn (pc/fnk [[:settings [:work-stealing offer-help-interval-ms reserve-timeout-ms]]
                                              [:state offers-allowed-semaphore router-id]
-                                             make-inter-router-requests-async-fn router-metrics-helpers]
+                                             enable-work-stealing-support? make-inter-router-requests-async-fn router-metrics-helpers]
                                       (fn start-work-stealing-balancer [populate-maintainer-chan! service-id]
-                                        (let [{:keys [service-id->router-id->metrics]} router-metrics-helpers]
-                                          (work-stealing/start-work-stealing-balancer
-                                            populate-maintainer-chan! reserve-timeout-ms offer-help-interval-ms
-                                            offers-allowed-semaphore service-id->router-id->metrics
-                                            make-inter-router-requests-async-fn router-id service-id))))
+                                        (let [support-work-stealing? (enable-work-stealing-support? service-id)]
+                                          (log/info service-id "has work-stealing support" (if support-work-stealing? "enabled" "disabled"))
+                                          (when support-work-stealing?
+                                            (let [{:keys [service-id->router-id->metrics]} router-metrics-helpers]
+                                              (work-stealing/start-work-stealing-balancer
+                                                populate-maintainer-chan! reserve-timeout-ms offer-help-interval-ms
+                                                offers-allowed-semaphore service-id->router-id->metrics
+                                                make-inter-router-requests-async-fn router-id service-id))))))
    :stop-work-stealing-balancer-fn (pc/fnk []
-                                     (fn stop-work-stealing-balancer [service-id work-stealing-chan-map]
-                                       (log/info "stopping work-stealing balancer for" service-id)
-                                       (async/go
-                                         (when-let [exit-chan (get work-stealing-chan-map [:exit-chan])]
-                                           (async/>! exit-chan :exit)))))
+                                     (fn stop-work-stealing-balancer [service-id {:keys [exit-chan]}]
+                                       (if exit-chan
+                                         (async/go
+                                           (log/info "stopping work-stealing balancer for" service-id)
+                                           (async/>! exit-chan :exit))
+                                         (log/info service-id "has no work-stealing cleanup required"))))
    :store-reference-fn (pc/fnk [[:curator synchronize-fn]
                                 [:state kv-store]]
                          (fn store-reference-fn [service-id reference]
@@ -1710,12 +1719,14 @@
                                               (fn state-service-maintainer-handler-fn [request]
                                                 (handler/get-query-fn-state router-id query-state-fn request)))))
    :state-service-handler-fn (pc/fnk [[:daemons populate-maintainer-chan! state-sources]
+                                      [:routines enable-work-stealing-support?]
                                       [:state local-usage-agent router-id]
                                       wrap-secure-request-fn]
                                (wrap-secure-request-fn
                                  (fn service-state-handler-fn [{{:keys [service-id]} :route-params :as request}]
-                                   (handler/get-service-state router-id populate-maintainer-chan! local-usage-agent
-                                                              service-id state-sources request))))
+                                   (handler/get-service-state
+                                     router-id enable-work-stealing-support? populate-maintainer-chan! local-usage-agent
+                                     service-id state-sources request))))
    :state-statsd-handler-fn (pc/fnk [[:state router-id]
                                      wrap-secure-request-fn]
                               (wrap-secure-request-fn

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -474,7 +474,7 @@
                       :ws-max-text-message-size (* 1024 1024 40)}
    :work-stealing {:max-in-flight-offers 4000
                    :offer-help-interval-ms 100
-                   :offer-idle-timeout-ms 1800000
+                   :offer-idle-timeout-ms 900000
                    :reserve-timeout-ms 1000
                    :supported-distribution-schemes #{"simple"}}
    :zookeeper {:base-path "/waiter"

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -187,6 +187,7 @@
                                        (s/required-key :ws-max-text-message-size) schema/positive-int}
    (s/required-key :work-stealing) {(s/required-key :max-in-flight-offers) schema/non-negative-int
                                     (s/required-key :offer-help-interval-ms) schema/positive-int
+                                    (s/required-key :offer-idle-timeout-ms) schema/positive-int
                                     (s/required-key :reserve-timeout-ms) schema/positive-int
                                     (s/required-key :supported-distribution-schemes) #{(s/pred #(contains? #{"balanced" "simple"} %) 'invalid-distribution-scheme)}}
    (s/required-key :zookeeper) {(s/required-key :base-path) schema/non-empty-string
@@ -473,6 +474,7 @@
                       :ws-max-text-message-size (* 1024 1024 40)}
    :work-stealing {:max-in-flight-offers 4000
                    :offer-help-interval-ms 100
+                   :offer-idle-timeout-ms 1800000
                    :reserve-timeout-ms 1000
                    :supported-distribution-schemes #{"simple"}}
    :zookeeper {:base-path "/waiter"

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -187,7 +187,8 @@
                                        (s/required-key :ws-max-text-message-size) schema/positive-int}
    (s/required-key :work-stealing) {(s/required-key :max-in-flight-offers) schema/non-negative-int
                                     (s/required-key :offer-help-interval-ms) schema/positive-int
-                                    (s/required-key :reserve-timeout-ms) schema/positive-int}
+                                    (s/required-key :reserve-timeout-ms) schema/positive-int
+                                    (s/required-key :supported-distribution-schemes) #{(s/pred #(contains? #{"balanced" "simple"} %) 'invalid-distribution-scheme)}}
    (s/required-key :zookeeper) {(s/required-key :base-path) schema/non-empty-string
                                 (s/required-key :connect-string) schema/valid-zookeeper-connect-config
                                 (s/required-key :curator-retry-policy) {(s/required-key :base-sleep-time-ms) schema/positive-int
@@ -472,7 +473,8 @@
                       :ws-max-text-message-size (* 1024 1024 40)}
    :work-stealing {:max-in-flight-offers 4000
                    :offer-help-interval-ms 100
-                   :reserve-timeout-ms 1000}
+                   :reserve-timeout-ms 1000
+                   :supported-distribution-schemes #{"simple"}}
    :zookeeper {:base-path "/waiter"
                :curator-retry-policy {:base-sleep-time-ms 100
                                       :max-retries 10

--- a/waiter/src/waiter/work_stealing.clj
+++ b/waiter/src/waiter/work_stealing.clj
@@ -224,7 +224,7 @@
 
 (defn start-work-stealing-balancer
   "Starts the work-stealing balancer for all services."
-  [populate-maintainer-chan! reserve-timeout-ms offer-help-interval-ms offers-allowed-semaphore
+  [populate-maintainer-chan! reserve-timeout-ms offer-help-interval-ms offer-idle-timeout-ms offers-allowed-semaphore
    service-id->router-id->metrics make-inter-router-requests-fn router-id service-id]
   (log/info "starting work-stealing balancer for" service-id)
   (letfn [(reserve-instance-fn
@@ -263,6 +263,7 @@
                   (let [{:keys [body error headers status] :as inter-router-response}
                         (some-> (make-inter-router-requests-fn "work-stealing"
                                                                :acceptable-router? #(= target-router-id %)
+                                                               :config {:idle-timeout offer-idle-timeout-ms}
                                                                :body (-> reservation-parameters
                                                                        (assoc :router-id router-id
                                                                               :service-id service-id)

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -1105,17 +1105,20 @@
       (start-maintainer-fn)
       (let [query-sources {:autoscaler-state (fn [{:keys [service-id]}]
                                                {:service-id service-id :source "autoscaler"})
-                           :maintainer-state maintainer-state-chan}
+                           :keyword-state :disabled
+                           :maintainer-state maintainer-state-chan
+                           :map-state {:foo "bar"}}
             response (async/<!! (get-service-state router-id enable-work-stealing-support? populate-maintainer-chan!
                                                    local-usage-agent service-id query-sources {}))
             service-state (json/read-str (:body response) :key-fn keyword)]
         (is (= router-id (get-in service-state [:router-id])))
-        (is (= responder-state (get-in service-state [:state :responder-state])))
-        (is (= {:last-request-time "foo"}
-               (get-in service-state [:state :local-usage])))
-        (is (= work-stealing-state (get-in service-state [:state :work-stealing-state])))
+        (is (= {:service-id service-id :source "autoscaler"} (get-in service-state [:state :autoscaler-state])))
+        (is (= (name :disabled) (get-in service-state [:state :keyword-state])))
+        (is (= {:last-request-time "foo"} (get-in service-state [:state :local-usage])))
         (is (= (assoc maintainer-state :service-id service-id) (get-in service-state [:state :maintainer-state])))
-        (is (= {:service-id service-id :source "autoscaler"} (get-in service-state [:state :autoscaler-state])))))))
+        (is (= {:foo "bar"} (get-in service-state [:state :map-state])))
+        (is (= responder-state (get-in service-state [:state :responder-state])))
+        (is (= work-stealing-state (get-in service-state [:state :work-stealing-state])))))))
 
 (deftest test-acknowledge-consent-handler
   (let [current-time-ms (System/currentTimeMillis)


### PR DESCRIPTION
## Changes proposed in this PR

- enables work-stealing only for simple distribution services
- allows configuring the idle timeout on work-stealing offers

## Why are we making these changes?

Our experience has show work-stealing to provide limited value when instance slots are distributed across all clusters. Work-stealing is required when instance slots may be unavailable by the partitioning algorithm and is especially helpful for long requests.


