### PR TITLE
Refactor await endpoint

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -95,7 +95,7 @@
                      "app-name" :app-name-handler-fn
                      "apps" {"" :service-list-handler-fn
                              ["/" :service-id] :service-handler-fn
-                             ["/" :service-id "/await-goal-existence"] :service-await-goal-existence-handler-fn
+                             ["/" :service-id "/await/" :goal-state] :service-await-handler-fn
                              ["/" :service-id "/logs"] :service-view-logs-handler-fn
                              ["/" :service-id "/override"] :service-override-handler-fn
                              ["/" :service-id "/refresh"] :service-refresh-handler-fn
@@ -1622,11 +1622,11 @@
                                      (sd/fetch-core kv-store service-id :refresh true)
                                      (sd/service-id->suspended-state kv-store service-id :refresh true)
                                      (sd/service-id->overrides kv-store service-id :refresh true))))
-   :service-await-goal-existence-handler-fn (pc/fnk [[:state fallback-state-atom]
+   :service-await-handler-fn (pc/fnk [[:state fallback-state-atom]
                                                wrap-router-auth-fn]
                                         (wrap-router-auth-fn
-                                          (fn service-await-deletion-handler [request]
-                                            (handler/service-await-goal-existence-handler fallback-state-atom request))))
+                                          (fn service-await-handler-handler [request]
+                                            (handler/service-await-handler fallback-state-atom request))))
    :service-resume-handler-fn (pc/fnk [[:routines allowed-to-manage-service?-fn make-inter-router-requests-sync-fn]
                                        [:state kv-store]
                                        wrap-secure-request-fn]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1625,7 +1625,7 @@
    :service-await-handler-fn (pc/fnk [[:state fallback-state-atom]
                                                wrap-router-auth-fn]
                                         (wrap-router-auth-fn
-                                          (fn service-await-handler-handler [request]
+                                          (fn service-await-handler-fn [request]
                                             (handler/service-await-handler fallback-state-atom request))))
    :service-resume-handler-fn (pc/fnk [[:routines allowed-to-manage-service?-fn make-inter-router-requests-sync-fn]
                                        [:state kv-store]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -95,7 +95,7 @@
                      "app-name" :app-name-handler-fn
                      "apps" {"" :service-list-handler-fn
                              ["/" :service-id] :service-handler-fn
-                             ["/" :service-id "/await-deletion"] :service-await-deletion-handler-fn
+                             ["/" :service-id "/await-goal-existence"] :service-await-goal-existence-handler-fn
                              ["/" :service-id "/logs"] :service-view-logs-handler-fn
                              ["/" :service-id "/override"] :service-override-handler-fn
                              ["/" :service-id "/refresh"] :service-refresh-handler-fn
@@ -1622,11 +1622,11 @@
                                      (sd/fetch-core kv-store service-id :refresh true)
                                      (sd/service-id->suspended-state kv-store service-id :refresh true)
                                      (sd/service-id->overrides kv-store service-id :refresh true))))
-   :service-await-deletion-handler-fn (pc/fnk [[:state fallback-state-atom]
+   :service-await-goal-existence-handler-fn (pc/fnk [[:state fallback-state-atom]
                                                wrap-router-auth-fn]
                                         (wrap-router-auth-fn
                                           (fn service-await-deletion-handler [request]
-                                            (handler/service-await-deletion-handler fallback-state-atom request))))
+                                            (handler/service-await-goal-existence-handler fallback-state-atom request))))
    :service-resume-handler-fn (pc/fnk [[:routines allowed-to-manage-service?-fn make-inter-router-requests-sync-fn]
                                        [:state kv-store]
                                        wrap-secure-request-fn]

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -407,7 +407,7 @@
                                                           (json/write-str
                                                             {:success? (async/<! (await-service-goal-fallback-state-locally
                                                                                   fallback-state-atom service-id timeout sleep-duration goal))}))}))]
