### PR TITLE
removes incorrect implementation of upgrade-insecure-requests request header

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1856,14 +1856,12 @@
                                (fn [request]
                                  (let [;; ignore websocket requests
                                        http-request? (= :http (utils/request->scheme request))
-                                       upgrade-insecure-requests? (= "1" (get-in request [:headers "upgrade-insecure-requests"]))
                                        https-redirect? (get-in request [:waiter-discovery :token-metadata "https-redirect"])]
-                                   (if (and http-request? (or upgrade-insecure-requests? https-redirect?))
+                                   (if (and http-request? https-redirect?)
                                      (do
                                        (log/info "triggering ssl redirect")
-                                       (cond-> (ssl/ssl-redirect-response request {})
-                                         upgrade-insecure-requests? (ru/attach-header "vary" "upgrade-insecure-requests")
-                                         true (utils/attach-waiter-source)))
+                                       (-> (ssl/ssl-redirect-response request {})
+                                         (utils/attach-waiter-source)))
                                      (handler request))))))
    :wrap-router-auth-fn (pc/fnk [[:state passwords router-id]]
                           (fn wrap-router-auth-fn [handler]

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -1675,20 +1675,6 @@
                   :headers {"Location" "https://token.localtest.me"}
                   :status http-301-moved-permanently
                   :waiter/response-source :waiter}
-                 response))))
-
-      (testing "http request with upgrade-insecure-requests header"
-        (let [test-request {:headers {"host" "token.localtest.me"
-                                      "upgrade-insecure-requests" "1"}
-                            :request-method :get
-                            :scheme :http}
-              {:keys [handled-request response]} (execute-request test-request)]
-          (is (nil? handled-request))
-          (is (= {:body ""
-                  :headers {"Location" "https://token.localtest.me"
-                            "vary" "upgrade-insecure-requests"}
-                  :status http-301-moved-permanently
-                  :waiter/response-source :waiter}
                  response)))))))
 
 (deftest test-request->protocol


### PR DESCRIPTION

## Changes proposed in this PR

- removes incorrect implementation of upgrade-insecure-requests request header

## Why are we making these changes?

Remove incorrect implementation.
