### PR TITLE
ignores auth cookie value if bearer token is provided

### DIFF
--- a/waiter/integration/waiter/authentication_test.clj
+++ b/waiter/integration/waiter/authentication_test.clj
@@ -272,7 +272,16 @@
           (with-service-cleanup
             service-id
             (validate-response service-id access-token "jwt" response)
-            (is (empty? cookies) (str response)))
+            (is (empty? cookies) (str response))
+            (testing "passing the cookie and bearer token should not use the cookie"
+              (let [{:keys [cookies] :as auth-response} (make-request waiter-url "/waiter-auth")]
+                (is (seq cookies) (str auth-response))
+                (->> (make-request target-url "/request-info"
+                                   :cookies cookies
+                                   :disable-auth true
+                                   :headers (dissoc request-headers "x-cid")
+                                   :method :get)
+                  (validate-response service-id access-token "jwt")))))
           (finally
             (delete-token-and-assert waiter-url host))))
       (log/info "JWT authentication is disabled"))))

--- a/waiter/src/waiter/auth/authentication.clj
+++ b/waiter/src/waiter/auth/authentication.clj
@@ -215,18 +215,28 @@
             "requests will use principal" run-as-user)
   (->SingleUserAuthenticator run-as-user password))
 
+(defn access-token?
+  "Predicate to determine if an authorization header represents an access token."
+  [authorization]
+  (let [authorization (str authorization)]
+    (and (str/starts-with? authorization bearer-prefix)
+         (= 3 (count (str/split authorization #"\."))))))
+
 (defn wrap-auth-cookie-handler
   "Returns a handler that can authenticate a request that contains a valid x-waiter-auth cookie."
   [password handler]
   (fn auth-cookie-handler
     [{:keys [headers] :as request}]
-    (let [decoded-auth-cookie (get-and-decode-auth-cookie-value headers password)
-          [auth-principal _ auth-metadata] decoded-auth-cookie]
-      (if (decoded-auth-valid? decoded-auth-cookie)
-        (let [auth-params-map (build-auth-params-map :cookie auth-principal auth-metadata)
-              handler' (middleware/wrap-merge handler auth-params-map)]
-          (handler' request))
-        (handler request)))))
+    ;; ignore auth cookie if a bearer token has been provided
+    (if (select-auth-header request access-token?)
+      (handler request)
+      (let [decoded-auth-cookie (get-and-decode-auth-cookie-value headers password)
+            [auth-principal _ auth-metadata] decoded-auth-cookie]
+        (if (decoded-auth-valid? decoded-auth-cookie)
+          (let [auth-params-map (build-auth-params-map :cookie auth-principal auth-metadata)
+                handler' (middleware/wrap-merge handler auth-params-map)]
+            (handler' request))
+          (handler request))))))
 
 (defn process-auth-expires-at-request
   "Handler to allow a client to update its knowledge of when a user's cookie-based credentials expire.

--- a/waiter/src/waiter/auth/authentication.clj
+++ b/waiter/src/waiter/auth/authentication.clj
@@ -24,8 +24,7 @@
             [waiter.service-description :as sd]
             [waiter.status-codes :refer :all]
             [waiter.util.ring-utils :as ru]
-            [waiter.util.utils :as utils])
-  (:import (java.net URI)))
+            [waiter.util.utils :as utils]))
 
 (def ^:const AUTH-COOKIE-EXPIRES-AT "x-auth-expires-at")
 
@@ -34,6 +33,8 @@
 (def ^:const auth-expires-at-uri "/.well-known/auth/expires-at")
 
 (def ^:const auth-keep-alive-uri "/.well-known/auth/keep-alive")
+
+(def ^:const bearer-prefix "Bearer ")
 
 (defprotocol Authenticator
   (wrap-auth-handler [this request-handler]

--- a/waiter/test/waiter/auth/authenticator_test.clj
+++ b/waiter/test/waiter/auth/authenticator_test.clj
@@ -82,6 +82,13 @@
         now-sec (long (/ now-ms 1000))
         expires-at (+ now-sec 900000)]
 
+    (testing "auth cookie and bearer token skips cookie auth"
+      (let [auth-cookie-handler (wrap-auth-cookie-handler password request-handler)]
+        (is (= {:body {:principal nil
+                       :user nil}}
+               (auth-cookie-handler {:headers {"authorization" (str bearer-prefix "john.doe")
+                                               "cookie" "x-waiter-auth=test-auth-cookie"}})))))
+
     (testing "valid auth cookie"
       (with-redefs [decode-auth-cookie (constantly [auth-principal (+ now-ms 60000) {:expires-at expires-at}])]
         (let [auth-cookie-handler (wrap-auth-cookie-handler password request-handler)]

--- a/waiter/test/waiter/auth/jwt_test.clj
+++ b/waiter/test/waiter/auth/jwt_test.clj
@@ -463,7 +463,7 @@
             request {:headers {"authorization" "Bearer foo.bar.baz"
                                "host" "www.test.com"}
                      :request-id (rand-int 10000)}
-            auth-header (str bearer-prefix "realm=\"www.test.com\"")]
+            auth-header (str auth/bearer-prefix "realm=\"www.test.com\"")]
         (with-redefs [validate-access-token (fn [& _] (throw ex))]
           (is (= (-> request
                    (assoc :headers {"www-authenticate" auth-header} :source ::request-handler :status http-401-unauthorized)


### PR DESCRIPTION
## Changes proposed in this PR

- moves bearer-prefix to authentication.clj
- ignores auth cookie value if bearer token is provided

## Why are we making these changes?

Bearer token authentication should be the source of truth when both the bearer token and the authentication cookie has been provided.

