### PR TITLE
Escape HTML for Maintenance Mode Message

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -137,10 +137,10 @@
       (is (= (cond-> {:health-check-url "/probe"
                       :name ~service-id-prefix
                       :owner (retrieve-username)}
-                     ~include-metadata (assoc :cluster ~token-cluster
-                                              :last-update-user (retrieve-username)
-                                              :root ~token-root)
-                     (and ~deleted ~include-metadata) (assoc :deleted ~deleted))
+               ~include-metadata (assoc :cluster ~token-cluster
+                                        :last-update-user (retrieve-username)
+                                        :root ~token-root)
+               (and ~deleted ~include-metadata) (assoc :deleted ~deleted))
              (dissoc token-description# :last-update-time :previous))))))
 
 (deftest ^:parallel ^:integration-fast test-token-create-delete
@@ -165,7 +165,7 @@
               {:keys [body] :as response} (post-token waiter-url {:fallback-period-secs 60 :token token})]
           (assert-response-status response http-200-ok)
           (is (str/includes? (str body) (str "Successfully created " token)) (str body))
-          (let [{:keys [body] :as response} (get-token waiter-url token :cookies cookies :query-params {"token" token})]
+          (let [{:keys [body] :as response}  (get-token waiter-url token :cookies cookies :query-params {"token" token})]
             (assert-response-status response http-200-ok)
             (is (= {"fallback-period-secs" 60 "owner" (retrieve-username)} (json/read-str body)) (str body)))
           (delete-token-and-assert waiter-url token))
@@ -174,7 +174,7 @@
               {:keys [body] :as response} (post-token waiter-url {:https-redirect true :token token})]
           (assert-response-status response http-200-ok)
           (is (str/includes? (str body) (str "Successfully created " token)) (str body))
-          (let [{:keys [body] :as response} (get-token waiter-url token :cookies cookies :query-params {"token" token})]
+          (let [{:keys [body] :as response}  (get-token waiter-url token :cookies cookies :query-params {"token" token})]
             (assert-response-status response http-200-ok)
             (is (= {"https-redirect" true "owner" (retrieve-username)} (json/read-str body)) (str body)))
           (delete-token-and-assert waiter-url token)))
@@ -246,9 +246,9 @@
               (when actual-etag
                 (let [convert-last-update-time (fn [{:strs [last-update-time] :as service-description}]
                                                  (cond-> service-description
-                                                         last-update-time
-                                                         (assoc "last-update-time"
-                                                                (-> last-update-time du/str-to-date .getMillis))))
+                                                   last-update-time
+                                                   (assoc "last-update-time"
+                                                          (-> last-update-time du/str-to-date .getMillis))))
                       expected-etag (str "E-"
                                          (-> body
                                              json/read-str
@@ -391,10 +391,10 @@
                   services (json/read-str body)
                   service-tokens (mapcat (fn [entry]
                                            (some->> entry
-                                                    walk/keywordize-keys
-                                                    :source-tokens
-                                                    flatten
-                                                    (map :token)))
+                                             walk/keywordize-keys
+                                             :source-tokens
+                                             flatten
+                                             (map :token)))
                                          services)]
               (assert-response-status response http-200-ok)
               (is (= (count @service-ids-atom) (count service-tokens))
@@ -411,10 +411,10 @@
                   services (json/read-str body)
                   service-tokens (mapcat (fn [entry]
                                            (some->> entry
-                                                    walk/keywordize-keys
-                                                    :source-tokens
-                                                    flatten
-                                                    (map :token)))
+                                             walk/keywordize-keys
+                                             :source-tokens
+                                             flatten
+                                             (map :token)))
                                          services)]
               (assert-response-status response http-200-ok)
               (is (= 3 (count service-tokens))
@@ -432,10 +432,10 @@
                     services (json/read-str body)
                     service-token-versions (mapcat (fn [entry]
                                                      (some->> entry
-                                                              walk/keywordize-keys
-                                                              :source-tokens
-                                                              flatten
-                                                              (map :version)))
+                                                       walk/keywordize-keys
+                                                       :source-tokens
+                                                       flatten
+                                                       (map :version)))
                                                    services)]
                 (assert-response-status response http-200-ok)
                 (is (= 1 (count service-token-versions))
@@ -1481,8 +1481,8 @@
   "Retrieves the etag header from a response."
   [response]
   (-> response
-      :headers
-      (get "etag")))
+    :headers
+    (get "etag")))
 
 (defn update-token
   "Updates the token and returns the etag."
@@ -1711,7 +1711,7 @@
                 (is (wait-for
                       (fn []
                         (let [active-instances (-> (service-settings router-url service-id-1 :cookies cookies)
-                                                   (get-in [:instances :active-instances]))]
+                                                 (get-in [:instances :active-instances]))]
                           (and (seq active-instances)
                                (some :healthy? active-instances))))))))
             (assert-response-status (post-token waiter-url token-description-2) http-200-ok)
