### PR TITLE
adds support for query string in the websocket upgrade request

### DIFF
--- a/waiter/integration/waiter/websocket_integration_test.clj
+++ b/waiter/integration/waiter/websocket_integration_test.clj
@@ -110,6 +110,43 @@
         (finally
           (delete-service waiter-url waiter-headers))))))
 
+(deftest ^:parallel ^:integration-fast test-request-auth-success-query-string
+  (testing-using-waiter-url
+    (let [auth-cookie-value (auth-cookie waiter-url)
+          ws-response-atom (atom [])
+          waiter-headers (assoc (kitchen-request-headers)
+                           "x-waiter-metric-group" "waiter_ws_test"
+                           "x-waiter-name" (rand-name))]
+      (is auth-cookie-value)
+      (try
+        (let [response-promise (promise)
+              connection (ws-client/connect!
+                           (websocket-client-factory)
+                           (ws-url waiter-url "/websocket-auth?foo=bar")
+                           (fn [{:keys [in out]}]
+                             (async/go
+                               (async/>! out "request-info")
+                               (swap! ws-response-atom conj (async/<! in))
+                               (swap! ws-response-atom conj (async/<! in))
+                               (deliver response-promise :done)
+                               (async/close! out)))
+                           {:middleware (fn [_ ^UpgradeRequest request]
+                                          (websocket/add-headers-to-upgrade-request! request waiter-headers)
+                                          (add-auth-cookie request auth-cookie-value))})
+              [close-code error] (connection->ctrl-data connection)]
+          (is (= :qbits.jet.websocket/close close-code))
+          (is (= websocket-1000-normal error))
+          (is (= :done (deref response-promise default-timeout-period :timed-out))))
+        (log/info "websocket responses:" @ws-response-atom)
+        (is (= "Connected to kitchen" (first @ws-response-atom)) (str @ws-response-atom))
+        (let [{:keys [headers]} (-> @ws-response-atom second str json/read-str walk/keywordize-keys)
+              {:keys [upgrade x-cid x-waiter-auth-principal]} headers]
+          (is x-cid)
+          (is (= upgrade "websocket"))
+          (is (= x-waiter-auth-principal (retrieve-username))))
+        (finally
+          (delete-service waiter-url waiter-headers))))))
+
 (deftest ^:parallel ^:integration-fast test-request-auth-disabled
   (testing-using-waiter-url
     (let [ws-response-atom (atom [])


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for query string in the websocket upgrade request

## Why are we making these changes?

Websocket upgrade requests may depend upon query parameters for correct behavior.


