### PR TITLE
Maintenance mode CLI

### DIFF
--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -365,3 +365,10 @@ def tokens_data(waiter_url=None, flags=None):
     cp, data = __tokens_json(waiter_url, flags)
     token_list = [token for entities in data['clusters'].values() for token in entities['tokens']]
     return cp, token_list
+
+
+def maintenance(subcommand, token_name, waiter_url=None, flags=None, maintenance_flags=None, stdin=None, env=None):
+    """Creates or updates a token via the CLI"""
+    args = f"maintenance {subcommand} {token_name} {maintenance_flags or ''}"
+    cp = cli(args, waiter_url, flags, stdin, env=env)
+    return cp

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1347,7 +1347,7 @@ class WaiterCliTest(util.WaiterTest):
         util.post_token(self.waiter_url, token_name, token_fields)
         try:
             cp = cli.maintenance('start', token_name, self.waiter_url,
-                                 maintenance_flags=f'--message "{custom_maintenance_message}"')
+                                 maintenance_flags=f'"{custom_maintenance_message}"')
             self.assertEqual(0, cp.returncode, cp.stderr)
             token_data = util.load_token(self.waiter_url, token_name)
             self.assertEqual({'message': custom_maintenance_message}, token_data['maintenance'])
@@ -1360,14 +1360,14 @@ class WaiterCliTest(util.WaiterTest):
         token_name = self.token_name()
         custom_maintenance_message = "custom maintenance message"
         cp = cli.maintenance('start', token_name, self.waiter_url,
-                             maintenance_flags=f'--message "{custom_maintenance_message}"')
+                             maintenance_flags=f'"{custom_maintenance_message}"')
         self.assertEqual(1, cp.returncode, cp.stderr)
         self.assertIn('The token does not exist. You must create it first.', cli.stderr(cp))
 
     def test_maintenance_start_no_cluster(self):
         custom_maintenance_message = "custom maintenance message"
         self.__test_no_cluster(partial(cli.maintenance, 'start',
-                                       maintenance_flags=f'--message "{custom_maintenance_message}"'))
+                                       maintenance_flags=f'"{custom_maintenance_message}"'))
 
     def test_maintenance_stop(self):
         token_name = self.token_name()

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1422,5 +1422,6 @@ class WaiterCliTest(util.WaiterTest):
 
     def test_maintenance_no_sub_command(self):
         cp = cli.maintenance('', '')
-        self.assertEqual(2, cp.returncode, cp.stderr)
-        self.assertIn("waiter maintenance: error: the following arguments are required: cmd", cli.stderr(cp))
+        cp_help = cli.maintenance('', '', maintenance_flags='-h')
+        self.assertEqual(0, cp.returncode, cp.stderr)
+        self.assertEqual(cli.stdout(cp_help), cli.stdout(cp))

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -8,7 +8,7 @@ import tempfile
 import threading
 import unittest
 import uuid
-
+from functools import partial
 import pytest
 
 from tests.waiter import util, cli
@@ -78,13 +78,16 @@ class WaiterCliTest(util.WaiterTest):
         self.assertIn('improper', cli.decode(cp.stderr))
         self.assertIn('cpus must be a positive number', cli.decode(cp.stderr))
 
-    def test_create_no_cluster(self):
+    def __test_no_cluster(self, cli_fn):
         config = {'clusters': []}
         with cli.temp_config_file(config) as path:
             flags = '--config %s' % path
-            cp = cli.create_minimal(token_name=self.token_name(), flags=flags)
+            cp = cli_fn(token_name=self.token_name(), flags=flags)
             self.assertEqual(1, cp.returncode, cp.stderr)
             self.assertIn('must specify at least one cluster', cli.decode(cp.stderr))
