### PR TITLE
avoids emitting x-waiter-auth cookie for bearer token authentication

### DIFF
--- a/waiter/integration/waiter/authentication_test.clj
+++ b/waiter/integration/waiter/authentication_test.clj
@@ -238,8 +238,7 @@
     (assert-response-status response http-200-ok)
     (is (= auth-method (get headers "x-waiter-auth-method")) assertion-message)
     (is (= (retrieve-username) (get headers "x-waiter-auth-user")) assertion-message)
-    (when-not (= auth-method "cookie")
-      (assert-auth-cookie set-cookie assertion-message))
+    (is (str/blank? set-cookie) assertion-message)
     (let [body-json (try-parse-json body)
           jwt-payload (try-parse-json (get-in body-json ["headers" "x-waiter-jwt-payload"]))]
       (log/info "jwt payload is" jwt-payload)
@@ -273,12 +272,7 @@
           (with-service-cleanup
             service-id
             (validate-response service-id access-token "jwt" response)
-            (->> (make-request target-url "/request-info"
-                               :cookies cookies
-                               :disable-auth true
-                               :headers (dissoc request-headers "authorization" "x-cid")
-                               :method :get)
-              (validate-response service-id access-token "cookie")))
+            (is (empty? cookies) (str response)))
           (finally
             (delete-token-and-assert waiter-url host))))
       (log/info "JWT authentication is disabled"))))

--- a/waiter/src/waiter/auth/authentication.clj
+++ b/waiter/src/waiter/auth/authentication.clj
@@ -101,11 +101,12 @@
   ([handler request auth-params-map password]
    (handle-request-auth handler request auth-params-map password nil))
   ([handler request auth-params-map password age-in-seconds]
+   (handle-request-auth handler request auth-params-map password age-in-seconds true))
+  ([handler request auth-params-map password age-in-seconds add-auth-cookie?]
    (let [{:keys [authorization/metadata authorization/principal]} auth-params-map
          handler' (middleware/wrap-merge handler auth-params-map)]
-     (-> request
-       handler'
-       (add-cached-auth password principal age-in-seconds metadata)))))
+     (cond-> (handler' request)
+       add-auth-cookie? (add-cached-auth password principal age-in-seconds metadata)))))
 
 (defn decode-auth-cookie
   "Decodes the provided cookie using the provided password.

--- a/waiter/src/waiter/auth/jwt.clj
+++ b/waiter/src/waiter/auth/jwt.clj
@@ -517,7 +517,7 @@
             auth-params-map (auth/build-auth-params-map :jwt subject auth-metadata)
             auth-cookie-age-in-seconds (- expiry-time (current-time-secs))]
         (auth/handle-request-auth
-          request-handler request auth-params-map password auth-cookie-age-in-seconds)))))
+          request-handler request auth-params-map password auth-cookie-age-in-seconds false)))))
 
 (defn wrap-auth-handler
   "Wraps the request handler with a handler to trigger JWT access token authentication."

--- a/waiter/test/waiter/auth/jwt_test.clj
+++ b/waiter/test/waiter/auth/jwt_test.clj
@@ -504,7 +504,8 @@
                                                   (is (= (= access-token-scope "true") in-accept-scope?))
                                                   (is (= "foo.bar.baz" in-access-token))
                                                   payload)
-                          auth/handle-request-auth (fn [request-handler request auth-params-map password auth-cookie-age-in-seconds]
+                          auth/handle-request-auth (fn [request-handler request auth-params-map password auth-cookie-age-in-seconds add-auth-cookie?]
+                                                     (is (false? add-auth-cookie?))
                                                      (-> request
                                                        (assoc :auth-cookie-age-in-seconds auth-cookie-age-in-seconds
                                                               :auth-params-map auth-params-map


### PR DESCRIPTION
## Changes proposed in this PR

- introduces parameter to skip emitting x-waiter-auth cookie in response
- avoids emitting x-waiter-auth cookie for bearer token authentication

## Why are we making these changes?

The delegation workflow (via scoped tokens) can be problematic to use when the client caches authentication credentials in cookies and passes them in incorrectly for a different access token. Instead, we now require every bearer token request to be authenticated without the cookie authentication bypass.
