### PR TITLE
convert websocket acceptor to have separate middleware

### DIFF
--- a/waiter/integration/waiter/websocket_integration_test.clj
+++ b/waiter/integration/waiter/websocket_integration_test.clj
@@ -59,7 +59,7 @@
   (str "ws://" waiter-url endpoint))
 
 (defn- wss-url [waiter-url endpoint ssl-port]
-  (str "wss://" (retrieve-ssl-url waiter-url (retrieve-ssl-port ssl-port)) waiter-url endpoint))
+  (str "wss://" (retrieve-ssl-url waiter-url (retrieve-ssl-port ssl-port)) endpoint))
 
 (defn- add-auth-cookie [request auth-cookie-value]
   (-> request (.getCookies) (.add (HttpCookie. "x-waiter-auth" auth-cookie-value))))

--- a/waiter/integration/waiter/websocket_integration_test.clj
+++ b/waiter/integration/waiter/websocket_integration_test.clj
@@ -248,7 +248,8 @@
                                  {:middleware (fn [_ ^UpgradeRequest request]
                                                 (websocket/add-headers-to-upgrade-request! request waiter-headers))})
                     [close-code error] (connection->ctrl-data connection)]
-                (assert-websocket-upgrade-error-response close-code error  "Unexpected HTTP Response Status Code: 503 Service Unavailable"))))
+                (assert-websocket-upgrade-error-response close-code error  "Unexpected HTTP Response Status Code: 503 Service Unavailable")
+                (is (= :done (deref response-promise default-timeout-period :timed-out))))))
           (finally
             (delete-token-and-assert waiter-url token))))
 

--- a/waiter/src/waiter/auth/authentication.clj
+++ b/waiter/src/waiter/auth/authentication.clj
@@ -402,7 +402,7 @@
   [handler]
   (make-wrap-auth-bypass
     handler
-    (fn on-process-auth-error-http [_ status message]
+    (fn send-http-error [_ status message]
       (utils/clj->json-response {:error message} :status status))))
 
 (defn wrap-auth-bypass-acceptor
@@ -411,6 +411,6 @@
   [handler]
   (make-wrap-auth-bypass
     handler
-    (fn on-process-auth-error-ws [{:keys [^ServletUpgradeResponse upgrade-response]} status message]
+    (fn send-ws-error [{:keys [^ServletUpgradeResponse upgrade-response]} status message]
       (.sendError upgrade-response status message)
       false)))

--- a/waiter/src/waiter/auth/authentication.clj
+++ b/waiter/src/waiter/auth/authentication.clj
@@ -402,7 +402,7 @@
   [handler]
   (make-wrap-auth-bypass
     handler
-    (fn on-error [_ status message]
+    (fn on-process-auth-error-http [_ status message]
       (utils/clj->json-response {:error message} :status status))))
 
 (defn wrap-auth-bypass-acceptor
@@ -411,6 +411,6 @@
   [handler]
   (make-wrap-auth-bypass
     handler
-    (fn on-error [{:keys [^ServletUpgradeResponse upgrade-response]} status message]
+    (fn on-process-auth-error-ws [{:keys [^ServletUpgradeResponse upgrade-response]} status message]
       (.sendError upgrade-response status message)
       false)))

--- a/waiter/src/waiter/auth/authentication.clj
+++ b/waiter/src/waiter/auth/authentication.clj
@@ -389,11 +389,11 @@
   (fn auth-bypass-handler [{:keys [waiter-discovery] :as request}]
     (process-authentication-parameter
       waiter-discovery
-      (fn [status message]
+      (fn on-process-authentication-error [status message]
         (on-error request status message))
-      (fn []
+      (fn on-auth-disabled []
         (handler (assoc request :skip-authentication true)))
-      (fn []
+      (fn on-auth-enabled []
         (handler request)))))
 
 (defn wrap-auth-bypass
@@ -402,7 +402,7 @@
   [handler]
   (make-wrap-auth-bypass
     handler
-    (fn [_ status message]
+    (fn on-error [_ status message]
       (utils/clj->json-response {:error message} :status status))))
 
 (defn wrap-auth-bypass-acceptor
@@ -411,6 +411,6 @@
   [handler]
   (make-wrap-auth-bypass
     handler
-    (fn [{:keys [^ServletUpgradeResponse upgrade-response]} status message]
+    (fn on-error [{:keys [^ServletUpgradeResponse upgrade-response]} status message]
       (.sendError upgrade-response status message)
       false)))

--- a/waiter/src/waiter/auth/authentication.clj
+++ b/waiter/src/waiter/auth/authentication.clj
@@ -24,7 +24,8 @@
             [waiter.service-description :as sd]
             [waiter.status-codes :refer :all]
             [waiter.util.ring-utils :as ru]
-            [waiter.util.utils :as utils]))
+            [waiter.util.utils :as utils])
+  (:import (org.eclipse.jetty.websocket.servlet ServletUpgradeResponse)))
 
 (def ^:const AUTH-COOKIE-EXPIRES-AT "x-auth-expires-at")
 
@@ -379,16 +380,37 @@
       :else
       (on-auth-required))))
 
