### PR TITLE
sends the JWT payload to the backend in request header

### DIFF
--- a/waiter/integration/waiter/authentication_test.clj
+++ b/waiter/integration/waiter/authentication_test.clj
@@ -308,8 +308,12 @@
     (is (= (retrieve-username) (get headers "x-waiter-auth-user")) assertion-message)
     (when-not (= auth-method "cookie")
       (assert-auth-cookie set-cookie assertion-message))
-    (let [body-json (try-parse-json body)]
-      (is (= access-token (get-in body-json ["headers" "x-waiter-jwt"])) assertion-message))))
+    (let [body-json (try-parse-json body)
+          jwt-payload (try-parse-json (get-in body-json ["headers" "x-waiter-jwt-payload"]))]
+      (log/info "jwt payload is" jwt-payload)
+      (is (= access-token (get-in body-json ["headers" "x-waiter-jwt"])) assertion-message)
+      (is (map? jwt-payload) assertion-message)
+      (is (every? #(contains? jwt-payload %) ["aud" "exp" "iss" "sub"]) assertion-message))))
 
 (deftest ^:parallel ^:integration-fast test-jwt-authentication-token-realm
   (testing-using-waiter-url

--- a/waiter/src/waiter/auth/jwt.clj
+++ b/waiter/src/waiter/auth/jwt.clj
@@ -504,8 +504,10 @@
           (make-401-response-updater request))
         ;; non-401 response avoids further downstream handler processing
         (utils/exception->response result-map-or-throwable request))
-      (let [{:keys [expiry-time subject]} result-map-or-throwable
-            auth-params-map (auth/build-auth-params-map :jwt subject {:jwt-access-token access-token})
+      (let [{:keys [claims expiry-time subject]} result-map-or-throwable
+            auth-metadata {:jwt-access-token access-token
+                           :jwt-payload (utils/clj->json claims)}
+            auth-params-map (auth/build-auth-params-map :jwt subject auth-metadata)
             auth-cookie-age-in-seconds (- expiry-time (current-time-secs))]
         (auth/handle-request-auth
           request-handler request auth-params-map password auth-cookie-age-in-seconds)))))

--- a/waiter/src/waiter/headers.clj
+++ b/waiter/src/waiter/headers.clj
@@ -113,12 +113,13 @@
 (defn assoc-auth-headers
   "`assoc`s the x-waiter-auth-principal and x-waiter-authenticated-principal headers if the
    username and principal are non-nil, respectively."
-  ([headers principal {:keys [jwt-access-token]}]
+  ([headers principal {:keys [jwt-access-token jwt-payload]}]
    (let [username (utils/principal->username principal)]
      (cond-> headers
        username (assoc "x-waiter-auth-principal" username)
        principal (assoc "x-waiter-authenticated-principal" principal)
-       jwt-access-token (assoc "x-waiter-jwt" jwt-access-token)))))
+       jwt-access-token (assoc "x-waiter-jwt" jwt-access-token)
+       jwt-payload (assoc "x-waiter-jwt-payload" jwt-payload)))))
 
 (defn basic-auth-header
   "Constructs the basic auth header for the provided username and password."

--- a/waiter/test/waiter/auth/jwt_test.clj
+++ b/waiter/test/waiter/auth/jwt_test.clj
@@ -493,7 +493,12 @@
                       t/now (constantly (tc/from-long (* current-time 1000)))]
           (is (= (assoc request
                    :auth-cookie-age-in-seconds expiry-interval-secs
-                   :auth-params-map (auth/build-auth-params-map :jwt principal {:jwt-access-token access-token})
+                   :auth-params-map (auth/build-auth-params-map :jwt principal {:jwt-access-token access-token
+                                                                                :jwt-payload (json/write-str
+                                                                                               {:aud realm
+                                                                                                :exp expiry-time
+                                                                                                :iss issuer-constraints
+                                                                                                :sub principal})})
                    :password password
                    :principal principal
                    :source ::request-handler)


### PR DESCRIPTION
## Changes proposed in this PR

- sends the JWT payload to the backend in request header

## Why are we making these changes?

Allows the backend access to the JWT claims used to authenticate the request.

