### PR TITLE
adds support for PDBs for ReplicaSets requiring greater than one min instance

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -981,7 +981,8 @@
         rs-replicas (get-in rs-spec [:spec :replicas])
         rs-selector (get-in rs-spec [:spec :selector])
         service-id (k8s-object->service-id rs-spec)
-        min-available (quot (inc rs-replicas) 2)]
+        min-available (quot (inc rs-replicas) 2)
+        pdb-hash (-> replicaset-uid (hash) (mod 9000) (+ 1000))]
     (log/info "creating pod disruption budget"
               {:min-available min-available
                :replicaset-name rs-name
@@ -989,7 +990,7 @@
     {:apiVersion pdb-api-version
      :kind "PodDisruptionBudget"
      :metadata {:annotations {:waiter/service-id service-id}
-                :name (str rs-name "-pdb")
+                :name (str rs-name "-pdb-" pdb-hash)
                 :ownerReferences [{:apiVersion rs-api-version
                                    :blockOwnerDeletion true
                                    :controller false

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -977,6 +977,7 @@
   [pdb-api-version rs-spec replicaset-uid]
   (let [rs-api-version (get rs-spec :apiVersion)
         rs-kind (get rs-spec :kind)
+        rs-labels (get-in rs-spec [:metadata :labels])
         rs-name (get-in rs-spec [:metadata :name])
         rs-replicas (get-in rs-spec [:spec :replicas])
         rs-selector (get-in rs-spec [:spec :selector])
@@ -990,6 +991,7 @@
     {:apiVersion pdb-api-version
      :kind "PodDisruptionBudget"
      :metadata {:annotations {:waiter/service-id service-id}
+                :labels rs-labels
                 :name (str rs-name "-pdb-" pdb-hash)
                 :ownerReferences [{:apiVersion rs-api-version
                                    :blockOwnerDeletion true

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -268,10 +268,12 @@
            {:min-available 3 :replicas 5}]]
     (let [pdb-api-version "pdb/api-version"
           service-id "test-service-id"
+          rs-labels {:l1 "v1" :l2 "v2"}
           rs-selector {:a "b" :c "d"}
           rs-spec {:apiVersion "rs/api-version"
                    :kind "kind/ReplicaSet"
                    :metadata {:annotations {:waiter/service-id service-id}
+                              :labels rs-labels
                               :name "replicaset-1234"}
                    :spec {:replicas replicas
                           :selector rs-selector}}
@@ -281,6 +283,7 @@
           expected-spec {:apiVersion "pdb/api-version"
                          :kind "PodDisruptionBudget"
                          :metadata {:annotations {:waiter/service-id service-id}
+                                    :labels rs-labels
                                     :name (str "replicaset-1234-pdb-" pdb-hash)
                                     :ownerReferences [{:apiVersion "rs/api-version"
                                                        :blockOwnerDeletion true

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -277,10 +277,11 @@
                           :selector rs-selector}}
           replicaset-uid "replicaset-1234-uid"
           actual-spec (default-pdb-spec-builder pdb-api-version rs-spec replicaset-uid)
+          pdb-hash (-> replicaset-uid (hash) (mod 9000) (+ 1000))
           expected-spec {:apiVersion "pdb/api-version"
                          :kind "PodDisruptionBudget"
                          :metadata {:annotations {:waiter/service-id service-id}
-                                    :name "replicaset-1234-pdb"
+                                    :name (str "replicaset-1234-pdb-" pdb-hash)
                                     :ownerReferences [{:apiVersion "rs/api-version"
                                                        :blockOwnerDeletion true
                                                        :controller false


### PR DESCRIPTION
## Changes proposed in this PR

- makes the ReplicaSet uid available on the Service
- adds support for PDBs for ReplicaSets requiring greater than one min instance

## Why are we making these changes?

For services configured to run more than one min-instance, we want to limit the number of disruptions that the service experiences. Configuring Pod Disruption Budgets allows for higher availability while permitting the cluster administrator to manage the cluster's nodes.

