### PR TITLE
configures the request/response buffer size

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -812,6 +812,10 @@
                                ;; service description:
                                :async-request-timeout-ms 60000
 
+                               ;; Size in the size of the buffer used to write/read individual request/response fragments to/from the backend.
+                               ;; The value must be a positive integer, defaults to 32 KiB.
+                               :client-buffer-size 32768
+
                                ;; The max time (milliseconds) a connection can be idle in the client connection pool:
                                :client-connection-idle-timeout-ms 10000
 
@@ -825,9 +829,9 @@
                                ;; expired instances will be eligible for killing:
                                :lingering-request-threshold-ms 60000
 
-                               ;; Size in bytes of the output buffer used to aggregate HTTP responses from a backend.
-                               ;; The value must be a positive integer.
-                               :output-buffer-size 2048
+                               ;; Size in bytes of the output buffer used to aggregate fragments of HTTP responses from a backend.
+                               ;; The value must be a positive integer, defaults to 4 KiB.
+                               :output-buffer-size 4096
 
                                ;; The default amount of time (milliseconds) each request will wait in
                                ;; the Waiter queue before an instance is available to process it. This

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -662,10 +662,12 @@
                           (utils/create-component entitlement-config))
    :fallback-state-atom (pc/fnk [] (atom {:available-service-ids #{}
                                           :healthy-service-ids #{}}))
-   :http-client-properties (pc/fnk [[:settings [:instance-request-properties client-connection-idle-timeout-ms connection-timeout-ms]]]
+   :http-client-properties (pc/fnk [[:settings [:instance-request-properties client-buffer-size client-connection-idle-timeout-ms connection-timeout-ms]]]
                              {:client-name "waiter-client"
                               :conn-timeout connection-timeout-ms
                               :follow-redirects? false
+                              :request-buffer-size client-buffer-size
+                              :response-buffer-size client-buffer-size
                               :socket-timeout client-connection-idle-timeout-ms})
    :http-clients (pc/fnk [http-client-properties]
                    (hu/prepare-http-clients http-client-properties))

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -62,6 +62,7 @@
    (s/required-key :instance-request-properties) {(s/required-key :async-check-interval-ms) schema/positive-int
                                                   (s/required-key :async-request-max-status-checks) schema/positive-int
                                                   (s/required-key :async-request-timeout-ms) schema/positive-int
+                                                  (s/required-key :client-buffer-size) schema/positive-int
                                                   (s/required-key :client-connection-idle-timeout-ms) schema/positive-int
                                                   (s/required-key :connection-timeout-ms) schema/positive-int
                                                   (s/required-key :initial-socket-timeout-ms) schema/positive-int
@@ -291,11 +292,12 @@
    :instance-request-properties {:async-check-interval-ms 3000
                                  :async-request-max-status-checks 50
                                  :async-request-timeout-ms 60000
+                                 :client-buffer-size 32768 ;; 32 KiB
                                  :client-connection-idle-timeout-ms 10000 ; 10 seconds
                                  :connection-timeout-ms 5000 ; 5 seconds
                                  :initial-socket-timeout-ms 900000 ; 15 minutes
                                  :lingering-request-threshold-ms 60000 ; 1 minute
-                                 :output-buffer-size 4096
+                                 :output-buffer-size 4096 ;; 4 KiB
                                  :queue-timeout-ms 300000
                                  :streaming-timeout-ms 20000}
    :kv-config {:kind :zk

--- a/waiter/src/waiter/util/http_utils.clj
+++ b/waiter/src/waiter/util/http_utils.clj
@@ -124,7 +124,7 @@
     :or {clear-content-decoders true}
     :as config}]
   (let [^HttpClient client
-        (http/client (cond-> (select-keys config [:client-name :follow-redirects? :transport])
+        (http/client (cond-> (select-keys config [:client-name :follow-redirects? :request-buffer-size :response-buffer-size :transport])
                        (some? conn-timeout) (assoc :connect-timeout conn-timeout)
                        (some? socket-timeout) (assoc :idle-timeout socket-timeout)))]
     (when clear-content-decoders


### PR DESCRIPTION
## Changes proposed in this PR

- configures the request/response buffer size

## Why are we making these changes?

The default buffer size is configured to 4MiB. When the backend server sends small fragments, this can lead Jetty to allocate 4MiB buffers for every such packet. This can eventually lead to OOM error.

### Example sceanrio:

Backend server sends 394 bytes which is read into an encryptedBuffer of capacity=18432 (which is in line with what the JDK requires), but the unwrapBuffer has capacity 4194304 (i.e. 4 MiB), of which only 433 are actual content. We have seen scenarios where 1300+ such buffers queued, so 1300*433=562900 i.e. about 550 KiB, which is not much data content, but it's a lot of memory content because 4 MiB buffers are used for just 433 bytes.


