### PR TITLE
adds support for filtering tokens by run-as-requester and parameterized services

### DIFF
--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -636,6 +636,18 @@
   [service-description username]
   (assoc service-description "run-as-user" username "permitted-user" username))
 
+(defn run-as-requester?
+  "Returns true if the service description maps to a run-as-requester service."
+  [{:strs [run-as-user]}]
+  (= "*" run-as-user))
+
+(defn requires-parameters?
+  "Returns true if the service description maps to a parameterized service whose parameters do not have a default value."
+  [{:strs [allowed-params env]}]
+  (boolean
+    (and (seq allowed-params)
+         (seq (set/difference allowed-params (set (keys env)))))))
+
 (let [hash-prefix "E-"]
   (defn token-data->token-hash
     "Converts the merged map of service-description and token-metadata to a hash."

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -589,12 +589,10 @@
       :get (let [{:strs [can-manage-as-user] :as request-params} (-> req ru/query-params-request :query-params)
                  include-deleted (utils/param-contains? request-params "include" "deleted")
                  show-metadata (utils/param-contains? request-params "include" "metadata")
-                 include-run-as-requester? (when (contains? request-params "run-as-requester")
-                                             (utils/request-flag request-params "run-as-requester"))
-                 include-requires-parameters? (when (contains? request-params "requires-parameters")
-                                                (utils/request-flag request-params "requires-parameters"))
-                 boolean-xnor (fn [b1 b2] (or (and b1 b2)
-                                              (and (not b1) (not b2))))
+                 include-run-as-requester (when (contains? request-params "run-as-requester")
+                                            (utils/request-flag request-params "run-as-requester"))
+                 include-requires-parameters (when (contains? request-params "requires-parameters")
+                                               (utils/request-flag request-params "requires-parameters"))
                  owner-param (get request-params "owner")
                  owners (cond
                           (string? owner-param) #{owner-param}
@@ -628,12 +626,10 @@
                                                         :error-on-missing false
                                                         :include-deleted include-deleted)]
                                  (and (every? #(% token-parameters) parameter-filter-predicates)
-                                      (or (nil? include-run-as-requester?)
-                                          (boolean-xnor include-run-as-requester?
-                                                        (sd/run-as-requester? token-parameters)))
-                                      (or (nil? include-requires-parameters?)
-                                          (boolean-xnor include-requires-parameters?
-                                                        (sd/requires-parameters? token-parameters)))))))
+                                      (or (nil? include-run-as-requester)
+                                          (= include-run-as-requester (sd/run-as-requester? token-parameters)))
+                                      (or (nil? include-requires-parameters)
+                                          (= include-requires-parameters (sd/requires-parameters? token-parameters)))))))
                            (map
                              (fn [[token entry]]
                                (-> (if show-metadata

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -3026,3 +3026,26 @@
                                                   "t2" {"last-update-time" 150}
                                                   "t3" {"last-update-time" 250}}}}]
     (is (= 250 (retrieve-most-recently-modified-token-update-time descriptor)))))
