### PR TITLE
adds logging for consent cookie validation

### DIFF
--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -86,7 +86,8 @@
                 location (str "/waiter-consent" uri (when-not (str/blank? query-string) (str "?" query-string)))]
             (counters/inc! (metrics/waiter-counter "auto-run-as-requester" "redirect"))
             (meters/mark! (metrics/waiter-meter "auto-run-as-requester" "redirect"))
-            {:headers {"location" location} :status http-303-see-other})
+            (log/info "redirecting to consent page as run-as-user is missing" (.getMessage e))
+            (utils/attach-waiter-source {:headers {"location" location} :status http-303-see-other}))
           (do
             ; For consistency with historical data, count errors looking up the descriptor as a "process error"
             (meters/mark! (metrics/waiter-meter "core" "process-errors"))

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -1241,6 +1241,7 @@
    b. the consent has not expired based on the timestamp in the cookie."
   [clock consent-expiry-days service-id token {:strs [owner]} decoded-consent-cookie]
   (let [[consent-mode auth-timestamp consent-id consent-owner] (vec decoded-consent-cookie)]
+    (log/info "consent cookie decoded as" consent-mode auth-timestamp consent-id consent-owner)
     (and
       consent-id
       auth-timestamp


### PR DESCRIPTION
## Changes proposed in this PR

- adds logging for consent cookie validation

## Why are we making these changes?

Helps debug the consent cookie workflows.
Also adds the server header to consent cookie responses.


