### PR TITLE
introduces configuration for the user-agent product names used for triggering redirects

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -267,6 +267,10 @@
                               ;; the OIDC auth flow will not be triggered on 401 responses.
                               ;; The default value is 20
                               :oidc-num-challenge-cookies-allowed-in-request 20
+                              ;; (optional) the user-agent header substrings to determine if the request came from a browser.
+                              ;; Relies on the heuristic of inspecting common user-agents to determine if it is a browser.
+                              ;; The default value is #{"chrome" "mozilla"}
+                              :oidc-redirect-user-agent-products #{"chrome" "mozilla"}
                               ;; (optional) url of the authorization server get token endpoint:
                               :oidc-token-uri "http://127.0.0.1:8040/id-token"
                               ;; The keyword used to retrieve the subject from the access token claims

--- a/waiter/src/waiter/schema.clj
+++ b/waiter/src/waiter/schema.clj
@@ -146,6 +146,7 @@
      (s/optional-key :oidc-authorize-uri) non-empty-string
      (s/optional-key :oidc-default-mode) valid-oidc-mode
      (s/optional-key :oidc-num-challenge-cookies-allowed-in-request) positive-int
+     (s/optional-key :oidc-redirect-user-agent-products) #{non-empty-string}
      (s/optional-key :oidc-token-uri) non-empty-string
      (s/required-key :subject-key) s/Keyword
      (s/optional-key :subject-regex) s/Regex

--- a/waiter/src/waiter/util/http_utils.clj
+++ b/waiter/src/waiter/util/http_utils.clj
@@ -208,13 +208,12 @@
       (and (grpc? (:headers request) (:client-protocol request))
            (= "14" (get-in response [:headers "grpc-status"])))))
 
-(defn browser-request?
+(defn request-has-user-agent-product?
   "Looks at the user-agent header to determine if the request came from a browser.
    This is useful, e.g., determining whether the client should be asked to handle redirects.
    Current implementation checks for the presence of chrome or mozilla is based on our heuristic
    of inspecting common user-agents to determine if it is a browser:
    https://www.networkinghowtos.com/howto/common-user-agent-list/"
-  [request]
+  [user-agent-products request]
   (when-let [user-agent (some-> request (get-in [:headers "user-agent"]) str/lower-case)]
-    (or (str/includes? user-agent "mozilla")
-        (str/includes? user-agent "chrome"))))
+    (some #(str/includes? user-agent %) user-agent-products)))

--- a/waiter/test/waiter/util/http_utils_test.clj
+++ b/waiter/test/waiter/util/http_utils_test.clj
@@ -138,9 +138,10 @@
              {:client-protocol "HTTP/2.0" :headers {"content-type" "application/grpc"}}
              {:headers {"grpc-status" 14} :status http-200-ok}))))
 
-(deftest test-browser-request?
-  (is (not (browser-request? {:headers {"user-agent" "curl"}})))
-  (is (not (browser-request? {:headers {"user-agent" "jetty"}})))
-  (is (not (browser-request? {:headers {"user-agent" "python-requests"}})))
-  (is (browser-request? {:headers {"user-agent" "chrome"}}))
-  (is (browser-request? {:headers {"user-agent" "mozilla"}})))
+(deftest test-request-has-user-agent-product?
+  (let [user-agent-products #{"chrome" "mozilla"}]
+    (is (not (request-has-user-agent-product? user-agent-products {:headers {"user-agent" "curl"}})))
+    (is (not (request-has-user-agent-product? user-agent-products {:headers {"user-agent" "jetty"}})))
+    (is (not (request-has-user-agent-product? user-agent-products {:headers {"user-agent" "python-requests"}})))
+    (is (request-has-user-agent-product? user-agent-products {:headers {"user-agent" "chrome"}}))
+    (is (request-has-user-agent-product? user-agent-products {:headers {"user-agent" "mozilla"}}))))


### PR DESCRIPTION

## Changes proposed in this PR

- introduces configuration for the user-agent product names used for triggering redirects

## Why are we making these changes?

We would like to be able to detect multiple user-agent products as supporting redirects. Making this value configurable makes it simpler to enable such combinations without requiring rebuilds of Waiter.
