### PR TITLE
adds support for include-flags to entitlement manager state

### DIFF
--- a/waiter/src/waiter/authorization.clj
+++ b/waiter/src/waiter/authorization.clj
@@ -20,7 +20,7 @@
   "Security related methods"
   (authorized? [this subject action resource]
     "Determines if a given subject can perform action on a given resource.")
-  (get-manager-state [this]
+  (get-manager-state [this include-flags]
     "Returns the state the entitlement manager is maintaining."))
 
 (defrecord SimpleEntitlementManager [_]
@@ -29,7 +29,7 @@
     (or (= subject (:user resource))
         (and (= :admin action)
              (= subject (System/getProperty "user.name")))))
-  (get-manager-state [_]
+  (get-manager-state [_ _]
     {:name "SimpleEntitlementManager"}))
 
 (defn- make-service-resource

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -854,7 +854,9 @@
 (defn get-entitlement-manager-state
   "Outputs the entitlement-manager state."
   [router-id entitlement-manager request]
-  (get-function-state #(authz/get-manager-state entitlement-manager) router-id request))
+  (let [{:strs [include]} (-> request ru/query-params-request :query-params)
+        include-flags (if (string? include) #{include} (set include))]
+    (get-function-state #(authz/get-manager-state entitlement-manager include-flags) router-id request)))
 
 (defn get-jwt-auth-server-state
   "Outputs the JWT auth server state."

--- a/waiter/test/waiter/authorization_test.clj
+++ b/waiter/test/waiter/authorization_test.clj
@@ -22,7 +22,7 @@
   authz/EntitlementManager
   (authorized? [_ subject action resource]
     (entitlements [subject action resource]))
-  (get-manager-state [_]
+  (get-manager-state [_ _]
     {:entitlements entitlements
      :name "TestEntitlementManager"}))
 


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for include-flags to entitlement manager state

## Why are we making these changes?

Make it possible to reduce content displayed by default in the entitlement manager state.


