### PR TITLE
includes exception stack traces in oidc error scenario

### DIFF
--- a/waiter/src/waiter/auth/oidc.clj
+++ b/waiter/src/waiter/auth/oidc.clj
@@ -161,9 +161,10 @@
                   request auth-params-map password auth-cookie-age-in-seconds)))
             (catch Throwable throwable
               (utils/exception->response
-                (ex-info "Error in retrieving access token"
+                (ex-info (str "Error in retrieving access token: " (ex-message throwable))
                          (-> (ex-data throwable)
-                           (utils/assoc-if-absent :log-level :info)
+                           (utils/assoc-if-absent :friendly-error-message "Error in retrieving access token")
+                           (utils/assoc-if-absent :log-level :warn)
                            (utils/assoc-if-absent :status http-401-unauthorized))
                          throwable)
                 request))))))))

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -379,8 +379,8 @@
         processed-headers (into {} (for [[k v] headers] [(name k) (str v)]))]
     (condp = log-level
       :info (log/info (.getMessage wrapped-ex))
-      :warn (log/warn (.getMessage wrapped-ex))
-      (log/error wrapped-ex))
+      :warn (log/warn wrapped-ex response-msg)
+      (log/error wrapped-ex response-msg))
     (-> {:details data
          :headers processed-headers
          :message response-msg


### PR DESCRIPTION
## Changes proposed in this PR

- includes exception stack traces in oidc error scenario

## Why are we making these changes?

We would like to see the stack traces for OIDC errors to help debug issues even if log levels are not set as error.


