### PR TITLE
JDK11 upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: xenial
 language: java
-jdk: openjdk8
+jdk: openjdk11
 
 addons:
   apt:

--- a/containers/test-apps/courier/pom.xml
+++ b/containers/test-apps/courier/pom.xml
@@ -6,15 +6,15 @@
 
     <groupId>twosigma</groupId>
     <artifactId>courier</artifactId>
-    <version>1.5.15</version>
+    <version>1.5.16</version>
 
     <name>courier</name>
     <url>https://github.com/twosigma/waiter/tree/master/test-apps/courier</url>
 
     <properties>
         <grpc.version>1.20.0</grpc.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <protobuf.version>3.7.1</protobuf.version>
         <protoc.version>3.7.1</protoc.version>
@@ -36,6 +36,11 @@
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
             <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>
@@ -66,7 +71,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.0</version>
+                    <version>3.8.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>

--- a/waiter/integration/waiter/metrics_output_test.clj
+++ b/waiter/integration/waiter/metrics_output_test.clj
@@ -70,7 +70,6 @@
 
 (def jvm-metrics-schema
   {(s/required-key "attribute") s/Any
-   (s/required-key "file") s/Any
    (s/required-key "gc") s/Any
    (s/required-key "memory") s/Any
    (s/required-key "thread") {(s/required-key "blocked") counted-gauge-metric-schema

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -45,7 +45,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20200504_104810-g200ef43"
+                 [twosigma/jet "0.7.10-20200702_185437-gc4443d3"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -93,9 +93,6 @@
                  [org.clojure/tools.logging "0.5.0"]
                  [org.clojure/tools.namespace "0.3.1"]
                  [org.clojure/tools.reader "1.3.2"]
-                 ;; use maven to download this jar so we can set up the boot classpath
-                 [org.mortbay.jetty.alpn/alpn-boot "8.1.13.v20181017"
-                  :scope "provided"]
                  [org.opensaml/opensaml "2.6.4"
                   :exclusions [commons-codec]]
                  [org.slf4j/slf4j-log4j12 "1.7.29"
@@ -131,10 +128,7 @@
              "-Dclojure.core.async.pool-size=64"
              ~(str "-Dwaiter.logFilePrefix=" (System/getenv "WAITER_LOG_FILE_PREFIX"))
              "-XX:+UseG1GC"
-             "-XX:MaxGCPauseMillis=50"
-             ~(str "-Xbootclasspath/p:"
-                (or (System/getenv "WAITER_MAVEN_LOCAL_REPO") (str (System/getenv "HOME") "/.m2/repository"))
-                "/org/mortbay/jetty/alpn/alpn-boot/8.1.13.v20181017/alpn-boot-8.1.13.v20181017.jar")]
+             "-XX:MaxGCPauseMillis=50"]
   :filespecs [{:type :fn
                :fn (fn [p]
                      {:type :bytes :path "git-log"

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -21,6 +21,7 @@
             [clojure.string :as str]
             [clojure.tools.cli :as cli]
             [clojure.tools.logging :as log]
+            [metrics.core :as mc]
             [metrics.jvm.core :as jvm-metrics]
             [plumbing.core :as pc]
             [plumbing.graph :as graph]
@@ -173,13 +174,25 @@
         validate-config (:schema-validate options)]
     {:validate-config validate-config}))
 
+(defn- instrument-jvm
+  "Glues together metrics-clojure and jvm instrumentation.
+   We explicitly avoid jvm-metrics/register-file-descriptor-ratio-gauge-set as it is not JDK 11 compatible
+   when we are stuck at using io.dropwizard.metrics/metrics-jvm/3.2.2"
+  []
+  (let [registry mc/default-registry]
+    (doseq [register-metric-set [jvm-metrics/register-jvm-attribute-gauge-set
+                                 jvm-metrics/register-memory-usage-gauge-set
+                                 jvm-metrics/register-garbage-collector-metric-set
+                                 jvm-metrics/register-thread-state-gauge-set]]
+      (register-metric-set registry))))
+
 (defn -main
   [config & args]
   (Thread/setDefaultUncaughtExceptionHandler
     (reify Thread$UncaughtExceptionHandler
       (uncaughtException [_ thread throwable]
         (log/error throwable (str (.getName thread) " threw exception: " (.getMessage throwable))))))
-  (jvm-metrics/instrument-jvm)
+  (instrument-jvm)
   (let [{:keys [validate-config]} (parse-options args)]
     (if validate-config
       (validate-config-schema config)

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -34,20 +34,14 @@
             [waiter.util.date-utils :as du]
             [waiter.util.http-utils :as hu]
             [waiter.util.utils :as utils])
-  (:import java.io.File
-           java.lang.UNIXProcess
-           java.util.ArrayList))
+  (:import (java.io File)
+           (java.util ArrayList)))
 
 (defn pid
-  "Returns the pid of the provided process (if it is a UNIXProcess)"
+  "Returns the pid of the provided process"
   [^Process process]
   (try
-    (when (= UNIXProcess (type process))
-      (let [field (.getDeclaredField (.getClass process) "pid")
-            _ (.setAccessible field true)
-            pid (.getLong field process)]
-        (.setAccessible field false)
-        pid))
+    (.pid process)
     (catch Exception e
       (log/error e "error getting pid from" process))))
 

--- a/waiter/test/waiter/metrics_test.clj
+++ b/waiter/test/waiter/metrics_test.clj
@@ -30,6 +30,7 @@
             [waiter.util.async-utils :as au]
             [waiter.util.utils :as utils])
   (:import (com.codahale.metrics MetricFilter)
+           (com.codahale.metrics.jvm FileDescriptorRatioGauge)
            (org.joda.time DateTime)))
 
 (deftest test-compress-strings
@@ -518,3 +519,11 @@
     (is (= {"bar" {"last-request-time" time-4}, "foo" {"last-request-time" time-2}}
            (cleanup-local-usage-metrics
              {"bar" {"last-request-time" time-4}, "foo" {"last-request-time" time-2}} "cid" "baz")))))
+
+(deftest test-metrics-clojure-jvm-file-descriptor-ratio-gauge
+  (try
+    (.getValue (FileDescriptorRatioGauge.))
+    (is false (str "No exception thrown while accessing FileDescriptorRatioGauge, "
+                   "if you upgraded io.dropwizard.metrics/metrics-jvm fix waiter.main/instrument-jvm and this test"))
+    (catch Exception ex
+      (is true (str "Expected Exception thrown:" (.getMessage ex))))))

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -181,14 +181,9 @@
       (is (= "Hello, World!\n" (slurp (:url (first (filter #(= "stdout" (:name %)) content)))))))))
 
 (deftest test-pid
-  (testing "Getting the pid of a Process"
-
-    (testing "should return nil if it is not a UNIXProcess"
-      (is (nil? (pid (proxy [Process] [])))))
-
-    (testing "should return nil if it catches an Exception"
-      (with-redefs [type (fn [_] (throw (ex-info "ERROR!" {})))]
-        (is (nil? (pid (:process (launch-process "foo" (work-dir) "ls" {})))))))))
+  (testing "Getting the pid of a Process should return nil if it catches an Exception"
+    (with-redefs [type (fn [_] (throw (ex-info "ERROR!" {})))]
+      (is (nil? (pid (Object.)))))))
 
 (defn common-scheduler-config
   []


### PR DESCRIPTION
## Changes proposed in this PR

- upgrade to jdk 11
- simplifies retrieval of process pid due to api change in jdk11
- handles issue with using FileDescriptorRatioGauge which uses invalid reflective calls
- removes bootclasspath requirement on alpn jar
- enable courier to compile on jdk11
- use jet with jdk11 compatible ALPN processors

## Why are we making these changes?

Upgrading to latest supported JDK.

## Related PRs: 

Jet: https://github.com/twosigma/jet/pull/47
