### PR TITLE
/waiter-ping ensures that all routers see service before responding

### DIFF
--- a/waiter/integration/waiter/health_check_test.clj
+++ b/waiter/integration/waiter/health_check_test.clj
@@ -35,9 +35,7 @@
                (get-in ping-response [:headers :x-kitchen-protocol-version]))
             (str ping-response))
         (is (= "get" (get-in ping-response [:headers :x-kitchen-request-method])) (str ping-response))
-        (is (:exists? service-state) (str service-state))
-        (is (= service-id (:service-id service-state)) (str service-state))
-        (is (contains? #{"Running" "Starting"} (:status service-state)) (str service-state)))
+        (is (= {:exists? true :healthy? true :service-id service-id :status "Running"} service-state)))
       (do
         (is (= "timed-out" (get ping-response :result)) (str ping-response))
         (is (= {:exists? true :healthy? false :service-id service-id :status "Starting"} service-state))))))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1504,8 +1504,8 @@
                                   (oidc/oidc-enabled-request-handler oidc-authenticator waiter-hostnames request))))
    :not-found-handler-fn (pc/fnk [] handler/not-found-handler)
    :ping-service-handler (pc/fnk [[:daemons router-state-maintainer]
-                                  [:state fallback-state-atom router-id user-agent-version]
                                   [:routines make-inter-router-requests-async-fn]
+                                  [:state fallback-state-atom router-id user-agent-version]
                                   process-request-handler-fn process-request-wrapper-fn wrap-secure-request-fn]
                            (let [{{:keys [query-state-fn]} :maintainer} router-state-maintainer
                                  user-agent (str "waiter-ping/" user-agent-version)

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -443,9 +443,8 @@
                                             <?
                                             vals
                                             reduce-results)))
