### PR TITLE
fixes typo in inital-delay-ms

### DIFF
--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -731,7 +731,7 @@
   ([waiter-url service-id limit]
    (when-not (str/blank? service-id)
      (try
-       ((utils/retry-strategy {:delay-multiplier 1.2, :inital-delay-ms 250, :max-retries limit})
+       ((utils/retry-strategy {:delay-multiplier 1.2, :initial-delay-ms 250, :max-retries limit})
          (fn []
            (let [app-delete-path (str "/apps/" service-id "?force=true")
                  delete-response (make-request waiter-url app-delete-path :method :delete)

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -450,18 +450,18 @@
    The returned function accepts a no-args function to be executed until it returns without throwing an error.
 
    `delay-multiplier` each previous delay is multiplied by delay-multiplier to generate the next delay.
-   `inital-delay-ms` the initial delay for the first retry.
+   `initial-delay-ms` the initial delay for the first retry.
    `max-delay-ms` the delay cap for exponential backoff delay.
    `max-retries`  limit the number of retries.
    "
-  [{:keys [delay-multiplier inital-delay-ms max-delay-ms max-retries]
+  [{:keys [delay-multiplier initial-delay-ms max-delay-ms max-retries]
     :or {delay-multiplier 1.0
-         inital-delay-ms 100
+         initial-delay-ms 100
          max-delay-ms 300000 ; 300k millis = 5 minutes
          max-retries 10}}]
   (fn [body-function]
     (loop [num-tries 1
-           current-delay-ms inital-delay-ms]
+           current-delay-ms initial-delay-ms]
       (let [{:keys [success result]}
             (try
               {:success true, :result (body-function)}

--- a/waiter/test/waiter/util/utils_test.clj
+++ b/waiter/test/waiter/util/utils_test.clj
@@ -272,7 +272,7 @@
     (testing "retry-strategy:no-retries"
       (let [[call-counter-atom function] (make-call-atom-and-function 0 return-value)
             retry-config {:delay-multiplier 1.0
-                          :inital-delay-ms 1
+                          :initial-delay-ms 1
                           :max-retries 0}
             actual-result ((retry-strategy retry-config) function)]
         (is (= return-value actual-result))
@@ -280,7 +280,7 @@
     (testing "retry-strategy:multiple-retries-success"
       (let [[call-counter-atom function] (make-call-atom-and-function 4 return-value)
             retry-config {:delay-multiplier 1.0
-                          :inital-delay-ms 1
+                          :initial-delay-ms 1
                           :max-retries 10}
             actual-result ((retry-strategy retry-config) function)]
         (is (= return-value actual-result))
@@ -288,7 +288,7 @@
     (testing "retry-strategy:multiple-retries-failure"
       (let [[call-counter-atom function] (make-call-atom-and-function 20 return-value)
             retry-config {:delay-multiplier 1.0
-                          :inital-delay-ms 1
+                          :initial-delay-ms 1
                           :max-retries 10}]
         (is (thrown-with-msg? IllegalStateException #"function throws error"
                               ((retry-strategy retry-config) function)))
@@ -298,7 +298,7 @@
         (with-redefs [sleep (fn [time] (swap! actual-elapsed-time-atom + time))]
           (let [[call-counter-atom function] (make-call-atom-and-function 20 return-value)
                 retry-config {:delay-multiplier 1.0
-                              :inital-delay-ms 10
+                              :initial-delay-ms 10
                               :max-retries 5}]
             (is (thrown-with-msg? IllegalStateException #"function throws error"
                                   ((retry-strategy retry-config) function)))
@@ -311,7 +311,7 @@
         (with-redefs [sleep (fn [time] (swap! actual-elapsed-time-atom + time))]
           (let [[call-counter-atom function] (make-call-atom-and-function 20 return-value)
                 retry-config {:delay-multiplier 2
-                              :inital-delay-ms 10
+                              :initial-delay-ms 10
                               :max-retries 5}]
             (is (thrown-with-msg? IllegalStateException #"function throws error"
                                   ((retry-strategy retry-config) function)))
@@ -324,7 +324,7 @@
         (with-redefs [sleep (fn [time] (swap! actual-elapsed-time-atom + time))]
           (let [[call-counter-atom function] (make-call-atom-and-function 8 return-value)
                 retry-config {:delay-multiplier 2
-                              :inital-delay-ms 10
+                              :initial-delay-ms 10
                               :max-retries 10}
                 actual-result ((retry-strategy retry-config) function)]
             (is (= return-value actual-result))
@@ -337,7 +337,7 @@
         (with-redefs [sleep (fn [time] (swap! actual-elapsed-time-atom + time))]
           (let [[call-counter-atom function] (make-call-atom-and-function 4 return-value)
                 retry-config {:delay-multiplier 5
-                              :inital-delay-ms 10
+                              :initial-delay-ms 10
                               :max-retries 10}
                 actual-result ((retry-strategy retry-config) function)]
             (is (= return-value actual-result))
@@ -350,7 +350,7 @@
         (with-redefs [sleep (fn [time] (swap! actual-elapsed-time-atom + time))]
           (let [[call-counter-atom function] (make-call-atom-and-function 5 return-value)
                 retry-config {:delay-multiplier 5
-                              :inital-delay-ms 10
+                              :initial-delay-ms 10
                               :max-delay-ms 100
                               :max-retries 10}
                 actual-result ((retry-strategy retry-config) function)]


### PR DESCRIPTION
## Changes proposed in this PR

- fixes typo in inital-delay-ms

## Why are we making these changes?

Code cleanup, typos are a minor nuisance.