-      (loop [result {}
+      (loop [router-id->success? {}
              [[router-id response-chan] & remaining] (seq router-id->response-chan)]
         (if (and router-id response-chan)
           (recur
@@ -418,4 +418,4 @@
                                             utils/try-parse-json
                                             (get "success?")))
             remaining)
-          result)))))
+          router-id->success?)))))

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -411,7 +411,7 @@
              [[router-id response-chan] & remaining] (seq router-id->response-chan)]
         (if (and router-id response-chan)
           (recur
-            (assoc result router-id (some-> response-chan
+            (assoc router-id->success? router-id (some-> response-chan
                                             async/<!
                                             :body
                                             async/<!

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -24,7 +24,7 @@
             [comb.template :as template]
             [metrics.counters :as counters]
             [metrics.meters :as meters]
-            [full.async :refer [<? go-try]]
+            [full.async :refer [<?]]
             [plumbing.core :as pc]
             [ring.middleware.multipart-params :as multipart-params]
             [waiter.async-request :as async-req]
@@ -356,48 +356,6 @@
                           viewable-service-ids)]
       (utils/clj->streaming-json-response response-data))))
 
-(defn- await-service-goal-existence-locally
-  "Polls fallback-state-atom locally and waits until timeout is reached or service existence is equal to the goal existence"
-  [fallback-state-atom service-id timeout sleep-duration goal-existence]
-  (async/go
-    (loop [time-left-ms timeout]
-      (let [fallback-state @fallback-state-atom
-            exists? (descriptor/service-exists? fallback-state service-id)]
-        (if (or (= exists? goal-existence) (not (pos? time-left-ms)))
-          exists?
-          (do
-            (async/<! (async/timeout sleep-duration))
-            (recur (- time-left-ms sleep-duration))))))))
-
-(defn await-service-goal-existence
-  "Polls local router and other routers and returns true if goal-existence is reached and false otherwise"
-  [fallback-state-atom make-inter-router-requests-fn router-id service-id timeout sleep-duration goal-existence]
-  (go-try
-    (let [router-id->response-chan (assoc
-                                     (make-inter-router-requests-fn (str "apps/" service-id "/await-goal-existence")
-                                                                    :method :get
-                                                                    :config {:query-string (str "timeout=" timeout "&goal-existence=" goal-existence)})
-                                     router-id (async/go
-                                                 {:body (async/go
-                                                          (json/write-str
-                                                            {:exists? (async/<! (await-service-goal-existence-locally
-                                                                                  fallback-state-atom service-id timeout sleep-duration goal-existence))}))}))
-          router-id->exists? (loop [result {}
-                                    [[router-id response-chan] & remaining] (seq router-id->response-chan)]
-                               (if (and router-id response-chan)
-                                 (recur
-                                   (assoc result router-id (some-> response-chan
-                                                                   async/<!
-                                                                   :body
-                                                                   async/<!
-                                                                   utils/try-parse-json
-                                                                   (get "exists?")))
-                                   remaining)
-                                 result))]
-      (every?
-        #(= goal-existence %)
-        (vals router-id->exists?)))))
-
 (defn delete-service-handler
   "Deletes the service from the scheduler (after authorization checks)."
   [router-id service-id core-service-description scheduler allowed-to-manage-service?-fn scheduler-interactions-thread-pool
@@ -432,7 +390,9 @@
                                            scheduler-interactions-thread-pool))]
             (if error
               (utils/exception->response error request)
-              (let [delete-result (:result result)
+              (let [goal "deleted"
+                    sleep-duration-ms 100
+                    delete-result (:result result)
                     response-status (case delete-result
                                       :deleted http-200-ok
                                       :no-such-service-exists http-404-not-found
@@ -441,7 +401,7 @@
                                       (pos? timeout))
                     routers-agree (when should-poll?
                                     (<?
-                                      (await-service-goal-existence fallback-state-atom make-inter-router-requests-fn router-id service-id timeout 100 false)))
+                                      (descriptor/await-service-goal-fallback-state fallback-state-atom make-inter-router-requests-fn router-id service-id timeout sleep-duration-ms goal)))
                     response-body-map (cond-> {:service-id service-id,
                                                :success (= http-200-ok response-status)}
                                               should-poll? (assoc :routers-agree routers-agree)
@@ -706,28 +666,22 @@
     (catch Exception ex
       (utils/exception->response ex request))))
 
-(defn service-await-goal-existence-handler
+(defn service-await-handler
   "Polls fallback-state-atom until timeout is reached or service does not exist"
-  [fallback-state-atom {{:keys [service-id]} :route-params
+  [fallback-state-atom {{:keys [service-id goal-state]} :route-params
                         {:keys [src-router-id]} :basic-authentication
                         :keys [request-method]
                         :as request}]
   (async/go
     (try
-      (log/info service-id "service-await-goal-existence-handler triggered by router" src-router-id)
+      (log/info service-id "service-await-handler triggered by router" src-router-id)
       (case request-method
-        :get (let [{:strs [timeout sleep-duration goal-existence] :or {sleep-duration "100"}} (-> request ru/query-params-request :query-params)
+        :get (let [{:strs [timeout sleep-duration] :or {sleep-duration "100"}} (-> request ru/query-params-request :query-params)
                    _ (when (nil? timeout)
                        (throw (ex-info "timeout is a required query parameter"
                                        {:log-level :info
                                         :request-method request-method
                                         :status http-400-bad-request})))
-                   _ (when (nil? goal-existence)
-                       (throw (ex-info "goal-existence is a required query parameter"
-                                       {:log-level :info
-                                        :request-method request-method
-                                        :status http-400-bad-request})))
-                   parsed-goal-existence (Boolean/parseBoolean goal-existence)
                    parsed-timeout (utils/parse-int timeout)
                    parsed-sleep-duration (utils/parse-int sleep-duration)]
                (when (or (nil? parsed-sleep-duration) (nil? parsed-timeout))
@@ -737,9 +691,9 @@
                                   :status http-400-bad-request
                                   :timeout timeout
                                   :sleep-duration sleep-duration})))
-               (utils/clj->json-response {:exists? (async/<!
-                                                     (await-service-goal-existence-locally
-                                                       fallback-state-atom service-id parsed-timeout parsed-sleep-duration parsed-goal-existence))
+               (utils/clj->json-response {:success? (async/<!
+                                                      (descriptor/await-service-goal-fallback-state-locally
+                                                        fallback-state-atom service-id parsed-timeout parsed-sleep-duration goal-state))
                                           :service-id service-id}))
         (utils/exception->response (ex-info "Only GET supported" {:log-level :info
                                               :request-method request-method

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -407,7 +407,7 @@
                                           (descriptor/await-service-goal-fallback-state fallback-state-atom make-inter-router-requests-fn router-id service-id timeout sleep-duration-ms goal)))))
                     response-body-map (cond-> {:service-id service-id,
                                                :success (= http-200-ok response-status)}
-                                              should-poll? (assoc :routers-agree routers-agree)
+                                              (some? routers-agree) (assoc :routers-agree routers-agree)
                                               true (merge result))]
                 (utils/clj->json-response response-body-map :status response-status))))
           (catch Throwable ex

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -376,7 +376,7 @@
     (let [router-id->response-chan (assoc
                                      (make-inter-router-requests-fn (str "apps/" service-id "/await-goal-existence")
                                                                     :method :get
-                                                                    :config {:query-string (str "timeout=" timeout "&goal-existence" goal-existence)})
+                                                                    :config {:query-string (str "timeout=" timeout "&goal-existence=" goal-existence)})
                                      router-id (async/go
                                                  {:body (async/go
                                                           (json/write-str

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -671,7 +671,7 @@
 
 (defn service-await-handler
   "Polls fallback-state-atom until timeout is reached or service does not exist"
-  [fallback-state-atom {{:keys [service-id goal-state]} :route-params
+  [fallback-state-atom {{:keys [goal-state service-id]} :route-params
                         {:keys [src-router-id]} :basic-authentication
                         :keys [request-method]
                         :as request}]

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -677,7 +677,7 @@
                         :as request}]
   (async/go
     (try
-      (log/info service-id "service-await-handler triggered by router" src-router-id)
+      (log/info service-id "service-await-handler triggered by router" src-router-id "with goal:" goal-state)
       (case request-method
         :get (let [{:strs [timeout sleep-duration] :or {sleep-duration "100"}} (-> request ru/query-params-request :query-params)
                    _ (when (nil? timeout)

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -723,11 +723,11 @@
                                         :request-method request-method
                                         :status http-400-bad-request})))
                    _ (when (nil? goal-existence)
-                       (throw (ex-info "goal-existence is required query parameter"
+                       (throw (ex-info "goal-existence is a required query parameter"
                                        {:log-level :info
                                         :request-method request-method
                                         :status http-400-bad-request})))
-                   parsed-goal-existence (utils/parse-bool goal-existence)
+                   parsed-goal-existence (Boolean/parseBoolean goal-existence)
                    parsed-timeout (utils/parse-int timeout)
                    parsed-sleep-duration (utils/parse-int sleep-duration)]
                (when (or (nil? parsed-sleep-duration) (nil? parsed-timeout))
@@ -737,12 +737,6 @@
                                   :status http-400-bad-request
                                   :timeout timeout
                                   :sleep-duration sleep-duration})))
-               (when (nil? parsed-goal-existence)
-                 (throw (ex-info "goal-existence must be boolean value"
-                                 {:log-level :info
-                                  :request-method request-method
-                                  :status http-400-bad-request
-                                  :goal-existence goal-existence})))
                (utils/clj->json-response {:exists? (async/<!
                                                      (await-service-goal-existence-locally
                                                        fallback-state-atom service-id parsed-timeout parsed-sleep-duration parsed-goal-existence))

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -370,7 +370,7 @@
             (recur (- time-left-ms sleep-duration))))))))
 
 (defn await-service-goal-existence
-  "Polls local router and other routers until timeout is reached or the service becomes available/unavailable"
+  "Polls local router and other routers and returns true if goal-existence is reached and false otherwise"
   [fallback-state-atom make-inter-router-requests-fn router-id service-id timeout sleep-duration goal-existence]
   (go-try
     (let [router-id->response-chan (assoc

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -400,8 +400,11 @@
                     should-poll? (and (= http-200-ok response-status)
                                       (pos? timeout))
                     routers-agree (when should-poll?
-                                    (<?
-                                      (descriptor/await-service-goal-fallback-state fallback-state-atom make-inter-router-requests-fn router-id service-id timeout sleep-duration-ms goal)))
+                                    (every?
+                                      true?
+                                      (vals
+                                        (<?
+                                          (descriptor/await-service-goal-fallback-state fallback-state-atom make-inter-router-requests-fn router-id service-id timeout sleep-duration-ms goal)))))
                     response-body-map (cond-> {:service-id service-id,
                                                :success (= http-200-ok response-status)}
                                               should-poll? (assoc :routers-agree routers-agree)

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -587,6 +587,16 @@
       (log/info "cannot convert value to an int:" value)
       nil)))
 
+(defn parse-bool
+  "Returns either the input as a boolean value or nil if there was an error in parsing."
+  [value]
+  (try
+    (when value
+      (Boolean/parseBoolean (str value)))
+    (catch Exception _
+      (log/info "cannot convert value to a boolean:" value)
+      nil)))
+
 (defn param-contains?
   "Returns true if and only if request parameter k is present in params and has a value equal to v."
   [params k v]

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -587,16 +587,6 @@
       (log/info "cannot convert value to an int:" value)
       nil)))
 
-(defn parse-bool
-  "Returns either the input as a boolean value or nil if there was an error in parsing."
-  [value]
-  (try
-    (when value
-      (Boolean/parseBoolean (str value)))
-    (catch Exception _
-      (log/info "cannot convert value to a boolean:" value)
-      nil)))
-
 (defn param-contains?
   "Returns true if and only if request parameter k is present in params and has a value equal to v."
   [params k v]

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -512,8 +512,8 @@
 
     (testing "service-handler:delete-multiple-router-response-agree"
       (reset! delete-service-result-atom {:result :deleted, :service-id service-id})
-      (reset! make-inter-router-requests-async-fn-atom (constantly {"r1" (async/go {:body (async/go (json/write-str {"exists?" false}))})
-                                                                    "r2" (async/go {:body (async/go (json/write-str {"exists?" false}))})}))
+      (reset! make-inter-router-requests-async-fn-atom (constantly {"r1" (async/go {:body (async/go (json/write-str {"success?" true}))})
+                                                                    "r2" (async/go {:body (async/go (json/write-str {"success?" true}))})}))
       (with-redefs [sd/fetch-core (fn [_ service-id & _] {"run-as-user" user, "name" (str service-id "-name")})]
         (let [request {:query-string "timeout=5000"
                        :request-method :delete
@@ -526,8 +526,8 @@
 
     (testing "service-handler:delete-multiple-router-response-disagree"
       (reset! delete-service-result-atom {:result :deleted, :service-id service-id})
-      (reset! make-inter-router-requests-async-fn-atom (constantly {"r1" (async/go {:body (async/go (json/write-str {"exists?" false}))})
-                                                                    "r2" (async/go {:body (async/go (json/write-str {"exists?" true}))})}))
+      (reset! make-inter-router-requests-async-fn-atom (constantly {"r1" (async/go {:body (async/go (json/write-str {"success?" false}))})
+                                                                    "r2" (async/go {:body (async/go (json/write-str {"success?" true}))})}))
       (with-redefs [sd/fetch-core (fn [_ service-id & _] {"run-as-user" user, "name" (str service-id "-name")})]
         (let [request {:query-string "timeout=5000"
                        :request-method :delete
@@ -553,8 +553,8 @@
 
     (testing "service-handler:delete-internal-json-error"
       (reset! delete-service-result-atom {:result :deleted, :service-id service-id})
-      (reset! make-inter-router-requests-async-fn-atom (constantly {"r1" (async/go {:body (async/go (json/write-str {"exists?" false}))})
-                                                                    "r2" (async/go {:body (async/go (json/write-str {"exists?" true}))})
+      (reset! make-inter-router-requests-async-fn-atom (constantly {"r1" (async/go {:body (async/go (json/write-str {"success?" false}))})
+                                                                    "r2" (async/go {:body (async/go (json/write-str {"success?" true}))})
                                                                     "r3" (async/go {:body (async/go nil)})
                                                                     "r4" (async/go {:body (async/go "non-parsable json")})}))
       (with-redefs [sd/fetch-core (fn [_ service-id & _] {"run-as-user" user, "name" (str service-id "-name")})]
@@ -1002,8 +1002,8 @@
            (exec-routes-mapper "/apps")))
     (is (= {:handler :service-handler-fn, :route-params {:service-id "test-service"}}
            (exec-routes-mapper "/apps/test-service")))
-    (is (= {:handler :service-await-goal-existence-handler-fn, :route-params {:service-id "test-service"}}
-           (exec-routes-mapper "/apps/test-service/await-goal-existence")))
+    (is (= {:handler :service-await-handler-fn, :route-params {:service-id "test-service" :goal-state "exists"}}
+           (exec-routes-mapper "/apps/test-service/await/exists")))
     (is (= {:handler :service-view-logs-handler-fn, :route-params {:service-id "test-service"}}
            (exec-routes-mapper "/apps/test-service/logs")))
     (is (= {:handler :service-override-handler-fn, :route-params {:service-id "test-service"}}

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -1002,8 +1002,8 @@
            (exec-routes-mapper "/apps")))
     (is (= {:handler :service-handler-fn, :route-params {:service-id "test-service"}}
            (exec-routes-mapper "/apps/test-service")))
-    (is (= {:handler :service-await-deletion-handler-fn, :route-params {:service-id "test-service"}}
-           (exec-routes-mapper "/apps/test-service/await-deletion")))
+    (is (= {:handler :service-await-goal-existence-handler-fn, :route-params {:service-id "test-service"}}
+           (exec-routes-mapper "/apps/test-service/await-goal-existence")))
     (is (= {:handler :service-view-logs-handler-fn, :route-params {:service-id "test-service"}}
            (exec-routes-mapper "/apps/test-service/logs")))
     (is (= {:handler :service-override-handler-fn, :route-params {:service-id "test-service"}}

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -840,7 +840,15 @@
             {:keys [body headers status]} (async/<!! (service-await-goal-existence-handler fallback-state-atom request-bad-query))]
         (is (= http-400-bad-request status))
         (is (= "text/plain" (get headers "content-type")))
-        (is (re-find #"timeout is a required query parameter" body))))))
+        (is (re-find #"timeout is a required query parameter" body))))
+
+    (testing (str handler-name ":nil-goal-existence")
+      (let [fallback-state-atom (atom {:available-service-ids #{}})
+            request-bad-query (assoc request :query-string (str "timeout=1000"))
+            {:keys [body headers status]} (async/<!! (service-await-goal-existence-handler fallback-state-atom request-bad-query))]
+        (is (= http-400-bad-request status))
+        (is (= "text/plain" (get headers "content-type")))
+        (is (re-find #"goal-existence is a required query parameter" body))))))
 
 (deftest test-work-stealing-handler
   (let [test-service-id "test-service-id"

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -780,111 +780,91 @@
 
       (.shutdown scheduler-interactions-thread-pool))))
 
-(deftest test-service-await-goal-existence-handler
-  (let [handler-name "service-await-goal-existence-handler"
-        request {:route-params {:service-id "s1"}
+(deftest test-service-await-handler
+  (let [handler-name "test-service-await-handler"
+        timeout 1000
+        request {:route-params {:service-id "s1" :goal-state "deleted"}
                  :basic-authentication {:src-router-id "r2"}
                  :request-method :get
-                 :query-string "timeout=1000&goal-existence=false"}]
+                 :query-string (str "timeout=" 1000)}
+        assert-immediate-success
+        (fn [goal-state fallback-state-atom request]
+          (let [request (assoc-in request [:route-params :goal-state] goal-state)
+                {:keys [body headers status]} (async/<!! (service-await-handler fallback-state-atom request))]
+            (is (= http-200-ok status))
+            (is (= "application/json" (get headers "content-type")))
+            (is (get (json/read-str body) "success?"))))
+        assert-force-timeout
+        (fn [timeout goal-state fallback-state-atom request]
+          (let [request (assoc-in request [:route-params :goal-state] goal-state)
+                start-time (System/currentTimeMillis)
+                {:keys [body headers status]} (async/<!! (service-await-handler fallback-state-atom request))
+                end-time (System/currentTimeMillis)]
+            (is (= http-200-ok status))
+            (is (= "application/json" (get headers "content-type")))
+            (is (not (get (json/read-str body) "success?")))
+            (is (>= (- end-time start-time) timeout))))]
 
-    (testing (str handler-name ":immediate-success-with-false-goal-existence")
-      (let [fallback-state-atom (atom {:available-service-ids #{"s0"}})
-            {:keys [body headers status]} (async/<!! (service-await-goal-existence-handler fallback-state-atom request))]
-        (is (= http-200-ok status))
-        (is (= "application/json" (get headers "content-type")))
-        (is (not (get (json/read-str body) "exists?")))))
+    (testing (str handler-name ":immediate-success-deleted")
+      (let [fallback-state-atom (atom {:available-service-ids #{"s0"}})]
+        (assert-immediate-success "deleted" fallback-state-atom request)))
 
-    (testing (str handler-name ":immediate-success-with-true-goal-existence")
+    (testing (str handler-name ":immediate-success-healthy")
+      (let [fallback-state-atom (atom {:available-service-ids #{"s1"} :healthy-service-ids #{"s1"}})]
+        (assert-immediate-success "healthy" fallback-state-atom request)))
+
+    (testing (str handler-name ":immediate-success-exist")
+      (let [fallback-state-atom (atom {:available-service-ids #{"s1"}})]
+        (assert-immediate-success "exist" fallback-state-atom request)))
+
+    (testing (str handler-name ":force-timeout-deleted")
+      (let [fallback-state-atom (atom {:available-service-ids #{"s1"}})]
+        (assert-force-timeout timeout "deleted" fallback-state-atom request)))
+
+    (testing (str handler-name ":force-timeout-healthy")
+      (let [fallback-state-atom (atom {:available-service-ids #{} :healthy-service-ids #{}})]
+        (assert-force-timeout timeout "healthy" fallback-state-atom request)))
+
+    (testing (str handler-name ":force-timeout-exist")
+      (let [fallback-state-atom (atom {:available-service-ids #{}})]
+        (assert-force-timeout timeout "exist" fallback-state-atom request)))
+
+    (testing (str handler-name ":success-with-large-sleep-duration")
       (let [fallback-state-atom (atom {:available-service-ids #{"s1"}})
-            request-query (assoc request :query-string "timeout=1000&goal-existence=true")
-            {:keys [body headers status]} (async/<!! (service-await-goal-existence-handler fallback-state-atom request-query))]
-        (is (= http-200-ok status))
-        (is (= "application/json" (get headers "content-type")))
-        (is (get (json/read-str body) "exists?"))))
-
-    (testing (str handler-name ":force-timeout-custom-with-false-goal-existence")
-      (let [fallback-state-atom (atom {:available-service-ids #{"s1"}})
-            timeout 1000
-            request-query (assoc request :query-string (str "timeout=" timeout "&sleep-duration=300&goal-existence=false"))
-            start-time (System/currentTimeMillis)
-            {:keys [body headers status]} (async/<!! (service-await-goal-existence-handler fallback-state-atom request-query))
-            end-time (System/currentTimeMillis)]
-        (is (= http-200-ok status))
-        (is (= "application/json" (get headers "content-type")))
-        (is (get (json/read-str body) "exists?"))
-        (is (>= (- end-time start-time) timeout))))
-
-    (testing (str handler-name ":force-timeout-custom-with-true-goal-existence")
-      (let [fallback-state-atom (atom {:available-service-ids #{}})
-            timeout 1000
-            request-query (assoc request :query-string (str "timeout=" timeout "&sleep-duration=300&goal-existence=true"))
-            start-time (System/currentTimeMillis)
-            {:keys [body headers status]} (async/<!! (service-await-goal-existence-handler fallback-state-atom request-query))
-            end-time (System/currentTimeMillis)]
-        (is (= http-200-ok status))
-        (is (= "application/json" (get headers "content-type")))
-        (is (not (get (json/read-str body) "exists?")))
-        (is (>= (- end-time start-time) timeout))))
-
-    (testing (str handler-name ":custom-timeout-delete-update-to-false-goal-existence")
-      (let [fallback-state-atom (atom {:available-service-ids #{"s1"}})
-            timeout 10000
-            update-delay 2000
-            request-query (assoc request :query-string (str "timeout=" timeout "&sleep-duration=300&goal-existence=false"))
+            goal-fallback-state {:available-service-ids #{}}
+            timeout 2000
+            update-delay 1000
+            request (assoc request :query-string (str "timeout=" timeout "&sleep-duration=" (* 10 timeout)))
             start-time (System/currentTimeMillis)
             _ (async/go
                 (async/<! (async/timeout update-delay))
-                (reset! fallback-state-atom {:available-service-ids #{}}))
-            {:keys [body headers status]} (async/<!! (service-await-goal-existence-handler fallback-state-atom request-query))
+                (reset! fallback-state-atom goal-fallback-state))
+            {:keys [body headers status]} (async/<!! (service-await-handler fallback-state-atom request))
             end-time (System/currentTimeMillis)]
         (is (= http-200-ok status))
         (is (= "application/json" (get headers "content-type")))
-        (is (not (get (json/read-str body) "exists?")))
-        (is (<= update-delay (- end-time start-time) timeout))))
+        (is (get (json/read-str body) "success?"))
+        (is (<= update-delay (- timeout 50) (- end-time start-time) (+ timeout 50)))))
 
-    (testing (str handler-name ":custom-timeout-delete-update-to-true-goal-existence")
-      (let [fallback-state-atom (atom {:available-service-ids #{}})
-            timeout 10000
-            update-delay 2000
-            request-query (assoc request :query-string (str "timeout=" timeout "&sleep-duration=300&goal-existence=true"))
-            start-time (System/currentTimeMillis)
-            _ (async/go
-                (async/<! (async/timeout update-delay))
-                (reset! fallback-state-atom {:available-service-ids #{"s1"}}))
-            {:keys [body headers status]} (async/<!! (service-await-goal-existence-handler fallback-state-atom request-query))
-            end-time (System/currentTimeMillis)]
-        (is (= http-200-ok status))
-        (is (= "application/json" (get headers "content-type")))
-        (is (get (json/read-str body) "exists?"))
-        (is (<= update-delay (- end-time start-time) timeout))))
-
-    (testing (str handler-name ":non-integer-query-params")
+    (testing (str handler-name ":non-integer-timeout-sleep-duration-params")
       (let [fallback-state-atom (atom {:available-service-ids #{}})
             timeout "Invalid timeout value"
             sleep-duration "Invalid sleep-duration value"
-            request-bad-query (assoc request :query-string (str "timeout=" timeout "&sleep-duration=" sleep-duration "&goal-existence=false"))
-            {:keys [body headers status]} (async/<!! (service-await-goal-existence-handler fallback-state-atom request-bad-query))]
+            request (assoc request :query-string (str "timeout=" timeout "&sleep-duration=" sleep-duration))
+            {:keys [body headers status]} (async/<!! (service-await-handler fallback-state-atom request))]
         (is (= http-400-bad-request status))
         (is (= "text/plain" (get headers "content-type")))
         (is (re-find #"timeout and sleep-duration must be integers" body))
         (is (re-find (re-pattern (str ":timeout \"" timeout "\"")) body))
         (is (re-find (re-pattern (str ":sleep-duration \"" sleep-duration "\"")) body))))
 
-    (testing (str handler-name ":nil-timeout")
+    (testing (str handler-name ":timeout-required-param")
       (let [fallback-state-atom (atom {:available-service-ids #{}})
-            request-bad-query (assoc request :query-string (str "goal-existence=false"))
-            {:keys [body headers status]} (async/<!! (service-await-goal-existence-handler fallback-state-atom request-bad-query))]
+            request (assoc request :query-string "")
+            {:keys [body headers status]} (async/<!! (service-await-handler fallback-state-atom request))]
         (is (= http-400-bad-request status))
         (is (= "text/plain" (get headers "content-type")))
-        (is (re-find #"timeout is a required query parameter" body))))
-
-    (testing (str handler-name ":nil-goal-existence")
-      (let [fallback-state-atom (atom {:available-service-ids #{}})
-            request-bad-query (assoc request :query-string (str "timeout=1000"))
-            {:keys [body headers status]} (async/<!! (service-await-goal-existence-handler fallback-state-atom request-bad-query))]
-        (is (= http-400-bad-request status))
-        (is (= "text/plain" (get headers "content-type")))
-        (is (re-find #"goal-existence is a required query parameter" body))))))
+        (is (re-find #"timeout is a required query parameter" body))))))
 
 (deftest test-work-stealing-handler
   (let [test-service-id "test-service-id"

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -836,7 +836,7 @@
 
     (testing (str handler-name ":nil-timeout")
       (let [fallback-state-atom (atom {:available-service-ids #{}})
-            request-bad-query (dissoc request :query-string)
+            request-bad-query (assoc request :query-string (str "goal-existence=false"))
             {:keys [body headers status]} (async/<!! (service-await-goal-existence-handler fallback-state-atom request-bad-query))]
         (is (= http-400-bad-request status))
         (is (= "text/plain" (get headers "content-type")))


### PR DESCRIPTION
## Changes proposed in this PR
- Refactor await deletion endpoint to just await different fallback state scenarios
- move functions to descriptor.clj

## Why are we making these changes?
- this function is planning to be reused by waiter-ping endpoint

