### PR TITLE
adds support for sanitize tokens command

### DIFF
--- a/token-syncer/src/token_syncer/main.clj
+++ b/token-syncer/src/token_syncer/main.clj
@@ -23,6 +23,7 @@
             [token-syncer.commands.cleanup :as cleanup]
             [token-syncer.commands.ping :as ping]
             [token-syncer.commands.restore :as restore]
+            [token-syncer.commands.sanitize :as sanitize]
             [token-syncer.commands.syncer :as syncer]
             [token-syncer.waiter :as waiter])
   (:import (org.eclipse.jetty.client HttpClient)))
@@ -118,6 +119,7 @@
                                          "cleanup-tokens" cleanup/cleanup-tokens-config
                                          "ping-token" ping/ping-token-config
                                          "restore-tokens" restore/restore-tokens-config
+                                         "sanitize-tokens" sanitize/sanitize-tokens-config
                                          "sync-clusters" syncer/sync-clusters-config}}
           {:keys [exit-code message]} (cli/process-command token-syncer-command-config context args)]
       (exit exit-code message))

--- a/token-syncer/test/token_syncer/commands/sanitize_test.clj
+++ b/token-syncer/test/token_syncer/commands/sanitize_test.clj
@@ -1,0 +1,126 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns token-syncer.commands.sanitize-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
+            [token-syncer.cli :as cli]
+            [token-syncer.commands.sanitize :refer :all]
+            [token-syncer.utils :as utils])
+  (:import (java.util.regex Pattern)))
+
+(deftest test-sanitize
+  (let [test-cluster-url "http://www.test-cluster.com"
+        limit 2
+        loaded-tokens-atom (atom #{})
+        stored-tokens-atom (atom #{})
+        waiter-api {:load-token (fn [cluster-url token]
+                                  (swap! loaded-tokens-atom conj token)
+                                  (is (= test-cluster-url cluster-url))
+                                  {:description {"metric-group" token "name" token}
+                                   :token-etag (str "etag-" token)})
+                    :load-token-list (fn [cluster-url]
+                                       (is (= test-cluster-url cluster-url))
+                                       [{"etag" "etag-token-1"
+                                         "last-update-time" (utils/millis->iso8601 10000)
+                                         "token" "token-1"}
+                                        {"deleted" true
+                                         "etag" "etag-token-B"
+                                         "last-update-time" (utils/millis->iso8601 20000)
+                                         "token" "token-B"}
+                                        {"deleted" true
+                                         "etag" "etag-token-3"
+                                         "last-update-time" (utils/millis->iso8601 30000)
+                                         "token" "token-3"}
+                                        {"deleted" true
+                                         "etag" "etag-token-4"
+                                         "last-update-time" (utils/millis->iso8601 40000)
+                                         "token" "token-4"}
+                                        {"deleted" false
+                                         "etag" "etag-token-E"
+                                         "last-update-time" (utils/millis->iso8601 50000)
+                                         "token" "token-E"}])
+                    :store-token (fn [cluster-url token token-etag description]
+                                   (swap! stored-tokens-atom conj token)
+                                   (is (= test-cluster-url cluster-url))
+                                   (is (= (str "etag-" token) token-etag))
+                                   (is (= {"metric-group" token "name" token} description)))}
+        regex (re-pattern "token-\\d+")
+        actual-result (sanitize-tokens waiter-api test-cluster-url limit regex)
+        expected-result #{"token-1" "token-3"}]
+
+    (is (= expected-result actual-result))
+    (is (= expected-result @loaded-tokens-atom))
+    (is (= expected-result @stored-tokens-atom))))
+
+(deftest test-sanitize-tokens-config
+  (let [test-command-config (assoc sanitize-tokens-config :command-name "test-command")
+        waiter-api {:load-token (constantly {})
+                    :load-token-list (constantly {})}
+        context {:waiter-api waiter-api}]
+    (let [args []]
+      (is (= {:exit-code 1
+              :message "test-command: expected one argument URL, provided 0: []"}
+             (cli/process-command test-command-config context args))))
+    (with-out-str
+      (let [args ["-h"]]
+        (is (= {:exit-code 0
+                :message "test-command: displayed documentation"}
+               (cli/process-command test-command-config context args)))))
+    (let [args ["some-file.txt" "cluster-1.com"]]
+      (is (= {:exit-code 1
+              :message "test-command: expected one argument URL, provided 2: [\"some-file.txt\" \"cluster-1.com\"]"}
+             (cli/process-command test-command-config context args))))
+    (let [limit-input (str 200000)
+          args ["--limit" limit-input "cluster-1.com"]]
+      (is (= {:data [(str "Failed to validate \"--limit " limit-input "\": "
+                          "Must be between 1 and 10000")]
+              :exit-code 1
+              :message "test-command: error in parsing arguments"}
+             (cli/process-command test-command-config context args))))
+
+    (let [regex-input 200000
+          args ["--regex" regex-input "cluster-1.com"]
+          actual-result (cli/process-command test-command-config context args)]
+      (is (= {:exit-code 1
+              :message "test-command: error in parsing arguments"}
+             (dissoc actual-result :data)))
+      (is (str/includes? (-> actual-result :data first) (str "Error while parsing option \"--regex " regex-input "\": ")))
+      (is (str/includes? (-> actual-result :data first) "java.lang.ClassCastException"))
+      (is (str/includes? (-> actual-result :data first) "java.lang.Long"))
+      (is (str/includes? (-> actual-result :data first) "java.lang.String")))
+
+    (let [cluster-url "http://cluster-1.com"
+          make-sanitize-tokens (fn [invocation-promise]
+                                (fn [in-waiter-api in-cluster-url count-limit token-regex]
+                                  (is (= waiter-api in-waiter-api))
+                                  (is (= cluster-url in-cluster-url))
+                                  (is (number? count-limit))
+                                  (is (instance? Pattern token-regex))
+                                  (deliver invocation-promise ::invoked)))]
+      (let [args [cluster-url]
+            invocation-promise (promise)]
+        (with-redefs [sanitize-tokens (make-sanitize-tokens invocation-promise)]
+          (is (= {:exit-code 0
+                  :message "test-command: exiting with code 0"}
+                 (cli/process-command test-command-config context args)))
+          (is (= ::invoked (deref invocation-promise 0 ::un-initialized)))))
+      (let [args ["--limit" (str 100) "--regex" ".*foo.*" cluster-url]
+            invocation-promise (promise)]
+        (with-redefs [sanitize-tokens (make-sanitize-tokens invocation-promise)]
+          (is (= {:exit-code 0
+                  :message "test-command: exiting with code 0"}
+                 (cli/process-command test-command-config context args)))
+          (is (= ::invoked (deref invocation-promise 0 ::un-initialized))))))))


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for sanitizing tokens command

## Why are we making these changes?

We would like a command that sanitizes the token description and stores it back in the Waiter cluster. This allows us to clean up any corrupt data for a token that can be successfully retrieved.

### Sample output displaying token update:
```
$ lein run -- sanitize-tokens http://localhost:9091
2020-07-28 16:27:36 INFO  eclipse.jetty.util.log - Logging initialized @6928ms to org.eclipse.jetty.util.log.Slf4jLog
2020-07-28 16:27:38 INFO  token-syncer.main - command-line arguments: [sanitize-tokens http://localhost:9091]
2020-07-28 16:27:38 INFO  token-syncer.commands.sanitize - sanitizing up to 1000 token(s) from http://localhost:9091
2020-07-28 16:27:38 INFO  token-syncer.waiter - token-syncer.9d3fb767-bf10-4b5a-884f-f44ddd4b7e1a making GET request to http://localhost:9091/tokens
2020-07-28 16:27:38 INFO  token-syncer.commands.sanitize - processing 2 of 2 token(s) on http://localhost:9091
2020-07-28 16:27:38 INFO  token-syncer.commands.sanitize - processing token wtrttslf758157625726526.t1.127 with etag E-3ea10345188d0ab506aa8d38d9dbb4d8 last updated on 2020-07-28T21:25:27.463Z
2020-07-28 16:27:38 INFO  token-syncer.waiter - token-syncer.43d7fad5-db2a-4d94-b0fa-2f50feff3ee5 making GET request to http://localhost:9091/token
2020-07-28 16:27:38 INFO  token-syncer.waiter - loading wtrttslf758157625726526.t1.127 on http://localhost:9091 responded with status 200 {content-type application/json, etag E-3ea10345188d0ab506aa8d38d9dbb4d8, x-cid token-syncer.43d7fad5-db2a-4d94-b0fa-2f50feff3ee5}
2020-07-28 16:27:38 INFO  token-syncer.commands.sanitize - sanitizing token wtrttslf758157625726526.t1.127 with etag E-3ea10345188d0ab506aa8d38d9dbb4d8 and description {...}
2020-07-28 16:27:38 INFO  token-syncer.waiter - storing token: wtrttslf758157625726526.t1.127 , soft-delete: false on http://localhost:9091 with etag E-3ea10345188d0ab506aa8d38d9dbb4d8
2020-07-28 16:27:38 INFO  token-syncer.waiter - token-syncer.015878f5-6c7a-4fb1-9173-5305200b3882 making POST request to http://localhost:9091/token
2020-07-28 16:27:38 INFO  token-syncer.waiter - storing wtrttslf758157625726526.t1.127 on http://localhost:9091 responded with status 200 {content-type application/json, etag E-109f15ce2bdf63bfaa27735c096fccb7, x-cid token-syncer.015878f5-6c7a-4fb1-9173-5305200b3882}
2020-07-28 16:27:38 INFO  token-syncer.commands.sanitize - token wtrttslf758157625726526.t1.127 updated after sanitize operation to etag E-109f15ce2bdf63bfaa27735c096fccb7
2020-07-28 16:27:38 INFO  token-syncer.commands.sanitize - processing token wtrttslf758157625726526.t2.127 with etag E-6b48da1de98e8b5d4d6ca366f5442c79 last updated on 2020-07-28T21:25:33.737Z
...
2020-07-28 16:27:38 INFO  token-syncer.commands.sanitize - token wtrttslf758157625726526.t2.127 did not update as result of the sanitize operation
2020-07-28 16:27:38 INFO  token-syncer.commands.sanitize - sanitized 1 token(s) on cluster http://localhost:9091
2020-07-28 16:27:38 INFO  token-syncer.commands.sanitize - result summary {:missing #{}, :processed #{wtrttslf758157625726526.t2.127 wtrttslf758157625726526.t1.127}, :updated #{wtrttslf758157625726526.t1.127}}
2020-07-28 16:27:38 INFO  token-syncer.main - token-syncer: sanitize-tokens: exiting with code 0
```
