### PR TITLE
Remove Unecessary Service Id

### DIFF
--- a/waiter/resources/web/maintenance.html
+++ b/waiter/resources/web/maintenance.html
@@ -125,11 +125,6 @@
                 <td class="field">Principal</td><td class="code"><%= principal %></td>
             </tr>
             <% ) %>
-            <% (when service-id %>
-            <tr>
-                <td class="field">Service Id</td><td class="code"><%= service-id %></td>
-            </tr>
-            <% ) %>
         </table>
     </div>
 </div>

--- a/waiter/resources/web/maintenance.html
+++ b/waiter/resources/web/maintenance.html
@@ -120,11 +120,6 @@
             <tr>
                 <td class="field">Time</td><td class="code"><%= timestamp %></td>
             </tr>
-            <% (when principal %>
-            <tr>
-                <td class="field">Principal</td><td class="code"><%= principal %></td>
-            </tr>
-            <% ) %>
         </table>
     </div>
 </div>

--- a/waiter/resources/web/maintenance.txt
+++ b/waiter/resources/web/maintenance.txt
@@ -12,8 +12,7 @@ Request Info
   Query String: <%= (or query-string "") %>
         Method: <%= request-method %>
            CID: <%= cid %>
-          Time: <%= timestamp %><% (when principal %>
-     Principal: <%= principal %><% ) %>
+          Time: <%= timestamp %>
 
 <% (when (or name token token-owner) %>
 Additional Info

--- a/waiter/resources/web/maintenance.txt
+++ b/waiter/resources/web/maintenance.txt
@@ -13,8 +13,7 @@ Request Info
         Method: <%= request-method %>
            CID: <%= cid %>
           Time: <%= timestamp %><% (when principal %>
-     Principal: <%= principal %><% ) %><% (when service-id %>
-    Service Id: <%= service-id %><% ) %>
+     Principal: <%= principal %><% ) %>
 
 <% (when (or name token token-owner) %>
 Additional Info

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -303,7 +303,7 @@
     (text-fn context)))
 
 (let [html-fn (template/fn
-                [{:keys [cid host instance-id message name principal query-string request-method
+                [{:keys [cid host instance-id message name query-string request-method
                          support-info timestamp token token-owner uri]}]
                 (slurp (io/resource "web/maintenance.html")))]
   (defn- render-maintenance-mode-html
@@ -312,7 +312,7 @@
     (html-fn context)))
 
 (let [text-fn (template/fn
-                [{:keys [cid host instance-id message name principal query-string request-method
+                [{:keys [cid host instance-id message name query-string request-method
                          support-info timestamp token token-owner uri]}]
                 (slurp (io/resource "web/maintenance.txt")))]
   (defn- render-maintenance-mode-text

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -304,7 +304,7 @@
 
 (let [html-fn (template/fn
                 [{:keys [cid host instance-id message name principal query-string request-method
-                         service-id support-info timestamp token token-owner uri]}]
+                         support-info timestamp token token-owner uri]}]
                 (slurp (io/resource "web/maintenance.html")))]
   (defn- render-maintenance-mode-html
     "Renders maintenance mode html"
@@ -313,7 +313,7 @@
 
 (let [text-fn (template/fn
                 [{:keys [cid host instance-id message name principal query-string request-method
-                         service-id support-info timestamp token token-owner uri]}]
+                         support-info timestamp token token-owner uri]}]
                 (slurp (io/resource "web/maintenance.txt")))]
   (defn- render-maintenance-mode-text
     "Renders maintenance mode text"


### PR DESCRIPTION
## Changes proposed in this PR

- maintenance middleware will never have service id available (no descriptor is provided until later middlewares)
- screenshot of html and txt output to confirm no changes to users
![Screenshot from 2020-10-30 09-26-53](https://user-images.githubusercontent.com/8290559/97716934-3748d700-1a92-11eb-8e48-17e1c313541c.png)
![Screenshot from 2020-10-30 09-26-47](https://user-images.githubusercontent.com/8290559/97716938-387a0400-1a92-11eb-95c6-5c9e6e1bfbe2.png)

## Why are we making these changes?

- smaller maintenance txt and html file
- users should not notice these changes (no changes to html and txt output for users)