+
+    def test_create_no_cluster(self):
+        self.__test_no_cluster(cli.create_minimal)
 
     def test_unspecified_create_cluster(self):
         config = {
@@ -1107,6 +1110,7 @@ class WaiterCliTest(util.WaiterTest):
             token_data = next(t for t in tokens if t['token'] == token_name)
             self.assertEqual(0, cp.returncode, cp.stderr)
             self.assertFalse(token_data['deleted'])
+            self.assertFalse(token_data['maintenance'])
 
             # Delete the token
             util.delete_token(self.waiter_url, token_name)
@@ -1119,6 +1123,29 @@ class WaiterCliTest(util.WaiterTest):
             self.assertFalse(any(t['token'] == token_name for t in tokens))
         finally:
             util.delete_token(self.waiter_url, token_name, assert_response=False)
+
+    def __test_tokens_maintenance(self, expected_maintenance_value, service_config={}):
+        token_name = self.token_name()
+        util.post_token(self.waiter_url, token_name, util.minimal_service_description(**service_config))
+        try:
+            cp = cli.tokens(self.waiter_url)
+            stdout = cli.stdout(cp)
+            lines = stdout.split('\n')
+            title_line = lines[0]
+            maintenance_index = title_line.index('Maintenance')
+            line_with_token = next(line for line in lines if token_name in line)
+            token_maintenance = line_with_token[maintenance_index:maintenance_index + len(expected_maintenance_value)]
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            self.assertEqual(token_maintenance, expected_maintenance_value)
+        finally:
+            util.delete_token(self.waiter_url, token_name)
+
+    def test_tokens_token_in_maintenance(self):
+        service_config = {"maintenance": {"message": "custom message"}}
+        self.__test_tokens_maintenance("True", service_config=service_config)
+
+    def test_tokens_token_not_in_maintenance(self):
+        self.__test_tokens_maintenance("False")
 
     def test_tokens_sorted(self):
         token_name_prefix = self.token_name()
@@ -1312,3 +1339,83 @@ class WaiterCliTest(util.WaiterTest):
 
     def test_update_token_no_admin_mode(self):
         self.__test_create_update_token_admin_mode('update', self.token_name(), False)
+
+    def test_maintenance_start(self):
+        token_name = self.token_name()
+        token_fields = {'cpus': 0.1, 'mem': 128, 'cmd': 'foo'}
+        custom_maintenance_message = "custom maintenance message"
+        util.post_token(self.waiter_url, token_name, token_fields)
+        try:
+            cp = cli.maintenance('start', token_name, self.waiter_url,
+                                 maintenance_flags=f'--message "{custom_maintenance_message}"')
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            token_data = util.load_token(self.waiter_url, token_name)
+            self.assertEqual({'message': custom_maintenance_message}, token_data['maintenance'])
+            for key, value in token_fields.items():
+                self.assertEqual(value, token_data[key])
+        finally:
+            util.delete_token(self.waiter_url, token_name)
+
+    def test_maintenance_start_nonexistent_token(self):
+        token_name = self.token_name()
+        custom_maintenance_message = "custom maintenance message"
+        cp = cli.maintenance('start', token_name, self.waiter_url,
+                             maintenance_flags=f'--message "{custom_maintenance_message}"')
+        self.assertEqual(1, cp.returncode, cp.stderr)
+        self.assertIn('The token does not exist. You must create it first.', cli.stderr(cp))
+
+    def test_maintenance_start_no_cluster(self):
+        custom_maintenance_message = "custom maintenance message"
+        self.__test_no_cluster(partial(cli.maintenance, 'start',
+                                       maintenance_flags=f'--message "{custom_maintenance_message}"'))
+
+    def test_maintenance_stop(self):
+        token_name = self.token_name()
+        token_fields = {'cpus': 0.1, 'mem': 128, 'cmd': 'foo'}
+        custom_maintenance_message = "custom maintenance message"
+        util.post_token(self.waiter_url, token_name,
+                        {**token_fields, 'maintenance': {'message': custom_maintenance_message}})
+        try:
+            cp = cli.maintenance('stop', token_name, self.waiter_url)
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            token_data = util.load_token(self.waiter_url, token_name)
+            self.assertEqual(None, token_data.get('maintenance', None))
+            for key, value in token_fields.items():
+                self.assertEqual(value, token_data[key])
+        finally:
+            util.delete_token(self.waiter_url, token_name)
+
+    def test_maintenance_stop_no_cluster(self):
+        self.__test_no_cluster(partial(cli.maintenance, 'stop'))
+
+    def test_maintenance_stop_not_in_maintenance(self):
+        token_name = self.token_name()
+        util.post_token(self.waiter_url, token_name, {'cpus': 0.1, 'mem': 128, 'cmd': 'foo'})
+        try:
+            cp = cli.maintenance('stop', token_name, self.waiter_url)
+            self.assertEqual(1, cp.returncode, cp.stderr)
+            self.assertIn('Token is not in maintenance mode', cli.stderr(cp))
+        finally:
+            util.delete_token(self.waiter_url, token_name)
+
+    def __test_maintenance_check(self, maintenance_active):
+        token_name = self.token_name()
+        output = f'{token_name} is {"" if maintenance_active else "not "}in maintenance mode'
+        cli_return_code = 0 if maintenance_active else 1
+        if maintenance_active:
+            util.post_token(self.waiter_url, token_name,
+                            {'cpus': 0.1, 'mem': 128, 'cmd': 'foo', 'maintenance': {'message': 'custom message'}})
+        else:
+            util.post_token(self.waiter_url, token_name, {'cpus': 0.1, 'mem': 128, 'cmd': 'foo'})
+        try:
+            cp = cli.maintenance('check', token_name, self.waiter_url)
+            self.assertEqual(cli_return_code, cp.returncode, cp.stderr)
+            self.assertIn(output, cli.stdout(cp))
+        finally:
+            util.delete_token(self.waiter_url, token_name)
+
+    def test_maintenance_check_not_in_maintenance_mode(self):
+        self.__test_maintenance_check(False)
+
+    def test_maintenance_check_in_maintenance_mode(self):
+        self.__test_maintenance_check(True)

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1419,3 +1419,8 @@ class WaiterCliTest(util.WaiterTest):
 
     def test_maintenance_check_in_maintenance_mode(self):
         self.__test_maintenance_check(True)
+
+    def test_maintenance_no_sub_command(self):
+        cp = cli.maintenance('', '')
+        self.assertEqual(2, cp.returncode, cp.stderr)
+        self.assertIn("waiter maintenance: error: the following arguments are required: cmd", cli.stderr(cp))

--- a/cli/waiter/cli.py
+++ b/cli/waiter/cli.py
@@ -3,7 +3,7 @@ import logging
 from urllib.parse import urlparse
 
 from waiter import configuration, http_util, metrics, version
-from waiter.subcommands import create, delete, init, kill, ping, show, tokens, update
+from waiter.subcommands import create, delete, init, kill, maintenance, ping, show, tokens, update
 
 parser = argparse.ArgumentParser(description='waiter is the Waiter CLI')
 parser.add_argument('--cluster', '-c', help='the name of the Waiter cluster to use')
@@ -30,6 +30,9 @@ actions = {
     },
     'kill': {
         'run-function': kill.register(subparsers.add_parser)
+    },
+    'maintenance': {
+        'run-function': maintenance.register(subparsers.add_parser)
     },
     'ping': {
         'run-function': ping.register(subparsers.add_parser)

--- a/cli/waiter/querying.py
+++ b/cli/waiter/querying.py
@@ -152,3 +152,12 @@ def query_tokens(clusters, user):
     return query_across_clusters(
         clusters,
         lambda cluster, executor: executor.submit(get_tokens_on_cluster, cluster, user))
+
+
+def get_cluster_with_token(clusters, token_name):
+    query_result = query_token(clusters, token_name)
+    if query_result["count"] == 0:
+        raise Exception('The token does not exist. You must create it first.')
+    else:
+        cluster_names_with_token = list(query_result['clusters'].keys())
+        return next(c for c in clusters if c['name'] == cluster_names_with_token[0])

--- a/cli/waiter/subcommands/maintenance.py
+++ b/cli/waiter/subcommands/maintenance.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 import requests
 
 from waiter import terminal, http_util
@@ -6,11 +8,14 @@ from waiter.querying import get_cluster_with_token, get_token
 from waiter.util import guard_no_cluster, logging, print_info
 
 
-def maintenance(clusters, args, _):
+def maintenance(parser, clusters, args, _):
     guard_no_cluster(clusters)
     logging.debug('args: %s' % args)
+    sub_action = args.get('sub_action', None)
+    if sub_action is None:
+        parser.print_help()
+        return 0
     token_name = args['token']
-    sub_action = args['sub_action']
     cluster = get_cluster_with_token(clusters, token_name)
     cluster_name = cluster['name']
     cluster_url = cluster['url']
@@ -74,8 +79,8 @@ def register(add_parser):
     parser = add_parser('maintenance',
                         help='manage maintenance mode for a token',
                         description='Manage maintenance mode for a Waiter token.')
-    subparsers = parser.add_subparsers(dest="cmd", required=True)
+    subparsers = parser.add_subparsers()
     register_check(subparsers.add_parser)
     register_start(subparsers.add_parser)
     register_stop(subparsers.add_parser)
-    return maintenance
+    return partial(maintenance, parser)

--- a/cli/waiter/subcommands/maintenance.py
+++ b/cli/waiter/subcommands/maintenance.py
@@ -8,34 +8,29 @@ from waiter.querying import get_cluster_with_token, get_token
 from waiter.util import guard_no_cluster, logging, print_info
 
 
-def maintenance(parser, clusters, args, _):
-    logging.debug('args: %s' % args)
-    sub_action = args.get('sub_action', None)
-    if sub_action is None:
-        parser.print_help()
-        return 0
+def check_maintenance(clusters, args):
+    guard_no_cluster(clusters)
+    token_name = args['token']
+    cluster = get_cluster_with_token(clusters, token_name)
+    existing_token_data, existing_token_etag = get_token(cluster, token_name)
+    maintenance_mode_active = 'maintenance' in existing_token_data
+    print_info(f'{token_name} is {"" if maintenance_mode_active else "not "}in maintenance mode')
+    return 0 if maintenance_mode_active else 1
+
+
+def start_maintenance(clusters, args):
     guard_no_cluster(clusters)
     token_name = args['token']
     cluster = get_cluster_with_token(clusters, token_name)
     cluster_name = cluster['name']
     cluster_url = cluster['url']
     existing_token_data, existing_token_etag = get_token(cluster, token_name)
-    maintenance_mode_active = 'maintenance' in existing_token_data
     json_body = existing_token_data
     headers = {'If-Match': existing_token_etag}
     params = {'token': token_name}
     try:
-        if sub_action == 'check':
-            print_info(f'{token_name} is {"" if maintenance_mode_active else "not "}in maintenance mode')
-            return 0 if maintenance_mode_active else 1
-        elif sub_action == 'start':
-            update_doc = {"maintenance": {"message": args['message']}}
-            json_body.update(update_doc)
-        elif sub_action == 'stop':
-            if maintenance_mode_active:
-                json_body.pop("maintenance")
-            else:
-                raise Exception("Token is not in maintenance mode")
+        update_doc = {"maintenance": {"message": args['message']}}
+        json_body.update(update_doc)
         resp = http_util.post(cluster, 'token', json_body, params=params, headers=headers)
         process_post_result(resp)
         return 0
@@ -51,23 +46,64 @@ def maintenance(parser, clusters, args, _):
         print_info(f'{message}\n')
 
 
-def register_action(add_parser, sub_action):
+def stop_maintenance(clusters, args):
+    guard_no_cluster(clusters)
+    token_name = args['token']
+    cluster = get_cluster_with_token(clusters, token_name)
+    cluster_name = cluster['name']
+    cluster_url = cluster['url']
+    existing_token_data, existing_token_etag = get_token(cluster, token_name)
+    maintenance_mode_active = 'maintenance' in existing_token_data
+    json_body = existing_token_data
+    headers = {'If-Match': existing_token_etag}
+    params = {'token': token_name}
+    try:
+        if maintenance_mode_active:
+            json_body.pop("maintenance")
+        else:
+            raise Exception("Token is not in maintenance mode")
+        resp = http_util.post(cluster, 'token', json_body, params=params, headers=headers)
+        process_post_result(resp)
+        return 0
+    except requests.exceptions.ReadTimeout as rt:
+        logging.exception(rt)
+        print_info(terminal.failed(
+            f'Encountered read timeout with {cluster_name} ({cluster_url}). The operation may have completed.'))
+        return 1
+    except IOError as ioe:
+        logging.exception(ioe)
+        reason = f'Cannot connect to {cluster_name} ({cluster_url})'
+        message = post_failed_message(cluster_name, reason)
+        print_info(f'{message}\n')
+
+
+def maintenance(parser, clusters, args, _):
+    logging.debug('args: %s' % args)
+    sub_func = args.get('sub_func', None)
+    if sub_func is None:
+        parser.print_help()
+        return 0
+    else:
+        return sub_func(clusters, args)
+
+
+def register_action(add_parser, sub_action, sub_func):
     parser = add_parser(sub_action, help=f'{sub_action} maintenance mode for a token')
     parser.add_argument('token')
-    parser.set_defaults(sub_action=sub_action)
+    parser.set_defaults(sub_func=sub_func)
     return parser
 
 
 def register_check(add_parser):
-    register_action(add_parser, 'check')
+    register_action(add_parser, 'check', check_maintenance)
 
 
 def register_stop(add_parser):
-    register_action(add_parser, 'stop')
+    register_action(add_parser, 'stop', stop_maintenance)
 
 
 def register_start(add_parser):
-    start_parser = register_action(add_parser, 'start')
+    start_parser = register_action(add_parser, 'start', start_maintenance)
     start_parser.add_argument('message',
                               help='Your message will be provided in a 503 response for requests to the token. '
                                    'The message cannot be more than 512 characters.')

--- a/cli/waiter/subcommands/maintenance.py
+++ b/cli/waiter/subcommands/maintenance.py
@@ -74,7 +74,7 @@ def register(add_parser):
     parser = add_parser('maintenance',
                         help='manage maintenance mode for a token',
                         description='Manage maintenance mode for a Waiter token.')
-    subparsers = parser.add_subparsers()
+    subparsers = parser.add_subparsers(dest="cmd", required=True)
     register_check(subparsers.add_parser)
     register_start(subparsers.add_parser)
     register_stop(subparsers.add_parser)

--- a/cli/waiter/subcommands/maintenance.py
+++ b/cli/waiter/subcommands/maintenance.py
@@ -41,6 +41,8 @@ def _update_token(cluster, token_name, existing_token_etag, body):
 
 
 def check_maintenance(clusters, args):
+    """Checks if a token is in maintenance mode and displays the result. Returns 0 if the token is in maintenance mode
+    and returns 1 if the token is NOT in maintenance mode."""
     token_name = args['token']
     _, existing_token_data, existing_token_etag = _get_existing_token_data(clusters, token_name)
     maintenance_mode_active = _is_token_in_maintenance_mode(existing_token_data)
@@ -49,6 +51,7 @@ def check_maintenance(clusters, args):
 
 
 def start_maintenance(clusters, args):
+    """Sets the token in maintenance mode by updating the token user metadata fields"""
     token_name = args['token']
     cluster, existing_token_data, existing_token_etag = _get_existing_token_data(clusters, token_name)
     json_body = existing_token_data
@@ -58,6 +61,7 @@ def start_maintenance(clusters, args):
 
 
 def stop_maintenance(clusters, args):
+    """Stops maintenance mode for a token by deleting the 'maintenance' user metadata field in the token data"""
     token_name = args['token']
     cluster, existing_token_data, existing_token_etag = _get_existing_token_data(clusters, token_name)
     maintenance_mode_active = _is_token_in_maintenance_mode(existing_token_data)
@@ -69,6 +73,7 @@ def stop_maintenance(clusters, args):
 
 
 def maintenance(parser, clusters, args, _):
+    """Calls the sub action for maintenance command. If no sub action is provided then displays the help message."""
     logging.debug('args: %s' % args)
     sub_func = args.get('sub_func', None)
     if sub_func is None:
@@ -79,6 +84,7 @@ def maintenance(parser, clusters, args, _):
 
 
 def register_check(add_parser):
+    """Registers the maintenance check parser"""
     parser = add_parser('check',
                         help='Checks if a token is in maintenance mode. Returns cli code 0 if the token is in '
                              'maintenance mode and 1 if the token not in maintenance mode')
@@ -87,12 +93,14 @@ def register_check(add_parser):
 
 
 def register_stop(add_parser):
+    """Registers the maintenance stop parser"""
     parser = add_parser('stop', help='Stop maintenance mode for a token. Requests will be handled normally.')
     parser.add_argument('token')
     parser.set_defaults(sub_func=stop_maintenance)
 
 
 def register_start(add_parser):
+    """Registers the maintenance start parser"""
     parser = add_parser('start',
                         help='Start maintenance mode for a token. All requests to this token will begin to receive a '
                              '503 response.')

--- a/cli/waiter/subcommands/maintenance.py
+++ b/cli/waiter/subcommands/maintenance.py
@@ -68,10 +68,9 @@ def register_stop(add_parser):
 
 def register_start(add_parser):
     start_parser = register_action(add_parser, 'start')
-    start_parser.add_argument('--message', '-m',
-                              help='Message is a required argument and cannot be more than 512 characters. '
-                                   'Your message will be provided in a 503 response for requests to the token.',
-                              required=True)
+    start_parser.add_argument('message',
+                              help='Your message will be provided in a 503 response for requests to the token. '
+                                   'The message cannot be more than 512 characters.')
 
 
 def register(add_parser):

--- a/cli/waiter/subcommands/maintenance.py
+++ b/cli/waiter/subcommands/maintenance.py
@@ -8,73 +8,63 @@ from waiter.querying import get_cluster_with_token, get_token
 from waiter.util import guard_no_cluster, logging, print_info
 
 
-def check_maintenance(clusters, args):
+def _is_token_in_maintenance_mode(token_data):
+    return 'maintenance' in token_data
+
+
+def _get_existing_token_data(clusters, token_name):
     guard_no_cluster(clusters)
-    token_name = args['token']
     cluster = get_cluster_with_token(clusters, token_name)
-    existing_token_data, existing_token_etag = get_token(cluster, token_name)
-    maintenance_mode_active = 'maintenance' in existing_token_data
+    return cluster, get_token(cluster, token_name)
+
+
+def _update_token(cluster, token_name, existing_token_etag, body):
+    cluster_name = cluster['name']
+    cluster_url = cluster['url']
+    headers = {'If-Match': existing_token_etag}
+    params = {'token': token_name}
+    try:
+        resp = http_util.post(cluster, 'token', body, params=params, headers=headers)
+        process_post_result(resp)
+        return 0
+    except requests.exceptions.ReadTimeout as rt:
+        logging.exception(rt)
+        print_info(terminal.failed(
+            f'Encountered read timeout with {cluster_name} ({cluster_url}). The operation may have completed.'))
+        return 1
+    except IOError as ioe:
+        logging.exception(ioe)
+        reason = f'Cannot connect to {cluster_name} ({cluster_url})'
+        message = post_failed_message(cluster_name, reason)
+        print_info(f'{message}\n')
+
+
+def check_maintenance(clusters, args):
+    token_name = args['token']
+    existing_token_data, existing_token_etag = _get_existing_token_data(clusters, token_name)
+    maintenance_mode_active = _is_token_in_maintenance_mode(existing_token_data)
     print_info(f'{token_name} is {"" if maintenance_mode_active else "not "}in maintenance mode')
     return 0 if maintenance_mode_active else 1
 
 
 def start_maintenance(clusters, args):
-    guard_no_cluster(clusters)
     token_name = args['token']
-    cluster = get_cluster_with_token(clusters, token_name)
-    cluster_name = cluster['name']
-    cluster_url = cluster['url']
-    existing_token_data, existing_token_etag = get_token(cluster, token_name)
+    cluster, existing_token_data, existing_token_etag = _get_existing_token_data(clusters, token_name)
     json_body = existing_token_data
-    headers = {'If-Match': existing_token_etag}
-    params = {'token': token_name}
-    try:
-        update_doc = {"maintenance": {"message": args['message']}}
-        json_body.update(update_doc)
-        resp = http_util.post(cluster, 'token', json_body, params=params, headers=headers)
-        process_post_result(resp)
-        return 0
-    except requests.exceptions.ReadTimeout as rt:
-        logging.exception(rt)
-        print_info(terminal.failed(
-            f'Encountered read timeout with {cluster_name} ({cluster_url}). The operation may have completed.'))
-        return 1
-    except IOError as ioe:
-        logging.exception(ioe)
-        reason = f'Cannot connect to {cluster_name} ({cluster_url})'
-        message = post_failed_message(cluster_name, reason)
-        print_info(f'{message}\n')
+    update_doc = {"maintenance": {"message": args['message']}}
+    json_body.update(update_doc)
+    return _update_token(cluster, token_name, existing_token_etag, json_body)
 
 
 def stop_maintenance(clusters, args):
-    guard_no_cluster(clusters)
     token_name = args['token']
-    cluster = get_cluster_with_token(clusters, token_name)
-    cluster_name = cluster['name']
-    cluster_url = cluster['url']
-    existing_token_data, existing_token_etag = get_token(cluster, token_name)
-    maintenance_mode_active = 'maintenance' in existing_token_data
+    cluster, existing_token_data, existing_token_etag = _get_existing_token_data(clusters, token_name)
+    maintenance_mode_active = _is_token_in_maintenance_mode(existing_token_data)
+    if not maintenance_mode_active:
+        raise Exception("Token is not in maintenance mode")
     json_body = existing_token_data
-    headers = {'If-Match': existing_token_etag}
-    params = {'token': token_name}
-    try:
-        if maintenance_mode_active:
-            json_body.pop("maintenance")
-        else:
-            raise Exception("Token is not in maintenance mode")
-        resp = http_util.post(cluster, 'token', json_body, params=params, headers=headers)
-        process_post_result(resp)
-        return 0
-    except requests.exceptions.ReadTimeout as rt:
-        logging.exception(rt)
-        print_info(terminal.failed(
-            f'Encountered read timeout with {cluster_name} ({cluster_url}). The operation may have completed.'))
-        return 1
-    except IOError as ioe:
-        logging.exception(ioe)
-        reason = f'Cannot connect to {cluster_name} ({cluster_url})'
-        message = post_failed_message(cluster_name, reason)
-        print_info(f'{message}\n')
+    json_body.pop("maintenance")
+    return _update_token(cluster, token_name, existing_token_etag, json_body)
 
 
 def maintenance(parser, clusters, args, _):
@@ -87,26 +77,28 @@ def maintenance(parser, clusters, args, _):
         return sub_func(clusters, args)
 
 
-def register_action(add_parser, sub_action, sub_func):
-    parser = add_parser(sub_action, help=f'{sub_action} maintenance mode for a token')
-    parser.add_argument('token')
-    parser.set_defaults(sub_func=sub_func)
-    return parser
-
-
 def register_check(add_parser):
-    register_action(add_parser, 'check', check_maintenance)
+    parser = add_parser('check',
+                        help='Checks if a token is in maintenance mode. Returns cli code 0 if the token is in '
+                             'maintenance mode and 1 if the token not in maintenance mode')
+    parser.add_argument('token')
+    parser.set_defaults(sub_func=check_maintenance)
 
 
 def register_stop(add_parser):
-    register_action(add_parser, 'stop', stop_maintenance)
+    parser = add_parser('stop', 'Stop maintenance mode for a token. Requests will be handled normally.')
+    parser.add_argument('token')
+    parser.set_defaults(sub_func=stop_maintenance)
 
 
 def register_start(add_parser):
-    start_parser = register_action(add_parser, 'start', start_maintenance)
-    start_parser.add_argument('message',
-                              help='Your message will be provided in a 503 response for requests to the token. '
-                                   'The message cannot be more than 512 characters.')
+    parser = add_parser('start', 'Start maintenance mode for a token. All requests to this token will begin to receive '
+                                 'a 503 response.')
+    parser.add_argument('token')
+    parser.add_argument('message',
+                        help='Your message will be provided in a 503 response for requests to the token. '
+                             'The message cannot be more than 512 characters.')
+    parser.set_defaults(sub_func=start_maintenance)
 
 
 def register(add_parser):

--- a/cli/waiter/subcommands/maintenance.py
+++ b/cli/waiter/subcommands/maintenance.py
@@ -15,7 +15,8 @@ def _is_token_in_maintenance_mode(token_data):
 def _get_existing_token_data(clusters, token_name):
     guard_no_cluster(clusters)
     cluster = get_cluster_with_token(clusters, token_name)
-    return cluster, get_token(cluster, token_name)
+    existing_token_data, existing_token_etag = get_token(cluster, token_name)
+    return cluster, existing_token_data, existing_token_etag
 
 
 def _update_token(cluster, token_name, existing_token_etag, body):
@@ -41,7 +42,7 @@ def _update_token(cluster, token_name, existing_token_etag, body):
 
 def check_maintenance(clusters, args):
     token_name = args['token']
-    existing_token_data, existing_token_etag = _get_existing_token_data(clusters, token_name)
+    _, existing_token_data, existing_token_etag = _get_existing_token_data(clusters, token_name)
     maintenance_mode_active = _is_token_in_maintenance_mode(existing_token_data)
     print_info(f'{token_name} is {"" if maintenance_mode_active else "not "}in maintenance mode')
     return 0 if maintenance_mode_active else 1
@@ -86,14 +87,15 @@ def register_check(add_parser):
 
 
 def register_stop(add_parser):
-    parser = add_parser('stop', 'Stop maintenance mode for a token. Requests will be handled normally.')
+    parser = add_parser('stop', help='Stop maintenance mode for a token. Requests will be handled normally.')
     parser.add_argument('token')
     parser.set_defaults(sub_func=stop_maintenance)
 
 
 def register_start(add_parser):
-    parser = add_parser('start', 'Start maintenance mode for a token. All requests to this token will begin to receive '
-                                 'a 503 response.')
+    parser = add_parser('start',
+                        help='Start maintenance mode for a token. All requests to this token will begin to receive a '
+                             '503 response.')
     parser.add_argument('token')
     parser.add_argument('message',
                         help='Your message will be provided in a 503 response for requests to the token. '

--- a/cli/waiter/subcommands/maintenance.py
+++ b/cli/waiter/subcommands/maintenance.py
@@ -1,0 +1,81 @@
+import requests
+
+from waiter import terminal, http_util
+from waiter.token_post import process_post_result, post_failed_message
+from waiter.querying import get_cluster_with_token, get_token
+from waiter.util import guard_no_cluster, logging, print_info
+
+
+def maintenance(clusters, args, _):
+    guard_no_cluster(clusters)
+    logging.debug('args: %s' % args)
+    token_name = args['token']
+    sub_action = args['sub_action']
+    cluster = get_cluster_with_token(clusters, token_name)
+    cluster_name = cluster['name']
+    cluster_url = cluster['url']
+    existing_token_data, existing_token_etag = get_token(cluster, token_name)
+    maintenance_mode_active = 'maintenance' in existing_token_data
+    json_body = existing_token_data
+    headers = {'If-Match': existing_token_etag}
+    params = {'token': token_name}
+    try:
+        if sub_action == 'check':
+            print_info(f'{token_name} is {"" if maintenance_mode_active else "not "}in maintenance mode')
+            return 0 if maintenance_mode_active else 1
+        elif sub_action == 'start':
+            update_doc = {"maintenance": {"message": args['message']}}
+            json_body.update(update_doc)
+        elif sub_action == 'stop':
+            if maintenance_mode_active:
+                json_body.pop("maintenance")
+            else:
+                raise Exception("Token is not in maintenance mode")
+        resp = http_util.post(cluster, 'token', json_body, params=params, headers=headers)
+        process_post_result(resp)
+        return 0
+    except requests.exceptions.ReadTimeout as rt:
+        logging.exception(rt)
+        print_info(terminal.failed(
+            f'Encountered read timeout with {cluster_name} ({cluster_url}). The operation may have completed.'))
+        return 1
+    except IOError as ioe:
+        logging.exception(ioe)
+        reason = f'Cannot connect to {cluster_name} ({cluster_url})'
+        message = post_failed_message(cluster_name, reason)
+        print_info(f'{message}\n')
+
+
+def register_action(add_parser, sub_action):
+    parser = add_parser(sub_action, help=f'{sub_action} maintenance mode for a token')
+    parser.add_argument('token')
+    parser.set_defaults(sub_action=sub_action)
+    return parser
+
+
+def register_check(add_parser):
+    register_action(add_parser, 'check')
+
+
+def register_stop(add_parser):
+    register_action(add_parser, 'stop')
+
+
+def register_start(add_parser):
+    start_parser = register_action(add_parser, 'start')
+    start_parser.add_argument('--message', '-m',
+                              help='Message is a required argument and cannot be more than 512 characters. '
+                                   'Your message will be provided in a 503 response for requests to the token.',
+                              required=True)
+
+
+def register(add_parser):
+    """Adds this sub-command's parser and returns the action function"""
+    parser = add_parser('maintenance',
+                        help='manage maintenance mode for a token',
+                        description='Manage maintenance mode for a Waiter token.')
+    subparsers = parser.add_subparsers()
+    register_check(subparsers.add_parser)
+    register_start(subparsers.add_parser)
+    register_stop(subparsers.add_parser)
+    return maintenance

--- a/cli/waiter/subcommands/maintenance.py
+++ b/cli/waiter/subcommands/maintenance.py
@@ -86,15 +86,16 @@ def maintenance(parser, clusters, args, _):
 def register_check(add_parser):
     """Registers the maintenance check parser"""
     parser = add_parser('check',
-                        help='Checks if a token is in maintenance mode. Returns cli code 0 if the token is in '
-                             'maintenance mode and 1 if the token not in maintenance mode')
+                        help='Checks if a token is in maintenance mode. Exits with code 0 if the token is in '
+                             'maintenance mode and 1 if the token is not in maintenance mode')
     parser.add_argument('token')
     parser.set_defaults(sub_func=check_maintenance)
 
 
 def register_stop(add_parser):
     """Registers the maintenance stop parser"""
-    parser = add_parser('stop', help='Stop maintenance mode for a token. Requests will be handled normally.')
+    parser = add_parser('stop', help='Stop maintenance mode for a token. Requests to the token will be handled '
+                                     'normally.')
     parser.add_argument('token')
     parser.set_defaults(sub_func=stop_maintenance)
 

--- a/cli/waiter/subcommands/maintenance.py
+++ b/cli/waiter/subcommands/maintenance.py
@@ -9,12 +9,12 @@ from waiter.util import guard_no_cluster, logging, print_info
 
 
 def maintenance(parser, clusters, args, _):
-    guard_no_cluster(clusters)
     logging.debug('args: %s' % args)
     sub_action = args.get('sub_action', None)
     if sub_action is None:
         parser.print_help()
         return 0
+    guard_no_cluster(clusters)
     token_name = args['token']
     cluster = get_cluster_with_token(clusters, token_name)
     cluster_name = cluster['name']

--- a/cli/waiter/subcommands/tokens.py
+++ b/cli/waiter/subcommands/tokens.py
@@ -20,6 +20,7 @@ def print_as_table(query_result):
     """Given a collection of (cluster, token) pairs, formats a table showing the most relevant token fields"""
     cluster_token_pairs = query_result_to_cluster_token_pairs(query_result)
     rows = [collections.OrderedDict([("Cluster", cluster),
+                                     ("Maintenance", token.get('maintenance', False)),
                                      ("Owner", token['owner']),
                                      ("Token", token['token']),
                                      ("Updated", format_timestamp_string(token['last-update-time']))])

--- a/cli/waiter/subcommands/tokens.py
+++ b/cli/waiter/subcommands/tokens.py
@@ -20,9 +20,9 @@ def print_as_table(query_result):
     """Given a collection of (cluster, token) pairs, formats a table showing the most relevant token fields"""
     cluster_token_pairs = query_result_to_cluster_token_pairs(query_result)
     rows = [collections.OrderedDict([("Cluster", cluster),
-                                     ("Maintenance", token.get('maintenance', False)),
                                      ("Owner", token['owner']),
                                      ("Token", token['token']),
+                                     ("Maintenance", token.get('maintenance', False)),
                                      ("Updated", format_timestamp_string(token['last-update-time']))])
             for (cluster, token) in cluster_token_pairs]
     token_table = tabulate(rows, headers='keys', tablefmt='plain')


### PR DESCRIPTION
## Changes proposed in this PR

- add sub command `waiter maintenance start [token] --message`
- add sub command `waiter maintenance stop [token]`
- add sub command `waiter maintenance check [token]`
- add "maintenance" column for `waiter tokens` command
- successful output for `start` and `stop`
![Screenshot from 2020-10-30 09-35-51](https://user-images.githubusercontent.com/8290559/97717945-5a27bb00-1a93-11eb-86db-109f4f6e591c.png)
- successful output for `check`
![Screenshot from 2020-10-30 13-28-45](https://user-images.githubusercontent.com/8290559/97743559-d92ceb80-1ab3-11eb-8b67-7f1209eee3bf.png)
- output for "stop" when token is not in maintenance mode
![Screenshot from 2020-10-30 09-36-51](https://user-images.githubusercontent.com/8290559/97718116-8b07f000-1a93-11eb-9283-10716ba30fa9.png)
- output when message is invalid (too long)
![Screenshot from 2020-10-30 09-38-42](https://user-images.githubusercontent.com/8290559/97718538-0e294600-1a94-11eb-884a-2fd18addc021.png)
- output with `waiter tokens`
![Screenshot from 2020-11-13 14-53-36](https://user-images.githubusercontent.com/8290559/99120199-161ed500-25c0-11eb-9423-2f22079f8b2b.png)
- help message output
![Screenshot from 2020-11-16 14-36-54](https://user-images.githubusercontent.com/8290559/99305312-39908c80-2819-11eb-82ce-8eeaff8e9960.png)
![Screenshot from 2020-10-30 13-30-47](https://user-images.githubusercontent.com/8290559/97743745-227d3b00-1ab4-11eb-8827-60640b154a1e.png)


## Why are we making these changes?
- users can now put their token in maintenance mode through the cli

