### PR TITLE
Disable Travis artifact upload to AWS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ addons:
   apt:
     packages:
     - nginx
-  artifacts: true
 
 branches:
   only:


### PR DESCRIPTION
## Changes proposed in this PR

Disable uploading Travis artifacts to AWS

## Why are we making these changes?

Subsequent to enabling this, we found out that artifacts are not stored for branches and we setup a process to upload logs to Google Drive, making this unnecessary.

