### PR TITLE
includes oidc state into the request log

### DIFF
--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -54,7 +54,8 @@
   "Convert a response into a context suitable for logging."
   [{:keys [authorization/method authorization/principal backend-response-latency-ns descriptor error-class
            get-instance-latency-ns handle-request-latency-ns headers instance instance-proto latest-service-id
-           protocol request-type status waiter-api-call?] :as response}]
+           protocol request-type status waiter-api-call? waiter/oidc-identifier waiter/oidc-mode waiter/oidc-redirect-uri]
+    :as response}]
   (let [{:keys [service-id service-description source-tokens]} descriptor
         token (or (some->> source-tokens (map #(get % "token")) seq (str/join ","))
                   ;; allow non-proxy requests to provide tokens for use in the request log
@@ -82,6 +83,9 @@
       instance-proto (assoc :instance-proto instance-proto)
       latest-service-id (assoc :fallback-triggered (not= service-id latest-service-id)
                                :latest-service-id latest-service-id)
+      oidc-identifier (assoc :oidc-identifier oidc-identifier)
+      oidc-mode (assoc :oidc-mode oidc-mode)
+      oidc-redirect-uri (assoc :oidc-redirect-uri oidc-redirect-uri)
       node-name (assoc :k8s-node-name node-name)
       pod-name (assoc :k8s-pod-name pod-name)
       principal (assoc :principal principal)

--- a/waiter/test/waiter/request_log_test.clj
+++ b/waiter/test/waiter/request_log_test.clj
@@ -86,6 +86,9 @@
                   :request-type "test-request"
                   :status http-200-ok
                   :waiter-api-call? false
+                  :waiter/oidc-identifier "oidc-identifier"
+                  :waiter/oidc-mode "oidc-mode"
+                  :waiter/oidc-redirect-uri "oidc-redirect-uri"
                   :waiter/token "test-token3"}]
     (is (= {:authentication-method "cookie"
             :backend-response-latency-ns 1000
@@ -102,6 +105,9 @@
             :k8s-pod-name "test-pod-name"
             :latest-service-id "latest-service-id"
             :metric-group "service-metric-group"
+            :oidc-identifier "oidc-identifier"
+            :oidc-mode "oidc-mode"
+            :oidc-redirect-uri "oidc-redirect-uri"
             :principal "principal@DOMAIN.COM"
             :request-type "test-request"
             :response-content-length "40"


### PR DESCRIPTION
## Changes proposed in this PR

- includes oidc state into the request log

## Why are we making these changes?

Including the OIDC state helps with debugging failed OIDC requests.

### Sample request log:

```
{
  "authentication-method": "oidc",
  "oidc-identifier": "7d1dc11141996641a93a965c30988e49",
  "oidc-mode": "relaxed",
  "oidc-redirecturi": "https://wattoar79441915071561.127.0.0.1/request-info",
  "path": "/oidc/v1/callback",
  "request-type": "waiter-api",
  "status": 302,
...
}
```