### PR TITLE
adds support for replicaset version label

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -17,7 +17,6 @@
   (:require [cheshire.core :as cheshire]
             [clj-http.client :as clj-http]
             [clj-time.core :as t]
-            [clj-time.format :as f]
             [clojure.data :as data]
             [clojure.data.zip.xml :as zx]
             [clojure.java.io :as io]
@@ -59,10 +58,6 @@
 (def k8s-timestamp-format
   "Kubernetes reports dates in ISO8061 format, sans the milliseconds component."
   (DateTimeFormat/forPattern "yyyy-MM-dd'T'HH:mm:ss'Z'"))
-
-(def rs-version-time-format
-  "The time format used while creating ReplicaSet version labels, only alphanumeric characters."
-  (f/formatters :basic-date-time-no-ms))
 
 (def max-failed-instances-to-keep
   "The maximum number of failed instances tracked per service."
@@ -120,7 +115,7 @@
       [[spec
         [:metadata name namespace uid [:annotations waiter/service-id]]
         [:status {replicas 0} {availableReplicas 0} {readyReplicas 0} {unavailableReplicas 0}]] replicaset-json
-       replicaset-version (get-in replicaset-json [:metadata :labels :waiter/replicaset-version] nil)
+       revision-timestamp (get-in replicaset-json [:metadata :annotations :waiter/revision-timestamp] nil)
        requested (get spec :replicas 0)
        staged (- replicas (+ availableReplicas unavailableReplicas))]
       (scheduler/make-Service
@@ -134,7 +129,7 @@
                               :running (- replicas staged)
                               :staged staged
                               :unhealthy (- replicas readyReplicas staged)}}
-          replicaset-version (assoc :k8s/replicaset-version replicaset-version))))
+          revision-timestamp (assoc :k8s/revision-timestamp revision-timestamp))))
     (catch Throwable t
       (log/error t "error converting ReplicaSet to Waiter Service"))))
 
@@ -275,7 +270,7 @@
           primary-container-status (first container-statuses)
           pod-annotations (get-in pod [:metadata :annotations])
           pod-started-at (-> pod (get-in [:status :startTime]) timestamp-str->datetime)
