### PR TITLE
Fix docker image for courier on jdk11

### DIFF
--- a/containers/test-apps/Dockerfile
+++ b/containers/test-apps/Dockerfile
@@ -1,9 +1,9 @@
-FROM twosigma/mesos-agent:1.0.0-1.0.1604
+FROM openjdk:11-slim
 
 # we need nginx for our http/2 tests
 # gettext-base is needed for envsubst in the nginx server
 # python is needed to launch kitchen
-RUN apt-get update && apt-get install -y gettext-base nginx python3
+RUN apt-get update && apt-get install -y curl gettext-base nginx python3
 
 COPY courier/bin/run-courier-server.sh /opt/courier/bin/run-courier-server.sh
 COPY courier/data/courier-uberjar.jar /opt/courier/data/courier-uberjar.jar


### PR DESCRIPTION
## Changes proposed in this PR

Use a jdk11 image as the base for our test-apps image.

## Why are we making these changes?

Our Courier test app needs jdk11, and the minimesos-agent image we were using doesn't have it.