### PR TITLE
increases async-request-timeout limit to 4 hours

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -806,10 +806,15 @@
                                ;; requests per async request using the following value:
                                :async-request-max-status-checks 50
 
+                               ;; The maximum amount of time (milliseconds) before the async request will be
+                               ;; considered timed out, and Waiter will release the allocated instance.
+                               :async-request-max-timeout-ms 14400000
+
                                ;; After this amount of time (milliseconds) the async request will be
                                ;; considered timed out, and Waiter will release the allocated
-                               ;; instance. This is the default value and can be overridden in the
-                               ;; service description:
+                               ;; instance. The value is capped by the value of async-request-max-timeout-ms.
+                               ;; This is the default value and can be overridden via the
+                               ;; x-waiter-async-request-timeout request header:
                                :async-request-timeout-ms 60000
 
                                ;; Size in the size of the buffer used to write/read individual request/response fragments to/from the backend.

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -199,15 +199,13 @@
          parsed-value)
        old-value))))
 
-(def ^:const async-request-timeout-limit-in-millis (-> 4 t/hours t/in-millis))
-
 (defn prepare-request-properties
-  [instance-request-properties waiter-headers]
+  [{:keys [async-request-max-timeout-ms] :as instance-request-properties} waiter-headers]
   (-> instance-request-properties
     (update :async-check-interval-ms lookup-configured-timeout
             (headers/get-waiter-header waiter-headers "async-check-interval") "async request check interval")
     (update :async-request-timeout-ms lookup-configured-timeout
-            (headers/get-waiter-header waiter-headers "async-request-timeout") "async request timeout" async-request-timeout-limit-in-millis)
+            (headers/get-waiter-header waiter-headers "async-request-timeout") "async request timeout" async-request-max-timeout-ms)
     (update :initial-socket-timeout-ms lookup-configured-timeout
             (headers/get-waiter-header waiter-headers "timeout") "socket timeout")
     (update :queue-timeout-ms lookup-configured-timeout

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -199,7 +199,7 @@
          parsed-value)
        old-value))))
 
-(def ^:const one-hour-in-millis (-> 1 t/hours t/in-millis))
+(def ^:const async-request-timeout-limit-in-millis (-> 4 t/hours t/in-millis))
 
 (defn prepare-request-properties
   [instance-request-properties waiter-headers]
@@ -207,7 +207,7 @@
     (update :async-check-interval-ms lookup-configured-timeout
             (headers/get-waiter-header waiter-headers "async-check-interval") "async request check interval")
     (update :async-request-timeout-ms lookup-configured-timeout
-            (headers/get-waiter-header waiter-headers "async-request-timeout") "async request timeout" one-hour-in-millis)
+            (headers/get-waiter-header waiter-headers "async-request-timeout") "async request timeout" async-request-timeout-limit-in-millis)
     (update :initial-socket-timeout-ms lookup-configured-timeout
             (headers/get-waiter-header waiter-headers "timeout") "socket timeout")
     (update :queue-timeout-ms lookup-configured-timeout

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -61,6 +61,7 @@
                                                                                    not-empty))
    (s/required-key :instance-request-properties) {(s/required-key :async-check-interval-ms) schema/positive-int
                                                   (s/required-key :async-request-max-status-checks) schema/positive-int
+                                                  (s/required-key :async-request-max-timeout-ms) schema/positive-int
                                                   (s/required-key :async-request-timeout-ms) schema/positive-int
                                                   (s/required-key :client-buffer-size) schema/positive-int
                                                   (s/required-key :client-connection-idle-timeout-ms) schema/positive-int
@@ -291,6 +292,7 @@
    :hostname "localhost"
    :instance-request-properties {:async-check-interval-ms 3000
                                  :async-request-max-status-checks 50
+                                 :async-request-max-timeout-ms (-> 4 t/hours t/in-millis)
                                  :async-request-timeout-ms 60000
                                  :client-buffer-size 32768 ;; 32 KiB
                                  :client-connection-idle-timeout-ms 10000 ; 10 seconds

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -108,8 +108,8 @@
                       }
                      {:name "test-prepare-request-properties:too-large-async-request-timeout-header"
                       :input {:request-properties {:fie "foe", :async-check-interval-ms 100, :async-request-timeout-ms 200}
-                              :waiter-headers {"async-request-timeout" (+ one-hour-in-millis 1000)}}
-                      :expected {:fie "foe", :async-check-interval-ms 100, :async-request-timeout-ms one-hour-in-millis, :initial-socket-timeout-ms nil, :queue-timeout-ms nil, :streaming-timeout-ms nil}
+                              :waiter-headers {"async-request-timeout" (+ async-request-timeout-limit-in-millis 1000)}}
+                      :expected {:fie "foe", :async-check-interval-ms 100, :async-request-timeout-ms async-request-timeout-limit-in-millis, :initial-socket-timeout-ms nil, :queue-timeout-ms nil, :streaming-timeout-ms nil}
                       })]
     (doseq [{:keys [name input expected]} test-cases]
       (testing (str "Test " name)

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -107,9 +107,9 @@
                       :expected {:fie "foe", :async-check-interval-ms 50, :async-request-timeout-ms 250, :initial-socket-timeout-ms nil, :queue-timeout-ms nil, :streaming-timeout-ms nil}
                       }
                      {:name "test-prepare-request-properties:too-large-async-request-timeout-header"
-                      :input {:request-properties {:fie "foe", :async-check-interval-ms 100, :async-request-timeout-ms 200}
-                              :waiter-headers {"async-request-timeout" (+ async-request-timeout-limit-in-millis 1000)}}
-                      :expected {:fie "foe", :async-check-interval-ms 100, :async-request-timeout-ms async-request-timeout-limit-in-millis, :initial-socket-timeout-ms nil, :queue-timeout-ms nil, :streaming-timeout-ms nil}
+                      :input {:request-properties {:fie "foe", :async-check-interval-ms 100, :async-request-max-timeout-ms 100000 :async-request-timeout-ms 200}
+                              :waiter-headers {"async-request-timeout" 101000}}
+                      :expected {:fie "foe", :async-check-interval-ms 100, :async-request-max-timeout-ms 100000 :async-request-timeout-ms 100000, :initial-socket-timeout-ms nil, :queue-timeout-ms nil, :streaming-timeout-ms nil}
                       })]
     (doseq [{:keys [name input expected]} test-cases]
       (testing (str "Test " name)


### PR DESCRIPTION
## Changes proposed in this PR

- increases async-request-timeout limit to 4 hours

## Why are we making these changes?

Some async requests would like longer intervals for completion. The one hour limit is too tight for such use-cases.

With the limit configured at 4 hours for an async request and a maximum number of status checks configured at 50, there will be ~5 minutes delay in determining when an instance is done processing an async request.


