### PR TITLE
adds state to the entitlement manager

### DIFF
--- a/waiter/src/waiter/authorization.clj
+++ b/waiter/src/waiter/authorization.clj
@@ -19,14 +19,18 @@
 (defprotocol EntitlementManager
   "Security related methods"
   (authorized? [this subject action resource]
-    "Determines if a given subject can perform action on a given resource."))
+    "Determines if a given subject can perform action on a given resource.")
+  (get-manager-state [this]
+    "Returns the state the entitlement manager is maintaining."))
 
 (defrecord SimpleEntitlementManager [_]
   EntitlementManager
   (authorized? [_ subject action resource]
     (or (= subject (:user resource))
         (and (= :admin action)
-             (= subject (System/getProperty "user.name"))))))
+             (= subject (System/getProperty "user.name")))))
+  (get-manager-state [_]
+    {:name "SimpleEntitlementManager"}))
 
 (defn- make-service-resource
   "Creates a resource from a service description for use with an entitlement manager"

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -114,6 +114,7 @@
                               ["/autoscaler" :state-autoscaler-handler-fn]
                               ["/autoscaling-multiplexer" :state-autoscaling-multiplexer-handler-fn]
                               ["/codahale-reporters" :state-codahale-reporters-handler-fn]
+                              ["/entitlement-manager" :state-entitlement-manager-handler-fn]
                               ["/fallback" :state-fallback-handler-fn]
                               ["/gc-broken-services" :state-gc-for-broken-services]
                               ["/gc-services" :state-gc-for-services]
@@ -1673,6 +1674,11 @@
                                               router-id
                                               #(pc/map-vals reporter/state codahale-reporters)
                                               request)))
+   :state-entitlement-manager-handler-fn (pc/fnk [[:state entitlement-manager router-id]
+                                                  wrap-secure-request-fn]
+                                           (wrap-secure-request-fn
+                                             (fn entitlement-manager-state-handler-fn [request]
+                                               (handler/get-entitlement-manager-state router-id entitlement-manager request))))
    :state-fallback-handler-fn (pc/fnk [[:daemons fallback-maintainer]
                                        [:state router-id]
                                        wrap-secure-request-fn]

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -762,8 +762,8 @@
           scheme (some-> request utils/request->scheme name)
           make-url (fn make-url [path]
                      (str (when scheme (str scheme "://")) host "/state/" path))]
-      (utils/clj->streaming-json-response {:details (->> ["autoscaler" "autoscaling-multiplexer" "codahale-reporters" "fallback"
-                                                          "gc-broken-services" "gc-services" "gc-transient-metrics" "interstitial"
+      (utils/clj->streaming-json-response {:details (->> ["autoscaler" "autoscaling-multiplexer" "codahale-reporters" "entitlement-manager"
+                                                          "fallback" "gc-broken-services" "gc-services" "gc-transient-metrics" "interstitial"
                                                           "jwt-auth-server" "kv-store" "launch-metrics" "leader" "local-usage"
                                                           "maintainer" "router-metrics" "scheduler" "service-description-builder"
                                                           "service-maintainer" "statsd" "work-stealing"]
@@ -811,6 +811,11 @@
   "Outputs the state retrieved by invoking the query-state-fn."
   [router-id query-state-fn request]
   (get-function-state query-state-fn router-id request))
+
+(defn get-entitlement-manager-state
+  "Outputs the entitlement-manager state."
+  [router-id entitlement-manager request]
+  (get-function-state #(authz/get-manager-state entitlement-manager) router-id request))
 
 (defn get-jwt-auth-server-state
   "Outputs the JWT auth server state."

--- a/waiter/test/waiter/authorization_test.clj
+++ b/waiter/test/waiter/authorization_test.clj
@@ -21,7 +21,10 @@
 (defrecord TestEntitlementManager [entitlements]
   authz/EntitlementManager
   (authorized? [_ subject action resource]
-    (entitlements [subject action resource])))
+    (entitlements [subject action resource]))
+  (get-manager-state [_]
+    {:entitlements entitlements
+     :name "TestEntitlementManager"}))
 
 (defn test-em
   "Creates a new TestEntitlementManager"


### PR DESCRIPTION
## Changes proposed in this PR

- adds state to the entitlement manager
- used the name `get-manager-state` since `state` is already taken for `Authorizer` in the same file

## Why are we making these changes?

We should like to be able to introspect the state of the entitlement manager via an endpoint.

### Screenshots

<img width="765" alt="Screen Shot 2020-11-03 at 5 05 43 PM" src="https://user-images.githubusercontent.com/6611249/98053593-7cf10100-1dfe-11eb-9286-810f6d5e42de.png">

<img width="502" alt="Screen Shot 2020-11-03 at 5 16 59 PM" src="https://user-images.githubusercontent.com/6611249/98053566-6f3b7b80-1dfe-11eb-8eaa-d4ecf8e235a0.png">



