### PR TITLE
causes reset frame errors to be treated as client errors

### DIFF
--- a/waiter/integration/waiter/grpc_test.clj
+++ b/waiter/integration/waiter/grpc_test.clj
@@ -304,6 +304,16 @@
               (assert-grpc-unauthenticated-status status assertion-message)
               (is (nil? reply) assertion-message))))
 
+        (testing "http/1.1 call to service"
+          (log/info "making http/1.1 call to service")
+          (let [correlation-id (rand-name)
+                request-headers (assoc request-headers "x-cid" correlation-id)
+                response (make-request waiter-url "/health"
+                                       :body "payload-for-health-check!"
+                              :headers request-headers
+                              :method :get)]
+            (assert-response-status response #{http-400-bad-request http-415-unsupported-media-type})))
+
         (testing "small request and reply"
           (log/info "starting small request and reply test")
           (let [correlation-id (rand-name)

--- a/waiter/src/waiter/status_codes.clj
+++ b/waiter/src/waiter/status_codes.clj
@@ -35,6 +35,7 @@
 (def ^:const http-405-method-not-allowed HttpStatus/METHOD_NOT_ALLOWED_405)
 (def ^:const http-409-conflict HttpStatus/CONFLICT_409)
 (def ^:const http-410-gone HttpStatus/GONE_410)
+(def ^:const http-415-unsupported-media-type HttpStatus/UNSUPPORTED_MEDIA_TYPE_415)
 (def ^:const http-423-locked HttpStatus/LOCKED_423)
 (def ^:const http-429-too-many-requests HttpStatus/TOO_MANY_REQUESTS_429)
 (def ^:const http-500-internal-server-error HttpStatus/INTERNAL_SERVER_ERROR_500)


### PR DESCRIPTION
## Changes proposed in this PR

- causes reset frame errors to be treated as client errors

## Why are we making these changes?

Sending requests that trigger reset frames from the server indicates a client error. E.g. sending HTTP requests to a gRPC backend if a protocol error and manifests as a reset frame in the response. This should not be treated as a 5XX response, instead it should generate a 4XX response.

### Sample logs confirming treating the exception as a client error:

```
2020-09-03 16:21:28,363 INFO  waiter.process-request [async-dispatch-13] - [CID=wgttguc185698849457363] exception occurred while streaming response for w9091-wgttguc185694238683538-7e5b0629b1fdebfe2c993dbc3dcae08f
clojure.lang.ExceptionInfo: error occurred after streaming 0 bytes in response {}
        at waiter.process_request$stream_http_response$fn__37396$state_machine__11550__auto____37457$fn__37463.invoke(process_request.clj:485)
        at waiter.process_request$stream_http_response$fn__37396$state_machine__11550__auto____37457.invoke(process_request.clj:485)
        ...
Caused by: java.io.IOException: internal_error
        at org.eclipse.jetty.http2.client.http.HttpReceiverOverHTTP2.onReset(HttpReceiverOverHTTP2.java:185)
        at org.eclipse.jetty.http2.api.Stream$Listener.onReset(Stream.java:177)
        ...
2020-09-03 16:21:28,364 INFO  waiter.process-request [async-dispatch-13] - [CID=wgttguc185698849457363] java.io.IOException internal_error identified as :client-error
2020-09-03 16:21:28,364 INFO  waiter.process-request [async-dispatch-13] - [CID=wgttguc185698849457363] clojure.lang.ExceptionInfo error occurred after streaming 0 bytes in response identified as :client-error
2020-09-03 16:21:28,364 INFO  waiter.process-request [async-dispatch-13] - [CID=wgttguc185698849457363] sending poison pill to response channel
2020-09-03 16:21:28,364 INFO  waiter.process-request [async-dispatch-13] - [CID=wgttguc185698849457363] done processing request :client-error
```

