### PR TITLE
avoids instance ejection on no_error responses

### DIFF
--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -98,7 +98,7 @@
                              ;; no_error is used to indicate that the stream is no longer needed
                              ;; HTTP2 spec: The associated condition is not a result of an error...indicate graceful shutdown of a connection.
                              (and (instance? IOException error) (= "no_error" error-message))
-                             [:generic-error "Bad request, server closed connection" http-400-bad-request error-class]
+                             [:generic-error "Server closed connection as stream no longer needed" http-400-bad-request error-class]
                              ;; connection has already been closed by the client
                              (and (instance? EofException error) (= "reset" error-message))
                              [:client-eagerly-closed "Connection eagerly closed by client" http-400-bad-request error-class]

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -95,6 +95,10 @@
                              ;; cancel_stream_error is used to indicate that the stream is no longer needed
                              (and (instance? IOException error) (= "cancel_stream_error" error-message))
                              [:client-error "Client action means stream is no longer needed" http-400-bad-request error-class]
+                             ;; no_error is used to indicate that the stream is no longer needed
+                             ;; HTTP2 spec: The associated condition is not a result of an error...indicate graceful shutdown of a connection.
+                             (and (instance? IOException error) (= "no_error" error-message))
+                             [:generic-error "Bad request, server closed connection" http-400-bad-request error-class]
                              ;; connection has already been closed by the client
                              (and (instance? EofException error) (= "reset" error-message))
                              [:client-eagerly-closed "Connection eagerly closed by client" http-400-bad-request error-class]

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -507,7 +507,7 @@
            (classify-error exception))))
   (is (= [:instance-error nil http-502-bad-gateway "java.io.IOException"]
          (classify-error (IOException. "internal_error"))))
-  (is (= [:generic-error "Bad request, server closed connection" http-400-bad-request "java.io.IOException"]
+  (is (= [:generic-error "Server closed connection as stream no longer needed" http-400-bad-request "java.io.IOException"]
          (classify-error (IOException. "no_error"))))
   (is (= [:client-error "Connection unexpectedly closed while streaming request" http-400-bad-request "org.eclipse.jetty.io.EofException"]
          (classify-error (ex-info "Test Exception" {:source :test :status http-400-bad-request} (EofException. "Test")))))

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -507,6 +507,8 @@
            (classify-error exception))))
   (is (= [:instance-error nil http-502-bad-gateway "java.io.IOException"]
          (classify-error (IOException. "internal_error"))))
+  (is (= [:generic-error "Bad request, server closed connection" http-400-bad-request "java.io.IOException"]
+         (classify-error (IOException. "no_error"))))
   (is (= [:client-error "Connection unexpectedly closed while streaming request" http-400-bad-request "org.eclipse.jetty.io.EofException"]
          (classify-error (ex-info "Test Exception" {:source :test :status http-400-bad-request} (EofException. "Test")))))
   (is (= [:client-eagerly-closed "Connection eagerly closed by client" http-400-bad-request "org.eclipse.jetty.io.EofException"]


### PR DESCRIPTION
## Changes proposed in this PR

- avoids instance ejection on no_error responses

## Why are we making these changes?

```
   NO_ERROR (0x0):  The associated condition is not a result of an
      error.  For example, a GOAWAY might include this code to indicate
      graceful shutdown of a connection.
```

https://tools.ietf.org/html/rfc7540#section-7


