### PR TITLE
handles multiple www-authenticate headers in the response

### DIFF
--- a/token-syncer/src/token_syncer/waiter.clj
+++ b/token-syncer/src/token_syncer/waiter.clj
@@ -46,7 +46,7 @@
   response)
 
 (defn contains-header?
-  "Returns true if the target value if present in the provided header value(s)."
+  "Returns true if the target value is present in the provided header value(s)."
   [header-value target-value]
   (if (string? header-value)
     (= target-value header-value)


### PR DESCRIPTION
## Changes proposed in this PR

- allows passing authorization header from the environment
- handles multiple www-authenticate headers in the response

## Why are we making these changes?

The token syncer should be able to sync using the Waiter API even if Waiter changes its authentication schemes (or starts returning multiple `www-authenticate` headers on 401 responses.

In addition, being able to explicitly use the authorization header to use allows us to decide the authentication method used by the tokensyncer client.