@@ -1743,7 +1743,7 @@
       (doseq [[profile {:keys [defaults]}] (seq profile-config)]
         (let [token (rand-name)
               token-description (-> (utils/remove-keys base-description (keys defaults))
-                                    (assoc :profile (name profile) :token token))]
+                                  (assoc :profile (name profile) :token token))]
           (try
             (testing (str "token creation with profile " profile)
               (let [register-response (post-token waiter-url token-description)]

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -137,10 +137,10 @@
       (is (= (cond-> {:health-check-url "/probe"
                       :name ~service-id-prefix
                       :owner (retrieve-username)}
-               ~include-metadata (assoc :cluster ~token-cluster
-                                        :last-update-user (retrieve-username)
-                                        :root ~token-root)
-               (and ~deleted ~include-metadata) (assoc :deleted ~deleted))
+                     ~include-metadata (assoc :cluster ~token-cluster
+                                              :last-update-user (retrieve-username)
+                                              :root ~token-root)
+                     (and ~deleted ~include-metadata) (assoc :deleted ~deleted))
              (dissoc token-description# :last-update-time :previous))))))
 
 (deftest ^:parallel ^:integration-fast test-token-create-delete
@@ -165,7 +165,7 @@
               {:keys [body] :as response} (post-token waiter-url {:fallback-period-secs 60 :token token})]
           (assert-response-status response http-200-ok)
           (is (str/includes? (str body) (str "Successfully created " token)) (str body))
-          (let [{:keys [body] :as response}  (get-token waiter-url token :cookies cookies :query-params {"token" token})]
+          (let [{:keys [body] :as response} (get-token waiter-url token :cookies cookies :query-params {"token" token})]
             (assert-response-status response http-200-ok)
             (is (= {"fallback-period-secs" 60 "owner" (retrieve-username)} (json/read-str body)) (str body)))
           (delete-token-and-assert waiter-url token))
@@ -174,7 +174,7 @@
               {:keys [body] :as response} (post-token waiter-url {:https-redirect true :token token})]
           (assert-response-status response http-200-ok)
           (is (str/includes? (str body) (str "Successfully created " token)) (str body))
-          (let [{:keys [body] :as response}  (get-token waiter-url token :cookies cookies :query-params {"token" token})]
+          (let [{:keys [body] :as response} (get-token waiter-url token :cookies cookies :query-params {"token" token})]
             (assert-response-status response http-200-ok)
             (is (= {"https-redirect" true "owner" (retrieve-username)} (json/read-str body)) (str body)))
           (delete-token-and-assert waiter-url token)))
@@ -246,9 +246,9 @@
               (when actual-etag
                 (let [convert-last-update-time (fn [{:strs [last-update-time] :as service-description}]
                                                  (cond-> service-description
-                                                   last-update-time
-                                                   (assoc "last-update-time"
-                                                          (-> last-update-time du/str-to-date .getMillis))))
+                                                         last-update-time
+                                                         (assoc "last-update-time"
+                                                                (-> last-update-time du/str-to-date .getMillis))))
                       expected-etag (str "E-"
                                          (-> body
                                              json/read-str
@@ -391,10 +391,10 @@
                   services (json/read-str body)
                   service-tokens (mapcat (fn [entry]
                                            (some->> entry
-                                             walk/keywordize-keys
-                                             :source-tokens
-                                             flatten
-                                             (map :token)))
+                                                    walk/keywordize-keys
+                                                    :source-tokens
+                                                    flatten
+                                                    (map :token)))
                                          services)]
               (assert-response-status response http-200-ok)
               (is (= (count @service-ids-atom) (count service-tokens))
@@ -411,10 +411,10 @@
                   services (json/read-str body)
                   service-tokens (mapcat (fn [entry]
                                            (some->> entry
-                                             walk/keywordize-keys
-                                             :source-tokens
-                                             flatten
-                                             (map :token)))
+                                                    walk/keywordize-keys
+                                                    :source-tokens
+                                                    flatten
+                                                    (map :token)))
                                          services)]
               (assert-response-status response http-200-ok)
               (is (= 3 (count service-tokens))
@@ -432,10 +432,10 @@
                     services (json/read-str body)
                     service-token-versions (mapcat (fn [entry]
                                                      (some->> entry
-                                                       walk/keywordize-keys
-                                                       :source-tokens
-                                                       flatten
-                                                       (map :version)))
+                                                              walk/keywordize-keys
+                                                              :source-tokens
+                                                              flatten
+                                                              (map :version)))
                                                    services)]
                 (assert-response-status response http-200-ok)
                 (is (= 1 (count service-token-versions))
@@ -1379,7 +1379,7 @@
                                          :run-as-user "*"))
           token-root (retrieve-token-root waiter-url)
           token-cluster (retrieve-token-cluster waiter-url)
