### PR TITLE
Revert "adds support for skipping token syncing on specific clusters"

### DIFF
--- a/token-syncer/README.md
+++ b/token-syncer/README.md
@@ -54,12 +54,6 @@ Outline of steps performed by the syncer:
     1. Update all clusters with stale tokens to the latest token.
     1. Hard-deletes tokens on all clusters once all clusters agree that a token has been soft-deleted.
 
-## Token sync exclusion
-
-Tokens may be manually excluded from synchronization across clusters.
-The exclusion is achieved via a specific metadata extry in the token: waiter-token-sync-cluster=regex-string
-where the regex-string includes a regex for the cluster urls that the token can be synced to.
-
 # Build Uberjar
 
 ```bash

--- a/token-syncer/src/token_syncer/commands/syncer.clj
+++ b/token-syncer/src/token_syncer/commands/syncer.clj
@@ -84,11 +84,7 @@
             (try
               (let [{:keys [description error status] :as token-data} (get cluster-url->token-data cluster-url)
                     {latest-root "root" latest-update-user "last-update-user"} latest-token-description
-                    {cluster-root "root" cluster-update-user "last-update-user"} description
-                    include-regex (-> latest-token-description
-                                    (get-in ["metadata" "waiter-token-sync-cluster"])
-                                    (or ".*")
-                                    (re-pattern))]
+                    {cluster-root "root" cluster-update-user "last-update-user"} description]
                 (cond
                   error
                   {:code :error/token-read
@@ -105,11 +101,6 @@
                   (and latest-root
                        (= latest-token-description description))
                   {:code :success/token-match}
-
-                  ;; target cluster skipped via metadata
-                  (nil? (re-matches include-regex cluster-url))
-                  {:code :success/skip-token-sync
-                   :details {:message "skipping token as cluster excluded from sync by metadata"}}
 
                   ;; deleted on both clusters, irrespective of remaining values
                   (and (get latest-token-description "deleted")

--- a/token-syncer/test/token_syncer/commands/syncer_test.clj
+++ b/token-syncer/test/token_syncer/commands/syncer_test.clj
@@ -18,7 +18,6 @@
             [clojure.string :as str]
             [clojure.test :refer :all]
             [clojure.tools.cli :as tools-cli]
-            [clojure.tools.logging :as log]
             [clojure.walk :as walk]
             [plumbing.core :as pc]
             [token-syncer.cli :as cli]
@@ -685,7 +684,7 @@
                                               :description token-desc-4
                                               :token-etag (str (get token-desc-4 "last-update-time"))}
                                    "token-5" {:cluster-url cluster-1
-                                              :description (assoc token-desc-4 "cpus" 1 "root" cluster-2)
+                                              :description (assoc token-desc-4 "cpus" 1 "root" "c2")
                                               :token-etag (str (get token-desc-4 "last-update-time"))}
                                    "token-6" {:cluster-url cluster-1
                                               :description (assoc token-desc-1 "cpus" 6 "root" cluster-1)
@@ -811,82 +810,3 @@
         (is (= {:exit-code 1
                 :message "test-command: exiting with code 1"}
                (cli/process-command test-command-config context args)))))))
-
-(deftest test-sync-token-on-clusters
-  (let [cluster-1 "www.cluster-1.com"
-        cluster-2 "www.cluster-2.com"
-        cluster-3 "www.cluster-3.com"
-        cluster-urls [cluster-1 cluster-2 cluster-3]
-        test-token "test-token"
-        current-time-ms (System/currentTimeMillis)
-        previous-time-ms (- current-time-ms 10101010)]
-    (doseq [{:keys [base-description expected-result test-name]}
-            [{:base-description {"cpus" 1
-                                  "last-update-time" current-time-ms
-                                  "name" "foo-bar"}
-              :expected-result {cluster-1 {:code :success/token-match}
-                                cluster-2 {:code :success/sync-update
-                                           :details {:status 200 :etag current-time-ms}}
-                                cluster-3 {:code :success/sync-update
-                                           :details {:status 200 :etag current-time-ms}}}
-              :test-name "sync across tokens"}
-             {:base-description {"cpus" 1
-                                 "last-update-time" current-time-ms
-                                 "metadata" {"waiter-token-sync-cluster" ".*cluster-[123].*"}
-                                 "name" "foo-bar"}
-              :expected-result {cluster-1 {:code :success/token-match}
-                                cluster-2 {:code :success/sync-update
-                                           :details {:status 200 :etag current-time-ms}}
-                                cluster-3 {:code :success/sync-update
-                                           :details {:status 200 :etag current-time-ms}}}
-              :test-name "skip sync configured but no cluster skipped"}
-             {:base-description {"cpus" 1
-                                 "last-update-time" current-time-ms
-                                 "metadata" {"waiter-token-sync-cluster" ".*cluster-[12].*"}
-                                 "name" "foo-bar"}
-              :expected-result {cluster-1 {:code :success/token-match}
-                                cluster-2 {:code :success/sync-update
-                                           :details {:status 200 :etag current-time-ms}}
-                                cluster-3 {:code :success/skip-token-sync
-                                           :details {:message "skipping token as cluster excluded from sync by metadata"}}}
-              :test-name "skip sync on specific cluster"}
-             {:base-description {"cpus" 1
-                                 "last-update-time" current-time-ms
-                                 "metadata" {"waiter-token-sync-cluster" ".*foo.*"}
-                                 "name" "foo-bar"}
-              :expected-result {cluster-1 {:code :success/token-match}
-                                cluster-2 {:code :success/skip-token-sync
-                                           :details {:message "skipping token as cluster excluded from sync by metadata"}}
-                                cluster-3 {:code :success/skip-token-sync
-                                           :details {:message "skipping token as cluster excluded from sync by metadata"}}}
-              :test-name "skip sync on all clusters"}]]
-      (testing test-name
-        (log/info "testing" test-name)
-        (let [latest-token-description (assoc base-description
-                                         "root" cluster-1)
-              cluster-url->token-data {cluster-1 {:description latest-token-description
-                                                  :status 200
-                                                  :token-etag current-time-ms}
-                                       cluster-2 {:description (-> base-description
-                                                                 (assoc "cpus" 2
-                                                                     "last-update-time" previous-time-ms
-                                                                     "root" cluster-2)
-                                                                 (dissoc "metadata"))
-                                                  :status 200
-                                                  :token-etag previous-time-ms}
-                                       cluster-3 {:description (-> base-description
-                                                                 (assoc "cpus" 3
-                                                                        "last-update-time" previous-time-ms
-                                                                        "root" cluster-3)
-                                                                 (dissoc "metadata"))
-                                                  :status 200
-                                                  :token-etag previous-time-ms}}
-              waiter-api {:store-token (fn [cluster-url in-token in-etag in-token-description]
-                                         (is (= test-token in-token))
-                                         (is (= latest-token-description in-token-description))
-                                         (is (= previous-time-ms in-etag))
-                                         {:body cluster-url
-                                          :headers {"etag" (get in-token-description "last-update-time")}
-                                          :status 200})}
-              actual-result (sync-token-on-clusters waiter-api cluster-urls test-token latest-token-description cluster-url->token-data)]
-          (is (= expected-result actual-result)))))))


### PR DESCRIPTION
Reverts twosigma/waiter#1200

We decided to solve this problem a different way.