### PR TITLE
adds support for token in the request log for OIDC callback requests

### DIFF
--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -56,7 +56,9 @@
            get-instance-latency-ns handle-request-latency-ns headers instance instance-proto latest-service-id
            protocol request-type status waiter-api-call?] :as response}]
   (let [{:keys [service-id service-description source-tokens]} descriptor
-        token (some->> source-tokens (map #(get % "token")) seq (str/join ","))
+        token (or (some->> source-tokens (map #(get % "token")) seq (str/join ","))
+                  ;; allow non-proxy requests to provide tokens for use in the request log
+                  (:waiter/token response))
         {:strs [image metric-group profile run-as-user version]} service-description
         {:strs [content-length content-type grpc-status location server]} headers
         {:keys [k8s/node-name k8s/pod-name]} instance]

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -33,7 +33,7 @@
            (clojure.lang ExceptionInfo)
            (java.io OutputStreamWriter)
            (java.lang Process)
-           (java.net ServerSocket)
+           (java.net ServerSocket URI)
            (java.nio ByteBuffer)
            (java.nio.charset StandardCharsets)
            (java.security MessageDigest)
@@ -574,6 +574,12 @@
   [authority & {:keys [default]}]
   (let [port-index (str/index-of (str authority) ":")]
     (if port-index (subs authority (inc port-index)) (str default))))
+
+(defn uri-string->host
+  "Parses the uri-string as a URI and extracts the authority from it."
+  [uri-string]
+  ;; we do not use (.getHost) on URI directly since our test tokens don't parse as hosts
+  (some-> uri-string (URI.) (.getAuthority) (authority->host)))
 
 (defn request->scheme
   "Extracts the scheme from the request, and returns it as a keyword."

--- a/waiter/test/waiter/auth/oidc_test.clj
+++ b/waiter/test/waiter/auth/oidc_test.clj
@@ -189,7 +189,8 @@
                 :authorization/principal "john.doe"
                 :authorization/user "john.doe"
                 :authorization/metadata {:jwt-access-token access-token}
-                :waiter/response-source :waiter}
+                :waiter/response-source :waiter
+                :waiter/token "www.test.com"}
                response))))
 
     (with-redefs [cookie-support/decode-cookie (fn [cookie-value in-password]

--- a/waiter/test/waiter/request_log_test.clj
+++ b/waiter/test/waiter/request_log_test.clj
@@ -85,7 +85,8 @@
                   :protocol "HTTP/2.0"
                   :request-type "test-request"
                   :status http-200-ok
-                  :waiter-api-call? false}]
+                  :waiter-api-call? false
+                  :waiter/token "test-token3"}]
     (is (= {:authentication-method "cookie"
             :backend-response-latency-ns 1000
             :backend-protocol "HTTP/2.0"


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for token in the request log for OIDC callback requests

## Why are we making these changes?

We would like to easily identify Waiter tokens that are authenticating using OIDC in the request log.


