### PR TITLE
uses common code for creation of x-waiter-auth cookie value

### DIFF
--- a/waiter/test/waiter/websocket_test.clj
+++ b/waiter/test/waiter/websocket_test.clj
@@ -171,7 +171,7 @@
           decoded-auth-value (cs/decode-cookie (URLDecoder/decode auth-cookie-value) password)]
       (is (= 1 (count cookie-list)))
       (is auth-cookie-value)
-      (is (= 2 (count decoded-auth-value)))
+      (is (auth/decoded-auth-valid? decoded-auth-value))
       (is (= (str router-id "@waiter-peer-router") (first decoded-auth-value))))))
 
 (deftest test-request-handler


### PR DESCRIPTION
## Changes proposed in this PR

- uses common code for creation of x-waiter-auth cookie value

## Why are we making these changes?

Inter-router metrics syncing is currently broken due to authentication failures for websocket requests.


