### PR TITLE
adds support for relaxed and strict mode for OIDC auth via environment variable

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -259,6 +259,10 @@
                               :max-expiry-duration-ms 86400000
                               ;; (optional) url of the authorization server authorize endpoint:
                               :oidc-authorize-uri "http://127.0.0.1:8040/authorize"
+                              ;; (optional) one of :relaxed or :strict
+                              ;; in relaxed mode, the Waiter auth cookie after OIDC auth has an expiry time of 1 day
+                              ;; in strict mode, the Waiter auth cookie after OIDC auth has an expiry time provided in the JWT access token
+                              :oidc-default-mode :relaxed
                               ;; (optional) maximum number of OIDC challenge cookies in the request beyond which
                               ;; the OIDC auth flow will not be triggered on 401 responses.
                               ;; The default value is 20

--- a/waiter/src/waiter/auth/oidc.clj
+++ b/waiter/src/waiter/auth/oidc.clj
@@ -20,11 +20,9 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [digest]
-            [schema.core :as s]
             [waiter.auth.authentication :as auth]
             [waiter.auth.jwt :as jwt]
             [waiter.cookie-support :as cookie-support]
-            [waiter.schema :as schema]
             [waiter.status-codes :refer :all]
             [waiter.util.http-utils :as hu]
             [waiter.util.ring-utils :as ru]
@@ -338,7 +336,7 @@
          (boolean? allow-oidc-auth-services?)
          (integer? oidc-num-challenge-cookies-allowed-in-request)
          (not (str/blank? oidc-authorize-uri))
-         (nil? (s/check schema/valid-oidc-mode oidc-default-mode))
+         (contains? #{:relaxed :strict} oidc-default-mode)
          (not-empty password)]}
   (->OidcAuthenticator allow-oidc-auth-api? allow-oidc-auth-services? oidc-authorize-uri oidc-default-mode
                        jwt-auth-server jwt-validator oidc-num-challenge-cookies-allowed-in-request password))

--- a/waiter/src/waiter/auth/oidc.clj
+++ b/waiter/src/waiter/auth/oidc.clj
@@ -20,9 +20,11 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [digest]
+            [schema.core :as s]
             [waiter.auth.authentication :as auth]
             [waiter.auth.jwt :as jwt]
             [waiter.cookie-support :as cookie-support]
+            [waiter.schema :as schema]
             [waiter.status-codes :refer :all]
             [waiter.util.http-utils :as hu]
             [waiter.util.ring-utils :as ru]
@@ -78,16 +80,17 @@
       (throw (ex-info "Query parameter code is missing" bad-request-map)))
     (when (str/blank? state)
       (throw (ex-info "Query parameter state is missing" bad-request-map)))
