### PR TITLE
POC: Maintenance mode with expires-at

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1543,6 +1543,7 @@
                                    (-> handler
                                      pr/wrap-too-many-requests
                                      pr/wrap-suspended-service
+                                     pr/wrap-maintenance-mode
                                      pr/wrap-response-status-metrics
                                      (interstitial/wrap-interstitial interstitial-state-atom)
                                      wrap-descriptor-fn

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1543,8 +1543,8 @@
                                    (-> handler
                                      pr/wrap-too-many-requests
                                      pr/wrap-suspended-service
-                                     pr/wrap-maintenance-mode
                                      pr/wrap-response-status-metrics
+                                     pr/wrap-maintenance-mode
                                      (interstitial/wrap-interstitial interstitial-state-atom)
                                      wrap-descriptor-fn
                                      wrap-secure-request-fn

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -181,7 +181,8 @@
   "Computes the fallback descriptor with a healthy instance based on the provided descriptor.
    Fallback descriptors can only be computed for token-based descriptors.
    The amount of history lookup for fallback descriptor candidates is limited by search-history-length.
-   Also, the fallback descriptor needs to be inside the fallback period to be returned."
+   Also, the fallback descriptor needs to be inside the fallback period to be returned.
+   Descriptors with maintenance field specified are skipped because the service is considered unhealthy"
   [descriptor->previous-descriptor search-history-length fallback-state request-time
    {:keys [component->previous-descriptor-fns] :as descriptor}]
   (when (seq component->previous-descriptor-fns)

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -182,7 +182,8 @@
    Fallback descriptors can only be computed for token-based descriptors.
    The amount of history lookup for fallback descriptor candidates is limited by search-history-length.
    Also, the fallback descriptor needs to be inside the fallback period to be returned.
-   Descriptors with maintenance field specified are skipped because the service is considered unhealthy"
+   Descriptors with maintenance field specified are included because they map to the same service-id as
+   the service with maintenance mode enabled."
   [descriptor->previous-descriptor search-history-length fallback-state request-time
    {:keys [component->previous-descriptor-fns] :as descriptor}]
   (when (seq component->previous-descriptor-fns)

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -885,7 +885,7 @@
                     (-> {:details response-map,
                          :message (or (get maintenance "message") default-message),
                          :status http-503-service-unavailable}
-                        (utils/data->error-response request))))))
+                        (utils/data->error-response request)))))))
 
 (defn wrap-too-many-requests
   "Check if a service has more pending requests than max-queue-length and immediately return a 503"

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -164,7 +164,7 @@
 (def ^:const system-metadata-keys #{"cluster" "deleted" "last-update-time" "last-update-user" "previous" "root"})
 
 ; keys allowed in user metadata for tokens, these need to be distinct from service description keys
-(def ^:const user-metadata-keys #{"cors-rules" "fallback-period-secs" "https-redirect" "owner" "stale-timeout-mins", "maintenance"})
+(def ^:const user-metadata-keys #{"cors-rules" "fallback-period-secs" "https-redirect" "maintenance" "owner" "stale-timeout-mins"})
 
 ; keys allowed in metadata for tokens, these need to be distinct from service description keys
 (def ^:const token-metadata-keys (set/union system-metadata-keys user-metadata-keys))

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -118,6 +118,7 @@
    (s/optional-key "https-redirect") s/Bool
    (s/optional-key "owner") schema/non-empty-string
    (s/optional-key "stale-timeout-mins") (s/both s/Int (s/pred #(<= 0 % (t/in-minutes (t/hours 4))) 'at-most-4-hours))
+   (s/optional-key "maintenance") {(s/required-key "message") (s/conditional #(<= 1 (count %) 512) s/Str)}
    s/Str s/Any})
 
 (def ^:const service-required-keys (->> (keys service-description-schema)
@@ -157,7 +158,7 @@
 (def ^:const system-metadata-keys #{"cluster" "deleted" "last-update-time" "last-update-user" "previous" "root"})
 
 ; keys allowed in user metadata for tokens, these need to be distinct from service description keys
-(def ^:const user-metadata-keys #{"cors-rules" "fallback-period-secs" "https-redirect" "owner" "stale-timeout-mins"})
+(def ^:const user-metadata-keys #{"cors-rules" "fallback-period-secs" "https-redirect" "owner" "stale-timeout-mins", "maintenance"})
 
 ; keys allowed in metadata for tokens, these need to be distinct from service description keys
 (def ^:const token-metadata-keys (set/union system-metadata-keys user-metadata-keys))

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -116,9 +116,9 @@
                                    (s/optional-key "methods") (s/both (s/pred not-empty) [schema/http-method])}]
    (s/optional-key "fallback-period-secs") (s/both s/Int (s/pred #(<= 0 % (t/in-seconds (t/days 1))) 'at-most-1-day))
    (s/optional-key "https-redirect") s/Bool
+   (s/optional-key "maintenance") {(s/optional-key "message") (s/conditional #(<= 1 (count %) 512) s/Str)}
    (s/optional-key "owner") schema/non-empty-string
    (s/optional-key "stale-timeout-mins") (s/both s/Int (s/pred #(<= 0 % (t/in-minutes (t/hours 4))) 'at-most-4-hours))
-   (s/optional-key "maintenance") {(s/optional-key "message") (s/conditional #(<= 1 (count %) 512) s/Str)}
    s/Str s/Any})
 
 (def ^:const service-required-keys (->> (keys service-description-schema)

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -116,7 +116,13 @@
                                    (s/optional-key "methods") (s/both (s/pred not-empty) [schema/http-method])}]
    (s/optional-key "fallback-period-secs") (s/both s/Int (s/pred #(<= 0 % (t/in-seconds (t/days 1))) 'at-most-1-day))
    (s/optional-key "https-redirect") s/Bool
-   (s/optional-key "maintenance") {(s/optional-key "message") (s/conditional #(<= 1 (count %) 512) s/Str)}
+   (s/optional-key "maintenance") {(s/optional-key "message") (s/conditional #(<= 1 (count %) 512) s/Str)
+                                   (s/required-key "expires-at") (s/conditional
+                                                                   #(= "*" %) s/Str
+                                                                   #(try
+                                                                      (du/str-to-date-safe %)
+                                                                      (catch Exception _
+                                                                        false)) s/Str)}
    (s/optional-key "owner") schema/non-empty-string
    (s/optional-key "stale-timeout-mins") (s/both s/Int (s/pred #(<= 0 % (t/in-minutes (t/hours 4))) 'at-most-4-hours))
    s/Str s/Any})

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -116,11 +116,11 @@
                                    (s/optional-key "methods") (s/both (s/pred not-empty) [schema/http-method])}]
    (s/optional-key "fallback-period-secs") (s/both s/Int (s/pred #(<= 0 % (t/in-seconds (t/days 1))) 'at-most-1-day))
    (s/optional-key "https-redirect") s/Bool
-   (s/optional-key "maintenance") {(s/optional-key "message") (s/conditional #(<= 1 (count %) 512) s/Str)
+   (s/optional-key "maintenance") {(s/optional-key "message") (s/constrained s/Str #(<= 1 (count %) 512))
                                    (s/required-key "expires-at") (s/conditional
                                                                    #(= "*" %) s/Str
                                                                    #(try
-                                                                      (du/str-to-date-safe %)
+                                                                      (du/str-to-date %)
                                                                       (catch Exception _
                                                                         false)) s/Str)}
    (s/optional-key "owner") schema/non-empty-string

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -118,7 +118,7 @@
    (s/optional-key "https-redirect") s/Bool
    (s/optional-key "owner") schema/non-empty-string
    (s/optional-key "stale-timeout-mins") (s/both s/Int (s/pred #(<= 0 % (t/in-minutes (t/hours 4))) 'at-most-4-hours))
-   (s/optional-key "maintenance") {(s/required-key "message") (s/conditional #(<= 1 (count %) 512) s/Str)}
+   (s/optional-key "maintenance") {(s/optional-key "message") (s/conditional #(<= 1 (count %) 512) s/Str)}
    s/Str s/Any})
 
 (def ^:const service-required-keys (->> (keys service-description-schema)

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -1837,6 +1837,11 @@
                 service-description (assoc-in service-description invalid-keys "invalid iso8601 format")]
             (test-bad-service-description service-description invalid-keys)))
 
+        (testing "post:new-user-metadata:maintenance-expires-is-nil"
+          (let [invalid-keys ["maintenance" "expires-at"]
+                service-description (assoc-in service-description invalid-keys nil)]
+            (test-bad-service-description service-description invalid-keys)))
+
         (testing "post:new-user-metadata:maintenance-is-not-a-map"
           (let [service-description (assoc service-description "maintenance" "not a map")]
             (test-bad-service-description service-description ["maintenance"]))))

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -1784,6 +1784,42 @@
           (is (str/includes? (str details) "maintenance") body)
           (is (str/includes? message "Validation failed for user metadata on token") body)))
 
+      (testing "post:new-user-metadata:maintenance-message-is-not-a-string"
+        (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+              service-description (walk/stringify-keys
+                                    {:maintenance {:message -100}
+                                     :token "abcdefgh"})
+              {:keys [body status]}
+              (run-handle-token-request
+                kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn validate-service-description-fn attach-service-defaults-fn
+                {:authorization/user auth-user
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
+                 :headers {"accept" "application/json"}
+                 :request-method :post})
+              {{:strs [details message]} "waiter-error"} (json/read-str body)]
+          (is (= http-400-bad-request status))
+          (is (not (str/includes? body "clojure")))
+          (is (str/includes? (str details) "maintenance") body)
+          (is (str/includes? message "Validation failed for user metadata on token") body)))
+
+      (testing "post:new-user-metadata:maintenance-is-not-a-map"
+        (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+              service-description (walk/stringify-keys
+                                    {:maintenance "invalid-value"
+                                     :token "abcdefgh"})
+              {:keys [body status]}
+              (run-handle-token-request
+                kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn validate-service-description-fn attach-service-defaults-fn
+                {:authorization/user auth-user
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
+                 :headers {"accept" "application/json"}
+                 :request-method :post})
+              {{:strs [details message]} "waiter-error"} (json/read-str body)]
+          (is (= http-400-bad-request status))
+          (is (not (str/includes? body "clojure")))
+          (is (str/includes? (str details) "maintenance") body)
+          (is (str/includes? message "Validation failed for user metadata on token") body)))
+
       (testing "post:new-service-description:token-limit-reached"
         (let [kv-store (kv/->LocalKeyValueStore (atom {}))
               test-user "test-user"


### PR DESCRIPTION
This is a proof of concept of how expires-at field in maintenance mode could work

## Changes proposed in this PR

- add schema definition for maintenance user metadata
- add middleware to respond to requests to user token that is in maintenance mode

## Why are we making these changes?

- users want a way to disable tokens or put tokens in maintenance temporarily

