### PR TITLE
reduces duplication of parameters while computing effective service description

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -772,7 +772,7 @@
    :service-description-builder (pc/fnk [[:curator synchronize-fn]
                                          [:settings metric-group-mappings service-description-builder-config
                                           service-description-constraints service-description-defaults]
-                                         custom-components kv-store-factory leader?-fn profile->defaults]
+                                         custom-components kv-store kv-store-factory leader?-fn profile->defaults]
                                   (when-let [unknown-keys (-> service-description-constraints
                                                             keys
                                                             set
@@ -783,6 +783,7 @@
                                                      :unsupported-keys (-> unknown-keys vec sort)})))
                                   (let [context {:constraints service-description-constraints
                                                  :custom-components custom-components
+                                                 :kv-store kv-store
                                                  :kv-store-factory kv-store-factory
                                                  :leader?-fn leader?-fn
                                                  :metric-group-mappings metric-group-mappings

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -894,13 +894,11 @@
                                  (digest/md5 (str service-id (first passwords)))))
    ; This function is only included here for initializing the scheduler above.
    ; Prefer accessing the non-starred version of this function through the routines map.
-   :service-id->service-description-fn* (pc/fnk [[:settings metric-group-mappings service-description-defaults]
-                                                 [:state kv-store profile->defaults]]
+   :service-id->service-description-fn* (pc/fnk [[:state kv-store service-description-builder]]
                                           (fn service-id->service-description
                                             [service-id & {:keys [effective?] :or {effective? true}}]
                                             (sd/service-id->service-description
-                                              kv-store service-id service-description-defaults profile->defaults
-                                              metric-group-mappings :effective? effective?)))
+                                              service-description-builder kv-store service-id :effective? effective?)))
    :start-scheduler-syncer-fn (pc/fnk [[:settings [:health-check-config health-check-timeout-ms failed-check-threshold]]
                                        [:state clock user-agent-version]
                                        service-id->password-fn* service-id->service-description-fn*]

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -625,7 +625,7 @@
   (build [this core-service-description args-map]
     "Returns a map of {:service-id ..., :service-description ..., :core-service-description...}")
 
-  (compute-effective [this service-id core-service-description args-map]
+  (compute-effective [this service-id core-service-description]
     "Returns the effective service description after processing the core description.")
 
   (retrieve-reference-type->stale-info-fn [this context]
@@ -705,12 +705,12 @@
                              (retrieve-token-update-epoch-time token (token->token-parameters token) version)))
                       (reduce utils/nil-safe-max nil))))))
 