+
+(deftest test-run-as-requester?
+  (is (false? (run-as-requester? {})))
+  (is (false? (run-as-requester? {"run-as-user" "john.doe*"})))
+  (is (false? (run-as-requester? {"run-as-user" "jane.doe*"})))
+  (is (true? (run-as-requester? {"run-as-user" "*"})))
+  (is (false? (run-as-requester? {"run-as-user" "john.doe*" "permitted-user" "*"})))
+  (is (false? (run-as-requester? {"run-as-user" "jane.doe*" "permitted-user" "*"})))
+  (is (true? (run-as-requester? {"run-as-user" "*" "permitted-user" "*"}))))
+
+(deftest test-requires-parameters?
+  (is (false? (requires-parameters? {"allowed-params" #{}})))
+  (is (true? (requires-parameters? {"allowed-params" #{"LOREM"}})))
+  (is (false? (requires-parameters? {"allowed-params" #{"LOREM"} "env" {"LOREM" "v1"}})))
+  (is (false? (requires-parameters? {"allowed-params" #{"LOREM"} "env" {"LOREM" "v1" "IPSUM" "v2"}})))
+  (is (true? (requires-parameters? {"allowed-params" #{"LOREM" "IPSUM"}})))
+  (is (true? (requires-parameters? {"allowed-params" #{"LOREM" "IPSUM"} "env" {"LOREM" "v1"}})))
+  (is (false? (requires-parameters? {"allowed-params" #{"LOREM" "IPSUM"} "env" {"LOREM" "v1" "IPSUM" "v2"}})))
+  (is (false? (requires-parameters? {})))
+  (is (false? (requires-parameters? {"env" {"LOREM" "v1"}})))
+  (is (false? (requires-parameters? {"env" {"LOREM" "v1" "IPSUM" "v2"}})))
+  (is (false? (requires-parameters? {"run-as-user" "john.doe*"})))
+  (is (false? (requires-parameters? {"run-as-user" "jane.doe*"}))))

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -2209,6 +2209,26 @@
       synchronize-fn kv-store history-length limit-per-owner "token4"
       {"cpus" 4 "idle-timeout-mins" 0 "mem" 2048}
       {"cluster" "c2" "deleted" true "last-update-time" (- last-update-time-seed 3000) "owner" "owner2"})
+    (store-service-description-for-token
+      synchronize-fn kv-store history-length limit-per-owner "token5"
+      {"cpus" 4 "mem" 2048 "run-as-user" "*"}
+      {"cluster" "c1" "last-update-time" (- last-update-time-seed 3000) "owner" "owner3"})
+    (store-service-description-for-token
+      synchronize-fn kv-store history-length limit-per-owner "token6"
+      {"cpus" 4 "idle-timeout-mins" 0 "mem" 2048 "run-as-user" "*"}
+      {"cluster" "c1" "last-update-time" (- last-update-time-seed 3000) "owner" "owner3"})
+    (store-service-description-for-token
+      synchronize-fn kv-store history-length limit-per-owner "token7"
+      {"allowed-params" #{"P1" "P2"} "cpus" 4 "mem" 1024}
+      {"cluster" "c1" "last-update-time" (- last-update-time-seed 3000) "owner" "owner3"})
+    (store-service-description-for-token
+      synchronize-fn kv-store history-length limit-per-owner "token8"
+      {"allowed-params" #{"P1" "P2"} "env" {"E1" "v0" "P1" "v1"} "cpus" 4 "mem" 1024}
+      {"cluster" "c1" "last-update-time" (- last-update-time-seed 3000) "owner" "owner3"})
+    (store-service-description-for-token
+      synchronize-fn kv-store history-length limit-per-owner "token9"
+      {"allowed-params" #{"P1" "P2"} "env" {"E1" "v0" "P1" "v1" "P2" "v2"} "cpus" 4 "mem" 1024}
+      {"cluster" "c1" "last-update-time" (- last-update-time-seed 3000) "owner" "owner3"})
     (let [request {:query-string "include=metadata" :request-method :get}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
@@ -2226,7 +2246,32 @@
                 "etag" (token->token-hash "token3")
                 "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
                 "owner" "owner2"
-                "token" "token3"}}
+                "token" "token3"}
+               {"deleted" false
+                "etag" (token->token-hash "token5")
+                "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "owner" "owner3"
+                "token" "token5"}
+               {"deleted" false
+                "etag" (token->token-hash "token6")
+                "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "owner" "owner3"
+                "token" "token6"}
+               {"deleted" false
+                "etag" (token->token-hash "token7")
+                "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "owner" "owner3"
+                "token" "token7"}
+               {"deleted" false
+                "etag" (token->token-hash "token8")
+                "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "owner" "owner3"
+                "token" "token8"}
+               {"deleted" false
+                "etag" (token->token-hash "token9")
+                "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "owner" "owner3"
+                "token" "token9"}}
              (set (json/read-str body)))))
     (let [request {:query-string "include=metadata&include=deleted" :request-method :get}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
@@ -2250,14 +2295,44 @@
                 "etag" (token->token-hash "token4")
                 "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
                 "owner" "owner2"
-                "token" "token4"}}
+                "token" "token4"}
+               {"deleted" false
+                "etag" (token->token-hash "token5")
+                "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "owner" "owner3"
+                "token" "token5"}
+               {"deleted" false
+                "etag" (token->token-hash "token6")
+                "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "owner" "owner3"
+                "token" "token6"}
+               {"deleted" false
+                "etag" (token->token-hash "token7")
+                "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "owner" "owner3"
+                "token" "token7"}
+               {"deleted" false
+                "etag" (token->token-hash "token8")
+                "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "owner" "owner3"
+                "token" "token8"}
+               {"deleted" false
+                "etag" (token->token-hash "token9")
+                "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "owner" "owner3"
+                "token" "token9"}}
              (set (json/read-str body)))))
     (let [request {:request-method :get}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
       (is (= #{{"owner" "owner1" "token" "token1"}
                {"owner" "owner1" "token" "token2"}
-               {"owner" "owner2" "token" "token3"}}
+               {"owner" "owner2" "token" "token3"}
+               {"owner" "owner3" "token" "token5"}
+               {"owner" "owner3" "token" "token6"}
+               {"owner" "owner3" "token" "token7"}
+               {"owner" "owner3" "token" "token8"}
+               {"owner" "owner3" "token" "token9"}}
              (set (json/read-str body)))))
     (let [entitlement-manager (reify authz/EntitlementManager
                                 (authorized? [_ subject action resource]
@@ -2268,7 +2343,12 @@
         (is (= http-200-ok status))
         (is (= #{{"owner" "owner1" "token" "token1"}
                  {"owner" "owner1" "token" "token2"}
-                 {"owner" "owner2" "token" "token3"}}
+                 {"owner" "owner2" "token" "token3"}
+                 {"owner" "owner3" "token" "token5"}
+                 {"owner" "owner3" "token" "token6"}
+                 {"owner" "owner3" "token" "token7"}
+                 {"owner" "owner3" "token" "token8"}
+                 {"owner" "owner3" "token" "token9"}}
                (set (json/read-str body)))))
       (let [request {:query-string "can-manage-as-user=owner1" :request-method :get}
             {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
@@ -2343,40 +2423,87 @@
     (let [request {:request-method :get :query-string "cpus=1"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
-      (is (= #{{"owner" "owner1", "token" "token1"}}
+      (is (= #{{"owner" "owner1" "token" "token1"}}
              (set (json/read-str body)))))
     (let [request {:request-method :get :query-string "mem=2048"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
-      (is (= #{{"owner" "owner1", "token" "token2"}
-               {"owner" "owner2", "token" "token3"}}
+      (is (= #{{"owner" "owner1" "token" "token2"}
+               {"owner" "owner2" "token" "token3"}
+               {"owner" "owner3" "token" "token5"}
+               {"owner" "owner3" "token" "token6"}}
              (set (json/read-str body)))))
     (let [request {:request-method :get :query-string "cluster=c1&mem=2048"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
-      (is (= #{{"owner" "owner1", "token" "token2"}}
+      (is (= #{{"owner" "owner1" "token" "token2"}
+               {"owner" "owner3" "token" "token5"}
+               {"owner" "owner3" "token" "token6"}}
              (set (json/read-str body)))))
     (let [request {:request-method :get :query-string "cluster=c2&mem=2048"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
-      (is (= #{{"owner" "owner2", "token" "token3"}}
+      (is (= #{{"owner" "owner2" "token" "token3"}}
              (set (json/read-str body)))))
     (let [request {:request-method :get :query-string "include=deleted&mem=2048"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
-      (is (= #{{"owner" "owner1", "token" "token2"}
-               {"owner" "owner2", "token" "token3"}
-               {"owner" "owner2", "token" "token4"}}
+      (is (= #{{"owner" "owner1" "token" "token2"}
+               {"owner" "owner2" "token" "token3"}
+               {"owner" "owner2" "token" "token4"}
+               {"owner" "owner3" "token" "token5"}
+               {"owner" "owner3" "token" "token6"}}
              (set (json/read-str body)))))
     (let [request {:request-method :get :query-string "idle-timeout-mins=0"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
-      (is (= #{{"owner" "owner1", "token" "token1"}}
+      (is (= #{{"owner" "owner1" "token" "token1"}
+               {"owner" "owner3" "token" "token6"}}
+             (set (json/read-str body)))))
+    (let [request {:request-method :get :query-string "idle-timeout-mins=0&include=deleted"}
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+      (is (= http-200-ok status))
+      (is (= #{{"owner" "owner1" "token" "token1"}
+               {"owner" "owner2" "token" "token4"}
+               {"owner" "owner3" "token" "token6"}}
              (set (json/read-str body)))))
     (let [request {:request-method :get :query-string "cluster=c1&idle-timeout-mins=0"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
-      (is (= #{{"owner" "owner1", "token" "token1"}}
+      (is (= #{{"owner" "owner1" "token" "token1"}
+               {"owner" "owner3" "token" "token6"}}
+             (set (json/read-str body)))))
+    (let [request {:request-method :get :query-string "run-as-requester=true"}
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+      (is (= http-200-ok status))
+      (is (= #{{"owner" "owner3" "token" "token5"}
+               {"owner" "owner3" "token" "token6"}}
+             (set (json/read-str body)))))
+    (let [request {:request-method :get :query-string "run-as-requester=false"}
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+      (is (= http-200-ok status))
+      (is (= #{{"owner" "owner1" "token" "token1"}
+               {"owner" "owner1" "token" "token2"}
+               {"owner" "owner2" "token" "token3"}
+               {"owner" "owner3" "token" "token7"}
+               {"owner" "owner3" "token" "token8"}
+               {"owner" "owner3" "token" "token9"}}
+             (set (json/read-str body)))))
+    (let [request {:request-method :get :query-string "requires-parameters=true"}
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+      (is (= http-200-ok status))
+      (is (= #{{"owner" "owner3" "token" "token7"}
+               {"owner" "owner3" "token" "token8"}}
+             (set (json/read-str body)))))
+    (let [request {:request-method :get :query-string "requires-parameters=false"}
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+      (is (= http-200-ok status))
+      (is (= #{{"owner" "owner1" "token" "token1"}
+               {"owner" "owner1" "token" "token2"}
+               {"owner" "owner2" "token" "token3"}
+               {"owner" "owner3" "token" "token5"}
+               {"owner" "owner3" "token" "token6"}
+               {"owner" "owner3" "token" "token9"}}
              (set (json/read-str body)))))
     (let [request {:request-method :get :query-string "cluster=c2&idle-timeout-mins=0"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
@@ -2385,7 +2512,7 @@
     (let [request {:request-method :get :query-string "idle-timeout-mins=5"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
-      (is (= #{{"owner" "owner2", "token" "token3"}}
+      (is (= #{{"owner" "owner2" "token" "token3"}}
              (set (json/read-str body)))))
     (let [request {:headers {"accept" "application/json"}
                    :request-method :get}


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for filtering tokens by run-as-requester and parameterized services

## Why are we making these changes?

We would like to be able to filter tokens by whether they are configured to run-as-requester or as parameterized services.