-          fallback-state @fallback-state-atom
           final-fallback-state (case ping-result
-                                 :timed-out (do
+                                 :timed-out (let [fallback-state @fallback-state-atom]
                                               (log/info "skipping inter router checks because ping timed out")
                                               {:healthy? (service-healthy? fallback-state service-id)
                                                :exists? (service-exists? fallback-state service-id)})

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -433,10 +433,11 @@
               (log/info "skipping inter router checks as ping timed out"))
           service-healthy? (if ping-timeout?
                              (service-healthy? fallback-state service-id)
-                             (and ping-success? (every?
-                                                  true?
-                                                  (vals
-                                                    (<? (await-service-goal-fallback-state fallback-state-atom make-inter-router-requests-async-fn router-id service-id router-comm-timeout-ms sleep-duration-ms "healthy"))))))
+                             (and ping-success?
+                                  (->> (await-service-goal-fallback-state fallback-state-atom make-inter-router-requests-async-fn router-id service-id router-comm-timeout-ms sleep-duration-ms "healthy")
+                                       (<?)
+                                       (vals)
+                                       (every? true?))))
           service-exists? (or
                             service-healthy?
                             (if ping-timeout?

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -438,7 +438,7 @@
                                                   (vals
                                                     (<? (await-service-goal-fallback-state fallback-state-atom make-inter-router-requests-async-fn router-id service-id router-comm-timeout-ms sleep-duration-ms "healthy"))))))
           service-exists? (or
-                            (and ping-success? service-healthy?)
+                            service-healthy?
                             (if ping-timeout?
                               (service-exists? fallback-state service-id)
                               (every?

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -21,6 +21,7 @@
             [clojure.set :as set]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
+            [clojure.walk :as walk]
             [full.async :refer [<? go-try]]
             [metrics.counters :as counters]
             [metrics.meters :as meters]
@@ -378,7 +379,8 @@
          :latest-descriptor latest-descriptor}))))
 
 (defn await-service-goal-fallback-state-locally
-  "Polls fallback-state-atom locally and returns true if the goal state was reached and false if timeout is reached"
+  "Polls fallback-state-atom locally and returns a map
+  {:goal-state :goal-success? :service-exists? service-healthy? :service-id}"
   [fallback-state-atom service-id timeout sleep-duration goal]
   (async/go
     (let [goal-reached-predicate (case goal
@@ -389,14 +391,18 @@
         (let [fallback-state @fallback-state-atom
               goal-reached? (goal-reached-predicate fallback-state)]
           (if (or goal-reached? (not (pos? time-left-ms)))
-            goal-reached?
+            {:goal-success? goal-reached?
+             :goal-state goal
+             :service-exists? (service-exists? fallback-state service-id)
+             :service-healthy? (service-healthy? fallback-state service-id)
+             :service-id service-id}
             (do
               (async/<! (async/timeout (min sleep-duration time-left-ms)))
               (recur (- time-left-ms sleep-duration)))))))))
 
 (defn await-service-goal-fallback-state
   "Polls local router and other routers and returns map router-id->result where the result
-  is a map of {:success? :fallback-state {:exists? healthy?}}"
+  is a map of {:goal-state :goal-success? :service-exists? service-healthy? :service-id}"
   [fallback-state-atom make-inter-router-requests-fn router-id service-id timeout sleep-duration goal]
   (go-try
     (let [router-id->response-chan (assoc
@@ -406,14 +412,8 @@
                                      router-id (async/go
                                                  {:body (async/go
                                                           (json/write-str
-                                                            {:success? (async/<! (await-service-goal-fallback-state-locally
-                                                                                   fallback-state-atom service-id timeout sleep-duration goal))
-                                                             :fallback-state {:exists? (service-exists? @fallback-state-atom service-id)
-                                                                              :healthy? (service-healthy? @fallback-state-atom service-id)}}))}))
-          extract-result-fn (fn [result]
-                              {:success? (get result "success?")
-                               :fallback-state {:exists? (get-in result ["fallback-state", "exists?"])
-                                                :healthy? (get-in result ["fallback-state", "healthy?"])}})]
+                                                            (async/<! (await-service-goal-fallback-state-locally
+                                                                        fallback-state-atom service-id timeout sleep-duration goal))))}))]
       (loop [router-id->result {}
              [[router-id response-chan] & remaining] (seq router-id->response-chan)]
         (if (and router-id response-chan)
@@ -423,23 +423,20 @@
                                                        :body
                                                        async/<!
                                                        utils/try-parse-json
-                                                       extract-result-fn))
+                                                       walk/keywordize-keys))
             remaining)
           router-id->result)))))
 
 (defn extract-service-state
-  "Extract the service state which is consistent on all routers. The ping-result determines what checks are made."
+  "Extract the service state which is consistent on all routers. The ping-result determines what checks are made.
+  The value returned is a map {:healthy? :exists? :service-id :status}"
   [router-id retrieve-service-status-label-fn fallback-state-atom make-inter-router-requests-async-fn service-id ping-result]
   (go-try
     (let [router-comm-timeout-ms 5000
           sleep-duration-ms 100
           reduce-results (fn [router-service-state-list]
-                           {:healthy? (every?
-                                        #(true? (get-in % [:fallback-state :healthy?]))
-                                        router-service-state-list)
-                            :exists? (every?
-                                       #(true? (get-in % [:fallback-state :exists?]))
-                                       router-service-state-list)})
+                           {:healthy? (every? :service-healthy? router-service-state-list)
+                            :exists? (every? :service-exists? router-service-state-list)})
           get-final-fallback-state (fn [event]
                                      (go-try
                                        (->> (await-service-goal-fallback-state fallback-state-atom make-inter-router-requests-async-fn router-id service-id router-comm-timeout-ms sleep-duration-ms event)

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -443,11 +443,12 @@
                                             <?
                                             vals
                                             reduce-results)))
+          fallback-state @fallback-state-atom
           final-fallback-state (case ping-result
                                  :timed-out (do
                                               (log/info "skipping inter router checks because ping timed out")
-                                              {:healthy? (service-healthy? @fallback-state-atom service-id)
-                                               :exists? (service-exists? @fallback-state-atom service-id)})
+                                              {:healthy? (service-healthy? fallback-state service-id)
+                                               :exists? (service-exists? fallback-state service-id)})
                                  :received-response (<? (get-final-fallback-state "healthy"))
                                  :else (<? (get-final-fallback-state "exist")))]
       (assoc final-fallback-state

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -450,6 +450,6 @@
                                                :exists? (service-exists? @fallback-state-atom service-id)})
                                  :received-response (<? (get-final-fallback-state "healthy"))
                                  :else (<? (get-final-fallback-state "exist")))]
