### PR TITLE
handles CORS responses for waiter api requests

### DIFF
--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -116,7 +116,7 @@
                                        websocket-config
                                        {:ring-handler (-> (core/ring-handler-factory waiter-request?-fn handlers)
                                                         (cors/wrap-cors-preflight
-                                                          cors-validator (:max-age cors-config) discover-service-parameters-fn)
+                                                          cors-validator (:max-age cors-config) discover-service-parameters-fn waiter-request?-fn)
                                                         core/wrap-error-handling
                                                         (core/wrap-debug generate-log-url-fn)
                                                         (core/attach-waiter-api-middleware waiter-request?-fn)


### PR DESCRIPTION
## Changes proposed in this PR

- handles CORS responses for waiter api requests

## Why are we making these changes?

Allows CORS requests to be made to Waiter API endpoints.

### Example:

#### Before:
```
$ curl -s -v -X OPTIONS -H'origin: https://foobar.test.com' -H'Access-Control-Request-Method: GET' -H'Access-Control-Request-Headers: origin, x-requested-with'  'http://waiter.test.com/.well-known/auth/expires-at'; echo
> OPTIONS /.well-known/auth/expires-at HTTP/1.1
> Host: waiter.test.com
> origin: https://foobar.test.com
> Access-Control-Request-Method: GET
> Access-Control-Request-Headers: origin, x-requested-with
>
< HTTP/1.1 403 Forbidden
< content-type: text/plain

  Waiter Error 403
  ================

    Cross-origin request not allowed
```

#### After:
````
$ curl -s -v -X OPTIONS -H'origin: https://foobar.test.com' -H'Access-Control-Request-Method: GET' -H'Access-Control-Request-Headers: origin, x-requested-with'  'http://waiter.test.com/.well-known/auth/expires-at'; echo
> OPTIONS /.well-known/auth/expires-at HTTP/1.1
> Host: waiter.test.com
> origin: https://foobar.test.com
> Access-Control-Request-Method: GET
> Access-Control-Request-Headers: origin, x-requested-with
>
< HTTP/1.1 200 OK
< access-control-allow-credentials: true
< access-control-allow-headers: origin, x-requested-with
< access-control-allow-methods: DELETE, OPTIONS, PATCH, TRACE, HEAD, POST, CONNECT, GET, PUT
< access-control-allow-origin: https://foobar.test.com
< access-control-max-age: 3600
````
