### PR TITLE
exposes the kv-store config in the schema

### DIFF
--- a/waiter/src/waiter/schema.clj
+++ b/waiter/src/waiter/schema.clj
@@ -158,3 +158,13 @@
 (def profile-definition
   "Validator for profile parameters."
   {(s/required-key :defaults) {non-empty-string s/Any}})
+
+(def kv-store-config
+  "Validator for the kv-store config."
+  (s/constrained
+    {:kind s/Keyword
+     (s/optional-key :encrypt) s/Bool
+     (s/optional-key :cache) {(s/required-key :threshold) positive-int
+                              (s/required-key :ttl) positive-int}
+     s/Keyword require-symbol-factory-fn}
+    contains-kind-sub-map?))

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -71,13 +71,7 @@
                                                   (s/required-key :output-buffer-size) schema/positive-int
                                                   (s/required-key :queue-timeout-ms) schema/positive-int
                                                   (s/required-key :streaming-timeout-ms) schema/positive-int}
-   (s/required-key :kv-config) (s/constrained
-                                 {:kind s/Keyword
-                                  (s/optional-key :encrypt) s/Bool
-                                  (s/optional-key :cache) {(s/required-key :threshold) schema/positive-int
-                                                           (s/required-key :ttl) schema/positive-int}
-                                  s/Keyword schema/require-symbol-factory-fn}
-                                 schema/contains-kind-sub-map?)
+   (s/required-key :kv-config) schema/kv-store-config
    (s/optional-key :messages) {s/Keyword s/Str}
    (s/required-key :metric-group-mappings) schema/valid-metric-group-mappings
    (s/required-key :metrics-config) {(s/required-key :inter-router-metrics-idle-timeout-ms) schema/positive-int


### PR DESCRIPTION
## Changes proposed in this PR

- exposes the kv-store config in the schema

## Why are we making these changes?

Allows custom components to reuse the kv-store schema for validation.