-          custom-maintenance-message "custom maintenance message"
+          custom-maintenance-message "&&><<&>a&&<b\"<<baa&<"
           token-maintenance {:message custom-maintenance-message}
           request-headers {:x-waiter-token token}]
       (try
@@ -1416,6 +1416,13 @@
             (assert-response-status response http-503-service-unavailable)
             (assert-waiter-response response)
             (is (str/includes? body custom-maintenance-message))))
+
+        (testing "request (text/html) to service should error with maintenance message where the special characters are html encoded"
+          (let [{:keys [body] :as response}
+                (make-request waiter-url "/hello-world" :headers (assoc request-headers :Accept "text/html"))]
+            (assert-response-status response http-503-service-unavailable)
+            (assert-waiter-response response)
+            (is (str/includes? body "&amp;&amp;&gt;&lt;&lt;&amp;&gt;a&amp;&amp;&lt;b&quot;&lt;&lt;baa&amp;&lt;"))))
 
         (testing "token update maintenance field not defined"
           (let [token-description (-> service-description
@@ -1474,8 +1481,8 @@
   "Retrieves the etag header from a response."
   [response]
   (-> response
-    :headers
-    (get "etag")))
+      :headers
+      (get "etag")))
 
 (defn update-token
   "Updates the token and returns the etag."
@@ -1704,7 +1711,7 @@
                 (is (wait-for
                       (fn []
                         (let [active-instances (-> (service-settings router-url service-id-1 :cookies cookies)
-                                                 (get-in [:instances :active-instances]))]
+                                                   (get-in [:instances :active-instances]))]
                           (and (seq active-instances)
                                (some :healthy? active-instances))))))))
             (assert-response-status (post-token waiter-url token-description-2) http-200-ok)
