### PR TITLE
add --admin as option

### DIFF
--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -66,22 +66,22 @@ def cli(args, waiter_url=None, flags=None, stdin=None, env=None, wait_for_exit=T
     return cp
 
 
-def create_or_update(subcommand, waiter_url=None, token_name=None, flags=None, create_flags=None, stdin=None):
+def create_or_update(subcommand, waiter_url=None, token_name=None, flags=None, create_flags=None, stdin=None, env=None):
     """Creates or updates a token via the CLI"""
     args = f"{subcommand} {token_name or ''} {create_flags or ''}"
-    cp = cli(args, waiter_url, flags, stdin)
+    cp = cli(args, waiter_url, flags, stdin, env=env)
     return cp
 
 
-def create(waiter_url=None, token_name=None, flags=None, create_flags=None, stdin=None):
+def create(waiter_url=None, token_name=None, flags=None, create_flags=None, stdin=None, env=None):
     """Creates a token via the CLI"""
-    cp = create_or_update('create', waiter_url, token_name, flags, create_flags, stdin)
+    cp = create_or_update('create', waiter_url, token_name, flags, create_flags, stdin, env=env)
     return cp
 
 
-def update(waiter_url=None, token_name=None, flags=None, update_flags=None, stdin=None):
+def update(waiter_url=None, token_name=None, flags=None, update_flags=None, stdin=None, env=None):
     """Updates a token via the CLI"""
-    cp = create_or_update('update', waiter_url, token_name, flags, update_flags, stdin)
+    cp = create_or_update('update', waiter_url, token_name, flags, update_flags, stdin, env=env)
     return cp
 
 

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1288,6 +1288,7 @@ class WaiterCliTest(util.WaiterTest):
         try:
             token_data = util.load_token(self.waiter_url, token_name)
             self.assertIn('update-mode=admin', cli.stderr(cp))
+            self.assertIn(f'Attempting to {action} token in ADMIN mode', cli.stdout(cp))
             self.assertEqual(cpus, token_data['cpus'])
             self.assertEqual(run_as_user, token_data['run-as-user'])
         finally:

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1274,17 +1274,22 @@ class WaiterCliTest(util.WaiterTest):
             util.delete_token(self.waiter_url, token_name_2, kill_services=True)
 
     def __test_create_update_token_admin_mode(self, action):
+        cpus = 0.1
+        run_as_user = 'FAKE_USERNAME'
         token_name = self.token_name()
         temp_env = os.environ.copy()
         temp_env["WAITER_ADMIN"] = 'true'
-        action_flags = f'--cpus 0.1 --admin --run-as-user FAKE_USERNAME'
+        action_flags = f'--cpus {cpus} --admin --run-as-user {run_as_user}'
         if action == 'create':
             cp = cli.create(self.waiter_url, token_name, flags="-v", create_flags=action_flags, env=temp_env)
         elif action == 'update':
             cp = cli.update(self.waiter_url, token_name, flags="-v", update_flags=action_flags, env=temp_env)
         self.assertEqual(0, cp.returncode, cp.stderr)
         try:
+            token_data = util.load_token(self.waiter_url, token_name)
             self.assertIn('update-mode=admin', cli.stderr(cp))
+            self.assertEqual(cpus, token_data['cpus'])
+            self.assertEqual(run_as_user, token_data['run-as-user'])
         finally:
             util.delete_token(self.waiter_url, token_name)
 

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1277,10 +1277,11 @@ class WaiterCliTest(util.WaiterTest):
         token_name = self.token_name()
         temp_env = os.environ.copy()
         temp_env["WAITER_ADMIN"] = 'true'
+        action_flags = f'--cpus 0.1 --admin --run-as-user FAKE_USERNAME'
         if action == 'create':
-            cp = cli.create(self.waiter_url, token_name, flags="-v", create_flags='--cpus 0.1 --admin', env=temp_env)
+            cp = cli.create(self.waiter_url, token_name, flags="-v", create_flags=action_flags, env=temp_env)
         elif action == 'update':
-            cp = cli.update(self.waiter_url, token_name, flags="-v", update_flags='--cpus 0.1 --admin', env=temp_env)
+            cp = cli.update(self.waiter_url, token_name, flags="-v", update_flags=action_flags, env=temp_env)
         self.assertEqual(0, cp.returncode, cp.stderr)
         try:
             self.assertIn('update-mode=admin', cli.stderr(cp))

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1272,3 +1272,23 @@ class WaiterCliTest(util.WaiterTest):
         finally:
             util.delete_token(self.waiter_url, token_name_1, kill_services=True)
             util.delete_token(self.waiter_url, token_name_2, kill_services=True)
+
+    def __test_create_update_token_admin_mode(self, action):
+        token_name = self.token_name()
+        temp_env = os.environ.copy()
+        temp_env["WAITER_ADMIN"] = 'true'
+        if action == 'create':
+            cp = cli.create(self.waiter_url, token_name, flags="-v", create_flags='--cpus 0.1 --admin', env=temp_env)
+        elif action == 'update':
+            cp = cli.update(self.waiter_url, token_name, flags="-v", update_flags='--cpus 0.1 --admin', env=temp_env)
+        self.assertEqual(0, cp.returncode, cp.stderr)
+        try:
+            self.assertIn('update-mode=admin', cli.stderr(cp))
+        finally:
+            util.delete_token(self.waiter_url, token_name)
+
+    def test_create_token_admin_mode(self):
+        self.__test_create_update_token_admin_mode('create')
+
+    def test_update_token_admin_mode(self):
+        self.__test_create_update_token_admin_mode('update')

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -52,9 +52,9 @@ def create_or_update(cluster, token_name, token_fields, action):
     try:
         print_info(f'Attempting to {action} token on {terminal.bold(cluster_name)}...')
         params = {'token': token_name}
-        if token_fields.get('update-mode') is not None:
-            params['update-mode'] = token_fields['update-mode']
-            del token_fields['update-mode']
+        if token_fields.get('admin'):
+            params['update-mode'] = 'admin'
+        del token_fields['admin']
         json_body = existing_token_data if existing_token_data and action.should_patch() else {}
         json_body.update(token_fields)
         headers = {'If-Match': existing_token_etag or ''}
@@ -139,7 +139,7 @@ def add_arguments(parser):
 
 def add_token_flags(parser):
     """Adds the "core" token-field flags to the given parser"""
-    parser.add_argument('-A', '--admin', help='run command in admin mode', action='store_const', dest='update-mode', const='admin')
+    parser.add_argument('-A', '--admin', help='run command in admin mode', action='store_true')
     parser.add_argument('--name', '-n', help='name of service')
     parser.add_argument('--owner', '-o', help='owner of service')
     parser.add_argument('--version', '-v', help='version of service')

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -44,7 +44,7 @@ def post_failed_message(cluster_name, reason):
     return f'Token post {terminal.failed("failed")} on {cluster_name}:\n{terminal.reason(reason)}'
 
 
-def create_or_update(cluster, token_name, token_fields, action, update_mode_admin=False):
+def create_or_update(cluster, token_name, token_fields, admin_mode, action):
     """Creates (or updates) the given token on the given cluster"""
     cluster_name = cluster['name']
     cluster_url = cluster['url']
@@ -53,7 +53,7 @@ def create_or_update(cluster, token_name, token_fields, action, update_mode_admi
     try:
         print_info(f'Attempting to {action} token on {terminal.bold(cluster_name)}...')
         params = {'token': token_name}
-        if update_mode_admin:
+        if admin_mode:
             params['update-mode'] = 'admin'
         json_body = existing_token_data if existing_token_data and action.should_patch() else {}
         json_body.update(token_fields)
@@ -125,7 +125,7 @@ def create_or_update_token(clusters, args, _, action):
     else:
         cluster = clusters[0]
 
-    return create_or_update(cluster, token_name, token_fields, action, update_mode_admin=admin_mode)
+    return create_or_update(cluster, token_name, token_fields, admin_mode, action)
 
 
 def add_arguments(parser):

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -51,7 +51,7 @@ def create_or_update(cluster, token_name, token_fields, admin_mode, action):
 
     existing_token_data, existing_token_etag = get_token(cluster, token_name)
     try:
-        print_info(f'Attempting to {action} token on {terminal.bold(cluster_name)}...')
+        print_info(f'Attempting to {action} token{(" in ADMIN mode" if admin_mode else "")} on {terminal.bold(cluster_name)}...')
         params = {'token': token_name}
         if admin_mode:
             params['update-mode'] = 'admin'

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import sys
+import os
 from enum import Enum
 
 import requests
@@ -129,9 +130,11 @@ def create_or_update_token(clusters, args, _, action):
 
 def add_arguments(parser):
     """Adds arguments to the given parser"""
+    is_admin_enabled = str2bool(os.getenv('WAITER_ADMIN', default=FALSE_STRINGS[0]))
     add_token_flags(parser)
     parser.add_argument('token', nargs='?')
-    parser.add_argument('--admin', '-a', help='run command in admin mode', action='store_true')
+    if is_admin_enabled:
+        parser.add_argument('--admin', '-a', help='run command in admin mode', action='store_true')
     format_group = parser.add_mutually_exclusive_group()
     format_group.add_argument('--json', help='provide the data in a JSON file', dest='json')
     format_group.add_argument('--yaml', help='provide the data in a YAML file', dest='yaml')


### PR DESCRIPTION
## Changes proposed in this PR
- add "--admin" flag in CLI for whenever attempting to create or update token

## Why are we making these changes?
- this allows admins to do token create and update operations as admins through CLI