-          {:keys [waiter/replicaset-version]} (get-in pod [:metadata :labels])]
+          {:keys [waiter/revision-timestamp]} (get-in pod [:metadata :annotations])]
       (scheduler/make-ServiceInstance
         (cond-> {:extra-ports (->> pod-annotations :waiter/port-count Integer/parseInt range next (mapv #(+ port0 %)))
                  :flags (cond-> #{}
@@ -296,7 +291,7 @@
                  :started-at pod-started-at}
           node-name (assoc :k8s/node-name node-name)
           phase (assoc :k8s/pod-phase phase)
-          replicaset-version (assoc :k8s/replicaset-version replicaset-version)
+          revision-timestamp (assoc :k8s/revision-timestamp revision-timestamp)
           (seq container-statuses) (assoc :k8s/container-statuses
                                           (map (fn [{:keys [state] :as status}]
                                                  (when (> (count state) 1)
@@ -926,7 +921,7 @@
                     (for [i (range ports)]
                       {:name (str "PORT" i) :value (str (+ port0 i))})))
         k8s-name (service-id->k8s-app-name scheduler service-id)
-        replicaset-version (str "v" (du/date-to-str (t/now) rs-version-time-format)) ;; we use a monotonically increasing version string
+        revision-timestamp (du/date-to-str (t/now)) ;; we use a monotonically increasing version string
         health-check-scheme (-> (or health-check-proto backend-proto) hu/backend-proto->scheme str/upper-case)
         health-check-url (sd/service-description->health-check-url service-description)
         memory (str mem "Mi")
@@ -941,12 +936,12 @@
                   ;; but store the full service-id as an annotation.
                   ;; https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
                   ;; https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
-                  :annotations {:waiter/service-id service-id}
+                  :annotations {:waiter/revision-timestamp revision-timestamp
+                                :waiter/service-id service-id}
                   :labels {:app k8s-name
                            :waiter/cluster cluster-name
                            :waiter/fileserver (if fileserver-enabled? "enabled" "disabled")
                            :waiter/proxy-sidecar (if has-reverse-proxy? "enabled" "disabled")
-                           :waiter/replicaset-version replicaset-version
                            :waiter/service-hash service-hash
                            :waiter/user run-as-user}
                   :name k8s-name
@@ -955,11 +950,11 @@
               :selector {:matchLabels {:app k8s-name
                                        :waiter/user run-as-user}}
               :template {:metadata {:annotations {:waiter/port-count (str ports)
+                                                  :waiter/revision-timestamp revision-timestamp
                                                   :waiter/service-id service-id
                                                   :waiter/service-port (str service-port)}
                                     :labels {:app k8s-name
                                              :waiter/cluster cluster-name
-                                             :waiter/replicaset-version replicaset-version
                                              :waiter/service-hash service-hash
                                              :waiter/user run-as-user}}
                          :spec {;; Service account tokens allow easy access to the k8s api server,

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -554,9 +554,13 @@
           :expected-result
           [(scheduler/make-Service {:id "test-app-1234"
                                     :instances 2
+                                    :k8s/revision-timestamp nil
                                     :task-count 2
                                     :task-stats {:running 2, :healthy 2, :unhealthy 0, :staged 0}})
-           (scheduler/make-Service {:id "test-app-6789" :instances 3 :task-count 3
+           (scheduler/make-Service {:id "test-app-6789"
+                                    :instances 3
+                                    :k8s/revision-timestamp nil
+                                    :task-count 3
                                     :task-stats {:running 3 :healthy 1 :unhealthy 2 :staged 0}})]}
          {:api-server-response
           {:kind "ReplicaSetList"
@@ -592,9 +596,13 @@
           :expected-result
           [(scheduler/make-Service {:id "test-app-abcd"
                                     :instances 2
+                                    :k8s/revision-timestamp nil
                                     :task-count 2
                                     :task-stats {:running 2, :healthy 2, :unhealthy 0, :staged 0}})
-           (scheduler/make-Service {:id "test-app-wxyz" :instances 3 :task-count 3
+           (scheduler/make-Service {:id "test-app-wxyz"
+                                    :instances 3
+                                    :k8s/revision-timestamp nil
+                                    :task-count 3
                                     :task-stats {:running 3 :healthy 1 :unhealthy 2 :staged 0}})]}
 
          {:api-server-response
@@ -615,7 +623,10 @@
                              :availableReplicas 1
                              :unavailableReplicas 1}}]}
           :expected-result
-          [(scheduler/make-Service {:id "test-app-4321" :instances 3 :task-count 3
+          [(scheduler/make-Service {:id "test-app-4321"
+                                    :instances 3
+                                    :k8s/revision-timestamp nil
+                                    :task-count 3
                                     :task-stats {:running 2 :healthy 1 :unhealthy 1 :staged 1}})]}
 
          {:api-server-response
@@ -626,7 +637,7 @@
                                :labels {:app "test-app-9999"
                                         :waiter/cluster "waiter"
                                         :waiter/service-hash "test-app-9999"}
-                               :annotations {:waiter/revision-timestamp "v20200922T202222Z"
+                               :annotations {:waiter/revision-timestamp "2020-09-22T20:22:22.000Z"
                                              :waiter/service-id "test-app-9999"}
                                :uid "test-app-9999-uid"}
                     :spec {:replicas 0
@@ -638,7 +649,7 @@
           :expected-result
           [(scheduler/make-Service {:id "test-app-9999"
                                     :instances 0
-                                    :k8s/revision-timestamp "v20200922T202222Z"
+                                    :k8s/revision-timestamp "2020-09-22T20:22:22.000Z"
                                     :task-count 0
                                     :task-stats {:running 0, :healthy 0, :unhealthy 0, :staged 0}})]}]]
     (log/info "Expecting Key error due to bad :mismatched-replicaset in API server response...")
@@ -660,7 +671,7 @@
                                       :waiter/cluster "waiter"
                                       :waiter/user "myself"
                                       :waiter/service-hash "test-app-1234"}
-                             :annotations {:waiter/revision-timestamp "v20200922T203333Z"
+                             :annotations {:waiter/revision-timestamp "2020-09-22T20:33:33.000Z"
                                            :waiter/service-id "test-app-1234"}
                              :uid "test-app-1234-uid"}
                   :spec {:replicas 2}
@@ -690,7 +701,7 @@
                                       :waiter/service-hash "test-app-1234"
                                       :waiter/user "myself"}
                              :annotations {:waiter/port-count "1"
-                                           :waiter/revision-timestamp "v20200922T200000Z"
+                                           :waiter/revision-timestamp "2020-09-22T20:00:00.000Z"
                                            :waiter/service-id "test-app-1234"}}
                   :spec {:containers [{:ports [{:containerPort 8080 :protocol "TCP"}]}]
                          :nodeName "node-0.k8s.com"}
@@ -707,7 +718,7 @@
                                       :waiter/service-hash "test-app-1234"
                                       :waiter/user "myself"}
                              :annotations {:waiter/port-count "1"
-                                           :waiter/revision-timestamp "v20200922T201111Z"
+                                           :waiter/revision-timestamp "2020-09-22T20:11:11.000Z"
                                            :waiter/service-id "test-app-1234"}}
                   :spec {:containers [{:ports [{:containerPort 8080 :protocol "TCP"}]}]}
                   :status {:phase "Running"
@@ -724,7 +735,7 @@
                                       :waiter/user "myself"
                                       :waiter/service-hash "test-app-1234"}
                              :annotations {:waiter/port-count "1"
-                                           :waiter/revision-timestamp "v20200922T202222Z"
+                                           :waiter/revision-timestamp "2020-09-22T20:22:22.000Z"
                                            :waiter/service-id "test-app-1234"}}
                   :spec {:containers [{:ports [{:containerPort 8080 :protocol "TCP"}]}]
                          :nodeName "node-2.k8s.com"}
@@ -740,7 +751,7 @@
                                       :waiter/service-hash "test-app-1234"
                                       :waiter/user "myself"}
                              :annotations {:waiter/port-count "1"
-                                           :waiter/revision-timestamp "v20200922T201111Z"
+                                           :waiter/revision-timestamp "2020-09-22T20:11:11.000Z"
                                            :waiter/service-id "test-app-1234"}}
                   :spec {:containers [{:ports [{:containerPort 8080 :protocol "TCP"}]}]}
                   :status {:phase "Failed"
@@ -797,7 +808,7 @@
         expected (hash-map
                    (scheduler/make-Service {:id "test-app-1234"
                                             :instances 2
-                                            :k8s/revision-timestamp "v20200922T203333Z"
+                                            :k8s/revision-timestamp "2020-09-22T20:33:33.000Z"
                                             :task-count 2
                                             :task-stats {:running 2, :healthy 2, :unhealthy 0, :staged 0}})
                    {:active-instances
@@ -809,7 +820,7 @@
                         :k8s/container-statuses [{:name "test-app-1234" :ready false :reason "ContainerCreating":state :waiting}]
                         :k8s/node-name "node-0.k8s.com"
                         :k8s/pod-phase "Pending"
-                        :k8s/revision-timestamp "v20200922T200000Z"
+                        :k8s/revision-timestamp "2020-09-22T20:00:00.000Z"
                         :log-directory "/home/myself/r0"
                         :port 8080
                         :service-id "test-app-1234"
@@ -821,7 +832,7 @@
                         :id "test-app-1234.test-app-1234-abcd1-0"
                         :k8s/container-statuses [{:name "test-app-1234" :ready true :state :running}]
                         :k8s/pod-phase "Running"
-                        :k8s/revision-timestamp "v20200922T201111Z"
+                        :k8s/revision-timestamp "2020-09-22T20:11:11.000Z"
                         :log-directory "/home/myself/r0"
                         :port 8080
                         :service-id "test-app-1234"
@@ -833,7 +844,7 @@
                         :id "test-app-1234.test-app-1234-abcd2-0"
                         :k8s/container-statuses [{:name "test-app-1234" :ready true}]
                         :k8s/node-name "node-2.k8s.com"
-                        :k8s/revision-timestamp "v20200922T202222Z"
+                        :k8s/revision-timestamp "2020-09-22T20:22:22.000Z"
                         :log-directory "/home/myself/r0"
                         :port 8080
                         :service-id "test-app-1234"
@@ -846,13 +857,16 @@
                         :id "test-app-1234.test-app-1234-abcd3-0"
                         :k8s/container-statuses [{:name "test-app-1234" :ready true :state :running}]
                         :k8s/pod-phase "Failed"
-                        :k8s/revision-timestamp "v20200922T201111Z"
+                        :k8s/revision-timestamp "2020-09-22T20:11:11.000Z"
                         :log-directory "/home/myself/r0"
                         :port 8080
                         :service-id "test-app-1234"
                         :started-at (du/str-to-date "2014-09-13T00:24:13Z" k8s-timestamp-format)})]}
 
-                   (scheduler/make-Service {:id "test-app-6789" :instances 3 :task-count 3
+                   (scheduler/make-Service {:id "test-app-6789"
+                                            :instances 3
+                                            :k8s/revision-timestamp nil
+                                            :task-count 3
                                             :task-stats {:running 3 :healthy 1 :unhealthy 2 :staged 0}})
                    {:active-instances
                     [(scheduler/make-ServiceInstance
@@ -893,7 +907,7 @@
                         :port 8080
                         :service-id "test-app-6789"
                         :started-at (du/str-to-date "2014-09-13T00:24:36Z" k8s-timestamp-format)})]})
-        watch-state-atom (atom {:service-id->service {"test-app-1234" "v20200922T203333Z"}})
+        watch-state-atom (atom {:service-id->service {"test-app-1234" "2020-09-22T20:33:33.000Z"}})
         dummy-scheduler (make-dummy-scheduler ["test-app-1234" "test-app-6789"]
                                               {:container-running-grace-secs 0
                                                :watch-state watch-state-atom})
@@ -2013,9 +2027,9 @@
 (deftest test-pod->ServiceInstance
   (let [api-server-url "https://k8s-api.example/"
         service-id "test-app-1234"
-        revision-timestamp-0 "v20200922T200000Z"
-        revision-timestamp-1 "v20200922T201111Z"
-        revision-timestamp-2 "v20200922T202222Z"
+        revision-timestamp-0 "2020-09-22T20:00:00.000Z"
+        revision-timestamp-1 "2020-09-22T20:11:11.000Z"
+        revision-timestamp-2 "2020-09-22T20:22:22.000Z"
         watch-state-atom (atom {:service-id->service {service-id {:k8s/revision-timestamp revision-timestamp-1}}})
         base-scheduler {:api-server-url api-server-url
                         :container-running-grace-secs 120


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for ReplicaSet revision timestamps
- marks instances from stale ReplicaSet revisions as expired

## Why are we making these changes?

Adds an explicit version label on the ReplicaSet to make it easy to identify the versions of a ReplicaSet that a pod maps to.
It makes it possible to identify stale pods if the ReplicaSet version ever changes.

Marking instance as stakes cause the instance expiry machinery to kick in and replace expired instances (pods).

### Example service and instance field value:

```
"k8s/revision-timestamp": "2020-09-23T20:35:40.581Z"
```
