### PR TITLE
adds support for upgrade-insecure-requests header

### DIFF
--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -1675,6 +1675,20 @@
                   :headers {"Location" "https://token.localtest.me"}
                   :status http-301-moved-permanently
                   :waiter/response-source :waiter}
+                 response))))
+
+      (testing "http request with upgrade-insecure-requests header"
+        (let [test-request {:headers {"host" "token.localtest.me"
+                                      "upgrade-insecure-requests" "1"}
+                            :request-method :get
+                            :scheme :http}
+              {:keys [handled-request response]} (execute-request test-request)]
+          (is (nil? handled-request))
+          (is (= {:body ""
+                  :headers {"Location" "https://token.localtest.me"
+                            "vary" "upgrade-insecure-requests"}
+                  :status http-301-moved-permanently
+                  :waiter/response-source :waiter}
                  response)))))))
 
 (deftest test-request->protocol


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for upgrade-insecure-requests header

## Why are we making these changes?

The HTTP Upgrade-Insecure-Requests request header sends a signal to the server expressing the client’s preference for an encrypted and authenticated response. When a server encounters this preference in an HTTP request’s headers, it should redirect the user to a potentially secure representation of the resource being requested.


