### PR TITLE
adjusts min-instances when only max-instances provided in profile

### DIFF
--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -2208,6 +2208,23 @@
                 "min-instances" 2}
                (merge-defaults {"max-instances" 2} {"min-instances" 3}
                                profile->defaults metric-group-mappings))))
+      (testing "min-instances should be adjusted when only max-instances provided in profile"
+        (is (= {"max-instances" 2
+                "metric-group" "other"
+                "min-instances" 2
+                "profile" "test-profile"}
+               (let [profile->defaults (assoc profile->defaults
+                                         "test-profile" {"max-instances" 2})]
+                 (merge-defaults {"profile" "test-profile"} {"min-instances" 3}
+                                 profile->defaults metric-group-mappings))))
+        (is (= {"max-instances" 2
+                "metric-group" "other"
+                "min-instances" 1
+                "profile" "test-profile"}
+               (let [profile->defaults (assoc profile->defaults
+                                         "test-profile" {"max-instances" 2})]
+                 (merge-defaults {"profile" "test-profile"} {"min-instances" 1}
+                                 profile->defaults metric-group-mappings)))))
       (testing "min-instances should not be updated when provided without max-instances"
         (is (= {"metric-group" "other"
                 "min-instances" 4}


### PR DESCRIPTION
## Changes proposed in this PR

- adjusts min-instances when only max-instances provided in profile

## Why are we making these changes?

Specifying only the max-instances in the profile should not yield a service description error (because the min-instance in the service description defaults is greater).


