### PR TITLE
adds the image parameter to the request log

### DIFF
--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -57,7 +57,7 @@
            protocol request-type status waiter-api-call?] :as response}]
   (let [{:keys [service-id service-description source-tokens]} descriptor
         token (some->> source-tokens (map #(get % "token")) seq (str/join ","))
-        {:strs [metric-group profile run-as-user version]} service-description
+        {:strs [image metric-group profile run-as-user version]} service-description
         {:strs [content-length content-type grpc-status location server]} headers
         {:keys [k8s/node-name k8s/pod-name]} instance]
     (cond-> {}
@@ -73,6 +73,7 @@
                         :service-version version)
       get-instance-latency-ns (assoc :get-instance-latency-ns get-instance-latency-ns)
       grpc-status (assoc :grpc-status grpc-status)
+      image (assoc :service-image image)
       instance (assoc :instance-host (:host instance)
                       :instance-port (:port instance))
       (:id instance) (assoc :instance-id (:id instance))

--- a/waiter/test/waiter/request_log_test.clj
+++ b/waiter/test/waiter/request_log_test.clj
@@ -59,7 +59,8 @@
                   :authorization/principal "principal@DOMAIN.COM"
                   :backend-response-latency-ns 1000
                   :descriptor {:service-id "service-id"
-                               :service-description {"metric-group" "service-metric-group"
+                               :service-description {"image" "service-image"
+                                                     "metric-group" "service-metric-group"
                                                      "name" "service-name"
                                                      "profile" "test-profile"
                                                      "run-as-user" "john.doe"
@@ -108,6 +109,7 @@
             :run-as-user "john.doe"
             :server "foo-bar"
             :service-id "service-id"
+            :service-image "service-image"
             :service-name "service-name"
             :service-profile "test-profile"
             :service-version "service-version"


### PR DESCRIPTION
## Changes proposed in this PR

- adds the image parameter to the request log

## Why are we making these changes?

We should be able to identify which image was used to process a request


