### PR TITLE
adds server header to cors and saml responses

### DIFF
--- a/waiter/src/waiter/cors.clj
+++ b/waiter/src/waiter/cors.clj
@@ -75,12 +75,13 @@
                                                                   :log-level :warn})))
             (log/info "cors preflight request allowed" summary)
             (let [{:strs [access-control-request-headers]} headers]
-              {:status http-200-ok
-               :headers {"access-control-allow-origin" origin
-                         "access-control-allow-headers" access-control-request-headers
-                         "access-control-allow-methods" (str/join ", " (or allowed-methods schema/http-methods))
-                         "access-control-allow-credentials" "true"
-                         "access-control-max-age" (str max-age)}}))))
+              (utils/attach-waiter-source
+                {:headers {"access-control-allow-origin" origin
+                           "access-control-allow-headers" access-control-request-headers
+                           "access-control-allow-methods" (str/join ", " (or allowed-methods schema/http-methods))
+                           "access-control-allow-credentials" "true"
+                           "access-control-max-age" (str max-age)}
+                 :status http-200-ok})))))
       (handler request))))
 
 (defn wrap-cors-request

--- a/waiter/test/waiter/auth/saml_test.clj
+++ b/waiter/test/waiter/auth/saml_test.clj
@@ -129,7 +129,8 @@
                   :body ""
                   :headers {"location" "redirect-url"
                             "set-cookie" (str "x-waiter-auth=" ["my-user@domain" (tc/to-long test-time)])}
-                  :status http-303-see-other}
+                  :status http-303-see-other
+                  :waiter/response-source :waiter}
                  (saml-auth-redirect-handler saml-authenticator dummy-request'))))))
 
     (testing "has saml-auth-data no expiry"
@@ -152,7 +153,8 @@
                   :body ""
                   :headers {"location" "redirect-url"
                             "set-cookie" (str "x-waiter-auth=" ["my-user@domain" (tc/to-long test-time)])}
-                  :status http-303-see-other}
+                  :status http-303-see-other
+                  :waiter/response-source :waiter}
                  (saml-auth-redirect-handler saml-authenticator dummy-request'))))))
 
     (testing "has saml-auth-data short expiry"
@@ -175,7 +177,8 @@
                   :body ""
                   :headers {"location" "redirect-url"
                             "set-cookie" (str "x-waiter-auth=" ["my-user@domain" (tc/to-long test-time)])}
-                  :status http-303-see-other}
+                  :status http-303-see-other
+                  :waiter/response-source :waiter}
                  (saml-auth-redirect-handler saml-authenticator dummy-request'))))))))
 
 (defn- saml-response-from-xml
@@ -197,7 +200,8 @@
                                         :saml-auth-data {:min-session-not-on-or-after expiry-time
                                                          :redirect-url "request-url"
                                                          :saml-principal "user1@example.com"}}
-                                 :status http-200-ok}]
+                                 :status http-200-ok
+                                 :waiter/response-source :waiter}]
     (with-redefs [nippy/freeze (fn [data _] (.getBytes (str data)))
                   t/now (fn [] test-time)
                   render-authenticated-redirect-template identity


### PR DESCRIPTION
## Changes proposed in this PR

- adds server header to cors and saml responses

## Why are we making these changes?

Ensures presence of the Waiter server header in the response.

### Example
```
$ curl -I -H "Origin: http://example.com"   -H "Access-Control-Request-Method: POST"   -H "Access-Control-Request-Headers: X-Requested-With"   -X OPTIONS http://w8r.localtest.me:9091/settings
HTTP/1.1 200 OK
access-control-allow-origin: http://example.com
access-control-allow-headers: X-Requested-With
access-control-allow-methods: DELETE, OPTIONS, PATCH, TRACE, HEAD, POST, CONNECT, GET, PUT
access-control-allow-credentials: true
access-control-max-age: 3600
Server: waiter/4df6fd4
x-cid: 70e0476c2ec6c-12adda5cb9973005
Transfer-Encoding: chunked
```
