### PR TITLE
Delay GC of services with stale references based on update time

### DIFF
--- a/waiter/docs/service-references.md
+++ b/waiter/docs/service-references.md
@@ -64,12 +64,12 @@ The service GC processes all known references for a service and marks the servic
 An individual reference, i.e. the `reference-type->entry` map computed in a request descriptor,
   is stale if any of its value entries is stale.
 This staleness check on the value is performed using the functions returned from
-  `retrieve-reference-type->stale-fn` of the builder and invoking the corresponding 'type' function on the value.
+  `retrieve-reference-type->stale-info-fn` of the builder and invoking the corresponding 'type' function on the value.
 
 **Note**: A service known to be directly referenced (i.e. has an empty map among its references) never goes stale.
 
 The default implementation of the `ServiceDescriptionBuilder` returns a map with a single entry for `:token`
-  from the `retrieve-reference-type->stale-fn`.
+  from the `retrieve-reference-type->stale-info-fn`.
 The provided `:token` staleness function deems services accessed via tokens to be stale if all tokens
   used to access the service have been updated.
 
@@ -81,9 +81,9 @@ E.g. a hypothetical implementation which treats the image parameter as docker im
   {:image {:name "twosigma/kitchen" :build "20191001"}
    :token {:sources [{"token" "foo" "version" "v1"}]}}
 ```
-The `retrieve-reference-type->stale-fn` must then provide an implementation for a function that
+The `retrieve-reference-type->stale-info-fn` must then provide an implementation for a function that
   can check staleness of `:image` reference types.
-E.g. if `retrieve-reference-type->stale-fn` returns:
+E.g. if `retrieve-reference-type->stale-info-fn` returns:
 ```
   {:image check-image-for-staleness-fn
    :token check-token-for-staleness-fn}

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1076,7 +1076,8 @@
    :service->gc-time-fn (pc/fnk [[:state service-description-builder]
                                  attach-token-defaults-fn service-id->service-description-fn service-id->references-fn
                                  token->token-hash token->token-parameters]
-                          (let [context {:token->token-hash token->token-hash}
+                          (let [context {:token->token-hash token->token-hash
+                                         :token->token-parameters token->token-parameters}
                                 reference-type->stale-info-fn (sd/retrieve-reference-type->stale-info-fn service-description-builder context)]
                             (fn service->gc-time-fn [service-id last-modified-time]
                               (sd/service->gc-time

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1077,11 +1077,11 @@
                                  attach-token-defaults-fn service-id->service-description-fn service-id->references-fn
                                  token->token-hash token->token-parameters]
                           (let [context {:token->token-hash token->token-hash}
-                                reference-type->stale-fn (sd/retrieve-reference-type->stale-fn service-description-builder context)]
+                                reference-type->stale-info-fn (sd/retrieve-reference-type->stale-info-fn service-description-builder context)]
                             (fn service->gc-time-fn [service-id last-modified-time]
                               (sd/service->gc-time
                                 service-id->service-description-fn service-id->references-fn token->token-parameters
-                                reference-type->stale-fn attach-token-defaults-fn service-id last-modified-time))))
+                                reference-type->stale-info-fn attach-token-defaults-fn service-id last-modified-time))))
    :service-id->password-fn (pc/fnk [[:scheduler service-id->password-fn*]]
                               service-id->password-fn*)
    :service-id->references-fn (pc/fnk [[:state kv-store]]

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -635,7 +635,7 @@
   [service-description username]
   (assoc service-description "run-as-user" username "permitted-user" username))
 
-(defn service-token-references-stale?
+(defn retrieve-token-stale-info
   "Returns true if every token used to access a service has been updated."
   [token->token-hash source-tokens]
   (and (seq source-tokens)
@@ -675,7 +675,7 @@
        :service-id service-id}))
 
   (retrieve-reference-type->stale-info-fn [_ {:keys [token->token-hash]}]
-    {:token (fn [{:keys [sources]}] (service-token-references-stale? token->token-hash sources))})
+    {:token (fn [{:keys [sources]}] (retrieve-token-stale-info token->token-hash sources))})
 
   (state [_]
     {})

--- a/waiter/src/waiter/util/descriptor_utils.clj
+++ b/waiter/src/waiter/util/descriptor_utils.clj
@@ -1,0 +1,32 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns waiter.util.descriptor-utils)
+
+(defn retrieve-update-time
+  "Returns the time at which the specific version of a input map went stale.
+   If no such version can be found, then the stale time is unknown and we, conservatively,
+   use the last known edit time of the history data.
+   Else if the data is not stale or no data is known, nil is returned."
+  [data->version data->update-time data->previous current-data data-version]
+  (when (and (seq current-data)
+             (not= data-version (data->version current-data)))
+    (loop [loop-previous-data (data->previous current-data)
+           loop-update-time (data->update-time current-data)]
+      (if (or (empty? loop-previous-data)
+              (= data-version (data->version loop-previous-data)))
+        loop-update-time
+        (recur (data->previous loop-previous-data)
+               (data->update-time loop-previous-data))))))

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -108,6 +108,15 @@
     (nil? y) x
     :else (max x y)))
 
