### PR TITLE
adds authorization checks before launching the latest service when fallback is triggered

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1092,6 +1092,10 @@
                                          service-id->service-description-fn*)
    :service-id->source-tokens-entries-fn (pc/fnk [[:state kv-store]]
                                            (partial sd/service-id->source-tokens-entries kv-store))
+   :service-invocation-authorized?-fn (pc/fnk [can-run-as?-fn]
+                                        (fn service-invocation-authorized?-fn
+                                          [auth-user descriptor]
+                                          (descriptor/service-invocation-authorized? can-run-as?-fn auth-user descriptor)))
    :start-new-service-fn (pc/fnk [[:scheduler scheduler]
                                   [:state start-service-cache scheduler-interactions-thread-pool]
                                   service-id->service-description-fn store-service-description-fn]
@@ -1848,10 +1852,11 @@
                                   (handler (assoc request :skip-authentication true)))
                                 (fn []
                                   (handler request))))))
-   :wrap-descriptor-fn (pc/fnk [[:routines request->descriptor-fn start-new-service-fn]
+   :wrap-descriptor-fn (pc/fnk [[:routines request->descriptor-fn service-invocation-authorized?-fn start-new-service-fn]
                                 [:state fallback-state-atom]]
                          (fn wrap-descriptor-fn [handler]
-                           (descriptor/wrap-descriptor handler request->descriptor-fn start-new-service-fn fallback-state-atom)))
+                           (descriptor/wrap-descriptor handler request->descriptor-fn service-invocation-authorized?-fn
+                                                       start-new-service-fn fallback-state-atom)))
    :wrap-https-redirect-fn (pc/fnk []
                              (fn wrap-https-redirect-fn
                                [handler]

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -421,9 +421,11 @@
                                    (ex-info "Test exception" {:type :service-description-error
                                                               :issue {"run-as-user" "missing-required-key"}
                                                               :x-waiter-headers {"queue-length" 100}})))
+        service-invocation-authorized? (constantly true)
         start-new-service-fn (constantly nil)
         fallback-state-atom (atom {})
-        handler (descriptor/wrap-descriptor (fn [_] {:status http-200-ok}) request->descriptor-fn start-new-service-fn fallback-state-atom)]
+        handler (descriptor/wrap-descriptor (fn [_] {:status http-200-ok}) request->descriptor-fn
+                                            service-invocation-authorized? start-new-service-fn fallback-state-atom)]
     (testing "with-query-params"
       (let [request {:headers {"host" "www.example.com:1234"}, :query-string "a=b&c=d", :uri "/path"}
             {:keys [headers status]} (handler request)]
@@ -444,9 +446,11 @@
 
 (deftest test-no-redirect-on-process-error
   (let [request->descriptor-fn (fn [_] (throw (Exception. "Exception message")))
+        service-invocation-authorized? (constantly true)
         start-new-service-fn (constantly nil)
         fallback-state-atom (atom {})
-        handler (descriptor/wrap-descriptor (fn [_] {:status http-200-ok}) request->descriptor-fn start-new-service-fn fallback-state-atom)
+        handler (descriptor/wrap-descriptor (fn [_] {:status http-200-ok}) request->descriptor-fn
+                                            service-invocation-authorized? start-new-service-fn fallback-state-atom)
         request {}
         {:keys [body headers status]} (handler request)]
     (is (= http-500-internal-server-error status))
@@ -456,9 +460,11 @@
 
 (deftest test-message-reaches-user-on-process-error
   (let [request->descriptor-fn (fn [_] (throw (ex-info "Error message for user" {:status http-404-not-found})))
+        service-invocation-authorized? (constantly true)
         start-new-service-fn (constantly nil)
         fallback-state-atom (atom {})
-        handler (descriptor/wrap-descriptor (fn [_] {:status http-200-ok}) request->descriptor-fn start-new-service-fn fallback-state-atom)
+        handler (descriptor/wrap-descriptor (fn [_] {:status http-200-ok}) request->descriptor-fn
+                                            service-invocation-authorized? start-new-service-fn fallback-state-atom)
         request {}
         {:keys [body headers status]} (handler request)]
     (is (= http-404-not-found status))


### PR DESCRIPTION
## Changes proposed in this PR

- adds authorization checks before launching the latest service when fallback is triggered

## Why are we making these changes?

Sending request to a service where the user is not allowed to make a request to triggers starting an instance of the service if it doesn't already exist. Since the user is not permitted to make a request to the service, it should not trigger the starting of the service.

### Sample Logs

```
2020-08-04 17:40:02,270 INFO  waiter.descriptor [qtp875272017-181] - [CID=1c6a427acd845524] w9091-whcttpwfe1237506232406905v2-66897d9441e1876645358650e661e18a has previous descriptor with service-id w9091-whcttpwfe1237506232406905v1-cd682d8
fc2aa7f7ed46ef3ad8abf496c computed using :token
2020-08-04 17:40:02,271 INFO  waiter.descriptor [qtp875272017-181] - [CID=1c6a427acd845524] iteration-1 w9091-whcttpwfe1237506232406905v2-66897d9441e1876645358650e661e18a falling back to w9091-whcttpwfe1237506232406905v1-cd682d8fc2aa7f7ed46
ef3ad8abf496c
...
2020-08-04 17:40:02,362 WARN  waiter.descriptor [qtp875272017-181] - [CID=1c6a427acd845524] This user isn't allowed to invoke this service {:authenticated-user shamsimam, :service-id w9091-whcttpwfe1237506232406905v2-66897d9441e1876645358650e661e18a}
2020-08-04 17:40:02,362 INFO  waiter.descriptor [qtp875272017-181] - [CID=1c6a427acd845524] not starting w9091-whcttpwfe1237506232406905v2-66897d9441e1876645358650e661e18a as shamsimam is not authorized to make a request to the service
```