### PR TITLE
caches resolution of reverse-proxy predicate function

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -915,10 +915,7 @@
         ;; delay iff the log-bucket-url setting was given the scheduler config.
         log-bucket-sync-secs (if log-bucket-url (:log-bucket-sync-secs context) 0)
         total-sigkill-delay-secs (+ pod-sigkill-delay-secs log-bucket-sync-secs)
-        envoy-sidecar-check-fn (some-> reverse-proxy
-                                       :predicate-fn
-                                       utils/resolve-symbol
-                                       deref)
+        envoy-sidecar-check-fn (:predicate-fn reverse-proxy)
         has-reverse-proxy? (when reverse-proxy
                              (envoy-sidecar-check-fn scheduler service-id service-description context))
         ;; Make $PORT0 value pseudo-random to ensure clients can't hardcode it.
@@ -1373,7 +1370,9 @@
         fileserver (update fileserver :predicate-fn (fn [predicate-fn]
                                                       (if (nil? predicate-fn)
                                                         fileserver-container-enabled?
-                                                        (utils/resolve-symbol! predicate-fn))))]
+                                                        (utils/resolve-symbol! predicate-fn))))
+        reverse-proxy (when reverse-proxy
+                        (update reverse-proxy :predicate-fn utils/resolve-symbol!))]
 
     (let [daemon-state (atom nil)
           auth-renewer (when authentication

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -185,7 +185,7 @@
     (let [service-id "proxy-test-service-id"
           scheduler (make-dummy-scheduler [service-id] {:reverse-proxy {:cmd ["/opt/waiter/envoy/bin/envoy-start"]
                                                                                :image "twosigma/waiter-envoy"
-                                                                               :predicate-fn 'waiter.scheduler.kubernetes/envoy-sidecar-enabled?
+                                                                               :predicate-fn envoy-sidecar-enabled?
                                                                                :resources {:cpu 0.1 :mem 256}
                                                                                :scheme "http"}})
           service-description (assoc dummy-service-description "env" {ct/reverse-proxy-flag "yes"
@@ -258,7 +258,7 @@
     (let [service-id "proxy-health-test-service-id"
           scheduler (make-dummy-scheduler [service-id] {:reverse-proxy {:cmd ["/opt/waiter/envoy/bin/envoy-start"]
                                                                                :image "twosigma/waiter-envoy"
-                                                                               :predicate-fn 'waiter.scheduler.kubernetes/envoy-sidecar-enabled?
+                                                                               :predicate-fn envoy-sidecar-enabled?
                                                                                :resources {:cpu 0.1 :mem 256}
                                                                                :scheme "http"}})
           service-description (assoc dummy-service-description


### PR DESCRIPTION
## Changes proposed in this PR

- caches resolution of reverse-proxy predicate function

## Why are we making these changes?

Avoids dynamically resolving the reverse-proxy predicate function for each replicaset build operation.

Fixes #1187 