-      (merge final-fallback-state
-             {:service-id service-id
-              :status (retrieve-service-status-label-fn service-id)}))))
+      (assoc final-fallback-state
+        :service-id service-id
+        :status (retrieve-service-status-label-fn service-id)))))

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -429,8 +429,8 @@
           sleep-duration-ms 100
           ping-timeout? (= ping-result :timed-out)
           ping-success? (= ping-result :received-response)
-          _ (when ping-timeout? (log/info (:ping-result ping-result)
-                                          "is :timed-out; therefore skipping inter router checks and defaulting to local service exists? and healthy? checks"))
+          _ (when ping-timeout?
+              (log/info "skipping inter router checks as ping timed out"))
           service-healthy? (if ping-timeout?
                              (service-healthy? fallback-state service-id)
                              (and ping-success? (every?

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -403,7 +403,7 @@
                                     (->> (descriptor/await-service-goal-fallback-state fallback-state-atom make-inter-router-requests-fn router-id service-id timeout sleep-duration-ms goal)
                                          (<?)
                                          (vals)
-                                         (every? #(true? (:success? %)))))
+                                         (every? :goal-success?)))
                     response-body-map (cond-> {:service-id service-id,
                                                :success (= http-200-ok response-status)}
                                               (some? routers-agree) (assoc :routers-agree routers-agree)
@@ -693,12 +693,9 @@
                                   :status http-400-bad-request
                                   :timeout timeout
                                   :sleep-duration sleep-duration})))
-               (utils/clj->json-response {:success? (async/<!
-                                                      (descriptor/await-service-goal-fallback-state-locally
-                                                        fallback-state-atom service-id parsed-timeout parsed-sleep-duration goal-state))
-                                          :fallback-state {:exists? (descriptor/service-exists? @fallback-state-atom service-id)
-                                                           :healthy? (descriptor/service-healthy? @fallback-state-atom service-id)}
-                                          :service-id service-id}))
+               (utils/clj->json-response (async/<!
+                                           (descriptor/await-service-goal-fallback-state-locally
+                                             fallback-state-atom service-id parsed-timeout parsed-sleep-duration goal-state))))
         (utils/exception->response (ex-info "Only GET supported" {:log-level :info
                                               :request-method request-method
                                               :status http-405-method-not-allowed})

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -400,11 +400,11 @@
                     should-poll? (and (= http-200-ok response-status)
                                       (pos? timeout))
                     routers-agree (when should-poll?
-                                    (every?
-                                      true?
-                                      (vals
-                                        (<?
-                                          (descriptor/await-service-goal-fallback-state fallback-state-atom make-inter-router-requests-fn router-id service-id timeout sleep-duration-ms goal)))))
+                                    (->> (descriptor/await-service-goal-fallback-state fallback-state-atom make-inter-router-requests-fn router-id service-id timeout sleep-duration-ms goal)
+                                         (<?)
+                                         (vals)
+                                         :success?
+                                         (every? true?)))
                     response-body-map (cond-> {:service-id service-id,
                                                :success (= http-200-ok response-status)}
                                               (some? routers-agree) (assoc :routers-agree routers-agree)

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -403,8 +403,7 @@
                                     (->> (descriptor/await-service-goal-fallback-state fallback-state-atom make-inter-router-requests-fn router-id service-id timeout sleep-duration-ms goal)
                                          (<?)
                                          (vals)
-                                         :success?
-                                         (every? true?)))
+                                         (every? #(true? (:success? %)))))
                     response-body-map (cond-> {:service-id service-id,
                                                :success (= http-200-ok response-status)}
                                               (some? routers-agree) (assoc :routers-agree routers-agree)

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -697,6 +697,8 @@
                (utils/clj->json-response {:success? (async/<!
                                                       (descriptor/await-service-goal-fallback-state-locally
                                                         fallback-state-atom service-id parsed-timeout parsed-sleep-duration goal-state))
+                                          :fallback-state {:exists? (descriptor/service-exists? @fallback-state-atom service-id)
+                                                           :healthy? (descriptor/service-healthy? @fallback-state-atom service-id)}
                                           :service-id service-id}))
         (utils/exception->response (ex-info "Only GET supported" {:log-level :info
                                               :request-method request-method

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -959,8 +959,7 @@
             request (assoc-in request [:headers "user-agent"] user-agent)
             idle-timeout-ms (Integer/parseInt (get headers "x-waiter-timeout" "300000"))
             health-check-protocol (scheduler/service-description->health-check-protocol service-description)
-            ping-response (async/<! (make-health-check-request process-request-handler-fn idle-timeout-ms request health-check-protocol))
-            ping-successful? (= (:result ping-response) :received-response)]
+            ping-response (async/<! (make-health-check-request process-request-handler-fn idle-timeout-ms request health-check-protocol))]
         (let [{:strs [health-check-url]} service-description
               backend-protocol (hu/backend-protocol->http-version health-check-protocol)
               backend-scheme (hu/backend-proto->scheme health-check-protocol)
@@ -982,6 +981,6 @@
           (utils/clj->json-response
             {:ping-response (select-keys ping-response [:body :headers :result :status])
              :service-description core-service-description
-             :service-state (fa/<? (service-state-fn service-id ping-successful?))})))
+             :service-state (fa/<? (service-state-fn service-id (:result ping-response)))})))
       (catch Exception ex
         (utils/exception->response ex request)))))

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -587,6 +587,16 @@
       (log/info "cannot convert value to an int:" value)
       nil)))
 
