### PR TITLE
restricts pytest-dist version to <2.0.0

### DIFF
--- a/cli/integration/requirements.txt
+++ b/cli/integration/requirements.txt
@@ -1,6 +1,6 @@
 pip==9.0.1; python_version >= '3.6'
 pytest>=4.3.0,<=5.3.5
-pytest-xdist>=1.20.1
+pytest-xdist>=1.20.1,<2.0.0
 pyyaml>=3.13
 requests>=2.20.0
 retrying>=1.3.3


### PR DESCRIPTION
## Changes proposed in this PR

- restricts pytest-dist version to `<2.0.0`

## Why are we making these changes?

```
ERROR: pytest-xdist 2.0.0 has requirement pytest>=6.0.0, but you'll have pytest 5.3.5 which is incompatible.
```


