### PR TITLE
CLI kill waits for routers to agree with timeout query parameter

### DIFF
--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -622,7 +622,7 @@ class WaiterCliTest(util.WaiterTest):
             self.assertIn(service_id, cli.stdout(cp))
             self.assertIn('no-wait enabled', cli.stdout(cp))
             self.assertIn('Successfully killed', cli.stdout(cp))
-            self.assertIn('but routers may not be updated yet!', cli.stdout(cp))
+            self.assertIn('Did not wait for routers to update.', cli.stdout(cp))
             self.assertIn('timeout=0', cli.stderr(cp))
             util.wait_until_no_services_for_token(self.waiter_url, token_name)
         finally:

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -622,11 +622,11 @@ class WaiterCliTest(util.WaiterTest):
             self.assertIn(service_id, cli.stdout(cp))
             self.assertIn('no-wait enabled', cli.stdout(cp))
             self.assertIn('Successfully killed', cli.stdout(cp))
+            self.assertIn('but routers may not be updated yet!', cli.stdout(cp))
             self.assertIn('timeout=0', cli.stderr(cp))
             util.wait_until_no_services_for_token(self.waiter_url, token_name)
         finally:
             util.delete_token(self.waiter_url, token_name, kill_services=True)
-
 
     def test_kill_multiple_services(self):
         token_name = self.token_name()

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -613,38 +613,23 @@ class WaiterCliTest(util.WaiterTest):
 
     def test_kill_timeout(self):
         token_name = self.token_name()
-        timeout = 10
-        util.post_token(self.waiter_url, token_name, util.minimal_service_description())
-        try:
-            service_id = util.ping_token(self.waiter_url, token_name)
-            self.assertEqual(1, len(util.services_for_token(self.waiter_url, token_name)))
-            cp = cli.kill(self.waiter_url, token_name, flags='-v', kill_flags=f'--timeout {timeout}')
-            self.assertEqual(0, cp.returncode, cp.stderr)
-            self.assertIn('Killing service', cli.stdout(cp))
-            self.assertIn(service_id, cli.stdout(cp))
-            self.assertIn(f"'timeout': {timeout * 1000}", cli.stderr(cp))
-            self.assertIn('Successfully killed', cli.stdout(cp))
-            util.wait_until_no_services_for_token(self.waiter_url, token_name)
-        finally:
-            util.delete_token(self.waiter_url, token_name, kill_services=True)
 
-    def test_kill_no_wait(self):
-        token_name = self.token_name()
-        util.post_token(self.waiter_url, token_name, util.minimal_service_description())
-        try:
-            service_id = util.ping_token(self.waiter_url, token_name)
-            self.assertEqual(1, len(util.services_for_token(self.waiter_url, token_name)))
-            cp = cli.kill(self.waiter_url, token_name, flags='-v', kill_flags='--no-wait')
-            self.assertEqual(0, cp.returncode, cp.stderr)
-            self.assertIn('no-wait enabled: command will not wait to confirm other routers are updated', cli.stdout(cp))
-            self.assertIn('Killing service', cli.stdout(cp))
-            self.assertIn(service_id, cli.stdout(cp))
-            self.assertIn("'timeout': 0}", cli.stderr(cp))
-            self.assertIn('Successfully killed', cli.stdout(cp))
-            util.wait_until_no_services_for_token(self.waiter_url, token_name)
-        finally:
-            util.delete_token(self.waiter_url, token_name, kill_services=True)
+        def ping_then_kill_with_small_timeout():
+            util.post_token(self.waiter_url, token_name, util.minimal_service_description())
+            util.ping_token(self.waiter_url, token_name)
+            assert 1 == len(util.services_for_token(self.waiter_url, token_name))
+            return cli.kill(self.waiter_url, token_name, kill_flags='--timeout 1')
 
