### PR TITLE
uses unique names for OIDC auth cookies

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -259,6 +259,10 @@
                               :max-expiry-duration-ms 86400000
                               ;; (optional) url of the authorization server authorize endpoint:
                               :oidc-authorize-uri "http://127.0.0.1:8040/authorize"
+                              ;; (optional) maximum number of OIDC challenge cookies in the request beyond which
+                              ;; the OIDC auth flow will not be triggered on 401 responses.
+                              ;; The default value is 20
+                              :oidc-num-challenge-cookies-allowed-in-request 20
                               ;; (optional) url of the authorization server get token endpoint:
                               :oidc-token-uri "http://127.0.0.1:8040/id-token"
                               ;; The keyword used to retrieve the subject from the access token claims

--- a/waiter/integration/waiter/authentication_test.clj
+++ b/waiter/integration/waiter/authentication_test.clj
@@ -390,10 +390,10 @@
   [set-cookie assertion-message]
   `(let [set-cookie# ~set-cookie
          assertion-message# ~assertion-message]
-     (is (str/includes? set-cookie# "x-waiter-oidc-challenge=") assertion-message#)
-     (is (str/includes? set-cookie# "Max-Age=") assertion-message#)
-     (is (str/includes? set-cookie# "Path=/") assertion-message#)
-     (is (str/includes? set-cookie# "HttpOnly=true") assertion-message#)))
+     (is (str/starts-with? set-cookie# "x-waiter-oidc-challenge-") assertion-message#)
+     (is (str/includes? set-cookie# ";Max-Age=") assertion-message#)
+     (is (str/includes? set-cookie# ";Path=/") assertion-message#)
+     (is (str/includes? set-cookie# ";HttpOnly=true") assertion-message#)))
 
 (defn- follow-authorize-redirects
   "Asserts for query parameters on the redirect url.
@@ -480,7 +480,7 @@
                                   :headers callback-request-headers)]
                 (assert-response-status callback-response http-302-moved-temporarily)
                 (is (= 2 (count cookies)))
-                (is (zero? (:max-age (first (filter #(= (:name %) "x-waiter-oidc-challenge") cookies)))))
+                (is (zero? (:max-age (first (filter #(str/starts-with? (:name %) "x-waiter-oidc-challenge-") cookies)))))
                 (is (pos? (:max-age (first (filter #(= (:name %) "x-waiter-auth") cookies)))))
                 (let [{:strs [location]} (:headers callback-response)
                       assertion-message (str {:headers (:headers callback-response)

--- a/waiter/src/waiter/auth/oidc.clj
+++ b/waiter/src/waiter/auth/oidc.clj
@@ -19,6 +19,7 @@
             [clojure.core.async :as async]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
+            [digest]
             [waiter.auth.authentication :as auth]
             [waiter.auth.jwt :as jwt]
             [waiter.cookie-support :as cookie-support]
@@ -35,9 +36,14 @@
 
 (def ^:const content-security-policy-value "default-src 'none'; frame-ancestors 'none'")
 
-(def ^:const oidc-challenge-cookie "x-waiter-oidc-challenge")
+(def ^:const oidc-challenge-cookie-prefix "x-waiter-oidc-challenge-")
 
 (def ^:const oidc-callback-uri "/oidc/v1/callback")
+
+(defn create-code-identifier
+  "Returns a string generated using the code verifier to use as an identifier for the OIDC workflow."
+  [code-verifier]
+  (digest/md5 code-verifier))
 
 ;; code_verifier = high-entropy cryptographic random STRING using the unreserved characters
 ;;   [A-Z] / [a-z] / [0-9] / "-" / "." / "_" / "~"
@@ -64,9 +70,6 @@
 (defn validate-oidc-callback-request
   [password {:keys [headers] :as request}]
   (let [{:strs [code state]} (-> request ru/query-params-request :query-params)
-        challenge-cookie (some-> headers
-                           (get "cookie")
-                           (cookie-support/cookie-value oidc-challenge-cookie))
         bad-request-map {:log-level :info
                          :query-param-state state
                          :status http-400-bad-request}]
@@ -74,29 +77,38 @@
       (throw (ex-info "Query parameter code is missing" bad-request-map)))
     (when (str/blank? state)
       (throw (ex-info "Query parameter state is missing" bad-request-map)))
-    (when (str/blank? challenge-cookie)
-      (throw (ex-info "No challenge cookie set" bad-request-map)))
-    (let [state-map (try
-                      (parse-state-code state password)
-                      (catch Throwable throwable
-                        (throw (ex-info "Unable to parse state"
-                                        bad-request-map throwable))))]
-      (when-not (and (map? state-map) (string? (get state-map :redirect-uri)))
+    (let [{:keys [identifier] :as state-map}
+          (try
+            (parse-state-code state password)
+            (catch Throwable throwable
+              (throw (ex-info "Unable to parse state"
+                              bad-request-map throwable))))]
+      (when-not (and (map? state-map)
+                     (string? (get state-map :redirect-uri))
+                     (string? identifier)
+                     (not (str/blank? identifier)))
         (throw (ex-info "The state query parameter is invalid" bad-request-map)))
-      (let [decoded-value (cookie-support/decode-cookie challenge-cookie password)]
-        (when-not (map? decoded-value)
-          (throw (ex-info "Decoded challenge cookie is invalid" bad-request-map)))
-        (let [{:keys [code-verifier expiry-time]} decoded-value]
-          (when-not (integer? expiry-time)
-            (throw (ex-info "The challenge cookie has invalid format" bad-request-map)))
-          (when-not (->> expiry-time (tc/from-long) (t/before? (t/now)))
-            (throw (ex-info "The challenge cookie has expired" bad-request-map)))
-          (when (or (not (string? code-verifier))
-                    (str/blank? code-verifier))
-            (throw (ex-info "No challenge code available from cookie" bad-request-map)))
-          {:code code
-           :code-verifier code-verifier
-           :state-map state-map})))))
+      (let [oidc-challenge-cookie (str oidc-challenge-cookie-prefix identifier)
+            challenge-cookie (some-> headers
+                               (get "cookie")
+                               (cookie-support/cookie-value oidc-challenge-cookie))]
+        (when (str/blank? challenge-cookie)
+          (throw (ex-info "No challenge cookie set"
+                          (assoc bad-request-map :cookie-name oidc-challenge-cookie))))
+        (let [decoded-value (cookie-support/decode-cookie challenge-cookie password)]
+          (when-not (map? decoded-value)
+            (throw (ex-info "Decoded challenge cookie is invalid" bad-request-map)))
+          (let [{:keys [code-verifier expiry-time]} decoded-value]
+            (when-not (integer? expiry-time)
+              (throw (ex-info "The challenge cookie has invalid format" bad-request-map)))
+            (when-not (->> expiry-time (tc/from-long) (t/before? (t/now)))
+              (throw (ex-info "The challenge cookie has expired" bad-request-map)))
+            (when (or (not (string? code-verifier))
+                      (str/blank? code-verifier))
+              (throw (ex-info "No challenge code available from cookie" bad-request-map)))
+            {:code code
+             :code-verifier code-verifier
+             :state-map state-map}))))))
 
 (defn attach-threat-remediation-headers
   "Threat remediation by
@@ -138,7 +150,8 @@
                     auth-cookie-age-in-seconds (- expiry-time (jwt/current-time-secs))]
                 (auth/handle-request-auth
                   (constantly
-                    (let [{:keys [redirect-uri]} state-map]
+                    (let [{:keys [identifier redirect-uri]} state-map
+                          oidc-challenge-cookie (str oidc-challenge-cookie-prefix identifier)]
                       (-> {:headers (attach-threat-remediation-headers {"location" redirect-uri})
                            :status http-302-moved-temporarily}
                         (cookie-support/add-encoded-cookie password oidc-challenge-cookie "" 0)
@@ -163,13 +176,16 @@
                                  (when query-string (str "?" query-string))))]
     (if (= :https request-scheme)
       (let [code-verifier (create-code-verifier)
-            state-data {:redirect-uri (make-redirect-uri identity)}
+            cookie-identifier (create-code-identifier code-verifier)
+            state-data {:identifier cookie-identifier
+                        :redirect-uri (make-redirect-uri identity)}
             state-code (create-state-code state-data password)
             authorize-uri (jwt/retrieve-authorize-url
                             jwt-auth-server request oidc-callback-uri code-verifier state-code)
             expiry-time (-> (t/now)
                           (t/plus (t/seconds challenge-cookie-duration-secs))
                           (tc/to-long))
+            oidc-challenge-cookie (str oidc-challenge-cookie-prefix cookie-identifier)
             challenge-cookie-value {:code-verifier code-verifier
                                     :expiry-time expiry-time}]
         (-> response

--- a/waiter/src/waiter/schema.clj
+++ b/waiter/src/waiter/schema.clj
@@ -139,6 +139,7 @@
      (s/required-key :jwks-url) non-empty-string
      (s/optional-key :max-expiry-duration-ms) positive-int
      (s/optional-key :oidc-authorize-uri) non-empty-string
+     (s/optional-key :oidc-num-challenge-cookies-allowed-in-request) positive-int
      (s/optional-key :oidc-token-uri) non-empty-string
      (s/required-key :subject-key) s/Keyword
      (s/optional-key :subject-regex) s/Regex


### PR DESCRIPTION
## Changes proposed in this PR

- uses unique names for OIDC auth cookies

## Why are we making these changes?

Concurrent requests from the same domain that trigger OIDC flows can end up overwriting each other's cookies. Using unique names for cookies avoids this issue.


