### PR TITLE
fixes computation of service default parameters while registering tokens

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1792,7 +1792,7 @@
                                          (handler/get-work-stealing-state offers-allowed-semaphore router-id request))))
    :status-handler-fn (pc/fnk [] handler/status-handler)
    :token-handler-fn (pc/fnk [[:curator synchronize-fn]
-                              [:routines attach-token-defaults-fn make-inter-router-requests-sync-fn validate-service-description-fn]
+                              [:routines attach-service-defaults-fn make-inter-router-requests-sync-fn validate-service-description-fn]
                               [:settings [:token-config history-length limit-per-owner]]
                               [:state clock entitlement-manager kv-store token-cluster-calculator token-root waiter-hostnames]
                               wrap-secure-request-fn]
@@ -1801,7 +1801,7 @@
                            (token/handle-token-request
                              clock synchronize-fn kv-store token-cluster-calculator token-root history-length limit-per-owner
                              waiter-hostnames entitlement-manager make-inter-router-requests-sync-fn validate-service-description-fn
-                             attach-token-defaults-fn request))))
+                             attach-service-defaults-fn request))))
    :token-list-handler-fn (pc/fnk [[:state entitlement-manager kv-store]
                                    wrap-secure-request-fn]
                             (wrap-secure-request-fn

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -434,21 +434,21 @@
       (when (not-empty unknown-keys)
         (throw (ex-info (str "Unsupported key(s) in token: " (str (vec unknown-keys)))
                         {:status http-400-bad-request :token token :log-level :warn}))))
-    (let [service-parameter-with-token-defaults (attach-service-defaults-fn new-service-parameter-template)
-          missing-parameters (->> sd/service-required-keys (remove #(contains? new-service-parameter-template %1)) seq)]
+    (let [service-parameter-with-service-defaults (attach-service-defaults-fn new-service-parameter-template)
+          missing-parameters (->> sd/service-required-keys (remove #(contains? service-parameter-with-service-defaults %1)) seq)]
       (when (= authentication "disabled")
         (when (not= permitted-user "*")
           (throw (ex-info (str "Tokens with authentication disabled must specify"
                                " permitted-user as *, instead provided " permitted-user)
                           {:status http-400-bad-request :token token :log-level :warn})))
         ;; partial tokens not supported when authentication is disabled
-        (when-not (sd/required-keys-present? service-parameter-with-token-defaults)
+        (when-not (sd/required-keys-present? service-parameter-with-service-defaults)
           (throw (ex-info "Tokens with authentication disabled must specify all required parameters"
                           {:log-level :warn
                            :missing-parameters missing-parameters
                            :service-description new-service-parameter-template
                            :status http-400-bad-request}))))
-      (when (and interstitial-secs (not (sd/required-keys-present? service-parameter-with-token-defaults)))
+      (when (and interstitial-secs (not (sd/required-keys-present? service-parameter-with-service-defaults)))
         (throw (ex-info (str "Tokens with missing required parameters cannot use interstitial support")
                         {:log-level :warn
                          :missing-parameters missing-parameters


### PR DESCRIPTION
## Changes proposed in this PR

- fixes computation of service default parameters while registering tokens

## Why are we making these changes?

Users should be able to create tokens where defaults for required parameters are provided by the profile.


