### PR TITLE
enables SSL tests after JDK11 migration

### DIFF
--- a/waiter/integration/waiter/proto_test.clj
+++ b/waiter/integration/waiter/proto_test.clj
@@ -120,12 +120,9 @@
     (is "test completed marker")))
 
 (deftest ^:parallel ^:integration-slow ^:resource-heavy test-https-backend-proto-service
-  ;; Disabled on Travis: https://github.com/twosigma/waiter/issues/1137
-  (if-not (= "true" (System/getenv "TRAVIS"))
-    (testing-using-waiter-url
-      (run-backend-proto-service-test waiter-url "https" "https" "HTTP/1.1")
-      (is "test completed marker")))
-  (log/info "Skipping test in the Travis environment"))
+  (testing-using-waiter-url
+    (run-backend-proto-service-test waiter-url "https" "https" "HTTP/1.1")
+    (is "test completed marker")))
 
 (deftest ^:parallel ^:integration-slow ^:resource-heavy ^:explicit test-h2c-backend-proto-service
   (testing-using-waiter-url
@@ -133,12 +130,9 @@
     (is "test completed marker")))
 
 (deftest ^:parallel ^:integration-slow ^:resource-heavy test-h2-backend-proto-service
-  ;; Disabled on Travis: https://github.com/twosigma/waiter/issues/1137
-  (if-not (= "true" (System/getenv "TRAVIS"))
-    (testing-using-waiter-url
-      (run-backend-proto-service-test waiter-url "h2" "https" "HTTP/2.0")
-      (is "test completed marker")))
-  (log/info "Skipping test in the Travis environment"))
+  (testing-using-waiter-url
+    (run-backend-proto-service-test waiter-url "h2" "https" "HTTP/2.0")
+    (is "test completed marker")))
 
 (deftest ^:parallel ^:integration-fast test-internal-protocol
   (testing-using-waiter-url


### PR DESCRIPTION
## Changes proposed in this PR

- enables SSL tests after JDK11 migration

## Why are we making these changes?

Fixes https://github.com/twosigma/waiter/issues/1137 after the JDK 11 migration.