+        def kill_timed_out(cp):
+            self.logger.info(f'Return code: {cp.returncode}')
+            assert 1 == cp.returncode
+            assert 'Timeout waiting for service to die' in cli.stderr(cp)
+            return True
+
+        try:
+            util.wait_until(ping_then_kill_with_small_timeout, kill_timed_out)
+        finally:
+            util.delete_token(self.waiter_url, token_name)
 
     @pytest.mark.xfail
     def test_kill_services_sorted(self):

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -611,26 +611,6 @@ class WaiterCliTest(util.WaiterTest):
         finally:
             util.delete_token(self.waiter_url, token_name, kill_services=True)
 
-    def test_kill_timeout(self):
-        token_name = self.token_name()
-
-        def ping_then_kill_with_small_timeout():
-            util.post_token(self.waiter_url, token_name, util.minimal_service_description())
-            util.ping_token(self.waiter_url, token_name)
-            assert 1 == len(util.services_for_token(self.waiter_url, token_name))
-            return cli.kill(self.waiter_url, token_name, kill_flags='--timeout 1')
-
-        def kill_timed_out(cp):
-            self.logger.info(f'Return code: {cp.returncode}')
-            assert 1 == cp.returncode
-            assert 'Timeout waiting for service to die' in cli.stderr(cp)
-            return True
-
-        try:
-            util.wait_until(ping_then_kill_with_small_timeout, kill_timed_out)
-        finally:
-            util.delete_token(self.waiter_url, token_name)
-
     @pytest.mark.xfail
     def test_kill_services_sorted(self):
         token_name = self.token_name()

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -620,7 +620,6 @@ class WaiterCliTest(util.WaiterTest):
             self.assertEqual(0, cp.returncode, cp.stderr)
             self.assertIn('Killing service', cli.stdout(cp))
             self.assertIn(service_id, cli.stdout(cp))
-            self.assertIn('no-wait enabled', cli.stdout(cp))
             self.assertIn('Successfully killed', cli.stdout(cp))
             self.assertIn('Did not wait for routers to update.', cli.stdout(cp))
             self.assertIn('timeout=0', cli.stderr(cp))

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -610,23 +610,6 @@ class WaiterCliTest(util.WaiterTest):
         finally:
             util.delete_token(self.waiter_url, token_name, kill_services=True)
 
-    def test_kill_no_wait(self):
-        token_name = self.token_name()
-        util.post_token(self.waiter_url, token_name, util.minimal_service_description())
-        try:
-            service_id = util.ping_token(self.waiter_url, token_name)
-            self.assertEqual(1, len(util.services_for_token(self.waiter_url, token_name)))
-            cp = cli.kill(self.waiter_url, token_name, flags="-v", kill_flags=f"--no-wait")
-            self.assertEqual(0, cp.returncode, cp.stderr)
-            self.assertIn('Killing service', cli.stdout(cp))
-            self.assertIn(service_id, cli.stdout(cp))
-            self.assertIn('Successfully killed', cli.stdout(cp))
-            self.assertIn('Did not wait for routers to update.', cli.stdout(cp))
-            self.assertIn('timeout=0', cli.stderr(cp))
-            util.wait_until_no_services_for_token(self.waiter_url, token_name)
-        finally:
-            util.delete_token(self.waiter_url, token_name, kill_services=True)
-
     def test_kill_multiple_services(self):
         token_name = self.token_name()
         util.post_token(self.waiter_url, token_name, util.minimal_service_description())

--- a/cli/waiter/http_util.py
+++ b/cli/waiter/http_util.py
@@ -72,7 +72,7 @@ def __delete(url, params=None, headers=None, read_timeout=None):
     delete_timeouts = timeouts
     if read_timeout is not None:
         delete_timeouts = (timeouts[0], read_timeout)
-    return session.delete(url, params=params, timeout=get_timeouts, headers=headers)
+    return session.delete(url, params=params, timeout=delete_timeouts, headers=headers)
 
 
 def __make_url(cluster, endpoint):

--- a/cli/waiter/http_util.py
+++ b/cli/waiter/http_util.py
@@ -69,9 +69,9 @@ def __get(url, params=None, read_timeout=None, **kwargs):
 def __delete(url, params=None, headers=None, read_timeout=None):
     """Sends a DELETE with params to the given url"""
     logging.debug(f'DELETE {url} with params {params} and headers {headers}')
