### PR TITLE
handles string ISO date data in token last-update-time

### DIFF
--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -655,9 +655,12 @@
    Else if the token is not stale or no data is known about the token, nil is returned."
   [current-token-data token-version]
   (let [token-data->update-time #(get % "last-update-time")
-        token-data->previous #(get % "previous")]
-    (descriptor-utils/retrieve-update-time
-      token-data->token-hash token-data->update-time token-data->previous current-token-data token-version)))
+        token-data->previous #(get % "previous")
+        update-time (descriptor-utils/retrieve-update-time
+                      token-data->token-hash token-data->update-time token-data->previous current-token-data token-version)]
+    (cond-> update-time
+      (string? update-time)
+      (-> du/str-to-date tc/to-long))))
 
 (defn retrieve-token-stale-info
   "The provided source-tokens are stale if every token used to access a service has been updated.

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -25,7 +25,8 @@
             [waiter.kv :as kv]
             [waiter.service-description :refer :all]
             [waiter.status-codes :refer :all]
-            [waiter.util.cache-utils :as cu])
+            [waiter.util.cache-utils :as cu]
+            [waiter.util.date-utils :as du])
   (:import (clojure.lang ExceptionInfo)
            (org.joda.time DateTime)))
 
@@ -2439,7 +2440,11 @@
       (testing "matching token version not found return last known update time"
         (is (= 50 (retrieve-token-update-epoch-time token-data "v40")))
         (is (= 50 (retrieve-token-update-epoch-time token-data "v30")))
-        (is (= 50 (retrieve-token-update-epoch-time token-data "v20")))))))
+        (is (= 50 (retrieve-token-update-epoch-time token-data "v20")))))
+
+    (testing "string last-update-time"
+      (let [token-data {"last-update-time" (-> 90 tc/from-long du/date-to-str)}]
+        (is (= 90 (retrieve-token-update-epoch-time token-data "v10")))))))
 
 (deftest test-retrieve-token-stale-info
   (with-redefs [token-data->token-hash #(str "v" (get % "last-update-time"))]


### PR DESCRIPTION
## Changes proposed in this PR

- handles corrupt string data in token last-update-time
- handles exception while computing service GC time

## Why are we making these changes?

We would like to be tolerant to corrupt string data for token update times while performing service GC.

