### PR TITLE
adds token parameter to control when upgrade-insecure-requests trigger SSL redirects

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -1008,12 +1008,18 @@
                                  "fallback-period-secs" 300
 
                                  ;; By default, Waiter allows non-secure HTTP requests from clients to services.
+                                 ;; When true, forces all HTTP requests to the token to be SSL redirected.
                                  "https-redirect" false
 
                                  ;; Stale services are detected by looking at the version of the
                                  ;; token used to create them, such services will have their idle timeout
                                  ;; reduced to stale-timeout-mins + fallback-period-secs.
-                                 "stale-timeout-mins" 15}}
+                                 "stale-timeout-mins" 15
+
+                                 ;; By default, Waiter ignores any SSL redirects due to the upgrade-insecure-requests header
+                                 ;; When true, forces all HTTP requests containing the upgrade-insecure-requests=1 header to
+                                 ;; the token to be SSL redirected.
+                                 "upgrade-insecure-requests" false}}
 
  ;; Waiter supports making websocket connections to backends.
  ;; The maximum binary and text message sizes in the websocket request or response can be configured

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1856,7 +1856,8 @@
                                (fn [request]
                                  (let [;; ignore websocket requests
                                        http-request? (= :http (utils/request->scheme request))
-                                       upgrade-insecure-requests? (= "1" (get-in request [:headers "upgrade-insecure-requests"]))
+                                       upgrade-insecure-requests? (and (get-in request [:waiter-discovery :token-metadata "upgrade-insecure-requests"])
+                                                                       (= "1" (get-in request [:headers "upgrade-insecure-requests"])))
                                        https-redirect? (get-in request [:waiter-discovery :token-metadata "https-redirect"])]
                                    (if (and http-request? (or upgrade-insecure-requests? https-redirect?))
                                      (do

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -117,6 +117,7 @@
    (s/optional-key "https-redirect") s/Bool
    (s/optional-key "owner") schema/non-empty-string
    (s/optional-key "stale-timeout-mins") (s/both s/Int (s/pred #(<= 0 % (t/in-minutes (t/hours 4))) 'at-most-4-hours))
+   (s/optional-key "upgrade-insecure-requests") s/Bool
    s/Str s/Any})
 
 (def ^:const service-required-keys (->> (keys service-description-schema)
@@ -156,7 +157,8 @@
 (def ^:const system-metadata-keys #{"cluster" "deleted" "last-update-time" "last-update-user" "previous" "root"})
 
 ; keys allowed in user metadata for tokens, these need to be distinct from service description keys
-(def ^:const user-metadata-keys #{"cors-rules" "fallback-period-secs" "https-redirect" "owner" "stale-timeout-mins"})
+(def ^:const user-metadata-keys #{"cors-rules" "fallback-period-secs" "https-redirect" "owner" "stale-timeout-mins"
+                                  "upgrade-insecure-requests"})
 
 ; keys allowed in metadata for tokens, these need to be distinct from service description keys
 (def ^:const token-metadata-keys (set/union system-metadata-keys user-metadata-keys))

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -181,7 +181,8 @@
                                    (s/required-key :limit-per-owner) schema/positive-int
                                    (s/required-key :token-defaults) {(s/required-key "fallback-period-secs") schema/non-negative-int
                                                                      (s/required-key "https-redirect") s/Bool
-                                                                     (s/required-key "stale-timeout-mins") schema/non-negative-int}}
+                                                                     (s/required-key "stale-timeout-mins") schema/non-negative-int
+                                                                     (s/required-key "upgrade-insecure-requests") s/Bool}}
    (s/required-key :waiter-principal) schema/non-empty-string
    (s/required-key :websocket-config) {(s/required-key :ws-max-binary-message-size) schema/positive-int
                                        (s/required-key :ws-max-text-message-size) schema/positive-int}
@@ -469,7 +470,8 @@
                   :limit-per-owner 1000
                   :token-defaults {"fallback-period-secs" (-> 5 t/minutes t/in-seconds)
                                    "https-redirect" false
-                                   "stale-timeout-mins" 15}}
+                                   "stale-timeout-mins" 15
+                                   "upgrade-insecure-requests" false}}
    :websocket-config {:ws-max-binary-message-size (* 1024 1024 40)
                       :ws-max-text-message-size (* 1024 1024 40)}
    :work-stealing {:max-in-flight-offers 4000

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -1678,18 +1678,36 @@
                  response))))
 
       (testing "http request with upgrade-insecure-requests header"
-        (let [test-request {:headers {"host" "token.localtest.me"
-                                      "upgrade-insecure-requests" "1"}
-                            :request-method :get
-                            :scheme :http}
-              {:keys [handled-request response]} (execute-request test-request)]
-          (is (nil? handled-request))
-          (is (= {:body ""
-                  :headers {"Location" "https://token.localtest.me"
-                            "vary" "upgrade-insecure-requests"}
-                  :status http-301-moved-permanently
-                  :waiter/response-source :waiter}
-                 response)))))))
+        (testing "enabled"
+          (let [test-request {:headers {"host" "token.localtest.me"
+                                        "upgrade-insecure-requests" "1"}
+                              :request-method :get
+                              :scheme :http
+                              :waiter-discovery {:passthrough-headers {}
+                                                 :service-description-template {}
+                                                 :token "token.localtest.me"
+                                                 :token-metadata {"upgrade-insecure-requests" true}}}
+                {:keys [handled-request response]} (execute-request test-request)]
+            (is (nil? handled-request))
+            (is (= {:body ""
+                    :headers {"Location" "https://token.localtest.me"
+                              "vary" "upgrade-insecure-requests"}
+                    :status http-301-moved-permanently
+                    :waiter/response-source :waiter}
+                   response))))
+
+        (testing "disabled"
+          (let [test-request {:headers {"host" "token.localtest.me"
+                                        "upgrade-insecure-requests" "1"}
+                              :request-method :get
+                              :scheme :http
+                              :waiter-discovery {:passthrough-headers {}
+                                                 :service-description-template {}
+                                                 :token "token.localtest.me"
+                                                 :token-metadata {"upgrade-insecure-requests" false}}}
+                {:keys [handled-request response]} (execute-request test-request)]
+            (is (= test-request handled-request))
+            (is (= handler-response response))))))))
 
 (deftest test-request->protocol
   (is (nil? (request->protocol {})))


### PR DESCRIPTION

## Changes proposed in this PR

- adds token parameter to control when upgrade-insecure-requests trigger SSL redirects

## Why are we making these changes?

Not every service may want to opt in to SSL redirects in the presence of the upgrade-insecure-requests header.