-(defn wrap-auth-bypass
-  "Middleware that checks if authentication is disabled for a token and sets the
-  :skip-authentication key of the request to true before passing to next handler."
-  [handler]
+(defn- make-wrap-auth-bypass
+  "Takes a handler and a function to call when there is an error with processing the
+  authentication parameter. If successful and authentication is disabled for the token,
+  then the :skip-authentication is set to true for the request object before getting passed
+  to the handler"
+  [handler on-error]
   (fn auth-bypass-handler [{:keys [waiter-discovery] :as request}]
     (process-authentication-parameter
       waiter-discovery
       (fn [status message]
-        (utils/clj->json-response {:error message} :status status))
+        (on-error request status message))
       (fn []
         (handler (assoc request :skip-authentication true)))
       (fn []
         (handler request)))))
+
+(defn wrap-auth-bypass
+  "Middleware that checks if authentication is disabled for a token and sets the
+  :skip-authentication key of the request to true before passing to next handler."
+  [handler]
+  (make-wrap-auth-bypass
+    handler
+    (fn [_ status message]
+      (utils/clj->json-response {:error message} :status status))))
+
+(defn wrap-auth-bypass-acceptor
+  "Middleware that checks if authentication is disabled for a token and sets the
+  :skip-authentication key of the request to true before passing to next handler."
+  [handler]
+  (make-wrap-auth-bypass
+    handler
+    (fn [{:keys [^ServletUpgradeResponse upgrade-response]} status message]
+      (.sendError upgrade-response status message)
+      false)))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1146,7 +1146,15 @@
                            (waiter-request?-factory hostnames)))
    :websocket-request-auth-cookie-attacher (pc/fnk [[:state passwords router-id]]
                                              (fn websocket-request-auth-cookie-attacher [request]
-                                               (ws/inter-router-request-middleware router-id (first passwords) request)))})
+                                               (ws/inter-router-request-middleware router-id (first passwords) request)))
+
+   :wrap-service-discovery-fn (pc/fnk [discover-service-parameters-fn]
+                                (fn wrap-service-discovery-fn
+                                  [handler]
+                                  (fn [{:keys [headers] :as request}]
+                                    ;; TODO optimization opportunity to avoid this re-computation later in the chain
+                                    (let [discovered-parameters (discover-service-parameters-fn headers)]
+                                      (handler (assoc request :waiter-discovery discovered-parameters))))))})
 
 (def daemons
   {:autoscaler (pc/fnk [[:routines router-metrics-helpers service-id->service-description-fn]
@@ -1370,9 +1378,9 @@
                                  (let [password (first passwords)]
                                    (fn auth-expires-at-handler-fn [request]
                                      (auth/process-auth-expires-at-request password request))))
-   :auth-keep-alive-handler-fn (pc/fnk [[:routines token->token-parameters]
+   :auth-keep-alive-handler-fn (pc/fnk [[:routines token->token-parameters wrap-service-discovery-fn]
                                         [:state passwords waiter-hostnames]
-                                        wrap-secure-request-fn wrap-service-discovery-fn]
+                                        wrap-secure-request-fn]
                                  (let [waiter-hostnames (cond-> waiter-hostnames
                                                           (contains? waiter-hostnames "localhost")
                                                           (conj "127.0.0.1"))
@@ -1436,8 +1444,8 @@
    :oidc-callback-handler-fn (pc/fnk [[:state oidc-authenticator]]
                                (fn oidc-callback-handler-fn [request]
                                  (oidc/oidc-callback-request-handler oidc-authenticator request)))
-   :oidc-enabled-handler-fn (pc/fnk [[:state oidc-authenticator waiter-hostnames]
-                                     wrap-service-discovery-fn]
+   :oidc-enabled-handler-fn (pc/fnk [[:routines wrap-service-discovery-fn]
+                                     [:state oidc-authenticator waiter-hostnames]]
                               (wrap-service-discovery-fn
                                 (fn oidc-enabled-handler-fn [request]
                                   (oidc/oidc-enabled-request-handler oidc-authenticator waiter-hostnames request))))
@@ -1475,8 +1483,9 @@
                                      (pr/process make-request-fn populate-maintainer-chan! start-new-service-fn
                                                  instance-request-properties determine-priority-fn process-response-fn
                                                  pr/abort-http-request-callback-factory local-usage-agent request))))
-   :process-request-wrapper-fn (pc/fnk [[:state interstitial-state-atom]
-                                        wrap-descriptor-fn wrap-secure-request-fn wrap-service-discovery-fn]
+   :process-request-wrapper-fn (pc/fnk [[:routines wrap-service-discovery-fn]
+                                        [:state interstitial-state-atom]
+                                        wrap-descriptor-fn wrap-secure-request-fn]
                                  ; If adding new middleware for process-request-wrapper-fn, consider adding the same middleware to
                                  ; websocket-request-acceptor for websocket upgrade requests
                                  (fn process-handler-wrapper-fn [handler]
@@ -1805,8 +1814,9 @@
                                              (wrap-secure-request-fn
                                                (fn waiter-request-interstitial-handler-fn [request]
                                                  (interstitial/display-interstitial-handler request))))
-   :websocket-request-acceptor (pc/fnk [[:state server-name]
-                                        websocket-secure-request-acceptor-fn wrap-service-discovery-fn]
+   :websocket-request-acceptor (pc/fnk [[:routines wrap-service-discovery-fn]
+                                        [:state server-name]
+                                        websocket-secure-request-acceptor-fn]
                                  ; If adding new middleware for websocket upgrade requests, consider adding the same middleware to
                                  ; process-request-wrapper-fn
                                  (let [handler (-> #(ws/request-subprotocol-acceptor (:upgrade-request %) (:upgrade-response %))
@@ -1863,11 +1873,4 @@
                                                  authentication-method-wrapper-fn)]
                                    (fn inner-wrap-secure-request-fn [{:keys [uri] :as request}]
                                      (log/debug "secure request received at" uri)
-                                     (handler request))))))
-   :wrap-service-discovery-fn (pc/fnk [[:routines discover-service-parameters-fn]]
-                                (fn wrap-service-discovery-fn
-                                  [handler]
-                                  (fn [{:keys [headers] :as request}]
-                                    ;; TODO optimization opportunity to avoid this re-computation later in the chain
-                                    (let [discovered-parameters (discover-service-parameters-fn headers)]
-                                      (handler (assoc request :waiter-discovery discovered-parameters))))))})
+                                     (handler request))))))})

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1147,38 +1147,26 @@
    :websocket-request-auth-cookie-attacher (pc/fnk [[:state passwords router-id]]
                                              (fn websocket-request-auth-cookie-attacher [request]
                                                (ws/inter-router-request-middleware router-id (first passwords) request)))