-    get_timeouts = timeouts
+    delete_timeouts = timeouts
     if read_timeout is not None:
-        get_timeouts = (timeouts[0], read_timeout)
+        delete_timeouts = (timeouts[0], read_timeout)
     return session.delete(url, params=params, timeout=get_timeouts, headers=headers)
 
 

--- a/cli/waiter/http_util.py
+++ b/cli/waiter/http_util.py
@@ -66,10 +66,13 @@ def __get(url, params=None, read_timeout=None, **kwargs):
     return session.get(url, params=params, timeout=get_timeouts, **kwargs)
 
 
-def __delete(url, params=None, headers=None):
+def __delete(url, params=None, headers=None, read_timeout=None):
     """Sends a DELETE with params to the given url"""
     logging.debug(f'DELETE {url} with params {params} and headers {headers}')
-    return session.delete(url, params=params, timeout=timeouts, headers=headers)
+    get_timeouts = timeouts
+    if read_timeout is not None:
+        get_timeouts = (timeouts[0], read_timeout)
+    return session.delete(url, params=params, timeout=get_timeouts, headers=headers)
 
 
 def __make_url(cluster, endpoint):
@@ -109,13 +112,13 @@ def get(cluster, endpoint, params=None, headers=None, read_timeout=None):
     return resp
 
 
-def delete(cluster, endpoint, params=None, headers=None):
+def delete(cluster, endpoint, params=None, headers=None, read_timeout=None):
     """DELETEs data corresponding to the given params on cluster at /endpoint"""
     if headers is None:
         headers = {}
     url = __make_url(cluster, endpoint)
     default_headers = default_http_headers()
-    resp = __delete(url, params, headers={**default_headers, **headers})
+    resp = __delete(url, params, headers={**default_headers, **headers}, read_timeout=read_timeout)
     logging.info(f'DELETE response: {resp.text}')
     return resp
 

--- a/cli/waiter/subcommands/kill.py
+++ b/cli/waiter/subcommands/kill.py
@@ -1,4 +1,5 @@
 import logging
+import requests
 from urllib.parse import urljoin
 
 from tabulate import tabulate
@@ -36,6 +37,10 @@ def kill_service_on_cluster(cluster, service_id, timeout_seconds):
         else:
             print_error(response_message(resp.json()))
             return False
+    except requests.exceptions.ReadTimeout:
+        message = f'Encountered request read timeout while killing {service_id} in {cluster_name}.'
+        logging.exception(message)
+        print_error(message)
     except Exception:
         message = f'Encountered error while killing {service_id} in {cluster_name}.'
         logging.exception(message)

--- a/cli/waiter/subcommands/kill.py
+++ b/cli/waiter/subcommands/kill.py
@@ -17,16 +17,12 @@ def kill_service_on_cluster(cluster, service_id, timeout_seconds):
     try:
         print(f'Killing service {terminal.bold(service_id)} in {terminal.bold(cluster_name)}...')
         params = {'timeout': timeout_seconds * 1000}
-        read_timeout = 5 if timeout_seconds == 0 else timeout_seconds
-        resp = http_util.delete(cluster, f'/apps/{service_id}', params=params, read_timeout=read_timeout)
+        resp = http_util.delete(cluster, f'/apps/{service_id}', params=params, read_timeout=timeout_seconds)
         logging.debug(f'Response status code: {resp.status_code}')
         if resp.status_code == 200:
             routers_agree = resp.json().get('routers-agree')
             if routers_agree:
                 print(f'Successfully killed {service_id} in {cluster_name}.')