-    (let [{:keys [identifier] :as state-map}
+    (let [{:keys [identifier oidc-mode redirect-uri] :as state-map}
           (try
             (parse-state-code state password)
             (catch Throwable throwable
               (throw (ex-info "Unable to parse state"
                               bad-request-map throwable))))]
       (when-not (and (map? state-map)
-                     (string? (get state-map :redirect-uri))
+                     (string? redirect-uri)
                      (string? identifier)
-                     (not (str/blank? identifier)))
+                     (not (str/blank? identifier))
+                     (contains? #{:relaxed :strict} oidc-mode))
         (throw (ex-info "The state query parameter is invalid" bad-request-map)))
       (let [oidc-challenge-cookie (str oidc-challenge-cookie-prefix identifier)
             challenge-cookie (some-> headers
@@ -146,9 +149,12 @@
                     _ (when (instance? Throwable result-map-or-throwable)
                         (throw result-map-or-throwable))
                     {:keys [expiry-time subject]} result-map-or-throwable
-                    _ (log/info "authenticated subject is" subject)
-                    auth-params-map (auth/build-auth-params-map :oidc subject {:jwt-access-token access-token})
-                    auth-cookie-age-in-seconds (- expiry-time (jwt/current-time-secs))]
+                    {:keys [oidc-mode]} state-map
+                    _ (log/info "authenticated subject is" subject "and oidc mode is" oidc-mode)
+                    ;; use token expiry time only in strict mode, else allow default value for cookie age to be chosen
+                    auth-cookie-age-in-seconds (when (= :strict oidc-mode)
+                                                 (- expiry-time (jwt/current-time-secs)))
+                    auth-params-map (auth/build-auth-params-map :oidc subject {:jwt-access-token access-token})]
                 (auth/handle-request-auth
                   (constantly
                     (let [{:keys [identifier redirect-uri]} state-map
@@ -172,7 +178,7 @@
 
 (defn trigger-authorize-redirect
   "Triggers a 302 temporary redirect response to the authorize endpoint."
-  [jwt-auth-server password {:keys [query-string request-method uri] :as request} response]
+  [jwt-auth-server oidc-mode password {:keys [query-string request-method uri] :as request} response]
   (let [request-host (utils/request->host request)
         request-scheme (utils/request->scheme request)
         make-redirect-uri (fn make-oidc-redirect-uri [transform-host]
@@ -182,6 +188,7 @@
       (let [code-verifier (create-code-verifier)
             cookie-identifier (create-code-identifier code-verifier)
             state-data {:identifier cookie-identifier
+                        :oidc-mode oidc-mode
                         :redirect-uri (make-redirect-uri identity)}
             state-code (create-state-code state-data password)
             authorize-uri (jwt/retrieve-authorize-url
@@ -206,29 +213,35 @@
 
 (defn make-oidc-auth-response-updater
   "Returns a response updater that rewrites 401 waiter responses to 302 redirects."
-  [jwt-auth-server password request]
+  [jwt-auth-server oidc-mode password request]
   (fn update-oidc-auth-response [{:keys [status] :as response}]
     (if (and (= status http-401-unauthorized)
              (utils/waiter-generated-response? response))
       ;; issue 302 redirect
-      (trigger-authorize-redirect jwt-auth-server password request response)
+      (trigger-authorize-redirect jwt-auth-server oidc-mode password request response)
       ;; non-401 response, avoid authentication challenge
       response)))
 
-(defn oidc-enabled-on-service?
-  "Returns true if OIDC auth is enabled for the service.
-   Result depends on whether OIDC auth is configured explicitly based on env variable or computed using allow-oidc-auth-services?"
-  [allow-oidc-auth-services? request]
+(defn retrieve-oidc-mode-on-service
+  "Returns the OIDC mode, one of :disabled :relaxed or :strict, if OIDC auth is enabled for the service.
+   Result depends on whether OIDC auth is configured explicitly based on env variable or
+   computed using allow-oidc-auth-services? and oidc-default-mode."
+  [allow-oidc-auth-services? oidc-default-mode request]
   ;; service requests will enable OIDC auth based on env variable or when absent, allow-oidc-auth-services?
   (let [use-oidc-auth-env (get-in request [:waiter-discovery :service-description-template "env" "USE_OIDC_AUTH"])]
-    (if (some? use-oidc-auth-env) (= "true" use-oidc-auth-env) allow-oidc-auth-services?)))
+    (if (some? use-oidc-auth-env)
+      (cond
+        (contains? #{"relaxed" "true"} use-oidc-auth-env) :relaxed
+        (= "strict" use-oidc-auth-env) :strict
+        :else :disabled)
+      (if allow-oidc-auth-services? oidc-default-mode :disabled))))
 
 (defn oidc-enabled-request-handler
   "Handler for the query that responds whether OIDC is enabled on the host.
    It returns a 200 response when OIDC authentication is enabled for the request host.
    It returns a 404 response when OIDC authentication is not enabled for request host.
    It returns a 501 response when OIDC authentication is not configured on Waiter."
-  [{:keys [allow-oidc-auth-api? allow-oidc-auth-services?] :as oidc-authenticator} waiter-hostnames request]
+  [{:keys [allow-oidc-auth-api? allow-oidc-auth-services? oidc-default-mode] :as oidc-authenticator} waiter-hostnames request]
   (if (nil? oidc-authenticator)
     (utils/exception->response
       (throw (ex-info "OIDC authentication disabled" {:status http-501-not-implemented}))
@@ -238,7 +251,7 @@
           waiter-host? (contains? waiter-hostnames client-id)
           enabled? (if waiter-host?
                      (true? allow-oidc-auth-api?)
-                     (oidc-enabled-on-service? allow-oidc-auth-services? request))
+                     (not= :disabled (retrieve-oidc-mode-on-service allow-oidc-auth-services? oidc-default-mode request)))
           response-status (if enabled? http-200-ok http-404-not-found)]
       (utils/clj->json-response
         {:client-id client-id
@@ -246,14 +259,14 @@
          :token? (not waiter-host?)}
         :status response-status))))
 
-(defn oidc-enabled-on-request?
+(defn request->oidc-mode
   "Returns true if OIDC auth is enabled for the request."
-  [allow-oidc-auth-api? allow-oidc-auth-services? {:keys [waiter-api-call?] :as request}]
-  (or
-    ;; delegate to oidc-enabled-on-service? for service requests
-    (and (not waiter-api-call?) (oidc-enabled-on-service? allow-oidc-auth-services? request))
+  [allow-oidc-auth-api? allow-oidc-auth-services? oidc-default-mode {:keys [waiter-api-call?] :as request}]
+  (if waiter-api-call?
     ;; waiter api requests will enable OIDC auth based on allow-oidc-auth-api?
-    (and waiter-api-call? allow-oidc-auth-api?)))
+    (if allow-oidc-auth-api? oidc-default-mode :disabled)
+    ;; delegate to oidc-enabled-on-service? for service requests
+    (retrieve-oidc-mode-on-service allow-oidc-auth-services? oidc-default-mode request)))
 
 ;; Accept-Redirect request header "yes" means the user-agent will follow redirects.
 ;; Accept-Redirect-Auth request header indicates which authorities the user-agent is willing to redirect to and authenticate at.
@@ -288,34 +301,36 @@
 (defn wrap-auth-handler
   "Wraps the request handler with a handler to trigger OIDC+PKCE authentication."
   [{:keys [allow-oidc-auth-api? allow-oidc-auth-services? jwt-auth-server oidc-authorize-uri
-           oidc-num-challenge-cookies-allowed-in-request password]}
+           oidc-default-mode oidc-num-challenge-cookies-allowed-in-request password]}
    request-handler]
   (let [oidc-authority (utils/uri-string->host oidc-authorize-uri)]
     (fn oidc-auth-handler [request]
-      (cond
-        (or (auth/request-authenticated? request)
-            (not (oidc-enabled-on-request? allow-oidc-auth-api? allow-oidc-auth-services? request))
-            ;; OIDC auth is no-op when request cannot be redirected
-            (not (supports-redirect? oidc-authority request))
-            ;; OIDC auth is avoided if client already has too many challenge cookies
-            (too-many-oidc-challenge-cookies? request oidc-num-challenge-cookies-allowed-in-request))
-        (request-handler request)
-
-        :else
-        (ru/update-response
+      (let [oidc-mode-delay (delay (request->oidc-mode allow-oidc-auth-api? allow-oidc-auth-services? oidc-default-mode request))]
+        (cond
+          (or (auth/request-authenticated? request)
+              (= :disabled @oidc-mode-delay)
+              ;; OIDC auth is no-op when request cannot be redirected
+              (not (supports-redirect? oidc-authority request))
+              ;; OIDC auth is avoided if client already has too many challenge cookies
+              (too-many-oidc-challenge-cookies? request oidc-num-challenge-cookies-allowed-in-request))
           (request-handler request)
-          (make-oidc-auth-response-updater jwt-auth-server password request))))))
 
-(defrecord OidcAuthenticator [allow-oidc-auth-api? allow-oidc-auth-services? oidc-authorize-uri
+          :else
+          (ru/update-response
+            (request-handler request)
+            (make-oidc-auth-response-updater jwt-auth-server @oidc-mode-delay password request)))))))
+
+(defrecord OidcAuthenticator [allow-oidc-auth-api? allow-oidc-auth-services? oidc-authorize-uri oidc-default-mode
                               jwt-auth-server jwt-validator oidc-num-challenge-cookies-allowed-in-request password])
 
 (defn create-oidc-authenticator
   "Factory function for creating OIDC authenticator middleware"
   [jwt-auth-server jwt-validator
-   {:keys [allow-oidc-auth-api? allow-oidc-auth-services? oidc-authorize-uri
+   {:keys [allow-oidc-auth-api? allow-oidc-auth-services? oidc-authorize-uri oidc-default-mode
            oidc-num-challenge-cookies-allowed-in-request password]
     :or {allow-oidc-auth-api? false
          allow-oidc-auth-services? false
+         oidc-default-mode :relaxed
          oidc-num-challenge-cookies-allowed-in-request 20}}]
   {:pre [(satisfies? jwt/AuthServer jwt-auth-server)
          (some? jwt-validator)
@@ -323,6 +338,7 @@
          (boolean? allow-oidc-auth-services?)
          (integer? oidc-num-challenge-cookies-allowed-in-request)
          (not (str/blank? oidc-authorize-uri))
+         (nil? (s/check schema/valid-oidc-mode oidc-default-mode))
          (not-empty password)]}
-  (->OidcAuthenticator allow-oidc-auth-api? allow-oidc-auth-services? oidc-authorize-uri
+  (->OidcAuthenticator allow-oidc-auth-api? allow-oidc-auth-services? oidc-authorize-uri oidc-default-mode
                        jwt-auth-server jwt-validator oidc-num-challenge-cookies-allowed-in-request password))

--- a/waiter/src/waiter/schema.clj
+++ b/waiter/src/waiter/schema.clj
@@ -124,6 +124,11 @@
     #(instance? Pattern %) regex-pattern
     :else (s/constrained [(s/either non-empty-string regex-pattern)] not-empty)))
 
+(def valid-oidc-mode
+  "Validator for the OIDC mode.
+   Valid values are :disabled, :relaxed or :strict."
+  (s/pred #(contains? #{:relaxed :strict} %) 'invalid-oidc-mode))
+
 (def valid-jwt-authenticator-config
   "Validator for the Zookeeper connection configuration. We allow either
   a non-empty string (representing a connection string), or the keyword
@@ -139,6 +144,7 @@
      (s/required-key :jwks-url) non-empty-string
      (s/optional-key :max-expiry-duration-ms) positive-int
      (s/optional-key :oidc-authorize-uri) non-empty-string
+     (s/optional-key :oidc-default-mode) valid-oidc-mode
      (s/optional-key :oidc-num-challenge-cookies-allowed-in-request) positive-int
      (s/optional-key :oidc-token-uri) non-empty-string
      (s/required-key :subject-key) s/Keyword


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for relaxed and strict mode for OIDC auth env

## Why are we making these changes?

The strict mode instructs Waiter to use the expiry time from the access token during OIDC authentication for the x-waiter-auth cookie. The relaxed mode instructs Waiter to use the default 24 hour expiry on the x-waiter-auth cookie. The relaxed mode allows clients to easily migrate between authentication schemes since the expiry duration is similar.