+(defn parse-bool
+  "Returns either the input as a boolean value or nil if there was an error in parsing."
+  [value]
+  (try
+    (when value
+      (Boolean/parseBoolean (str value)))
+    (catch Exception _
+      (log/info "cannot convert value to a boolean:" value)
+      nil)))
+
 (defn param-contains?
   "Returns true if and only if request parameter k is present in params and has a value equal to v."
   [params k v]

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -587,16 +587,6 @@
       (log/info "cannot convert value to an int:" value)
       nil)))
 
-(defn parse-bool
-  "Returns either the input as a boolean value or nil if there was an error in parsing."
-  [value]
-  (try
-    (when value
-      (Boolean/parseBoolean (str value)))
-    (catch Exception _
-      (log/info "cannot convert value to a boolean:" value)
-      nil)))
-
 (defn param-contains?
   "Returns true if and only if request parameter k is present in params and has a value equal to v."
   [params k v]

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -512,8 +512,8 @@
 
     (testing "service-handler:delete-multiple-router-response-agree"
       (reset! delete-service-result-atom {:result :deleted, :service-id service-id})
-      (reset! make-inter-router-requests-async-fn-atom (constantly {"r1" (async/go {:body (async/go (json/write-str {"success?" true}))})
-                                                                    "r2" (async/go {:body (async/go (json/write-str {"success?" true}))})}))
+      (reset! make-inter-router-requests-async-fn-atom (constantly {"r1" (async/go {:body (async/go (json/write-str {"goal-success?" true}))})
+                                                                    "r2" (async/go {:body (async/go (json/write-str {"goal-success?" true}))})}))
       (with-redefs [sd/fetch-core (fn [_ service-id & _] {"run-as-user" user, "name" (str service-id "-name")})]
         (let [request {:query-string "timeout=5000"
                        :request-method :delete
@@ -526,8 +526,8 @@
 
     (testing "service-handler:delete-multiple-router-response-disagree"
       (reset! delete-service-result-atom {:result :deleted, :service-id service-id})
-      (reset! make-inter-router-requests-async-fn-atom (constantly {"r1" (async/go {:body (async/go (json/write-str {"success?" false}))})
-                                                                    "r2" (async/go {:body (async/go (json/write-str {"success?" true}))})}))
+      (reset! make-inter-router-requests-async-fn-atom (constantly {"r1" (async/go {:body (async/go (json/write-str {"goal-success?" false}))})
+                                                                    "r2" (async/go {:body (async/go (json/write-str {"goal-success?" true}))})}))
       (with-redefs [sd/fetch-core (fn [_ service-id & _] {"run-as-user" user, "name" (str service-id "-name")})]
         (let [request {:query-string "timeout=5000"
                        :request-method :delete
@@ -553,8 +553,8 @@
 
     (testing "service-handler:delete-internal-json-error"
       (reset! delete-service-result-atom {:result :deleted, :service-id service-id})
-      (reset! make-inter-router-requests-async-fn-atom (constantly {"r1" (async/go {:body (async/go (json/write-str {"success?" false}))})
-                                                                    "r2" (async/go {:body (async/go (json/write-str {"success?" true}))})
+      (reset! make-inter-router-requests-async-fn-atom (constantly {"r1" (async/go {:body (async/go (json/write-str {"goal-success?" false}))})
+                                                                    "r2" (async/go {:body (async/go (json/write-str {"goal-success?" true}))})
                                                                     "r3" (async/go {:body (async/go nil)})
                                                                     "r4" (async/go {:body (async/go "non-parsable json")})}))
       (with-redefs [sd/fetch-core (fn [_ service-id & _] {"run-as-user" user, "name" (str service-id "-name")})]

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -435,7 +435,7 @@
                        :state {:kv-store nil
                                :router-id "router-id"
                                :scheduler-interactions-thread-pool scheduler-interactions-thread-pool
-                               :fallback-state-atom (atom {:available-service-ids #{}})}
+                               :fallback-state-atom (atom {:available-service-ids #{} :healthy-service-ids #{}})}
                        :wrap-secure-request-fn utils/wrap-identity}
         handlers {:service-handler-fn ((:service-handler-fn request-handlers) configuration)}]
 

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -510,7 +510,6 @@
           (is (= http-500-internal-server-error status))
           (is (= expected-json-response-headers headers)))))
 
-    (println "START")
     (testing "service-handler:delete-multiple-router-response-agree"
       (reset! delete-service-result-atom {:result :deleted, :service-id service-id})
       (reset! make-inter-router-requests-async-fn-atom (constantly {"r1" (async/go {:body (async/go (json/write-str {"success?" true}))})

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -510,6 +510,7 @@
           (is (= http-500-internal-server-error status))
           (is (= expected-json-response-headers headers)))))
 
+    (println "START")
     (testing "service-handler:delete-multiple-router-response-agree"
       (reset! delete-service-result-atom {:result :deleted, :service-id service-id})
       (reset! make-inter-router-requests-async-fn-atom (constantly {"r1" (async/go {:body (async/go (json/write-str {"success?" true}))})

--- a/waiter/test/waiter/descriptor_test.clj
+++ b/waiter/test/waiter/descriptor_test.clj
@@ -1137,8 +1137,7 @@
 
     (testing (str fn-name ":ping-result-timed-out")
       (let [ping-result :timed-out
-            make-inter-router-requests-async-fn (fn [& _]
-                                                  (throw (Exception. "Should not call this function")))
+            make-inter-router-requests-async-fn (fn [& _] (is false))
             fallback-state-atom (atom {:available-service-ids #{"s1"}
                                        :healthy-service-ids #{"s1"}})
             service-state (<?? (extract-service-state router-id retrieve-service-status-label-fn fallback-state-atom make-inter-router-requests-async-fn service-id ping-result))]

--- a/waiter/test/waiter/descriptor_test.clj
+++ b/waiter/test/waiter/descriptor_test.clj
@@ -1129,15 +1129,15 @@
                                                   {"r1" (async/go
                                                           {:body (async/go
                                                                    (json/write-str
-                                                                     {:success? true
-                                                                      :fallback-state {:exists? true
-                                                                                       :healthy? true}}))})
+                                                                     {:goal-success? true
+                                                                      :service-exists? true
+                                                                      :service-healthy? true}))})
                                                    "r2" (async/go
                                                           {:body (async/go
                                                                    (json/write-str
-                                                                     {:success? true
-                                                                      :fallback-state {:exists? true
-                                                                                       :healthy? true}}))})})
+                                                                     {:goal-success? true
+                                                                      :service-exists? true
+                                                                      :service-healthy? true}))})})
             fallback-state-atom (atom {:available-service-ids #{"s1"}
                                        :healthy-service-ids #{"s1"}})
             service-state (<?? (extract-service-state router-id retrieve-service-status-label-fn fallback-state-atom make-inter-router-requests-async-fn service-id ping-result))]
@@ -1163,15 +1163,15 @@
                                                   {"r1" (async/go
                                                           {:body (async/go
                                                                    (json/write-str
-                                                                     {:success? true
-                                                                      :fallback-state {:exists? true
-                                                                                       :healthy? true}}))})
+                                                                     {:goal-success? true
+                                                                      :service-exists? true
+                                                                      :service-healthy? true}))})
                                                    "r2" (async/go
                                                           {:body (async/go
                                                                    (json/write-str
-                                                                     {:success? false
-                                                                      :fallback-state {:exists? true
-                                                                                       :healthy? false}}))})})
+                                                                     {:goal-success? false
+                                                                      :service-exists? true
+                                                                      :service-healthy? false}))})})
             fallback-state-atom (atom {:available-service-ids #{"s1"}
                                        :healthy-service-ids #{"s1"}})
             service-state (<?? (extract-service-state router-id retrieve-service-status-label-fn fallback-state-atom make-inter-router-requests-async-fn service-id ping-result))]

--- a/waiter/test/waiter/descriptor_test.clj
+++ b/waiter/test/waiter/descriptor_test.clj
@@ -1126,8 +1126,18 @@
             goal-state "healthy"
             make-inter-router-requests-async-fn (fn [endpoint & _]
                                                   (is (= endpoint (str "apps/" service-id "/await/" goal-state)))
-                                                  {"r1" (async/go {:body (async/go (json/write-str {"success?" true}))})
-                                                   "r2" (async/go {:body (async/go (json/write-str {"success?" true}))})})
+                                                  {"r1" (async/go
+                                                          {:body (async/go
+                                                                   (json/write-str
+                                                                     {:success? true
+                                                                      :fallback-state {:exists? true
+                                                                                       :healthy? true}}))})
+                                                   "r2" (async/go
+                                                          {:body (async/go
+                                                                   (json/write-str
+                                                                     {:success? true
+                                                                      :fallback-state {:exists? true
+                                                                                       :healthy? true}}))})})
             fallback-state-atom (atom {:available-service-ids #{"s1"}
                                        :healthy-service-ids #{"s1"}})
             service-state (<?? (extract-service-state router-id retrieve-service-status-label-fn fallback-state-atom make-inter-router-requests-async-fn service-id ping-result))]
@@ -1149,16 +1159,21 @@
       (let [ping-result :received-response
             goal-state "healthy"
             make-inter-router-requests-async-fn (fn [endpoint & _]
-                                                  (cond
-                                                    (= endpoint (str "apps/" service-id "/await/" goal-state))
-                                                    {"r1" (async/go {:body (async/go (json/write-str {"success?" true}))})
-                                                     "r2" (async/go {:body (async/go (json/write-str {"success?" false}))})}
-                                                    (= endpoint (str "apps/" service-id "/await/" "exist"))
-                                                    {"r1" (async/go {:body (async/go (json/write-str {"success?" true}))})
-                                                     "r2" (async/go {:body (async/go (json/write-str {"success?" true}))})}
-                                                    :else (is false)))
+                                                  (is (= endpoint (str "apps/" service-id "/await/" goal-state)))
+                                                  {"r1" (async/go
+                                                          {:body (async/go
+                                                                   (json/write-str
+                                                                     {:success? true
+                                                                      :fallback-state {:exists? true
+                                                                                       :healthy? true}}))})
+                                                   "r2" (async/go
+                                                          {:body (async/go
+                                                                   (json/write-str
+                                                                     {:success? false
+                                                                      :fallback-state {:exists? true
+                                                                                       :healthy? false}}))})})
             fallback-state-atom (atom {:available-service-ids #{"s1"}
-                                       :healthy-service-ids #{}})
+                                       :healthy-service-ids #{"s1"}})
             service-state (<?? (extract-service-state router-id retrieve-service-status-label-fn fallback-state-atom make-inter-router-requests-async-fn service-id ping-result))]
         (is (= (:service-id service-state) service-id))
         (is (true? (:exists? service-state)))

--- a/waiter/test/waiter/descriptor_test.clj
+++ b/waiter/test/waiter/descriptor_test.clj
@@ -16,9 +16,11 @@
 (ns waiter.descriptor-test
   (:require [clj-time.core :as t]
             [clojure.core.async :as async]
+            [clojure.data.json :as json]
             [clojure.set :as set]
             [clojure.test :refer :all]
             [clojure.walk :as walk]
+            [full.async :refer [<??]]
             [plumbing.core :as pc]
             [waiter.descriptor :refer :all]
             [waiter.kv :as kv]
@@ -1112,3 +1114,34 @@
                                             "run-as-user" auth-user}
                       :service-preauthorized false}]
       (is (true? (service-invocation-authorized? can-run-as? auth-user descriptor))))))
+
+(deftest test-extract-service-state
+  (let [fn-name "test-extract-service-state"
+        router-id "r1"
+        service-id "s1"
+        retrieve-service-status-label-fn (constantly nil)]
+
+    (testing (str fn-name ":ping-result-received-response")
+      (let [ping-result :received-response
+            goal-state "healthy"
+            make-inter-router-requests-async-fn (fn [endpoint & _]
+                                                  (is (= endpoint (str "apps/" service-id "/await/" goal-state)))
+                                                  {"r1" (async/go {:body (async/go (json/write-str {"success?" true}))})
+                                                   "r2" (async/go {:body (async/go (json/write-str {"success?" true}))})})
+            fallback-state-atom (atom {:available-service-ids #{"s1"}
+                                       :healthy-service-ids #{"s1"}})
+            service-state (<?? (extract-service-state router-id retrieve-service-status-label-fn fallback-state-atom make-inter-router-requests-async-fn service-id ping-result))]
+        (is (= (:service-id service-state) service-id))
+        (is (true? (:exists? service-state)))
+        (is (true? (:healthy? service-state)))))
+
+    (testing (str fn-name ":ping-result-timed-out")
+      (let [ping-result :timed-out
+            make-inter-router-requests-async-fn (fn [& _]
+                                                  (throw (Exception. "Should not call this function")))
+            fallback-state-atom (atom {:available-service-ids #{"s1"}
+                                       :healthy-service-ids #{"s1"}})
+            service-state (<?? (extract-service-state router-id retrieve-service-status-label-fn fallback-state-atom make-inter-router-requests-async-fn service-id ping-result))]
+        (is (= (:service-id service-state) service-id))
+        (is (true? (:exists? service-state)))
+        (is (true? (:healthy? service-state)))))))

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -864,7 +864,15 @@
             {:keys [body headers status]} (async/<!! (service-await-handler fallback-state-atom request))]
         (is (= http-400-bad-request status))
         (is (= "text/plain" (get headers "content-type")))
-        (is (re-find #"timeout is a required query parameter" body))))))
+        (is (re-find #"timeout is a required query parameter" body))))
+
+    (testing (str handler-name ":nil-goal-existence")
+      (let [fallback-state-atom (atom {:available-service-ids #{}})
+            request-bad-query (assoc request :query-string (str "timeout=1000"))
+            {:keys [body headers status]} (async/<!! (service-await-goal-existence-handler fallback-state-atom request-bad-query))]
+        (is (= http-400-bad-request status))
+        (is (= "text/plain" (get headers "content-type")))
+        (is (re-find #"goal-existence is a required query parameter" body))))))
 
 (deftest test-work-stealing-handler
   (let [test-service-id "test-service-id"

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -839,10 +839,10 @@
             timeout 2000
             update-delay 1000
             request (assoc request :query-string (str "timeout=" timeout "&sleep-duration=" (* 10 timeout)))
-            start-time (System/currentTimeMillis)
             _ (async/go
                 (async/<! (async/timeout update-delay))
                 (reset! fallback-state-atom goal-fallback-state))
+            start-time (System/currentTimeMillis)
             {:keys [body headers status]} (async/<!! (service-await-handler fallback-state-atom request))
             end-time (System/currentTimeMillis)
             parsed-body (json/read-str body)]
@@ -857,10 +857,10 @@
             timeout 10000
             update-delay 2000
             request-query (assoc request :query-string (str "timeout=" timeout))
-            start-time (System/currentTimeMillis)
             _ (async/go
                 (async/<! (async/timeout update-delay))
                 (reset! fallback-state-atom {:available-service-ids #{} :healthy-service-ids #{}}))
+            start-time (System/currentTimeMillis)
             {:keys [body headers status]} (async/<!! (service-await-handler fallback-state-atom request-query))
             end-time (System/currentTimeMillis)
             parsed-body (json/read-str body)]


### PR DESCRIPTION
## Changes proposed in this PR
- /waiter-ping command should wait for routers to agree that the service is healthy and exists

## Why are we making these changes?
- users expect the command to return when all routers have a consistent state