-                return True
-            elif routers_agree is None:
-                print(f'Successfully killed {service_id} in {cluster_name}. Did not wait for routers to update.')
                 return True
             else:
                 print(f'Successfully killed {service_id} in {cluster_name}. '
@@ -132,9 +128,6 @@ def register(add_parser):
     parser.add_argument('--force', '-f', help='kill all services, never prompt', dest='force', action='store_true')
     parser.add_argument('--service-id', '-s', help='kill by service id instead of token',
                         dest='is-service-id', action='store_true')
-    timeout_group = parser.add_mutually_exclusive_group()
-    timeout_group.add_argument('--timeout', '-t', help='timeout (in seconds) for kill to complete',
+    parser.add_argument('--timeout', '-t', help='timeout (in seconds) for kill to complete',
                         type=check_positive, default=30)
-    timeout_group.add_argument('--no-wait', help="does not wait for all routers to confirm deletion", dest='timeout',
-                        action='store_const', const=0)
     return kill

--- a/cli/waiter/subcommands/kill.py
+++ b/cli/waiter/subcommands/kill.py
@@ -17,10 +17,8 @@ def kill_service_on_cluster(cluster, service_id, timeout_seconds):
     try:
         print(f'Killing service {terminal.bold(service_id)} in {terminal.bold(cluster_name)}...')
         params = {'timeout': timeout_seconds * 1000}
-        if timeout_seconds == 0:
-            resp = http_util.delete(cluster, f'/apps/{service_id}', params=params)
-        else:
-            resp = http_util.delete(cluster, f'/apps/{service_id}', params=params, read_timeout=timeout_seconds)
+        read_timeout = 5 if timeout_seconds == 0 else timeout_seconds
+        resp = http_util.delete(cluster, f'/apps/{service_id}', params=params, read_timeout=read_timeout)
         logging.debug(f'Response status code: {resp.status_code}')
         if resp.status_code == 200:
             routers_agree = resp.json().get('routers-agree')

--- a/cli/waiter/subcommands/kill.py
+++ b/cli/waiter/subcommands/kill.py
@@ -5,20 +5,21 @@ from tabulate import tabulate
 
 from waiter import http_util, terminal
 from waiter.format import format_last_request_time, format_status
-from waiter.querying import get_service, print_no_data, query_service, query_services
+from waiter.querying import print_no_data, query_service, query_services
 from waiter.util import guard_no_cluster, str2bool, response_message, print_error, wait_until, check_positive
 
 
 def kill_service_on_cluster(cluster, service_id, timeout_seconds, no_wait):
     """Kills the service with the given service id in the given cluster."""
     cluster_name = cluster['name']
+    http_util.set_retries(0)
     try:
         print(f'Killing service {terminal.bold(service_id)} in {terminal.bold(cluster_name)}...')
         params = {'timeout': timeout_seconds * 1000}
         if no_wait:
             print('no-wait enabled: command will not wait to confirm other routers are updated')
             params['timeout'] = 0
-        resp = http_util.delete(cluster, f'/apps/{service_id}', params=params)
+        resp = http_util.delete(cluster, f'/apps/{service_id}', params=params, read_timeout=timeout_seconds)
         logging.debug(f'Response status code: {resp.status_code}')
         if resp.status_code == 200:
             if resp.json().get('routers-agree', False):

--- a/cli/waiter/subcommands/kill.py
+++ b/cli/waiter/subcommands/kill.py
@@ -16,7 +16,10 @@ def kill_service_on_cluster(cluster, service_id, timeout_seconds):
     try:
         print(f'Killing service {terminal.bold(service_id)} in {terminal.bold(cluster_name)}...')
         params = {'timeout': timeout_seconds * 1000}
-        resp = http_util.delete(cluster, f'/apps/{service_id}', params=params, read_timeout=timeout_seconds)
+        if timeout_seconds == 0:
+            resp = http_util.delete(cluster, f'/apps/{service_id}', params=params)
+        else:
+            resp = http_util.delete(cluster, f'/apps/{service_id}', params=params, read_timeout=timeout_seconds)
         logging.debug(f'Response status code: {resp.status_code}')
         if resp.status_code == 200:
             routers_agree = resp.json().get('routers-agree')

--- a/cli/waiter/subcommands/kill.py
+++ b/cli/waiter/subcommands/kill.py
@@ -18,12 +18,12 @@ def kill_service_on_cluster(cluster, service_id, timeout_seconds, no_wait):
     cluster_name = cluster['name']
     try:
         print(f'Killing service {terminal.bold(service_id)} in {terminal.bold(cluster_name)}...')
-        params=None
+        params= {"timeout": 5000}
         if timeout_seconds:
-            params={"timeout": timeout_seconds * 1000}
+            params["timeout"] = timeout_seconds * 1000
         if no_wait:
             print('no-wait enabled: command will not wait to confirm other routers are updated')
-            params={"timeout": 0}
+            params["timeout"] = 0
         resp = http_util.delete(cluster, f'/apps/{service_id}', params=params)
         logging.debug(f'Response status code: {resp.status_code}')
         if resp.status_code == 200:

--- a/cli/waiter/subcommands/kill.py
+++ b/cli/waiter/subcommands/kill.py
@@ -32,7 +32,7 @@ def kill_service_on_cluster(cluster, service_id, timeout_seconds):
             print_error(response_message(resp.json()))
             return False
     except requests.exceptions.ReadTimeout:
-        message = f'Encountered request read timeout while killing {service_id} in {cluster_name}.'
+        message = f'Request timed out while killing {service_id} in {cluster_name}.'
         logging.exception(message)
         print_error(message)
     except Exception:

--- a/cli/waiter/subcommands/kill.py
+++ b/cli/waiter/subcommands/kill.py
@@ -27,7 +27,7 @@ def kill_service_on_cluster(cluster, service_id, timeout_seconds):
             else:
                 print(f'Successfully killed {service_id} in {cluster_name}. '
                       f'Server-side timeout waiting for routers to update.')
-                return True
+                return False
         else:
             print_error(response_message(resp.json()))
             return False

--- a/cli/waiter/subcommands/kill.py
+++ b/cli/waiter/subcommands/kill.py
@@ -6,7 +6,7 @@ from tabulate import tabulate
 from waiter import http_util, terminal
 from waiter.format import format_last_request_time, format_status
 from waiter.querying import get_service, print_no_data, query_service, query_services
-from waiter.util import guard_no_cluster, str2bool, response_message, print_error, wait_until, check_positive
+from waiter.util import guard_no_cluster, str2bool, response_message, print_error, check_positive
 
 
 def kill_service_on_cluster(cluster, service_id, timeout_seconds, no_wait):
@@ -19,17 +19,15 @@ def kill_service_on_cluster(cluster, service_id, timeout_seconds, no_wait):
     try:
         print(f'Killing service {terminal.bold(service_id)} in {terminal.bold(cluster_name)}...')
         params=None
+        if timeout_seconds:
+            params={"timeout": timeout_seconds * 1000}
         if no_wait:
-            print('no-wait enabled: command will return before other routers are updated')
+            print('no-wait enabled: command will not wait to confirm other routers are updated')
             params={"timeout": 0}
         resp = http_util.delete(cluster, f'/apps/{service_id}', params=params)
         logging.debug(f'Response status code: {resp.status_code}')
         if resp.status_code == 200:
-            if resp.json()["routers-agree"]:
-                print(f'Successfully killed {service_id} in {cluster_name}.')
-                return True
-            killed = wait_until(service_is_killed, timeout=timeout_seconds, interval=1)
-            if killed:
+            if (no_wait and resp.json()["success"]) or resp.json()["routers-agree"]:
                 print(f'Successfully killed {service_id} in {cluster_name}.')
                 return True
             else:
@@ -129,10 +127,11 @@ def register(add_parser):
     parser = add_parser('kill', help='kill services')
     parser.add_argument('token-or-service-id')
     parser.add_argument('--force', '-f', help='kill all services, never prompt', dest='force', action='store_true')
-    parser.add_argument('--timeout', '-t', help='timeout (in seconds) for kill to complete',
-                        type=check_positive, default=30)
     parser.add_argument('--service-id', '-s', help='kill by service id instead of token',
                         dest='is-service-id', action='store_true')
-    parser.add_argument('--no-wait', help="does not wait for all routers to confirm deletion", dest='no-wait',
-                        action='store_true')
+    timeout_group = parser.add_mutually_exclusive_group()
+    timeout_group.add_argument('--timeout', '-t', help='timeout (in seconds) for kill to complete',
+                               type=check_positive, default=30)
+    timeout_group.add_argument('--no-wait', help="does not wait for all routers to confirm deletion", dest='no-wait',
+                               action='store_true')
     return kill

--- a/cli/waiter/subcommands/kill.py
+++ b/cli/waiter/subcommands/kill.py
@@ -14,19 +14,14 @@ def kill_service_on_cluster(cluster, service_id, timeout_seconds, no_wait):
     cluster_name = cluster['name']
     try:
         print(f'Killing service {terminal.bold(service_id)} in {terminal.bold(cluster_name)}...')
-        params = {"timeout": 5000}
-        if timeout_seconds:
-            params["timeout"] = timeout_seconds * 1000
+        params = {'timeout': timeout_seconds * 1000}
         if no_wait:
             print('no-wait enabled: command will not wait to confirm other routers are updated')
-            params["timeout"] = 0
+            params['timeout'] = 0
         resp = http_util.delete(cluster, f'/apps/{service_id}', params=params)
         logging.debug(f'Response status code: {resp.status_code}')
         if resp.status_code == 200:
-            if no_wait:
-                print(f'Successfully marked {service_id} in {cluster_name} for deletion.')
-                return True
-            elif resp.json()["routers-agree"]:
+            if no_wait or resp.json()['routers-agree']:
                 print(f'Successfully killed {service_id} in {cluster_name}.')
                 return True
             else:

--- a/cli/waiter/subcommands/kill.py
+++ b/cli/waiter/subcommands/kill.py
@@ -25,6 +25,9 @@ def kill_service_on_cluster(cluster, service_id, timeout_seconds, no_wait):
         resp = http_util.delete(cluster, f'/apps/{service_id}', params=params)
         logging.debug(f'Response status code: {resp.status_code}')
         if resp.status_code == 200:
+            if resp.json()["routers-agree"]:
+                print(f'Successfully killed {service_id} in {cluster_name}.')
+                return True
             killed = wait_until(service_is_killed, timeout=timeout_seconds, interval=1)
             if killed:
                 print(f'Successfully killed {service_id} in {cluster_name}.')

--- a/cli/waiter/subcommands/kill.py
+++ b/cli/waiter/subcommands/kill.py
@@ -21,12 +21,12 @@ def kill_service_on_cluster(cluster, service_id, timeout_seconds, no_wait):
         resp = http_util.delete(cluster, f'/apps/{service_id}', params=params)
         logging.debug(f'Response status code: {resp.status_code}')
         if resp.status_code == 200:
-            if no_wait or resp.json()['routers-agree']:
+            if resp.json().get('routers-agree', False):
                 print(f'Successfully killed {service_id} in {cluster_name}.')
                 return True
             else:
-                print_error('Timeout waiting for routers to agree that service is killed')
-                return False
+                print(f'Successfully killed {service_id} in {cluster_name}, but routers may not be updated yet!')
+                return True
         else:
             print_error(response_message(resp.json()))
             return False


### PR DESCRIPTION
## Changes proposed in this PR

- for `waiter kill service-id --timeout TIMEOUT` command: use the timeout query parameter instead of the client side polling method

Here is timing evidence where server sleeps and client is forced to timeout:
```
$ time waiter kill service-id --timeout 5
Killing service w9091-499285cd09532196626361355fe0699d in WAITER1...
Encountered error while killing w9091-499285cd09532196626361355fe0699d in WAITER1.
waiter kill service-id --timeout 5  
0.18s user 
0.02s system 3% cpu 
5.204 total
```

## Why are we making these changes?

- removes the need to poll on the client side and ensures that the command returns when all routers agree that a service has been deleted

depends on #1203 