@@ -1736,7 +1743,7 @@
       (doseq [[profile {:keys [defaults]}] (seq profile-config)]
         (let [token (rand-name)
               token-description (-> (utils/remove-keys base-description (keys defaults))
-                                  (assoc :profile (name profile) :token token))]
+                                    (assoc :profile (name profile) :token token))]
           (try
             (testing (str "token creation with profile " profile)
               (let [register-response (post-token waiter-url token-description)]

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -237,11 +237,12 @@
 (defn escape-html
   "Change special characters into HTML character entities to prevent XSS."
   [text]
-  (-> text
-      (str/replace #"&" "&amp;")
-      (str/replace #"<" "&lt;")
-      (str/replace #">" "&gt;")
-      (str/replace #"\"" "&quot;")))
+  (when text
+    (-> text
+        (str/replace #"&" "&amp;")
+        (str/replace #"<" "&lt;")
+        (str/replace #">" "&gt;")
+        (str/replace #"\"" "&quot;"))))
 
 (defn urls->html-links
   "Converts any URLs in a string to HTML links."

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -234,6 +234,15 @@
       (attach-waiter-namespace-keys data-map)
       (attach-waiter-source))))
 
+(defn escape-html
+  "Change special characters into HTML character entities to prevent XSS."
+  [text]
+  (-> text
+      (str/replace #"&" "&amp;")
+      (str/replace #"<" "&lt;")
+      (str/replace #">" "&gt;")
+      (str/replace #"\"" "&quot;")))
+
 (defn urls->html-links
   "Converts any URLs in a string to HTML links."
   [message]
@@ -332,6 +341,7 @@
   "Converts the error-context to the response body html string."
   [error-context render-fn]
   (-> error-context
+    (update :message escape-html)
     (update :message urls->html-links)
     (update :details #(with-out-str (pprint/pprint %)))
     render-fn))

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -338,7 +338,7 @@
                   :key-fn stringify-keys
                   :value-fn stringify-elements))
 
-(defn- error-context->html-body
+(defn error-context->html-body
   "Converts the error-context to the response body html string."
   [error-context render-fn]
   (-> error-context

--- a/waiter/test/waiter/util/utils_test.clj
+++ b/waiter/test/waiter/util/utils_test.clj
@@ -570,7 +570,16 @@
     (is (nil? (escape-html nil))))
   (testing "script tag"
     (is (= "&lt;script&gt;&lt;/script&gt;"
-           (escape-html "<script></script>")))))
+           (escape-html "<script></script>"))))
+  (testing "quotes"
+    (is (= "&quot;&quot;&quot;hello world&quot;"
+           (escape-html "\"\"\"hello world\""))))
+  (testing "ampersand"
+    (is (= "&amp;&amp;&amp;hello world"
+           (escape-html "&&&hello world"))))
+  (testing "combination of quotes, ampersands, script tags, and letters"
+    (is (= "&amp;&amp;&gt;&lt;&lt;&amp;&gt;a&amp;&amp;&lt;b&quot;&lt;&lt;baa&amp;&lt;"
+          (escape-html "&&><<&>a&&<b\"<<baa&<")))))
 
 (deftest test-urls->html-links
   (testing "nil"

--- a/waiter/test/waiter/util/utils_test.clj
+++ b/waiter/test/waiter/util/utils_test.clj
@@ -600,7 +600,7 @@
 (deftest test-error-context->html-body
   (let [render-fn (fn render [transformed-context] transformed-context)]
     (testing "nil message"
-      (let [transformed-context (error-context->html-body {:message nil} render-fn)]
+      (let [transformed-context (error-context->html-body {} render-fn)]
         (is (nil? (:message transformed-context)))))
     (testing "html tags with urls should still wrap urls in <a> tags but url encode the href value"
       (let [transformed-context (error-context->html-body

--- a/waiter/test/waiter/util/utils_test.clj
+++ b/waiter/test/waiter/util/utils_test.clj
@@ -597,6 +597,18 @@
     (is (= "hello <a href=\"https://localhost/path\">https://localhost/path</a> world"
            (urls->html-links "hello https://localhost/path world")))))
 
+(deftest test-error-context->html-body
+  (let [render-fn (fn render [transformed-context] transformed-context)]
+    (testing "nil message"
+      (let [transformed-context (error-context->html-body {:message nil} render-fn)]
+        (is (nil? (:message transformed-context)))))
+    (testing "html tags with urls should still wrap urls in <a> tags but url encode the href value"
+      (let [transformed-context (error-context->html-body
+                                  {:message "<h1>http://e.com/a=b&b=c </h1>"}
+                                  render-fn)]
+        (is (= (:message transformed-context)
+               "&lt;h1&gt;<a href=\"http://e.com/a=b&amp;b=c\">http://e.com/a=b&amp;b=c</a> &lt;/h1&gt;"))))))
+
 (deftest test-request->content-type
   (testing "application/json if specified"
     (is (= "application/json" (request->content-type {:headers {"accept" "application/json"}}))))

--- a/waiter/test/waiter/util/utils_test.clj
+++ b/waiter/test/waiter/util/utils_test.clj
@@ -565,6 +565,13 @@
       (.close ss))
     (is (port-available? port))))
 
+(deftest test-escape-html
+  (testing "nil"
+    (is (nil? (escape-html nil))))
+  (testing "script tag"
+    (is (= "&lt;script&gt;&lt;/script&gt;"
+           (escape-html "<script></script>")))))
+
 (deftest test-urls->html-links
   (testing "nil"
     (is (nil? (urls->html-links nil))))


### PR DESCRIPTION
## Changes proposed in this PR

- Escape HTML for Maintenance Mode Message

## Why are we making these changes?

- prevent XSS vulnerability