+(defn nil-safe-min
+  "If an argument is nil, returns the other argument.
+   Else returns the min of the arguments."
+  [x y]
+  (cond
+    (nil? x) y
+    (nil? y) x
+    :else (min x y)))
+
 (defn assoc-if-absent
   "If the specified key, k, is not already associated with a value, v, in the map, m, associate k with v in m."
   [m k v]
@@ -680,19 +689,3 @@
   [principal]
   (when principal
     (first (str/split principal #"@" 2))))
-
-(defn retrieve-update-time
-  "Returns the time at which the specific version of a input map went stale.
-   If no such version can be found, then the stale time is unknown and we, conservatively,
-   use the last known edit time of the history data.
-   Else if the data is not stale or no data is known, nil is returned."
-  [data->version data->update-time data->previous current-data data-version]
-  (when (and (seq current-data)
-             (not= data-version (data->version current-data)))
-    (loop [loop-previous-data (data->previous current-data)
-           loop-update-time (data->update-time current-data)]
-      (if (or (empty? loop-previous-data)
-              (= data-version (data->version loop-previous-data)))
-        loop-update-time
-        (recur (data->previous loop-previous-data)
-               (data->update-time loop-previous-data))))))

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -99,6 +99,15 @@
   "Returns true if x is a non-negative integer"
   (and (integer? x) (non-neg? x)))
 
+(defn nil-safe-max
+  "If an argument is nil, returns the other argument.
+   Else returns the max of the arguments."
+  [x y]
+  (cond
+    (nil? x) y
+    (nil? y) x
+    :else (max x y)))
+
 (defn assoc-if-absent
   "If the specified key, k, is not already associated with a value, v, in the map, m, associate k with v in m."
   [m k v]
@@ -671,3 +680,19 @@
   [principal]
   (when principal
     (first (str/split principal #"@" 2))))
+
+(defn retrieve-update-time
+  "Returns the time at which the specific version of a input map went stale.
+   If no such version can be found, then the stale time is unknown and we, conservatively,
+   use the last known edit time of the history data.
+   Else if the data is not stale or no data is known, nil is returned."
+  [data->version data->update-time data->previous current-data data-version]
+  (when (and (seq current-data)
+             (not= data-version (data->version current-data)))
+    (loop [loop-previous-data (data->previous current-data)
+           loop-update-time (data->update-time current-data)]
+      (if (or (empty? loop-previous-data)
+              (= data-version (data->version loop-previous-data)))
+        loop-update-time
+        (recur (data->previous loop-previous-data)
+               (data->update-time loop-previous-data))))))

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -2553,7 +2553,7 @@
            (accumulate-stale-info {:stale? true :update-epoch-time 200} {:stale? s :update-epoch-time nil})))
     (is (= {:stale? true :update-epoch-time 200}
            (accumulate-stale-info {:stale? s :update-epoch-time nil} {:stale? true :update-epoch-time 200}))))
-  (is (= {:stale? true :update-epoch-time 400}
+  (is (= {:stale? true :update-epoch-time 200}
          (accumulate-stale-info {:stale? true :update-epoch-time 200} {:stale? true :update-epoch-time 400}))))
 
 (deftest test-references->stale-info
@@ -2571,7 +2571,7 @@
     (is (= {:stale? true :update-epoch-time 100}
            (run-references->stale-info [{"type1" {:stale-info {:stale? true :update-epoch-time 100}}
                                          "type2" {:stale-info {:stale? false :update-epoch-time 200}}}])))
-    (is (= {:stale? true :update-epoch-time 500}
+    (is (= {:stale? true :update-epoch-time 300}
            (run-references->stale-info [{"type1" {:stale-info {:stale? true :update-epoch-time nil}}
                                          "type2" {:stale-info {:stale? false :update-epoch-time nil}}
                                          "type3" {:stale-info {:stale? true :update-epoch-time 300}}

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -2440,7 +2440,7 @@
                                              (is (str/starts-with? in-service-id service-id))
                                              {"idle-timeout-mins" idle-timeout-mins})
         token->token-hash (fn [in-token] (str in-token ".latest"))
-        reference-type->stale-info-fn {:token #(service-token-references-stale? token->token-hash (:sources %))}
+        reference-type->stale-info-fn {:token #(retrieve-token-stale-info token->token-hash (:sources %))}
         token->token-data-factory (fn [token->token-data]
                                     (fn [in-token]
                                       (get token->token-data in-token)))


### PR DESCRIPTION
## Changes proposed in this PR

- uses token update times to delay GC of services

## Why are we making these changes?

For improved user experience with fallback, it is better to delay the deletion of services with stale references based on the update time of the reference.