-   :websocket-request-acceptor (pc/fnk [[:state passwords server-name]
-                                        discover-service-parameters-fn]
-                                 ; TODO: add middleware checks - https-redirect, maintenance-mode, etc.
-                                 (fn websocket-request-acceptor [^ServletUpgradeRequest request ^ServletUpgradeResponse response]
-                                   (let [request-headers (->> (.getHeaders request)
-                                                           (pc/map-vals #(str/join "," %))
-                                                           (pc/map-keys str/lower-case))
-                                         correlation-id (or (get request-headers "x-cid")
-                                                            (str "ws-" (utils/unique-identifier)))
-                                         password (first passwords)]
-                                     (cid/with-correlation-id
-                                       correlation-id
-                                       (log/info "request received (websocket upgrade)"
-                                                 {:headers (headers/truncate-header-values request-headers)
-                                                  :http-version (.getHttpVersion request)
-                                                  :method (some-> request .getMethod str/lower-case)
-                                                  :protocol-version (.getProtocolVersion request)
-                                                  :sub-protocols (some-> request .getSubProtocols seq)
-                                                  :uri (some-> request .getRequestURI .getPath)})
-                                       (.setHeader response "server" server-name)
-                                       (.setHeader response "x-cid" correlation-id)
-                                       (let [waiter-discovery (discover-service-parameters-fn request-headers)]
-                                         (auth/process-authentication-parameter
-                                           waiter-discovery
-                                           (fn [status message]
-                                             (.sendError response status message)
-                                             false)
-                                           (fn []
-                                             (ws/request-subprotocol-acceptor request response))
-                                           (fn []
-                                             (and (ws/request-authenticator password request response)
-                                                  (ws/request-subprotocol-acceptor request response)))))))))
+   :websocket-request-acceptor (pc/fnk [[:state server-name]
+                                        websocket-secure-request-acceptor-fn wrap-service-discovery-fn]
+                                 ; If adding new middleware for websocket upgrade requests, consider adding the same middleware to
+                                 ; process-request-wrapper-fn
+                                 (let [handler (-> #(ws/request-subprotocol-acceptor (:upgrade-request %) (:upgrade-response %))
+                                                   websocket-secure-request-acceptor-fn
+                                                   auth/wrap-auth-bypass-acceptor
+                                                   pr/wrap-maintenance-mode-acceptor
+                                                   handler/wrap-wss-redirect
+                                                   wrap-service-discovery-fn)]
+                                   (handler/make-websocket-request-acceptor server-name handler)))
+   :websocket-secure-request-acceptor-fn (pc/fnk [[:state passwords]]
+                                      (fn websocket-secure-request-acceptor-fn
+                                        [handler]
+                                        (fn [{:keys [skip-authentication upgrade-request upgrade-response] :as request}]
+                                          (if skip-authentication
+                                            (handler request)
+                                            (do
+                                              (and (ws/request-authenticator (first passwords) upgrade-request upgrade-response)
+                                                   (handler request)))))))
    :wrap-service-discovery-fn (pc/fnk [discover-service-parameters-fn]
                                 (fn wrap-service-discovery-fn
                                   [handler]
@@ -1517,6 +1505,8 @@
    :process-request-wrapper-fn (pc/fnk [[:routines wrap-service-discovery-fn]
                                         [:state interstitial-state-atom]
                                         wrap-descriptor-fn wrap-secure-request-fn]
+                                 ; If adding new middleware for process-request-wrapper-fn, consider adding the same middleware to
+                                 ; websocket-request-acceptor for websocket upgrade requests
                                  (fn process-handler-wrapper-fn [handler]
                                    (-> handler
                                      pr/wrap-too-many-requests

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -107,7 +107,7 @@
    :scheduler core/scheduler
    :settings (pc/fnk dummy-symbol-for-fnk-schema-logic :- settings/settings-schema [] settings)
    :state core/state
-   :http-server (pc/fnk [[:routines discover-service-parameters-fn generate-log-url-fn waiter-request?-fn websocket-request-acceptor]
+   :http-server (pc/fnk [[:routines discover-service-parameters-fn generate-log-url-fn waiter-request?-fn]
                          [:settings cors-config host port server-options support-info websocket-config]
                          [:state cors-validator router-id server-name]
                          handlers] ; Insist that all systems are running before we start server
@@ -125,7 +125,7 @@
                                                         core/correlation-id-middleware
                                                         (core/wrap-request-info router-id support-info)
                                                         consume-request-stream)
-                                        :websocket-acceptor websocket-request-acceptor
+                                        :websocket-acceptor (:websocket-request-acceptor handlers)
                                         :websocket-handler (-> (core/websocket-handler-factory handlers)
                                                              rlog/wrap-log
                                                              core/correlation-id-middleware

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -111,7 +111,8 @@
                          [:settings cors-config host port server-options support-info websocket-config]
                          [:state cors-validator router-id server-name]
                          handlers] ; Insist that all systems are running before we start server
-                  (let [options (merge (cond-> server-options
+                  (let [websocket-request-acceptor (:websocket-request-acceptor handlers)
+                        options (merge (cond-> server-options
                                          (:ssl-port server-options) (assoc :ssl? true))
                                        websocket-config
                                        {:ring-handler (-> (core/ring-handler-factory waiter-request?-fn handlers)
@@ -125,7 +126,7 @@
                                                         core/correlation-id-middleware
                                                         (core/wrap-request-info router-id support-info)
                                                         consume-request-stream)
-                                        :websocket-acceptor (:websocket-request-acceptor handlers)
+                                        :websocket-acceptor websocket-request-acceptor
                                         :websocket-handler (-> (core/websocket-handler-factory handlers)
                                                              rlog/wrap-log
                                                              core/correlation-id-middleware

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -111,7 +111,7 @@
                          [:settings cors-config host port server-options support-info websocket-config]
                          [:state cors-validator router-id server-name]
                          handlers] ; Insist that all systems are running before we start server
-                  (let [websocket-request-acceptor (:websocket-request-acceptor handlers)
+                  (let [{:keys [websocket-request-acceptor]} handlers
                         options (merge (cond-> server-options
                                          (:ssl-port server-options) (assoc :ssl? true))
                                        websocket-config

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -894,16 +894,16 @@
   [handler]
   (make-maintenance-mode
     handler
-    (fn [data-map request]
+    (fn send-header-error [data-map request]
       (utils/data->error-response data-map request))
-    (fn [data-map request]
+    (fn send-maintenance-mode-error [data-map request]
       (utils/data->maintenance-mode-response data-map request))))
 
 (defn wrap-maintenance-mode-acceptor
   "websocket-request-acceptor middleware to check for maintenance mode of a token and if improper maintenance
   mode header is provided"
   [handler]
-  (let [on-error (fn [{:keys [message status]} {^ServletUpgradeResponse upgrade-response :upgrade-response}]
+  (let [on-error (fn send-ws-error [{:keys [message status]} {^ServletUpgradeResponse upgrade-response :upgrade-response}]
                    (.sendError upgrade-response status message)
                    false)]
     (make-maintenance-mode handler on-error on-error)))

--- a/waiter/test/waiter/websocket_test.clj
+++ b/waiter/test/waiter/websocket_test.clj
@@ -26,8 +26,7 @@
   (:import (java.net HttpCookie SocketTimeoutException URLDecoder)
            (java.util ArrayList Collection)
            (org.eclipse.jetty.websocket.api MessageTooLargeException UpgradeRequest)
-           (org.eclipse.jetty.websocket.client ClientUpgradeRequest)
-           (org.eclipse.jetty.websocket.servlet ServletUpgradeResponse)))
+           (org.eclipse.jetty.websocket.client ClientUpgradeRequest)))
 
 (defn- reified-upgrade-request
   [config-map]
@@ -43,23 +42,6 @@
             (doseq [value header-value]
               (.add result-list value)))
           result-list)))))
-
-(defn- reified-upgrade-response
-  []
-  (let [response-reason-atom (atom nil)
-        response-status-atom (atom 0)
-        response-subprotocol-atom (atom nil)]
-    (proxy [ServletUpgradeResponse] [nil]
-      (getAcceptedSubProtocol [] @response-subprotocol-atom)
-      (getStatusCode [] @response-status-atom)
-      (getStatusReason [] @response-reason-atom)
-      (sendError [status reason]
-        (reset! response-status-atom status)
-        (reset! response-reason-atom reason))
-      (sendForbidden [reason]
-        (reset! response-status-atom http-403-forbidden)
-        (reset! response-reason-atom reason))
-      (setAcceptedSubProtocol [subprotocol] (reset! response-subprotocol-atom subprotocol)))))
 
 (deftest test-request-authenticator
   (let [password (Object.)


### PR DESCRIPTION
## Changes proposed in this PR

- adds two middleware for websocket upgrade request acceptor: https-redirect and maintenance-mode

## Why are we making these changes?

- websockets upgrade requests need to go through similar logic as regular requests. Both already support authentication, but not https-redirect or maintenance-mode logic. There is still some more work to be done, but this PR should make it easier to add middleware to websocket upgrade requests.
