### PR TITLE
adds support for skipping token syncing on specific clusters

### DIFF
--- a/token-syncer/README.md
+++ b/token-syncer/README.md
@@ -54,6 +54,12 @@ Outline of steps performed by the syncer:
     1. Update all clusters with stale tokens to the latest token.
     1. Hard-deletes tokens on all clusters once all clusters agree that a token has been soft-deleted.
 
+## Token sync exclusion
+
+Tokens may be manually excluded from synchronization across clusters.
+The exclusion is achieved via a specific metadata extry in the token: waiter-token-sync-cluster=regex-string
+where the regex-string includes a regex for the cluster urls that the token can be synced to.
+
 # Build Uberjar
 
 ```bash

--- a/token-syncer/src/token_syncer/commands/syncer.clj
+++ b/token-syncer/src/token_syncer/commands/syncer.clj
@@ -84,7 +84,11 @@
             (try
               (let [{:keys [description error status] :as token-data} (get cluster-url->token-data cluster-url)
                     {latest-root "root" latest-update-user "last-update-user"} latest-token-description
-                    {cluster-root "root" cluster-update-user "last-update-user"} description]
+                    {cluster-root "root" cluster-update-user "last-update-user"} description
+                    include-regex (-> latest-token-description
+                                    (get-in ["metadata" "waiter-token-sync-cluster"])
+                                    (or ".*")
+                                    (re-pattern))]
                 (cond
                   error
                   {:code :error/token-read
@@ -101,6 +105,11 @@
                   (and latest-root
                        (= latest-token-description description))
                   {:code :success/token-match}
+
+                  ;; target cluster skipped via metadata
+                  (nil? (re-matches include-regex cluster-url))
+                  {:code :success/skip-token-sync
+                   :details {:message "skipping token as cluster excluded from sync by metadata"}}
 
                   ;; deleted on both clusters, irrespective of remaining values
                   (and (get latest-token-description "deleted")


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for skipping token syncing on specific clusters

## Why are we making these changes?

Allows service owners to configure which clusters they want to include for token syncing. By default, a token can be synced on any cluster.


