### PR TITLE
moves accept scoped token flag to metadata from environment variable

### DIFF
--- a/waiter/src/waiter/auth/jwt.clj
+++ b/waiter/src/waiter/auth/jwt.clj
@@ -456,7 +456,7 @@
     (try
       (let [realm (request->realm request)
             request-scheme (utils/request->scheme request)
-            accept-scope? (= "true" (get-in request [:waiter-discovery :service-description-template "env" "ACCEPT_SCOPED_TOKEN"]))
+            accept-scope? (= "true" (get-in request [:waiter-discovery :service-description-template "metadata" "accept-scoped-token"]))
             claims (validate-access-token jwt-validator key-id->jwk realm request-scheme accept-scope? access-token)
             {:keys [exp]} claims
             subject (subject-key claims)]

--- a/waiter/test/waiter/auth/jwt_test.clj
+++ b/waiter/test/waiter/auth/jwt_test.clj
@@ -490,7 +490,7 @@
                                  :request-id (rand-int 10000)
                                  :scheme :test-scheme}
                           access-token-scope
-                          (assoc-in [:waiter-discovery :service-description-template "env" "ACCEPT_SCOPED_TOKEN"] access-token-scope))]
+                          (assoc-in [:waiter-discovery :service-description-template "metadata" "accept-scoped-token"] access-token-scope))]
             (with-redefs [validate-access-token (fn [jwt-validator in-keys in-realm in-request-scheme in-accept-scope? in-access-token]
                                                   (is (= token-type (:token-type jwt-validator)))
                                                   (is (= issuer-constraints (:issuer-constraints jwt-validator)))


### PR DESCRIPTION
## Changes proposed in this PR

- moves accept scoped token flag to metadata from environment variable

## Why are we making these changes?

We wish to avoid polluting the backend environment with variables for metadata information instructing Waiter to modify its authentication behavior for a service.