-(defrecord DefaultServiceDescriptionBuilder [max-constraints-schema metric-group-mappings profile->defaults
+(defrecord DefaultServiceDescriptionBuilder [kv-store max-constraints-schema metric-group-mappings profile->defaults
                                              service-description-defaults]
   ServiceDescriptionBuilder
 
   (build [this user-service-description
-          {:keys [assoc-run-as-user-approved? component->previous-descriptor-fns kv-store reference-type->entry
+          {:keys [assoc-run-as-user-approved? component->previous-descriptor-fns reference-type->entry
                   service-id-prefix source-tokens username]}]
     (let [core-service-description
           (if (get user-service-description "run-as-user")
@@ -723,7 +723,7 @@
                   candidate-service-description)
                 user-service-description)))
           service-id (service-description->service-id service-id-prefix core-service-description)
-          service-description (compute-effective this service-id core-service-description {:kv-store kv-store})
+          service-description (compute-effective this service-id core-service-description)
           reference-type->entry (cond-> (or reference-type->entry {})
                                   (seq source-tokens)
                                   (assoc :token {:sources (map walk/keywordize-keys source-tokens)}))]
@@ -733,8 +733,8 @@
        :service-description service-description
        :service-id service-id}))
 
-  (compute-effective [_ service-id core-service-description {:keys [kv-store]}]
-     ;; attaches defaults and overrides to the core service description
+  (compute-effective [_ service-id core-service-description]
+    ;; attaches defaults and overrides to the core service description
     (default-and-override
       core-service-description service-description-defaults profile->defaults
       metric-group-mappings kv-store service-id))
@@ -770,10 +770,10 @@
 
 (defn create-default-service-description-builder
   "Returns a new DefaultServiceDescriptionBuilder which uses the specified resource limits."
-  [{:keys [constraints metric-group-mappings profile->defaults service-description-defaults]}]
+  [{:keys [constraints kv-store metric-group-mappings profile->defaults service-description-defaults]}]
   (let [max-constraints-schema (extract-max-constraints-schema constraints)]
     (->DefaultServiceDescriptionBuilder
-      max-constraints-schema metric-group-mappings profile->defaults service-description-defaults)))
+      kv-store max-constraints-schema metric-group-mappings profile->defaults service-description-defaults)))
 
 (defn service-description->health-check-url
   "Returns the configured health check Url or a default value (available in `default-health-check-path`)"
@@ -1086,7 +1086,7 @@
      If after the merge a run-as-user is not available, then `username` becomes the run-as-user.
      If after the merge a permitted-user is not available, then `username` becomes the permitted-user."
     [{:keys [headers service-description-template source-tokens token-authentication-disabled token-preauthorized]}
-     waiter-headers passthrough-headers component->previous-descriptor-fns kv-store service-id-prefix username
+     waiter-headers passthrough-headers component->previous-descriptor-fns service-id-prefix username
      assoc-run-as-user-approved? service-description-builder]
     (let [headers-without-params (dissoc headers "param")
           header-params (get headers "param")
@@ -1144,7 +1144,6 @@
         (let [build-map (build service-description-builder user-service-description
                                {:assoc-run-as-user-approved? assoc-run-as-user-approved?
                                 :component->previous-descriptor-fns component->previous-descriptor-fns
-                                :kv-store kv-store
                                 :reference-type->entry {}
                                 :service-id-prefix service-id-prefix
                                 :source-tokens source-tokens
@@ -1188,9 +1187,9 @@
 (defn merge-service-description-and-id
   "Populates the descriptor with the service-description and service-id."
   [{:keys [component->previous-descriptor-fns passthrough-headers sources waiter-headers] :as descriptor}
-   kv-store service-id-prefix username service-description-builder assoc-run-as-user-approved?]
+   service-id-prefix username service-description-builder assoc-run-as-user-approved?]
   (->> (compute-service-description
-         sources waiter-headers passthrough-headers component->previous-descriptor-fns kv-store service-id-prefix
+         sources waiter-headers passthrough-headers component->previous-descriptor-fns service-id-prefix
          username assoc-run-as-user-approved? service-description-builder)
        (merge descriptor)))
 
@@ -1204,7 +1203,7 @@
     [descriptor throw-exception?]
     (try
       (-> descriptor
-        (merge-service-description-and-id kv-store service-id-prefix current-request-user
+        (merge-service-description-and-id service-id-prefix current-request-user
                                           service-description-builder assoc-run-as-user-approved?)
         (merge-suspended kv-store))
       (catch Throwable ex
@@ -1238,7 +1237,7 @@
   [service-description-builder kv-store service-id & {:keys [effective?] :or {effective? true}}]
   (let [core-service-description (fetch-core kv-store service-id :refresh false)]
     (if effective?
-      (compute-effective service-description-builder service-id core-service-description {:kv-store kv-store})
+      (compute-effective service-description-builder service-id core-service-description)
       core-service-description)))
 
 (defn can-manage-service?

--- a/waiter/test/waiter/descriptor_test.clj
+++ b/waiter/test/waiter/descriptor_test.clj
@@ -519,18 +519,18 @@
       service-description-defaults {}
       token-defaults {"fallback-period-secs" 300}
       metric-group-mappings []
-      profile->defaults {"webapp" {"concurrency-level" 120
-                                   "fallback-period-secs" 100}}
       attach-service-defaults-fn #(sd/merge-defaults % service-description-defaults profile->defaults metric-group-mappings)
       attach-token-defaults-fn #(sd/attach-token-defaults % token-defaults profile->defaults)
       username "test-user"
       metric-group-mappings []
       service-description-defaults {"metric-group" "other" "permitted-user" "*"}
       constraints {"cpus" {:max 100} "mem" {:max 1024}}
-      builder (sd/create-default-service-description-builder {:constraints constraints
-                                                              :metric-group-mappings metric-group-mappings
-                                                              :profile->defaults profile->defaults
-                                                              :service-description-defaults service-description-defaults})
+      builder-context {:constraints constraints
+                       :kv-store kv-store
+                       :metric-group-mappings metric-group-mappings
+                       :profile->defaults profile->defaults
+                       :service-description-defaults service-description-defaults}
+      builder (sd/create-default-service-description-builder builder-context)
       assoc-run-as-user-approved? (constantly false)
       build-service-description-and-id-helper (sd/make-build-service-description-and-id-helper
                                                 kv-store service-id-prefix username builder assoc-run-as-user-approved?)]

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -815,12 +815,13 @@
            passthrough-headers {}
            metric-group-mappings []
            current-user "current-request-user"
-           builder-context {:metric-group-mappings metric-group-mappings
+           builder-context {:kv-store kv-store
+                            :metric-group-mappings metric-group-mappings
                             :profile->defaults profile->defaults
                             :service-description-defaults service-description-defaults}
            service-description-builder (create-default-service-description-builder builder-context)]
        (compute-service-description
-         sources waiter-headers passthrough-headers component->previous-descriptor-fns kv-store service-id-prefix
+         sources waiter-headers passthrough-headers component->previous-descriptor-fns service-id-prefix
          current-user assoc-run-as-user-approved? service-description-builder)))))
 
 (defn- service-description
@@ -1509,12 +1510,13 @@
         assoc-run-as-user-approved? (constantly false)
         run-compute-service-description
         (fn run-compute-service-description [{:keys [profile->defaults service-description-defaults] :as sources}]
-          (let [builder-context {:profile->defaults profile->defaults
+          (let [builder-context {:kv-store kv-store
+                                 :profile->defaults profile->defaults
                                  :service-description-defaults service-description-defaults}
                 service-description-builder (create-default-service-description-builder builder-context)
                 result-descriptor
                 (compute-service-description
-                  sources waiter-headers passthrough-headers component->previous-descriptor-fns kv-store service-id-prefix
+                  sources waiter-headers passthrough-headers component->previous-descriptor-fns service-id-prefix
                   test-user assoc-run-as-user-approved? service-description-builder)
                 result-errors (validate-service-description kv-store service-description-builder result-descriptor)]
             (when result-errors
@@ -1812,7 +1814,8 @@
                                                    :or {effective? false
                                                         profile->defaults {"webapp" {"concurrency-level" 120}}
                                                         service-description-defaults {}}}]
-                                    (let [context {:profile->defaults profile->defaults
+                                    (let [context {:kv-store kv-store
+                                                   :profile->defaults profile->defaults
                                                    :service-description-defaults service-description-defaults}
                                           service-description-builder (create-default-service-description-builder context)]
                                       (service-id->service-description

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -1812,9 +1812,11 @@
                                                    :or {effective? false
                                                         profile->defaults {"webapp" {"concurrency-level" 120}}
                                                         service-description-defaults {}}}]
-                                    (service-id->service-description
-                                      kv-store service-id service-description-defaults profile->defaults []
-                                      :effective? effective?))]
+                                    (let [context {:profile->defaults profile->defaults
+                                                   :service-description-defaults service-description-defaults}
+                                          service-description-builder (create-default-service-description-builder context)]
+                                      (service-id->service-description
+                                        service-description-builder kv-store service-id :effective? effective?)))]
 
     (testing "no data available"
       (let [kv-store (kv/->LocalKeyValueStore (atom {}))]


### PR DESCRIPTION
## Changes proposed in this PR

- reduces duplication of parameters while computing effective service description
- introduces kv-store parameter in DefaultServiceDescriptionBuilder

## Why are we making these changes?

It unifies the logic for computing the effective service description and allows `service-id->service-description` to always return the effective description that is in sync with what the `ServiceDescriptionBuilder` computes.

