### PR TITLE
Maintenance Mode API Changes

### DIFF
--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -381,7 +381,7 @@
         (finally
           (cleanup-token waiter-api waiter-urls token-name))))))
 
-(deftest test-token-update-maintenance-mode
+(deftest ^:integration test-token-update-maintenance-mode
   (testing "token sync token enabled maintenance mode"
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)

--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -424,8 +424,6 @@
                                                         :processed {:count 1 :value #{token-name}}
                                                         :selected {:count 1 :value #{token-name}}
                                                         :total {:count 1 :value #{token-name}}}}}]
-                (clojure.pprint/pprint expected-result)
-                (clojure.pprint/pprint actual-result)
                 (is (= expected-result actual-result))
                 (doseq [waiter-url waiter-urls]
                   (is (= {:description (assoc token-description "maintenance" maintenance-config)
@@ -479,8 +477,6 @@
                                                           :processed {:count 1 :value #{token-name}}
                                                           :selected {:count 1 :value #{token-name}}
                                                           :total {:count 1 :value #{token-name}}}}}]
-                  (clojure.pprint/pprint expected-result)
-                  (clojure.pprint/pprint actual-result)
                   (is (= expected-result actual-result))
                   (doseq [waiter-url waiter-urls]
                     (is (= {:description token-description

--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -382,7 +382,7 @@
           (cleanup-token waiter-api waiter-urls token-name))))))
 
 (deftest test-token-update-maintenance-mode
-  (testing "token sync maintenance-mode"
+  (testing "token sync token enabled maintenance mode"
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
           limit 10
@@ -436,7 +436,61 @@
                          (load-token waiter-url token-name))))))))
         (finally
           (cleanup-token waiter-api waiter-urls token-name))))
-    ))
+
+    (testing "token sync token disabled maintenance mode"
+      (let [waiter-urls (waiter-urls)
+            {:keys [load-token store-token] :as waiter-api} (waiter-api)
+            limit 10
+            token-name (str "test-token-maintenance-mode-" (UUID/randomUUID))]
+        (try
+          ;; ARRANGE
+          (let [current-time-ms (System/currentTimeMillis)
+                token-metadata (basic-token-metadata current-time-ms)
+                token-description (merge basic-description token-metadata)
+                maintenance-config {"message" "custom maintenance message"}]
+
+            (store-token (first waiter-urls) token-name nil token-description)
+            (doseq [waiter-url (rest waiter-urls)]
+              (let [last-update-time-ms (- current-time-ms 10000)]
+                (store-token waiter-url token-name nil
+                             (assoc token-description
+                               "last-update-time" last-update-time-ms
+                               "maintenance" maintenance-config))))
+
+            (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
+
+              ;; ACT
+              (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit)]
+
+                ;; ASSERT
+                (let [waiter-sync-result (constantly
+                                           {:code :success/sync-update
+                                            :details {:etag token-etag
+                                                      :status 200}})
+                      expected-result {:details {token-name {:latest {:cluster-url (first waiter-urls)
+                                                                      :description token-description
+                                                                      :token-etag token-etag}
+                                                             :sync-result (pc/map-from-keys waiter-sync-result (rest waiter-urls))}}
+                                       :summary {:sync {:failed #{}
+                                                        :unmodified #{}
+                                                        :updated #{token-name}}
+                                                 :tokens {:pending {:count 1 :value #{token-name}}
+                                                          :previously-synced {:count 0 :value #{}}
+                                                          :processed {:count 1 :value #{token-name}}
+                                                          :selected {:count 1 :value #{token-name}}
+                                                          :total {:count 1 :value #{token-name}}}}}]
+                  (clojure.pprint/pprint expected-result)
+                  (clojure.pprint/pprint actual-result)
+                  (is (= expected-result actual-result))
+                  (doseq [waiter-url waiter-urls]
+                    (is (= {:description token-description
+                            :headers {"content-type" "application/json"
+                                      "etag" token-etag}
+                            :status 200
+                            :token-etag token-etag}
+                           (load-token waiter-url token-name))))))))
+          (finally
+            (cleanup-token waiter-api waiter-urls token-name)))))))
 
 (deftest ^:integration test-token-different-owners-but-same-root
   (testing "token sync update with different owners but same root"

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1391,6 +1391,7 @@
         (testing "token retrieval"
           (let [token-response (get-token waiter-url token)
                 response-body (-> token-response :body json/read-str pc/keywordize-map)]
+            (assert-response-status token-response http-200-ok)
             (is (contains? response-body :last-update-time))
             (is (= (assoc service-description
                      :cluster token-cluster

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1405,7 +1405,7 @@
         (testing "index should be updated with maintenance enabled"
           (let [response (make-request waiter-url "/tokens")
                 body (-> response :body try-parse-json walk/keywordize-keys)
-                index (first body)]
+                index (first (filter #(= (:token %) token) body))]
             (is (true? (:maintenance index)))))
 
         (testing "request to service should error with custom maintenance message"
@@ -1424,7 +1424,7 @@
         (testing "index should be updated with maintenance disabled"
           (let [response (make-request waiter-url "/tokens")
                 body (-> response :body try-parse-json walk/keywordize-keys)
-                index (first body)]
+                index (first (filter #(= (:token %) token) body))]
             (is (false? (:maintenance index)))))
 
         (testing "service should handle request if maintenance mode is not enabled"

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1401,7 +1401,7 @@
                      :root token-root)
                    (dissoc response-body :last-update-time)))))
 
-        (testing "index should be updated"
+        (testing "index should be updated with maintenance enabled"
           (let [response (make-request waiter-url "/tokens")
                 body (-> response :body json/read-str walk/keywordize-keys)
                 index (first body)]
@@ -1420,7 +1420,7 @@
                 response (post-token waiter-url token-description)]
             (assert-response-status response http-200-ok)))
 
-        (testing "index should be updated"
+        (testing "index should be updated with maintenance disabled"
           (let [response (make-request waiter-url "/tokens")
                 body (-> response :body json/read-str walk/keywordize-keys)
                 index (first body)]

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1372,9 +1372,11 @@
           token (create-token-name waiter-url service-name)
           current-user (retrieve-username)
           service-description (-> (kitchen-request-headers :prefix "")
-                                  (assoc :name service-name
+                                  (assoc :https-redirect true
+                                         :interstitial-secs 60
+                                         :name service-name
                                          :permitted-user "*"
-                                         :run-as-user current-user))
+                                         :run-as-user "*"))
           token-root (retrieve-token-root waiter-url)
           token-cluster (retrieve-token-cluster waiter-url)
           custom-maintenance-message "custom maintenance message"
@@ -1416,8 +1418,9 @@
             (is (str/includes? body custom-maintenance-message))))
 
         (testing "token update maintenance field not defined"
-          (let [token-description (assoc service-description
-                                    :token token)
+          (let [token-description (-> service-description
+                                      (dissoc :https-redirect :interstitial-secs)
+                                      (assoc :token token :run-as-user current-user))
                 response (post-token waiter-url token-description)]
             (assert-response-status response http-200-ok)))
 

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1390,7 +1390,7 @@
 
         (testing "token retrieval"
           (let [token-response (get-token waiter-url token)
-                response-body (-> token-response :body json/read-str pc/keywordize-map)]
+                response-body (-> token-response :body try-parse-json walk/keywordize-keys)]
             (assert-response-status token-response http-200-ok)
             (is (contains? response-body :last-update-time))
             (is (= (assoc service-description
@@ -1404,7 +1404,7 @@
 
         (testing "index should be updated with maintenance enabled"
           (let [response (make-request waiter-url "/tokens")
-                body (-> response :body json/read-str walk/keywordize-keys)
+                body (-> response :body try-parse-json walk/keywordize-keys)
                 index (first body)]
             (is (true? (:maintenance index)))))
 
@@ -1423,7 +1423,7 @@
 
         (testing "index should be updated with maintenance disabled"
           (let [response (make-request waiter-url "/tokens")
-                body (-> response :body json/read-str walk/keywordize-keys)
+                body (-> response :body try-parse-json walk/keywordize-keys)
                 index (first body)]
             (is (false? (:maintenance index)))))
 

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1401,6 +1401,12 @@
                      :root token-root)
                    (dissoc response-body :last-update-time)))))
 
+        (testing "index should be updated"
+          (let [response (make-request waiter-url "/tokens")
+                body (-> response :body json/read-str walk/keywordize-keys)
+                index (first body)]
+            (is (true? (:maintenance index)))))
+
         (testing "request to service should error with custom maintenance message"
           (let [{:keys [body] :as response}
                 (make-request waiter-url "/hello-world" :headers request-headers)]
@@ -1413,6 +1419,12 @@
                                     :token token)
                 response (post-token waiter-url token-description)]
             (assert-response-status response http-200-ok)))
+
+        (testing "index should be updated"
+          (let [response (make-request waiter-url "/tokens")
+                body (-> response :body json/read-str walk/keywordize-keys)
+                index (first body)]
+            (is (false? (:maintenance index)))))
 
         (testing "service should handle request if maintenance mode is not enabled"
           (let [{:keys [body] :as response}

--- a/waiter/resources/web/maintenance.html
+++ b/waiter/resources/web/maintenance.html
@@ -1,0 +1,177 @@
+<!doctype html>
+<html>
+<head>
+    <title>Token in Maintenance Mode</title>
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <style type="text/css">
+        html {
+            font-family: 'Lato', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+            color: rgba(0,0,0,.87);
+        }
+
+        .main-content {
+            margin: auto;
+            margin-top: 4em;
+            width: 800px;
+        }
+
+        .main-content h1 {
+            font-size: 1.6rem;
+        }
+
+        .main-content p {
+            font-size: 1.2rem;
+            margin-left: 1em;
+        }
+
+        .divider {
+            /* ui divider */
+            border-top: 1px solid rgba(34,36,38,.15);
+            border-bottom: 1px solid rgba(255,255,255,.1);
+            margin: 1rem 0;
+            line-height: 1;
+            height: 0;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: .05em;
+            color: rgba(0,0,0,.85);
+        }
+
+        .additional-info {
+            width: 800px;
+            margin: auto;
+            margin-top: 2em;
+        }
+
+        .additional-info h3 {
+            margin-top: 2em;
+        }
+
+        .additional-info li {
+            line-height: 2em;
+        }
+
+        .code {
+            font-family: "Lucida Console", Monaco, monospace;
+            line-height: 2em;
+            font-size: 0.9rem;
+        }
+
+        pre.code {
+            margin-left: 1em;
+            margin-right: 1em;
+            white-space: pre-wrap;
+            font-size: 0.8rem;
+        }
+
+        .additional-info td {
+            padding-right: 1em;
+        }
+
+        .additional-info td.field {
+            font-weight: bold;
+            text-align: right;
+            vertical-align: baseline;
+        }
+
+        .additional-info td.code {
+            vertical-align: baseline;
+        }
+
+        .additional-info table {
+            margin-left: 1em;
+            border-collapse: collapse;
+        }
+
+    </style>
+</head>
+<body>
+
+<div class="main-content">
+    <h1>
+        Token in Maintenance Mode
+    </h1>
+    <p>
+        <%= message %>
+    </p>
+</div>
+
+<div class="additional-info">
+    <div class="divider"></div>
+    <div>
+        <h3>Request Info</h3>
+        <table>
+            <% (when host %>
+            <tr>
+                <td class="field">Host</td><td class="code"><%= host %></td>
+            </tr>
+            <% ) %>
+            <tr>
+                <td class="field">Path</td><td class="code"><%= uri %></td>
+            </tr>
+            <% (when query-string %>
+            <tr>
+                <td class="field">Query String</td><td class="code"><%= query-string %></td>
+            </tr>
+            <% ) %>
+            <tr>
+                <td class="field">CID</td><td class="code"><%= cid %></td>
+            </tr>
+            <tr>
+                <td class="field">Time</td><td class="code"><%= timestamp %></td>
+            </tr>
+            <% (when principal %>
+            <tr>
+                <td class="field">Principal</td><td class="code"><%= principal %></td>
+            </tr>
+            <% ) %>
+            <% (when service-id %>
+            <tr>
+                <td class="field">Service Id</td><td class="code"><%= service-id %></td>
+            </tr>
+            <% ) %>
+        </table>
+    </div>
+</div>
+
+<% (when (or token token-owner) %>
+<div class="additional-info">
+    <div class="divider"></div>
+    <div>
+        <h3>Additional Info</h3>
+        <table>
+            <% (when token %>
+            <tr>
+                <td class="field">Token</td><td class="code"><%= token %></td>
+            </tr>
+            <% ) %>
+            <% (when token-owner %>
+            <tr>
+                <td class="field">Token Owner</td><td class="code"><%= token-owner %></td>
+            </tr>
+            <% ) %>
+        </table>
+    </div>
+</div>
+<% ) %>
+
+<% (when (seq support-info) %>
+<div class="additional-info">
+    <div class="divider"></div>
+    <div>
+        <h3>Getting Help</h3>
+        <ul>
+            <% (doseq [{label :label {:keys [type value]} :link} support-info] %>
+            <li>
+                <%= label %>:
+                <% (when (= type :url) %> <a href="<%= value %>"><%= value %></a><% ) %>
+                <% (when (= type :email) %> <a href="mailto:<%= value %>"><%= value %></a><% ) %>
+            </li>
+            <% ) %>
+        </ul>
+    </div>
+    <% ) %>
+
+</body>
+
+</html>

--- a/waiter/resources/web/maintenance.html
+++ b/waiter/resources/web/maintenance.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-    <title>"<%= token %>" in Maintenance Mode</title>
+    <title><%= token %> in Maintenance Mode</title>
     <meta http-equiv="x-ua-compatible" content="IE=edge" />
     <style type="text/css">
         html {
@@ -89,7 +89,7 @@
 
 <div class="main-content">
     <h1>
-        "<%= token %>" is Down For Maintenance
+        <%= token %> is Down For Maintenance
     </h1>
     <p>
         <%= message %>
@@ -134,7 +134,7 @@
     </div>
 </div>
 
-<% (when (or token token-owner) %>
+<% (when (or name token token-owner) %>
 <div class="additional-info">
     <div class="divider"></div>
     <div>
@@ -143,6 +143,11 @@
             <% (when token %>
             <tr>
                 <td class="field">Token</td><td class="code"><%= token %></td>
+            </tr>
+            <% ) %>
+            <% (when name %>
+            <tr>
+                <td class="field">Service Name</td><td class="code"><%= name %></td>
             </tr>
             <% ) %>
             <% (when token-owner %>

--- a/waiter/resources/web/maintenance.html
+++ b/waiter/resources/web/maintenance.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-    <title>Token in Maintenance Mode</title>
+    <title>"<%= token %>" in Maintenance Mode</title>
     <meta http-equiv="x-ua-compatible" content="IE=edge" />
     <style type="text/css">
         html {
@@ -89,7 +89,7 @@
 
 <div class="main-content">
     <h1>
-        Token in Maintenance Mode
+        "<%= token %>" is Down For Maintenance
     </h1>
     <p>
         <%= message %>

--- a/waiter/resources/web/maintenance.txt
+++ b/waiter/resources/web/maintenance.txt
@@ -1,5 +1,5 @@
 
-Token in Maintenance Mode
+"<%= token %>" is Down For Maintenance
 ================
 
   <%= message %>

--- a/waiter/resources/web/maintenance.txt
+++ b/waiter/resources/web/maintenance.txt
@@ -1,5 +1,5 @@
 
-"<%= token %>" is Down For Maintenance
+<%= token %> is Down For Maintenance
 ================
 
   <%= message %>

--- a/waiter/resources/web/maintenance.txt
+++ b/waiter/resources/web/maintenance.txt
@@ -1,0 +1,30 @@
+
+Token in Maintenance Mode
+================
+
+  <%= message %>
+
+Request Info
+============
+
+          Host: <%= (or host "") %>
+          Path: <%= uri %>
+  Query String: <%= (or query-string "") %>
+        Method: <%= request-method %>
+           CID: <%= cid %>
+          Time: <%= timestamp %><% (when principal %>
+     Principal: <%= principal %><% ) %><% (when service-id %>
+    Service Id: <%= service-id %><% ) %>
+
+<% (when (or token token-owner) %>
+Additional Info
+===============
+<% (when token %>
+         Token: <%= token %><% ) %><% (when token-owner %>
+   Token Owner: <%= token-owner %><% ) %>
+<% ) %>
+<% (when (seq support-info) %>Getting Help
+============
+<% (doseq [{label :label {:keys [value]} :link} support-info] %>
+  <%= label %>: <%= value %> <% ) %>
+<% ) %>

--- a/waiter/resources/web/maintenance.txt
+++ b/waiter/resources/web/maintenance.txt
@@ -16,11 +16,12 @@ Request Info
      Principal: <%= principal %><% ) %><% (when service-id %>
     Service Id: <%= service-id %><% ) %>
 
-<% (when (or token token-owner) %>
+<% (when (or name token token-owner) %>
 Additional Info
 ===============
 <% (when token %>
-         Token: <%= token %><% ) %><% (when token-owner %>
+         Token: <%= token %><% ) %><% (when name %>
+  Service Name: <%= name %><% ) %><% (when token-owner %>
    Token Owner: <%= token-owner %><% ) %>
 <% ) %>
 <% (when (seq support-info) %>Getting Help

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1543,6 +1543,7 @@
                                    (-> handler
                                      pr/wrap-too-many-requests
                                      pr/wrap-suspended-service
+                                     pr/wrap-maintenance-mode
                                      pr/wrap-response-status-metrics
                                      (interstitial/wrap-interstitial interstitial-state-atom)
                                      wrap-descriptor-fn

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1545,11 +1545,11 @@
                                      pr/wrap-suspended-service
                                      pr/wrap-response-status-metrics
                                      (interstitial/wrap-interstitial interstitial-state-atom)
-                                     pr/wrap-maintenance-mode
                                      wrap-descriptor-fn
                                      wrap-secure-request-fn
                                      wrap-auth-bypass-fn
                                      wrap-https-redirect-fn
+                                     pr/wrap-maintenance-mode
                                      wrap-service-discovery-fn)))
    :profile-list-handler-fn (pc/fnk [[:state profile->defaults]
                                      wrap-secure-request-fn]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1543,8 +1543,8 @@
                                    (-> handler
                                      pr/wrap-too-many-requests
                                      pr/wrap-suspended-service
-                                     pr/wrap-maintenance-mode
                                      pr/wrap-response-status-metrics
+                                     pr/wrap-maintenance-mode
                                      (interstitial/wrap-interstitial interstitial-state-atom)
                                      wrap-descriptor-fn
                                      wrap-secure-request-fn

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1544,8 +1544,8 @@
                                      pr/wrap-too-many-requests
                                      pr/wrap-suspended-service
                                      pr/wrap-response-status-metrics
-                                     pr/wrap-maintenance-mode
                                      (interstitial/wrap-interstitial interstitial-state-atom)
+                                     pr/wrap-maintenance-mode
                                      wrap-descriptor-fn
                                      wrap-secure-request-fn
                                      wrap-auth-bypass-fn

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1179,6 +1179,7 @@
                                                (ws/inter-router-request-middleware router-id (first passwords) request)))
    :websocket-request-acceptor (pc/fnk [[:state passwords server-name]
                                         discover-service-parameters-fn]
+                                 ; TODO: add middleware checks - https-redirect, maintenance-mode, etc.
                                  (fn websocket-request-acceptor [^ServletUpgradeRequest request ^ServletUpgradeResponse response]
                                    (let [request-headers (->> (.getHeaders request)
                                                            (pc/map-vals #(str/join "," %))

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -181,7 +181,8 @@
   "Computes the fallback descriptor with a healthy instance based on the provided descriptor.
    Fallback descriptors can only be computed for token-based descriptors.
    The amount of history lookup for fallback descriptor candidates is limited by search-history-length.
-   Also, the fallback descriptor needs to be inside the fallback period to be returned."
+   Also, the fallback descriptor needs to be inside the fallback period to be returned.
+   Descriptors with maintenance field specified are skipped because the service is considered unhealthy"
   [descriptor->previous-descriptor search-history-length fallback-state request-time
    {:keys [component->previous-descriptor-fns] :as descriptor}]
   (when (seq component->previous-descriptor-fns)

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -182,7 +182,8 @@
    Fallback descriptors can only be computed for token-based descriptors.
    The amount of history lookup for fallback descriptor candidates is limited by search-history-length.
    Also, the fallback descriptor needs to be inside the fallback period to be returned.
-   Descriptors with maintenance field specified are skipped because the service is considered unhealthy"
+   Descriptors with maintenance field specified are included because they map to the same service-id as
+   the service with maintenance mode enabled."
   [descriptor->previous-descriptor search-history-length fallback-state request-time
    {:keys [component->previous-descriptor-fns] :as descriptor}]
   (when (seq component->previous-descriptor-fns)

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -860,7 +860,8 @@
 
 (defn wrap-maintenance-mode
   "Check if a service's token is in maintenance mode and immediately return a 503 response
-  with a custom message if specified"
+  with a custom message if specified. Check if x-waiter-maintenance header is set and return
+  400 response because the header is not supported."
   [handler]
   (fn [{{:keys [token-metadata token waiter-headers service-description-template]} :waiter-discovery
         {:keys [service-id]} :descriptor

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -880,7 +880,7 @@
             (some? maintenance)
             (do
               (log/info (str "token " token " is in maintenance mode (service-id: " service-id ")"))
-              (meters/mark! (metrics/service-meter service-id "response-rate" "error" "maintenance"))
+              (meters/mark! (metrics/waiter-meter "maintenance" "response-rate"))
               (-> {:details response-map
                    :message (get maintenance "message")
                    :status http-503-service-unavailable}

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -880,7 +880,7 @@
                   (utils/data->error-response request)))
             (some? maintenance)
             (do
-              (log/info "token is in maintenance mode" response-map)
+              (log/info (str "token " token " is in maintenance mode (service-id: " service-id ")"))
               (meters/mark! (metrics/service-meter service-id "response-rate" "error" "maintenance"))
               (-> {:details response-map,
                    :message (get maintenance "message"),

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -874,7 +874,7 @@
             (do
               (log/info "x-waiter-maintenance is not supported as an on-the-fly header"
                         {:service-description service-description-template :token token})
-              (-> {:message "Maintenance parameter is not supported for on-the-fly headers"
+              (-> {:message "The maintenance parameter is not supported for on-the-fly requests"
                    :status http-400-bad-request
                    :waiter-headers waiter-headers}
                   (utils/data->error-response request)))

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -863,13 +863,12 @@
   with a custom message if specified. Check if x-waiter-maintenance header is set and return
   400 response because the header is not supported."
   [handler]
-  (fn [{{:keys [token-metadata token waiter-headers service-description-template]} :waiter-discovery
+  (fn [{{:keys [service-description-template token-metadata token waiter-headers]} :waiter-discovery
         {:keys [service-id]} :descriptor
         :as request}]
     (let [maintenance (get token-metadata "maintenance")
-          response-map {:maintenance maintenance
-                        :token token
-                        :service-id service-id}]
+          response-map {:token token
+                        :token-owner (get token-metadata "owner")}]
       (cond (contains? waiter-headers "x-waiter-maintenance")
             (do
               (log/info "x-waiter-maintenance is not supported as an on-the-fly header"
@@ -885,7 +884,7 @@
               (-> {:details response-map
                    :message (get maintenance "message")
                    :status http-503-service-unavailable}
-                  (utils/data->error-response request)))
+                  (utils/data->maintenance-mode-response request)))
             :else (handler request)))))
 
 (defn wrap-too-many-requests

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -885,7 +885,7 @@
                     (-> {:details response-map,
                          :message (or (get maintenance "message") default-message),
                          :status http-503-service-unavailable}
-                        (utils/data->error-response request))))))
+                        (utils/data->error-response request)))))))
 
 (defn wrap-too-many-requests
   "Check if a service has more pending requests than max-queue-length and immediately return a 503"

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -882,8 +882,8 @@
             (do
               (log/info (str "token " token " is in maintenance mode (service-id: " service-id ")"))
               (meters/mark! (metrics/service-meter service-id "response-rate" "error" "maintenance"))
-              (-> {:details response-map,
-                   :message (get maintenance "message"),
+              (-> {:details response-map
+                   :message (get maintenance "message")
                    :status http-503-service-unavailable}
                   (utils/data->error-response request)))
             :else (handler request)))))

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -863,12 +863,13 @@
   with a custom message if specified. Check if x-waiter-maintenance header is set and return
   400 response because the header is not supported."
   [handler]
-  (fn [{{:keys [service-description-template token-metadata token waiter-headers]} :waiter-discovery
+  (fn [{{:keys [service-description-template token waiter-headers]
+         {:strs [maintenance owner]} :token-metadata} :waiter-discovery
         {:keys [service-id]} :descriptor
         :as request}]
-    (let [maintenance (get token-metadata "maintenance")
-          response-map {:token token
-                        :token-owner (get token-metadata "owner")}]
+    (let [response-map {:name (get service-description-template "name")
+                        :token token
+                        :token-owner owner}]
       (cond (contains? waiter-headers "x-waiter-maintenance")
             (do
               (log/info "x-waiter-maintenance is not supported as an on-the-fly header"

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -164,7 +164,7 @@
 (def ^:const system-metadata-keys #{"cluster" "deleted" "last-update-time" "last-update-user" "previous" "root"})
 
 ; keys allowed in user metadata for tokens, these need to be distinct from service description keys
-(def ^:const user-metadata-keys #{"cors-rules" "fallback-period-secs" "https-redirect" "owner" "stale-timeout-mins", "maintenance"})
+(def ^:const user-metadata-keys #{"cors-rules" "fallback-period-secs" "https-redirect" "maintenance" "owner" "stale-timeout-mins"})
 
 ; keys allowed in metadata for tokens, these need to be distinct from service description keys
 (def ^:const token-metadata-keys (set/union system-metadata-keys user-metadata-keys))

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -118,6 +118,7 @@
    (s/optional-key "https-redirect") s/Bool
    (s/optional-key "owner") schema/non-empty-string
    (s/optional-key "stale-timeout-mins") (s/both s/Int (s/pred #(<= 0 % (t/in-minutes (t/hours 4))) 'at-most-4-hours))
+   (s/optional-key "maintenance") {(s/required-key "message") (s/conditional #(<= 1 (count %) 512) s/Str)}
    s/Str s/Any})
 
 (def ^:const service-required-keys (->> (keys service-description-schema)
@@ -157,7 +158,7 @@
 (def ^:const system-metadata-keys #{"cluster" "deleted" "last-update-time" "last-update-user" "previous" "root"})
 
 ; keys allowed in user metadata for tokens, these need to be distinct from service description keys
-(def ^:const user-metadata-keys #{"cors-rules" "fallback-period-secs" "https-redirect" "owner" "stale-timeout-mins"})
+(def ^:const user-metadata-keys #{"cors-rules" "fallback-period-secs" "https-redirect" "owner" "stale-timeout-mins", "maintenance"})
 
 ; keys allowed in metadata for tokens, these need to be distinct from service description keys
 (def ^:const token-metadata-keys (set/union system-metadata-keys user-metadata-keys))

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -116,13 +116,7 @@
                                    (s/optional-key "methods") (s/both (s/pred not-empty) [schema/http-method])}]
    (s/optional-key "fallback-period-secs") (s/both s/Int (s/pred #(<= 0 % (t/in-seconds (t/days 1))) 'at-most-1-day))
    (s/optional-key "https-redirect") s/Bool
-   (s/optional-key "maintenance") {(s/optional-key "message") (s/constrained s/Str #(<= 1 (count %) 512))
-                                   (s/required-key "expires-at") (s/conditional
-                                                                   #(= "*" %) s/Str
-                                                                   #(try
-                                                                      (du/str-to-date %)
-                                                                      (catch Exception _
-                                                                        false)) s/Str)}
+   (s/optional-key "maintenance") {(s/required-key "message") (s/constrained s/Str #(<= 1 (count %) 512))}
    (s/optional-key "owner") schema/non-empty-string
    (s/optional-key "stale-timeout-mins") (s/both s/Int (s/pred #(<= 0 % (t/in-minutes (t/hours 4))) 'at-most-4-hours))
    s/Str s/Any})

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -116,9 +116,9 @@
                                    (s/optional-key "methods") (s/both (s/pred not-empty) [schema/http-method])}]
    (s/optional-key "fallback-period-secs") (s/both s/Int (s/pred #(<= 0 % (t/in-seconds (t/days 1))) 'at-most-1-day))
    (s/optional-key "https-redirect") s/Bool
+   (s/optional-key "maintenance") {(s/optional-key "message") (s/conditional #(<= 1 (count %) 512) s/Str)}
    (s/optional-key "owner") schema/non-empty-string
    (s/optional-key "stale-timeout-mins") (s/both s/Int (s/pred #(<= 0 % (t/in-minutes (t/hours 4))) 'at-most-4-hours))
-   (s/optional-key "maintenance") {(s/optional-key "message") (s/conditional #(<= 1 (count %) 512) s/Str)}
    s/Str s/Any})
 
 (def ^:const service-required-keys (->> (keys service-description-schema)

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -116,7 +116,13 @@
                                    (s/optional-key "methods") (s/both (s/pred not-empty) [schema/http-method])}]
    (s/optional-key "fallback-period-secs") (s/both s/Int (s/pred #(<= 0 % (t/in-seconds (t/days 1))) 'at-most-1-day))
    (s/optional-key "https-redirect") s/Bool
-   (s/optional-key "maintenance") {(s/optional-key "message") (s/conditional #(<= 1 (count %) 512) s/Str)}
+   (s/optional-key "maintenance") {(s/optional-key "message") (s/conditional #(<= 1 (count %) 512) s/Str)
+                                   (s/required-key "expires-at") (s/conditional
+                                                                   #(= "*" %) s/Str
+                                                                   #(try
+                                                                      (du/str-to-date-safe %)
+                                                                      (catch Exception _
+                                                                        false)) s/Str)}
    (s/optional-key "owner") schema/non-empty-string
    (s/optional-key "stale-timeout-mins") (s/both s/Int (s/pred #(<= 0 % (t/in-minutes (t/hours 4))) 'at-most-4-hours))
    s/Str s/Any})

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -116,11 +116,11 @@
                                    (s/optional-key "methods") (s/both (s/pred not-empty) [schema/http-method])}]
    (s/optional-key "fallback-period-secs") (s/both s/Int (s/pred #(<= 0 % (t/in-seconds (t/days 1))) 'at-most-1-day))
    (s/optional-key "https-redirect") s/Bool
-   (s/optional-key "maintenance") {(s/optional-key "message") (s/conditional #(<= 1 (count %) 512) s/Str)
+   (s/optional-key "maintenance") {(s/optional-key "message") (s/constrained s/Str #(<= 1 (count %) 512))
                                    (s/required-key "expires-at") (s/conditional
                                                                    #(= "*" %) s/Str
                                                                    #(try
-                                                                      (du/str-to-date-safe %)
+                                                                      (du/str-to-date %)
                                                                       (catch Exception _
                                                                         false)) s/Str)}
    (s/optional-key "owner") schema/non-empty-string

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -118,7 +118,7 @@
    (s/optional-key "https-redirect") s/Bool
    (s/optional-key "owner") schema/non-empty-string
    (s/optional-key "stale-timeout-mins") (s/both s/Int (s/pred #(<= 0 % (t/in-minutes (t/hours 4))) 'at-most-4-hours))
-   (s/optional-key "maintenance") {(s/required-key "message") (s/conditional #(<= 1 (count %) 512) s/Str)}
+   (s/optional-key "maintenance") {(s/optional-key "message") (s/conditional #(<= 1 (count %) 512) s/Str)}
    s/Str s/Any})
 
 (def ^:const service-required-keys (->> (keys service-description-schema)

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -101,7 +101,7 @@
       token-lock
       (fn inner-store-service-description-for-token []
         (log/info "storing service description for token:" token)
-        (let [{:strs [deleted last-update-time owner maintenance] :as new-token-data}
+        (let [{:strs [deleted last-update-time maintenance owner] :as new-token-data}
               (-> (merge service-parameter-template token-metadata)
                   (select-keys sd/token-data-keys)
                   (sd/sanitize-service-description sd/token-data-keys))

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -392,7 +392,7 @@
 (defn- data-map->response
   "Converts the provided data map and render functions into a ring response.
    The data map is expected to contain the following keys: details, headers, message, and status."
-  [{:keys [details headers status] :or {status http-400-bad-request} :as data-map} request build-context-fn render-html-fn render-text-fn]
+  [{:keys [details headers status] :or {status http-400-bad-request} :as data-map} build-context-fn render-html-fn render-text-fn request]
   (let [error-context (build-context-fn data-map request)
         content-type (request->content-type request)]
     (-> {:body (case content-type
@@ -413,7 +413,7 @@
   "Converts the provided data map into a ring response and renders as a generic error.
    The data map is expected to contain the following keys: details, headers, message, and status."
   [data-map request]
-  (data-map->response data-map request build-error-context render-error-html render-error-text))
+  (data-map->response data-map build-error-context render-error-html render-error-text request))
 
 (defn data->maintenance-mode-response
   "Converts the provided data map into a ring response and renders as a maintenance mode error.
@@ -421,7 +421,7 @@
    The message field should correspond with the maintenance message and details is a map with keys:
    token and token-owner"
   [data-map request]
-  (data-map->response data-map request build-maintenance-context render-maintenance-mode-html render-maintenance-mode-text))
+  (data-map->response data-map build-maintenance-context render-maintenance-mode-html render-maintenance-mode-text request))
 
 (defn- wrap-unhandled-exception
   "Wraps any exception that doesn't already set status in a parent

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -401,10 +401,10 @@
          :headers (-> headers
                     (assoc-if-absent "content-type" content-type))
          :status status}
-        (attach-error-class details)
-        (attach-grpc-status error-context request)
-        (attach-waiter-namespace-keys details)
-        (attach-waiter-source))))
+      (attach-error-class details)
+      (attach-grpc-status error-context request)
+      (attach-waiter-namespace-keys details)
+      (attach-waiter-source))))
 
 (defn data->error-response
   "Converts the provided data map into a ring response and renders as a generic error.

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -276,6 +276,9 @@
      :uri uri}))
 
 (defn- build-maintenance-context
+  "Creates a context from a data map and request.
+   The data map is expected to contain the following keys: details, message, and status.
+   The key details is a map with keys: token and token-owner"
   [{{:keys [token token-owner]} :details :as data-map} request]
   (merge
     (build-error-context data-map request)
@@ -304,7 +307,7 @@
                          service-id support-info timestamp token token-owner uri]}]
                 (slurp (io/resource "web/maintenance.html")))]
   (defn- render-maintenance-mode-html
-    "Renders maintenance mode error"
+    "Renders maintenance mode html"
     [context]
     (html-fn context)))
 
@@ -313,7 +316,7 @@
                          service-id support-info timestamp token token-owner uri]}]
                 (slurp (io/resource "web/maintenance.txt")))]
   (defn- render-maintenance-mode-text
-    "Renders maintenance error text"
+    "Renders maintenance mode text"
     [context]
     (text-fn context)))
 
@@ -414,7 +417,9 @@
 
 (defn data->maintenance-mode-response
   "Converts the provided data map into a ring response and renders as a maintenance mode error.
-   The data map is expected to contain the following keys: details, headers, message, and status."
+   The data map is expected to contain the following keys: details, headers, message, and status.
+   The message field should correspond with the maintenance message and details is a map with keys:
+   token and token-owner"
   [data-map request]
   (data-render-fn->error-response data-map request build-maintenance-context render-maintenance-mode-html render-maintenance-mode-text))
 

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -275,25 +275,53 @@
      :timestamp (du/date-to-str request-time)
      :uri uri}))
 
-(let [html-fn (template/fn
-                [{:keys [cid details host instance-id message principal query-string request-method
-                         service-id status support-info timestamp uri]}]
-                (slurp (io/resource "web/error.html")))]
+(defn- build-maintenance-context
+  [{{:keys [token token-owner]} :details :as data-map} request]
+  (merge
+    (build-error-context data-map request)
+    {:token token :token-owner token-owner}))
+
+(let [html-fn
+      (template/fn
+        [{:keys [cid details host instance-id message principal query-string request-method
+                 service-id status support-info timestamp uri]}]
+        (slurp (io/resource "web/error.html")))]
   (defn- render-error-html
     "Renders error html"
     [context]
     (html-fn context)))
 
-(let [text-fn (template/fn
-                [{:keys [cid details host instance-id message principal query-string request-method
-                         service-id status support-info timestamp uri]}]
-                (slurp (io/resource "web/error.txt")))]
+(let [text-fn
+      (template/fn
+        [{:keys [cid details host instance-id message principal query-string request-method
+                 service-id status support-info timestamp uri]}]
+        (slurp (io/resource "web/error.txt")))]
   (defn- render-error-text
     "Renders error text"
     [context]
     (text-fn context)))
 
-(defn error-context->json-body
+(let [html-fn
+      (template/fn
+        [{:keys [cid host instance-id message principal query-string request-method
+                 service-id support-info timestamp token token-owner uri]}]
+        (slurp (io/resource "web/maintenance.html")))]
+  (defn- render-maintenance-mode-html
+    "Renders maintenance mode error"
+    [context]
+    (html-fn context)))
+
+(let [text-fn
+      (template/fn
+        [{:keys [cid host instance-id message principal query-string request-method
+                 service-id support-info timestamp token token-owner uri]}]
+        (slurp (io/resource "web/maintenance.txt")))]
+  (defn- render-maintenance-mode-text
+    "Renders maintenance error text"
+    [context]
+    (text-fn context)))
+
+(defn- error-context->json-body
   "Converts the error-context to the response body json string."
   [error-context]
   (json/write-str {:waiter-error error-context}
@@ -301,22 +329,22 @@
                   :key-fn stringify-keys
                   :value-fn stringify-elements))
 
-(defn error-context->html-body
+(defn- error-context->html-body
   "Converts the error-context to the response body html string."
-  [error-context]
+  [error-context render-fn]
   (-> error-context
     (update :message urls->html-links)
     (update :details #(with-out-str (pprint/pprint %)))
-    render-error-html))
+    render-fn))
 
-(defn error-context->text-body
+(defn- error-context->text-body
   "Converts the error-context to the response body plaintext string."
-  [error-context]
+  [error-context render-fn]
   (-> error-context
     (update :details (fn [v]
                        (when v
                          (str/replace (with-out-str (pprint/pprint v)) #"\n" "\n  "))))
-    render-error-text
+    render-fn
     (str/replace #"\n" "\n  ")
     (str/replace #"\n  $" "\n")))
 
@@ -362,25 +390,37 @@
   (cond-> response
     error-class (assoc :error-class error-class)))
 
-(defn data->error-response
-  "Converts the provided data map into a ring response.
+(defn- data-render-fn->error-response
+  "Converts the provided data map and render functions into a ring response.
    The data map is expected to contain the following keys: details, headers, message, and status."
-  [{:keys [details headers status] :or {status http-400-bad-request} :as data-map} request]
-  (let [error-context (build-error-context data-map request)
+  [{:keys [details headers status] :or {status http-400-bad-request} :as data-map} request build-context-fn render-html-fn render-text-fn]
+  (let [error-context (build-context-fn data-map request)
         content-type (request->content-type request)]
     (-> {:body (case content-type
                  ;; grpc error responses should not have a body as the client will try to parse it into a proto object
                  "application/grpc" nil
                  "application/json" (error-context->json-body error-context)
-                 "text/html" (error-context->html-body error-context)
-                 "text/plain" (error-context->text-body error-context))
+                 "text/html" (error-context->html-body error-context render-html-fn)
+                 "text/plain" (error-context->text-body error-context render-text-fn))
          :headers (-> headers
-                    (assoc-if-absent "content-type" content-type))
+                      (assoc-if-absent "content-type" content-type))
          :status status}
-      (attach-error-class details)
-      (attach-grpc-status error-context request)
-      (attach-waiter-namespace-keys details)
-      (attach-waiter-source))))
+        (attach-error-class details)
+        (attach-grpc-status error-context request)
+        (attach-waiter-namespace-keys details)
+        (attach-waiter-source))))
+
+(defn data->error-response
+  "Converts the provided data map into a ring response and renders as a generic error.
+   The data map is expected to contain the following keys: details, headers, message, and status."
+  [data-map request]
+  (data-render-fn->error-response data-map request build-error-context render-error-html render-error-text))
+
+(defn data->maintenance-mode-response
+  "Converts the provided data map into a ring response and renders as a maintenance mode error.
+   The data map is expected to contain the following keys: details, headers, message, and status."
+  [data-map request]
+  (data-render-fn->error-response data-map request build-maintenance-context render-maintenance-mode-html render-maintenance-mode-text))
 
 (defn- wrap-unhandled-exception
   "Wraps any exception that doesn't already set status in a parent

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -399,7 +399,7 @@
                  "text/html" (error-context->html-body error-context render-html-fn)
                  "text/plain" (error-context->text-body error-context render-text-fn))
          :headers (-> headers
-                      (assoc-if-absent "content-type" content-type))
+                    (assoc-if-absent "content-type" content-type))
          :status status}
         (attach-error-class details)
         (attach-grpc-status error-context request)

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -281,41 +281,37 @@
     (build-error-context data-map request)
     {:token token :token-owner token-owner}))
 
-(let [html-fn
-      (template/fn
-        [{:keys [cid details host instance-id message principal query-string request-method
-                 service-id status support-info timestamp uri]}]
-        (slurp (io/resource "web/error.html")))]
+(let [html-fn (template/fn
+                [{:keys [cid details host instance-id message principal query-string request-method
+                         service-id status support-info timestamp uri]}]
+                (slurp (io/resource "web/error.html")))]
   (defn- render-error-html
     "Renders error html"
     [context]
     (html-fn context)))
 
-(let [text-fn
-      (template/fn
-        [{:keys [cid details host instance-id message principal query-string request-method
-                 service-id status support-info timestamp uri]}]
-        (slurp (io/resource "web/error.txt")))]
+(let [text-fn (template/fn
+                [{:keys [cid details host instance-id message principal query-string request-method
+                         service-id status support-info timestamp uri]}]
+                (slurp (io/resource "web/error.txt")))]
   (defn- render-error-text
     "Renders error text"
     [context]
     (text-fn context)))
 
-(let [html-fn
-      (template/fn
-        [{:keys [cid host instance-id message principal query-string request-method
-                 service-id support-info timestamp token token-owner uri]}]
-        (slurp (io/resource "web/maintenance.html")))]
+(let [html-fn (template/fn
+                [{:keys [cid host instance-id message principal query-string request-method
+                         service-id support-info timestamp token token-owner uri]}]
+                (slurp (io/resource "web/maintenance.html")))]
   (defn- render-maintenance-mode-html
     "Renders maintenance mode error"
     [context]
     (html-fn context)))
 
-(let [text-fn
-      (template/fn
-        [{:keys [cid host instance-id message principal query-string request-method
-                 service-id support-info timestamp token token-owner uri]}]
-        (slurp (io/resource "web/maintenance.txt")))]
+(let [text-fn (template/fn
+                [{:keys [cid host instance-id message principal query-string request-method
+                         service-id support-info timestamp token token-owner uri]}]
+                (slurp (io/resource "web/maintenance.txt")))]
   (defn- render-maintenance-mode-text
     "Renders maintenance error text"
     [context]

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -278,11 +278,11 @@
 (defn- build-maintenance-context
   "Creates a context from a data map and request.
    The data map is expected to contain the following keys: details, message, and status.
-   The key details is a map with keys: token and token-owner"
-  [{{:keys [token token-owner]} :details :as data-map} request]
+   The key details is a map with keys: name, token and token-owner"
+  [{{:keys [name token token-owner]} :details :as data-map} request]
   (merge
     (build-error-context data-map request)
-    {:token token :token-owner token-owner}))
+    {:name name :token token :token-owner token-owner}))
 
 (let [html-fn (template/fn
                 [{:keys [cid details host instance-id message principal query-string request-method
@@ -303,7 +303,7 @@
     (text-fn context)))
 
 (let [html-fn (template/fn
-                [{:keys [cid host instance-id message principal query-string request-method
+                [{:keys [cid host instance-id message name principal query-string request-method
                          service-id support-info timestamp token token-owner uri]}]
                 (slurp (io/resource "web/maintenance.html")))]
   (defn- render-maintenance-mode-html
@@ -312,7 +312,7 @@
     (html-fn context)))
 
 (let [text-fn (template/fn
-                [{:keys [cid host instance-id message principal query-string request-method
+                [{:keys [cid host instance-id message name principal query-string request-method
                          service-id support-info timestamp token token-owner uri]}]
                 (slurp (io/resource "web/maintenance.txt")))]
   (defn- render-maintenance-mode-text
@@ -419,7 +419,7 @@
   "Converts the provided data map into a ring response and renders as a maintenance mode error.
    The data map is expected to contain the following keys: details, headers, message, and status.
    The message field should correspond with the maintenance message and details is a map with keys:
-   token and token-owner"
+   name, token and token-owner"
   [data-map request]
   (data-map->response data-map build-maintenance-context render-maintenance-mode-html render-maintenance-mode-text request))
 

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -389,7 +389,7 @@
   (cond-> response
     error-class (assoc :error-class error-class)))
 
-(defn- data-render-fn->error-response
+(defn- data-map->response
   "Converts the provided data map and render functions into a ring response.
    The data map is expected to contain the following keys: details, headers, message, and status."
   [{:keys [details headers status] :or {status http-400-bad-request} :as data-map} request build-context-fn render-html-fn render-text-fn]
@@ -413,7 +413,7 @@
   "Converts the provided data map into a ring response and renders as a generic error.
    The data map is expected to contain the following keys: details, headers, message, and status."
   [data-map request]
-  (data-render-fn->error-response data-map request build-error-context render-error-html render-error-text))
+  (data-map->response data-map request build-error-context render-error-html render-error-text))
 
 (defn data->maintenance-mode-response
   "Converts the provided data map into a ring response and renders as a maintenance mode error.
@@ -421,7 +421,7 @@
    The message field should correspond with the maintenance message and details is a map with keys:
    token and token-owner"
   [data-map request]
-  (data-render-fn->error-response data-map request build-maintenance-context render-maintenance-mode-html render-maintenance-mode-text))
+  (data-map->response data-map request build-maintenance-context render-maintenance-mode-html render-maintenance-mode-text))
 
 (defn- wrap-unhandled-exception
   "Wraps any exception that doesn't already set status in a parent

--- a/waiter/test/waiter/auth/spnego_test.clj
+++ b/waiter/test/waiter/auth/spnego_test.clj
@@ -43,7 +43,7 @@
                                :status http-401-unauthorized
                                :waiter/response-source :waiter}]
 
-    (with-redefs [utils/error-context->text-body (fn mocked-error-context->text-body[data-map _] (-> data-map :message str))]
+    (with-redefs [utils/error-context->text-body (fn mocked-error-context->text-body [data-map _] (-> data-map :message str))]
 
       (testing "spnego authentication disabled"
         (with-redefs [too-many-pending-auth-requests? (constantly true)]

--- a/waiter/test/waiter/auth/spnego_test.clj
+++ b/waiter/test/waiter/auth/spnego_test.clj
@@ -43,7 +43,7 @@
                                :status http-401-unauthorized
                                :waiter/response-source :waiter}]
 
-    (with-redefs [utils/error-context->text-body #(-> % :message str)]
+    (with-redefs [utils/error-context->text-body (fn mocked-error-context->text-body[data-map _] (-> data-map :message str))]
 
       (testing "spnego authentication disabled"
         (with-redefs [too-many-pending-auth-requests? (constantly true)]

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -394,13 +394,14 @@
 (deftest test-wrap-maintenance-mode
   (testing "returns 503 for token in maintenance mode with custom message"
     (let [handler (wrap-maintenance-mode (fn [_] {:status http-200-ok}))
-          request {:waiter-discovery {:token-metadata {"maintenance" {"message" "test maintenance message"}}
+          maintenance-message "test maintenance message"
+          request {:waiter-discovery {:token-metadata {"maintenance" {"message" maintenance-message}}
                                       :token "token"
                                       :waiter-headers {}}
                    :descriptor {:service-id "service-id-1"}}
           {:keys [status body]} (handler request)]
       (is (= http-503-service-unavailable status))
-      (is (str/includes? body (get-in request [:waiter-discovery :token-metadata "maintenance" "message"])))))
+      (is (str/includes? body maintenance-message))))
 
   (testing "returns 400 if x-waiter-maintenance is specified in headers"
     (let [handler (wrap-maintenance-mode (fn [_] {:status http-200-ok}))
@@ -410,7 +411,7 @@
                    :descriptor {:service-id "service-id-1"}}
           {:keys [status body]} (handler request)]
       (is (= http-400-bad-request status))
-      (is (str/includes? body "Maintenance parameter is not supported for on-the-fly headers"))))
+      (is (str/includes? body "The maintenance parameter is not supported for on-the-fly requests"))))
 
   (testing "passes apps by default"
     (let [handler (wrap-maintenance-mode (fn [_] {:status http-200-ok}))

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -392,18 +392,7 @@
       (is (= http-200-ok status)))))
 
 (deftest test-wrap-maintenance-mode
-  (testing "returns error for token in maintenance mode with no message"
-    (let [handler (wrap-maintenance-mode (fn [_] {:status http-200-ok}))
-          request {:waiter-discovery {:token-metadata {"maintenance" {}}
-                                      :token "token"
-                                      :waiter-headers {}}
-                   :descriptor {:service-id "service-id-1"}}
-          default-message "Token is under maintenance"
-          {:keys [status body]} (handler request)]
-      (is (= http-503-service-unavailable status))
-      (is (str/includes? body default-message))))
-
-  (testing "returns error for token in maintenance mode with custom message"
+  (testing "returns 503 for token in maintenance mode with custom message"
     (let [handler (wrap-maintenance-mode (fn [_] {:status http-200-ok}))
           request {:waiter-discovery {:token-metadata {"maintenance" {"message" "test maintenance message"}}
                                       :token "token"
@@ -413,7 +402,7 @@
       (is (= http-503-service-unavailable status))
       (is (str/includes? body (get-in request [:waiter-discovery :token-metadata "maintenance" "message"])))))
 
-  (testing "returns error if x-waiter-maintenance is specified in headers"
+  (testing "returns 400 if x-waiter-maintenance is specified in headers"
     (let [handler (wrap-maintenance-mode (fn [_] {:status http-200-ok}))
           request {:waiter-discovery {:token-metadata {}
                                       :token "token"
@@ -423,7 +412,7 @@
       (is (= http-400-bad-request status))
       (is (str/includes? body "Maintenance parameter is not supported for on-the-fly headers"))))
 
-  (testing "passes apps if maintenance field is not specified"
+  (testing "passes apps by default"
     (let [handler (wrap-maintenance-mode (fn [_] {:status http-200-ok}))
           request {:waiter-discovery {:token-metadata {}
                                       :token "token"

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -2247,16 +2247,16 @@
                            (f)))
         tokens {"token1" {"last-update-time" 1000 "owner" "owner1"}
                 "token2" {"owner" "owner1"}
-                "token3" {"last-update-time" 3000 "owner" "owner2"}}
+                "token3" {"last-update-time" 3000 "owner" "owner2" "maintenance" {"message" "custom maintenance message"}}}
         kv-store (kv/->LocalKeyValueStore (atom {}))
         token-owners-key "^TOKEN_OWNERS"
         token1-etag (sd/token-data->token-hash (get tokens "token1"))
-        token1-index-entry (make-index-entry token1-etag false 1000)
+        token1-index-entry (make-index-entry token1-etag false 1000 nil)
         token2-etag (sd/token-data->token-hash (get tokens "token2"))
-        token2-index-entry (make-index-entry token2-etag false nil)
+        token2-index-entry (make-index-entry token2-etag false nil nil)
         token3-etag (sd/token-data->token-hash (get tokens "token3"))
-        token3-index-entry (make-index-entry token3-etag false 3000)
-        bad-token-entry (make-index-entry "E-123456" true 2000)]
+        token3-index-entry (make-index-entry token3-etag false 3000 true)
+        bad-token-entry (make-index-entry "E-123456" true 2000 true)]
     (doseq [[token token-data] tokens]
       (kv/store kv-store token token-data))
     (reindex-tokens synchronize-fn kv-store (keys tokens))

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -1837,6 +1837,11 @@
                 service-description (assoc-in service-description invalid-keys "invalid iso8601 format")]
             (test-bad-service-description service-description invalid-keys)))
 
+        (testing "post:new-user-metadata:maintenance-expires-is-nil"
+          (let [invalid-keys ["maintenance" "expires-at"]
+                service-description (assoc-in service-description invalid-keys nil)]
+            (test-bad-service-description service-description invalid-keys)))
+
         (testing "post:new-user-metadata:maintenance-is-not-a-map"
           (let [service-description (assoc service-description "maintenance" "not a map")]
             (test-bad-service-description service-description ["maintenance"]))))

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -1784,6 +1784,42 @@
           (is (str/includes? (str details) "maintenance") body)
           (is (str/includes? message "Validation failed for user metadata on token") body)))
 
+      (testing "post:new-user-metadata:maintenance-message-is-not-a-string"
+        (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+              service-description (walk/stringify-keys
+                                    {:maintenance {:message -100}
+                                     :token "abcdefgh"})
+              {:keys [body status]}
+              (run-handle-token-request
+                kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn validate-service-description-fn attach-service-defaults-fn
+                {:authorization/user auth-user
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
+                 :headers {"accept" "application/json"}
+                 :request-method :post})
+              {{:strs [details message]} "waiter-error"} (json/read-str body)]
+          (is (= http-400-bad-request status))
+          (is (not (str/includes? body "clojure")))
+          (is (str/includes? (str details) "maintenance") body)
+          (is (str/includes? message "Validation failed for user metadata on token") body)))
+
+      (testing "post:new-user-metadata:maintenance-is-not-a-map"
+        (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+              service-description (walk/stringify-keys
+                                    {:maintenance "invalid-value"
+                                     :token "abcdefgh"})
+              {:keys [body status]}
+              (run-handle-token-request
+                kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn validate-service-description-fn attach-service-defaults-fn
+                {:authorization/user auth-user
+                 :body (StringBufferInputStream. (utils/clj->json service-description))
+                 :headers {"accept" "application/json"}
+                 :request-method :post})
+              {{:strs [details message]} "waiter-error"} (json/read-str body)]
+          (is (= http-400-bad-request status))
+          (is (not (str/includes? body "clojure")))
+          (is (str/includes? (str details) "maintenance") body)
+          (is (str/includes? message "Validation failed for user metadata on token") body)))
+
       (testing "post:new-service-description:token-limit-reached"
         (let [kv-store (kv/->LocalKeyValueStore (atom {}))
               test-user "test-user"

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -378,6 +378,7 @@
           (is (= [{"deleted" false
                    "etag" (sd/token-data->token-hash token-data)
                    "last-update-time" (-> last-update-time tc/from-long du/date-to-str)
+                   "maintenance" false
                    "owner" "tu1"
                    "token" token}]
                  (json/read-str body)))))

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -721,7 +721,7 @@
                 kv-store token-root waiter-hostnames entitlement-manager make-peer-requests-fn (constantly true) attach-service-defaults-fn
                 {:authorization/user auth-user
                  :body (-> service-description-1
-                           (assoc "maintenance" {:message "custom maintenance message"}
+                           (assoc "maintenance" {"message" "custom maintenance message"}
                                   "token" token)
                            utils/clj->json StringBufferInputStream.)
                  :headers {}

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -2164,7 +2164,7 @@
       synchronize-fn kv-store history-length limit-per-owner token service-parameter-template token-metadata)
 
     (is (= token-data (kv/fetch kv-store token)))
-    (is (= {token {:deleted false :etag (sd/token-data->token-hash token-data) :last-update-time nil}}
+    (is (= {token {:deleted false :etag (sd/token-data->token-hash token-data) :last-update-time nil :maintenance false}}
            (list-index-entries-for-owner kv-store owner-1)))
 
     (delete-service-description-for-token
@@ -2176,7 +2176,7 @@
                                "last-update-user" owner-1
                                "previous" token-data)]
       (is (= deleted-token-data (kv/fetch kv-store token)))
-      (is (= {token {:deleted true :etag (sd/token-data->token-hash deleted-token-data) :last-update-time nil}}
+      (is (= {token {:deleted true :etag (sd/token-data->token-hash deleted-token-data) :last-update-time nil :maintenance false}}
              (list-index-entries-for-owner kv-store owner-1))))
 
     (let [service-parameter-template {"cpus" 2}
@@ -2187,7 +2187,7 @@
         synchronize-fn kv-store history-length limit-per-owner token service-parameter-template token-metadata)
 
       (is (= token-data (kv/fetch kv-store token)))
-      (is (= {token {:deleted false :etag (sd/token-data->token-hash token-data) :last-update-time nil}}
+      (is (= {token {:deleted false :etag (sd/token-data->token-hash token-data) :last-update-time nil :maintenance false}}
              (list-index-entries-for-owner kv-store owner-2)))
       (is (empty? (list-index-entries-for-owner kv-store owner-1))))))
 

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -2374,48 +2374,56 @@
     (store-service-description-for-token
       synchronize-fn kv-store history-length limit-per-owner "token9"
       {"allowed-params" #{"P1" "P2"} "env" {"E1" "v0" "P1" "v1" "P2" "v2"} "cpus" 4 "mem" 1024}
-      {"cluster" "c1" "last-update-time" (- last-update-time-seed 3000) "owner" "owner3"})
+      {"cluster" "c1" "last-update-time" (- last-update-time-seed 3000) "maintenance" {"message" "msg1"} "owner" "owner3"})
     (let [request {:query-string "include=metadata" :request-method :get}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
       (is (= #{{"deleted" false
                 "etag" (token->token-hash "token1")
                 "last-update-time" (-> (- last-update-time-seed 1000) tc/from-long du/date-to-str)
+                "maintenance" false
                 "owner" "owner1"
                 "token" "token1"}
                {"deleted" false
                 "etag" (token->token-hash "token2")
                 "last-update-time" (-> (- last-update-time-seed 2000) tc/from-long du/date-to-str)
+                "maintenance" false
                 "owner" "owner1"
                 "token" "token2"}
                {"deleted" false
                 "etag" (token->token-hash "token3")
                 "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "maintenance" false
                 "owner" "owner2"
                 "token" "token3"}
                {"deleted" false
                 "etag" (token->token-hash "token5")
                 "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "maintenance" false
                 "owner" "owner3"
                 "token" "token5"}
                {"deleted" false
                 "etag" (token->token-hash "token6")
                 "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "maintenance" false
                 "owner" "owner3"
                 "token" "token6"}
                {"deleted" false
                 "etag" (token->token-hash "token7")
                 "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "maintenance" false
                 "owner" "owner3"
                 "token" "token7"}
                {"deleted" false
                 "etag" (token->token-hash "token8")
                 "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "maintenance" false
                 "owner" "owner3"
                 "token" "token8"}
                {"deleted" false
                 "etag" (token->token-hash "token9")
                 "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "maintenance" true
                 "owner" "owner3"
                 "token" "token9"}}
              (set (json/read-str body)))))
@@ -2425,60 +2433,69 @@
       (is (= #{{"deleted" false
                 "etag" (token->token-hash "token1")
                 "last-update-time" (-> (- last-update-time-seed 1000) tc/from-long du/date-to-str)
+                "maintenance" false
                 "owner" "owner1"
                 "token" "token1"}
                {"deleted" false
                 "etag" (token->token-hash "token2")
                 "last-update-time" (-> (- last-update-time-seed 2000) tc/from-long du/date-to-str)
+                "maintenance" false
                 "owner" "owner1"
                 "token" "token2"}
                {"deleted" false
                 "etag" (token->token-hash "token3")
                 "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "maintenance" false
                 "owner" "owner2"
                 "token" "token3"}
                {"deleted" true
                 "etag" (token->token-hash "token4")
                 "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "maintenance" false
                 "owner" "owner2"
                 "token" "token4"}
                {"deleted" false
                 "etag" (token->token-hash "token5")
                 "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "maintenance" false
                 "owner" "owner3"
                 "token" "token5"}
                {"deleted" false
                 "etag" (token->token-hash "token6")
                 "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "maintenance" false
                 "owner" "owner3"
                 "token" "token6"}
                {"deleted" false
                 "etag" (token->token-hash "token7")
                 "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "maintenance" false
                 "owner" "owner3"
                 "token" "token7"}
                {"deleted" false
                 "etag" (token->token-hash "token8")
                 "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "maintenance" false
                 "owner" "owner3"
                 "token" "token8"}
                {"deleted" false
                 "etag" (token->token-hash "token9")
                 "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "maintenance" true
                 "owner" "owner3"
                 "token" "token9"}}
              (set (json/read-str body)))))
     (let [request {:request-method :get}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
-      (is (= #{{"owner" "owner1" "token" "token1"}
-               {"owner" "owner1" "token" "token2"}
-               {"owner" "owner2" "token" "token3"}
-               {"owner" "owner3" "token" "token5"}
-               {"owner" "owner3" "token" "token6"}
-               {"owner" "owner3" "token" "token7"}
-               {"owner" "owner3" "token" "token8"}
-               {"owner" "owner3" "token" "token9"}}
+      (is (= #{{"maintenance" false "owner" "owner1" "token" "token1"}
+               {"maintenance" false "owner" "owner1" "token" "token2"}
+               {"maintenance" false "owner" "owner2" "token" "token3"}
+               {"maintenance" false "owner" "owner3" "token" "token5"}
+               {"maintenance" false "owner" "owner3" "token" "token6"}
+               {"maintenance" false "owner" "owner3" "token" "token7"}
+               {"maintenance" false "owner" "owner3" "token" "token8"}
+               {"maintenance" true "owner" "owner3" "token" "token9"}}
              (set (json/read-str body)))))
     (let [entitlement-manager (reify authz/EntitlementManager
                                 (authorized? [_ subject action resource]
@@ -2487,25 +2504,25 @@
       (let [request {:query-string "can-manage-as-user=owner" :request-method :get}
             {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
         (is (= http-200-ok status))
-        (is (= #{{"owner" "owner1" "token" "token1"}
-                 {"owner" "owner1" "token" "token2"}
-                 {"owner" "owner2" "token" "token3"}
-                 {"owner" "owner3" "token" "token5"}
-                 {"owner" "owner3" "token" "token6"}
-                 {"owner" "owner3" "token" "token7"}
-                 {"owner" "owner3" "token" "token8"}
-                 {"owner" "owner3" "token" "token9"}}
+        (is (= #{{"maintenance" false "owner" "owner1" "token" "token1"}
+                 {"maintenance" false "owner" "owner1" "token" "token2"}
+                 {"maintenance" false "owner" "owner2" "token" "token3"}
+                 {"maintenance" false "owner" "owner3" "token" "token5"}
+                 {"maintenance" false "owner" "owner3" "token" "token6"}
+                 {"maintenance" false "owner" "owner3" "token" "token7"}
+                 {"maintenance" false "owner" "owner3" "token" "token8"}
+                 {"maintenance" true "owner" "owner3" "token" "token9"}}
                (set (json/read-str body)))))
       (let [request {:query-string "can-manage-as-user=owner1" :request-method :get}
             {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
         (is (= http-200-ok status))
-        (is (= #{{"owner" "owner1" "token" "token1"}
-                 {"owner" "owner1" "token" "token2"}}
+        (is (= #{{"maintenance" false "owner" "owner1" "token" "token1"}
+                 {"maintenance" false "owner" "owner1" "token" "token2"}}
                (set (json/read-str body)))))
       (let [request {:query-string "can-manage-as-user=owner2" :request-method :get}
             {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
         (is (= http-200-ok status))
-        (is (= #{{"owner" "owner2" "token" "token3"}}
+        (is (= #{{"maintenance" false "owner" "owner2" "token" "token3"}}
                (set (json/read-str body)))))
       (let [request {:query-string "can-manage-as-user=test" :request-method :get}
             {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
@@ -2514,8 +2531,8 @@
     (let [request {:query-string "owner=owner1" :request-method :get}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
-      (is (= #{{"owner" "owner1" "token" "token1"}
-               {"owner" "owner1" "token" "token2"}}
+      (is (= #{{"maintenance" false "owner" "owner1" "token" "token1"}
+               {"maintenance" false "owner" "owner1" "token" "token2"}}
              (set (json/read-str body)))))
     (let [request {:query-string "owner=owner1&include=metadata" :request-method :get}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
@@ -2523,11 +2540,13 @@
       (is (= #{{"deleted" false
                 "etag" (token->token-hash "token1")
                 "last-update-time" (-> (- last-update-time-seed 1000) tc/from-long du/date-to-str)
+                "maintenance" false
                 "owner" "owner1"
                 "token" "token1"}
                {"deleted" false
                 "etag" (token->token-hash "token2")
                 "last-update-time" (-> (- last-update-time-seed 2000) tc/from-long du/date-to-str)
+                "maintenance" false
                 "owner" "owner1"
                 "token" "token2"}}
              (set (json/read-str body)))))
@@ -2549,6 +2568,7 @@
       (is (= #{{"deleted" false
                 "etag" (token->token-hash "token3")
                 "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "maintenance" false
                 "owner" "owner2"
                 "token" "token3"}}
              (set (json/read-str body)))))
@@ -2558,98 +2578,100 @@
       (is (= #{{"deleted" false
                 "etag" (token->token-hash "token3")
                 "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "maintenance" false
                 "owner" "owner2"
                 "token" "token3"}
                {"deleted" true
                 "etag" (token->token-hash "token4")
                 "last-update-time" (-> (- last-update-time-seed 3000) tc/from-long du/date-to-str)
+                "maintenance" false
                 "owner" "owner2"
                 "token" "token4"}}
              (set (json/read-str body)))))
     (let [request {:request-method :get :query-string "cpus=1"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
-      (is (= #{{"owner" "owner1" "token" "token1"}}
+      (is (= #{{"maintenance" false "owner" "owner1" "token" "token1"}}
              (set (json/read-str body)))))
     (let [request {:request-method :get :query-string "mem=2048"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
-      (is (= #{{"owner" "owner1" "token" "token2"}
-               {"owner" "owner2" "token" "token3"}
-               {"owner" "owner3" "token" "token5"}
-               {"owner" "owner3" "token" "token6"}}
+      (is (= #{{"maintenance" false "owner" "owner1" "token" "token2"}
+               {"maintenance" false "owner" "owner2" "token" "token3"}
+               {"maintenance" false "owner" "owner3" "token" "token5"}
+               {"maintenance" false "owner" "owner3" "token" "token6"}}
              (set (json/read-str body)))))
     (let [request {:request-method :get :query-string "cluster=c1&mem=2048"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
-      (is (= #{{"owner" "owner1" "token" "token2"}
-               {"owner" "owner3" "token" "token5"}
-               {"owner" "owner3" "token" "token6"}}
+      (is (= #{{"maintenance" false "owner" "owner1" "token" "token2"}
+               {"maintenance" false "owner" "owner3" "token" "token5"}
+               {"maintenance" false "owner" "owner3" "token" "token6"}}
              (set (json/read-str body)))))
     (let [request {:request-method :get :query-string "cluster=c2&mem=2048"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
-      (is (= #{{"owner" "owner2" "token" "token3"}}
+      (is (= #{{"maintenance" false "owner" "owner2" "token" "token3"}}
              (set (json/read-str body)))))
     (let [request {:request-method :get :query-string "include=deleted&mem=2048"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
-      (is (= #{{"owner" "owner1" "token" "token2"}
-               {"owner" "owner2" "token" "token3"}
-               {"owner" "owner2" "token" "token4"}
-               {"owner" "owner3" "token" "token5"}
-               {"owner" "owner3" "token" "token6"}}
+      (is (= #{{"maintenance" false "owner" "owner1" "token" "token2"}
+               {"maintenance" false "owner" "owner2" "token" "token3"}
+               {"maintenance" false "owner" "owner2" "token" "token4"}
+               {"maintenance" false "owner" "owner3" "token" "token5"}
+               {"maintenance" false "owner" "owner3" "token" "token6"}}
              (set (json/read-str body)))))
     (let [request {:request-method :get :query-string "idle-timeout-mins=0"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
-      (is (= #{{"owner" "owner1" "token" "token1"}
-               {"owner" "owner3" "token" "token6"}}
+      (is (= #{{"maintenance" false "owner" "owner1" "token" "token1"}
+               {"maintenance" false "owner" "owner3" "token" "token6"}}
              (set (json/read-str body)))))
     (let [request {:request-method :get :query-string "idle-timeout-mins=0&include=deleted"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
-      (is (= #{{"owner" "owner1" "token" "token1"}
-               {"owner" "owner2" "token" "token4"}
-               {"owner" "owner3" "token" "token6"}}
+      (is (= #{{"maintenance" false "owner" "owner1" "token" "token1"}
+               {"maintenance" false "owner" "owner2" "token" "token4"}
+               {"maintenance" false "owner" "owner3" "token" "token6"}}
              (set (json/read-str body)))))
     (let [request {:request-method :get :query-string "cluster=c1&idle-timeout-mins=0"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
-      (is (= #{{"owner" "owner1" "token" "token1"}
-               {"owner" "owner3" "token" "token6"}}
+      (is (= #{{"maintenance" false "owner" "owner1" "token" "token1"}
+               {"maintenance" false "owner" "owner3" "token" "token6"}}
              (set (json/read-str body)))))
     (let [request {:request-method :get :query-string "run-as-requester=true"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
-      (is (= #{{"owner" "owner3" "token" "token5"}
-               {"owner" "owner3" "token" "token6"}}
+      (is (= #{{"maintenance" false "owner" "owner3" "token" "token5"}
+               {"maintenance" false "owner" "owner3" "token" "token6"}}
              (set (json/read-str body)))))
     (let [request {:request-method :get :query-string "run-as-requester=false"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
-      (is (= #{{"owner" "owner1" "token" "token1"}
-               {"owner" "owner1" "token" "token2"}
-               {"owner" "owner2" "token" "token3"}
-               {"owner" "owner3" "token" "token7"}
-               {"owner" "owner3" "token" "token8"}
-               {"owner" "owner3" "token" "token9"}}
+      (is (= #{{"maintenance" false "owner" "owner1" "token" "token1"}
+               {"maintenance" false "owner" "owner1" "token" "token2"}
+               {"maintenance" false "owner" "owner2" "token" "token3"}
+               {"maintenance" false "owner" "owner3" "token" "token7"}
+               {"maintenance" false "owner" "owner3" "token" "token8"}
+               {"maintenance" true "owner" "owner3" "token" "token9"}}
              (set (json/read-str body)))))
     (let [request {:request-method :get :query-string "requires-parameters=true"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
-      (is (= #{{"owner" "owner3" "token" "token7"}
-               {"owner" "owner3" "token" "token8"}}
+      (is (= #{{"maintenance" false "owner" "owner3" "token" "token7"}
+               {"maintenance" false "owner" "owner3" "token" "token8"}}
              (set (json/read-str body)))))
     (let [request {:request-method :get :query-string "requires-parameters=false"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
-      (is (= #{{"owner" "owner1" "token" "token1"}
-               {"owner" "owner1" "token" "token2"}
-               {"owner" "owner2" "token" "token3"}
-               {"owner" "owner3" "token" "token5"}
-               {"owner" "owner3" "token" "token6"}
-               {"owner" "owner3" "token" "token9"}}
+      (is (= #{{"maintenance" false "owner" "owner1" "token" "token1"}
+               {"maintenance" false "owner" "owner1" "token" "token2"}
+               {"maintenance" false "owner" "owner2" "token" "token3"}
+               {"maintenance" false "owner" "owner3" "token" "token5"}
+               {"maintenance" false "owner" "owner3" "token" "token6"}
+               {"maintenance" true "owner" "owner3" "token" "token9"}}
              (set (json/read-str body)))))
     (let [request {:request-method :get :query-string "cluster=c2&idle-timeout-mins=0"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
@@ -2658,11 +2680,16 @@
     (let [request {:request-method :get :query-string "idle-timeout-mins=5"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
-      (is (= #{{"owner" "owner2" "token" "token3"}}
+      (is (= #{{"maintenance" false "owner" "owner2" "token" "token3"}}
              (set (json/read-str body)))))
     (let [request {:headers {"accept" "application/json"}
                    :request-method :get}
           {:keys [body]} (handle-list-token-owners-request kv-store request)
           owner-map-keys (keys (json/read-str body))]
       (is (some #(= "owner1" %) owner-map-keys) "Should have had a key 'owner1'")
-      (is (some #(= "owner2" %) owner-map-keys) "Should have had a key 'owner2'"))))
+      (is (some #(= "owner2" %) owner-map-keys) "Should have had a key 'owner2'"))
+    (let [request {:request-method :get :query-string "maintenance={\"message\" \"msg1\"}"}
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+      (is (= http-200-ok status))
+      (is (= #{{"maintenance" true "owner" "owner3" "token" "token9"}}
+             (set (json/read-str body)))))))


### PR DESCRIPTION
## Changes proposed in this PR
- add schema definition for maintenance user metadata
- add middleware to respond to requests to user token that is in maintenance mode
- Token in Maintenance Mode page
![Screenshot from 2020-10-29 13-11-46](https://user-images.githubusercontent.com/8290559/97614804-66a30980-19e8-11eb-98f6-33c80059a5bc.png)
- Token in Maintenance Mode text response
![Screenshot from 2020-10-29 15-13-25](https://user-images.githubusercontent.com/8290559/97627415-57788780-19f9-11eb-9b56-5e5f199e1c55.png)
- Request Log Output
![Screenshot from 2020-10-27 15-31-28](https://user-images.githubusercontent.com/8290559/97358636-86f88a00-1869-11eb-8f83-7b2bbea463fe.png)


## Why are we making these changes?

- users want a way to disable tokens or put tokens in maintenance temporarily


