### PR TITLE
upgrades to jdk11 compatible jet

### DIFF
--- a/containers/test-apps/jwks-server/project.clj
+++ b/containers/test-apps/jwks-server/project.clj
@@ -24,12 +24,12 @@
                  [prismatic/plumbing "0.5.5"]
                  [ring/ring-core "1.7.1"
                   :exclusions [org.clojure/tools.reader]]
-                 [twosigma/jet "0.7.10-20190831_055713-gf193d34"
+                 [twosigma/jet "0.7.10-20200709_171405-gea4b7b6"
                   :exclusions [org.eclipse.jetty/jetty-client
                                org.eclipse.jetty.alpn/alpn-api
                                org.eclipse.jetty.http2/http2-client
                                org.eclipse.jetty.websocket/websocket-client
-                               org.eclipse.jetty/jetty-alpn-openjdk8-client
+                               org.eclipse.jetty/jetty-alpn-java-client
                                org.mortbay.jetty.alpn/alpn-boot]]]
   :jvm-opts ["-server"
              "-XX:+UseG1GC"

--- a/token-syncer/project.clj
+++ b/token-syncer/project.clj
@@ -14,7 +14,7 @@
 ;; limitations under the License.
 ;;
 (defproject token-syncer "0.1.0-SNAPSHOT"
-  :dependencies [[twosigma/jet "0.7.10-20191230_163338-g0dabe28"]
+  :dependencies [[twosigma/jet "0.7.10-20200709_171405-gea4b7b6"]
                  [clj-time "0.15.2"]
                  [commons-codec/commons-codec "1.13"]
                  [org.clojure/clojure "1.10.1"]

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -45,7 +45,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20200708_174405-g610da82"
+                 [twosigma/jet "0.7.10-20200709_171405-gea4b7b6"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]


### PR DESCRIPTION
## Changes proposed in this PR

- upgrades to jdk11 compatible jet

## Why are we making these changes?

We should be able to run all the jet dependent projects with JDK11. Without the jet version upgrade, this is not currently true.

