### PR TITLE
Remove service id from maintenance middleware

### DIFF
--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -865,7 +865,6 @@
   [handler]
   (fn [{{:keys [service-description-template token waiter-headers]
          {:strs [maintenance owner]} :token-metadata} :waiter-discovery
-        {:keys [service-id]} :descriptor
         :as request}]
     (let [response-map {:name (get service-description-template "name")
                         :token token
@@ -880,7 +879,7 @@
                   (utils/data->error-response request)))
             (some? maintenance)
             (do
-              (log/info (str "token " token " is in maintenance mode (service-id: " service-id ")"))
+              (log/info (str "token " token " is in maintenance mode"))
               (meters/mark! (metrics/waiter-meter "maintenance" "response-rate"))
               (-> {:details response-map
                    :message (get maintenance "message")

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -397,8 +397,7 @@
           maintenance-message "test maintenance message"
           request {:waiter-discovery {:token-metadata {"maintenance" {"message" maintenance-message}}
                                       :token "token"
-                                      :waiter-headers {}}
-                   :descriptor {:service-id "service-id-1"}}
+                                      :waiter-headers {}}}
           {:keys [status body]} (handler request)]
       (is (= http-503-service-unavailable status))
       (is (str/includes? body maintenance-message))))
@@ -407,8 +406,7 @@
     (let [handler (wrap-maintenance-mode (fn [_] {:status http-200-ok}))
           request {:waiter-discovery {:token-metadata {}
                                       :token "token"
-                                      :waiter-headers {"x-waiter-maintenance" "some value"}}
-                   :descriptor {:service-id "service-id-1"}}
+                                      :waiter-headers {"x-waiter-maintenance" "some value"}}}
           {:keys [status body]} (handler request)]
       (is (= http-400-bad-request status))
       (is (str/includes? body "The maintenance parameter is not supported for on-the-fly requests"))))
@@ -417,8 +415,7 @@
     (let [handler (wrap-maintenance-mode (fn [_] {:status http-200-ok}))
           request {:waiter-discovery {:token-metadata {}
                                       :token "token"
-                                      :waiter-headers {}}
-                   :descriptor {:service-id "service-id-1"}}
+                                      :waiter-headers {}}}
           {:keys [status]} (handler request)]
       (is (= http-200-ok status)))))
 


### PR DESCRIPTION
## Changes proposed in this PR
- remove logging of service-id
## Why are we making these changes?
- the service-id and descriptor field does not get populated before the middleware is called

