### PR TITLE
makes the fileserver configurable per service

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -486,9 +486,6 @@
                                                            :default-container-image "twosigma/waiter-test-apps:latest"
                                                            ;; The default namespace to use for Kubernetes objects created by Waiter
                                                            :default-namespace "waiter"
-                                                           ;; Function that determines if the fileserver container should be enabled for a service.
-                                                           ;; The function takes the service description as input.
-                                                           :fileserver-container-enabled? waiter.some.package/fileserver-enabled?
                                                            ;; Map of image aliases. One of these aliases can be specified in the `image` field and the
                                                            ;; resolved image will be used.
                                                            :image-aliases {"alias/sample-alias" "real/image"}}
@@ -526,6 +523,7 @@
                                  :fileserver {:cmd ["/bin/fileserver-start"]
                                               :image "twosigma/waiter-fileserver:latest"
                                               :port 9090
+                                              :predicate-fn waiter.scheduler.kubernetes/fileserver-container-enabled?
                                               :resources {:cpu 0.1 :mem 128}
                                               :scheme "http"}
 

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -486,6 +486,9 @@
                                                            :default-container-image "twosigma/waiter-test-apps:latest"
                                                            ;; The default namespace to use for Kubernetes objects created by Waiter
                                                            :default-namespace "waiter"
+                                                           ;; Function that determines if the fileserver container should be enabled for a service.
+                                                           ;; The function takes the service description as input.
+                                                           :fileserver-container-enabled? waiter.some.package/fileserver-enabled?
                                                            ;; Map of image aliases. One of these aliases can be specified in the `image` field and the
                                                            ;; resolved image will be used.
                                                            :image-aliases {"alias/sample-alias" "real/image"}}

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -48,8 +48,6 @@
 
 (def dummy-scheduler-default-namespace "waiter")
 
-(defn fileserver-container-enabled? [_ _ _ _] true)
-
 (defn- make-dummy-scheduler
   ([service-ids] (make-dummy-scheduler service-ids {}))
   ([service-ids args]
@@ -1217,7 +1215,7 @@
 
         (testing "should work with valid fileserver predicate-fn?"
           (let [scheduler (kubernetes-scheduler (assoc-in base-config [:fileserver :predicate-fn]
-                                                          'waiter.scheduler.kubernetes-test/fileserver-container-enabled?))]
+                                                          'waiter.scheduler.kubernetes/fileserver-container-enabled?))]
             (is (instance? KubernetesScheduler scheduler))))
 
         (testing "should work with PodDisruptionBudget api version"

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -48,6 +48,8 @@
 
 (def dummy-scheduler-default-namespace "waiter")
 
+(defn fileserver-fileserver-container-enabled? [_] true)
+
 (defn- make-dummy-scheduler
   ([service-ids] (make-dummy-scheduler service-ids {}))
   ([service-ids args]
@@ -60,6 +62,7 @@
       :container-running-grace-secs 120
       :fileserver {:port 9090
                    :scheme "http"}
+      :fileserver-container-enabled?-fn fileserver-fileserver-container-enabled?
       :log-bucket-sync-secs 60
       :log-bucket-url "http://waiter.example.com:8888/waiter-service-logs"
       :max-patch-retries 5
@@ -123,6 +126,31 @@
        (clojure.pprint/pprint
          (clojure.data/diff expected# actual#)))
      (is (= expected# actual#))))
+
+(deftest replicaset-spec-fileserver-container-and-metadata
+  (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")
+                config/retrieve-waiter-principal (constantly "waiter@test.com")]
+    (doseq [fileserver-enabled [true false]]
+      (let [{:strs [run-as-user] :as service-description} (assoc dummy-service-description "health-check-port-index" 2 "ports" 3)
+            test-service-id "waiter-testservice123456789"
+            scheduler (make-dummy-scheduler
+                        [test-service-id]
+                        {:fileserver-container-enabled?-fn (constantly fileserver-enabled)
+                         :service-id->service-description-fn (constantly service-description)})
+            replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler test-service-id service-description)]
+        (is (= {:waiter/service-id test-service-id}
+               (get-in replicaset-spec [:metadata :annotations])))
+        (is (= {:app test-service-id
+                :waiter/cluster dummy-scheduler-default-namespace
+                :waiter/fileserver (if fileserver-enabled "enabled" "disabled")
+                :waiter/service-hash test-service-id
+                :waiter/user run-as-user}
+               (get-in replicaset-spec [:metadata :labels])))
+        (let [fileserver-containers (filter #(= "waiter-fileserver" (:name %))
+                                           (get-in replicaset-spec [:spec :template :spec :containers]))]
+          (if fileserver-enabled
+            (is (= 1 (count fileserver-containers)))
+            (is (empty? fileserver-containers))))))))
 
 (deftest replicaset-spec-health-check-port-index
   (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")
@@ -1163,6 +1191,10 @@
             (is (thrown? Throwable (kubernetes-scheduler (assoc-in base-config [:replicaset-spec-builder :factory-fn] "not a symbol"))))
             (is (thrown? Throwable (kubernetes-scheduler (assoc-in base-config [:replicaset-spec-builder :factory-fn] :not-a-symbol))))
             (is (thrown? Throwable (kubernetes-scheduler (assoc-in base-config [:replicaset-spec-builder :factory-fn] 'not.a.namespace/not-a-fn)))))
+          (testing "bad replicaset-spec-builder fileserver-container-enabled?"
+            (is (thrown? Throwable (kubernetes-scheduler (assoc-in base-config [:replicaset-spec-builder :fileserver-container-enabled?] false))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc-in base-config [:replicaset-spec-builder :fileserver-container-enabled?]
+                                                                   'waiter.scheduler.kubernetes-test/does-not-exist?)))))
           (testing "bad base port number"
             (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-base-port -1))))
             (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-base-port "8080"))))
@@ -1180,6 +1212,11 @@
 
         (testing "should work with valid configuration"
           (is (instance? KubernetesScheduler (kubernetes-scheduler base-config))))
+
+        (testing "should work with valid fileserver-container-enabled?"
+          (let [scheduler (kubernetes-scheduler (assoc-in base-config [:replicaset-spec-builder :fileserver-container-enabled?]
+                                                          'waiter.scheduler.kubernetes-test/fileserver-fileserver-container-enabled?))]
+            (is (instance? KubernetesScheduler scheduler))))
 
         (testing "should work with PodDisruptionBudget api version"
           (let [scheduler (kubernetes-scheduler (assoc base-config :pdb-api-version "/policy.pdb-v1"))]


### PR DESCRIPTION
## Changes proposed in this PR

- makes the fileserver configurable per service

## Why are we making these changes?

We wish to make the configurable per service. For example, this can be useful while trying to support limited access to backend instance logs.


