### PR TITLE
avoids updating caches for empty responses from prestash cache query

### DIFF
--- a/waiter/src/waiter/auth/kerberos.clj
+++ b/waiter/src/waiter/auth/kerberos.clj
@@ -36,7 +36,7 @@
         (some->> out
           (str/split-lines)
           (remove str/blank?) ;; remove empty lines
-          (map #(utils/principal->username %))
+          (map utils/principal->username)
           (remove str/blank?) ;; remove entries we couldn't translate to principals
           (seq)
           (set))

--- a/waiter/test/waiter/auth/kerberos_test.clj
+++ b/waiter/test/waiter/auth/kerberos_test.clj
@@ -26,10 +26,17 @@
 
 (deftest test-get-opt-in-accounts
   (testing "success"
-    (with-redefs [shell/sh (constantly
-                             {:exit 0
-                              :out "test1@N.EXAMPLE.COM\ntest2@N.EXAMPLE.COM"})]
-      (is (= #{"test1" "test2"} (get-opt-in-accounts "host")))))
+    (testing "non-empty response"
+      (with-redefs [shell/sh (constantly
+                               {:exit 0
+                                :out "test1@N.EXAMPLE.COM\ntest2@N.EXAMPLE.COM"})]
+        (is (= #{"test1" "test2"} (get-opt-in-accounts "host")))))
+
+    (testing "empty response"
+      (with-redefs [shell/sh (constantly {:exit 0 :out nil})]
+        (is (nil? (get-opt-in-accounts "host"))))
+      (with-redefs [shell/sh (constantly {:exit 0 :out ""})]
+        (is (nil? (get-opt-in-accounts "host"))))))
 
   (testing "failure"
     (with-redefs [shell/sh (constantly {:exit 1 :err ""})]


### PR DESCRIPTION
## Changes proposed in this PR

- avoids updating caches for empty responses from prestash cache query

## Why are we making these changes?

We wish to avoid flushing our cache when we get an empty response from the prestash query.


