### PR TITLE
add preference for application/json in health request

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -990,7 +990,7 @@
 
  :health-check-config {
                        ;; HTTP accept header that is sent to a service when making health check request through /waiter-ping
-                       :health-check-headers-accept "application/json;q=1.0, */*;q=0.9"
+                       :health-check-accept-headers "application/json;q=1.0, */*;q=0.9"
 
                        ;; The HTTP connect timeout and idle timeout (milliseconds) for instance health checks:
                        :health-check-timeout-ms 200

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -990,7 +990,7 @@
 
  :health-check-config {
                        ;; HTTP accept header that is sent to a service when making health check request through /waiter-ping
-                       :health-check-accept-headers "application/json;q=1.0, */*;q=0.9"
+                       :health-check-accept-header "application/json;q=1.0, */*;q=0.9"
 
                        ;; The HTTP connect timeout and idle timeout (milliseconds) for instance health checks:
                        :health-check-timeout-ms 200

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -989,6 +989,9 @@
                            :min-hosts 2}
 
  :health-check-config {
+                       ;; HTTP accept header that is sent to a service when making health check request through /waiter-ping
+                       :health-check-headers-accept "application/json;q=1.0, */*;q=0.9"
+
                        ;; The HTTP connect timeout and idle timeout (milliseconds) for instance health checks:
                        :health-check-timeout-ms 200
 

--- a/waiter/integration/waiter/deployment_errors_test.clj
+++ b/waiter/integration/waiter/deployment_errors_test.clj
@@ -61,7 +61,14 @@
      (is (= "received-response" (get ping-response# :result)) (str ping-response#))
      (is (= {:exists? true :healthy? false :service-id service-id# :status "Failing"} service-state#))
      (is (= error-message# (deployment-error->str ~'waiter-url ~deployment-error))
-         (formatted-service-state ~'waiter-url service-id#))))
+         (formatted-service-state ~'waiter-url service-id#))
+     (testing "status is reported as failing"
+       (is
+         (wait-for
+           (fn []
+             (let [service-settings# (service-settings ~'waiter-url service-id#)]
+               (= "Failing" (get service-settings# :status))))
+           :interval 2 :timeout 30)))))
 
 (deftest ^:parallel ^:integration-slow test-invalid-health-check-response
   (testing-using-waiter-url

--- a/waiter/integration/waiter/deployment_errors_test.clj
+++ b/waiter/integration/waiter/deployment_errors_test.clj
@@ -58,7 +58,7 @@
      (assert-waiter-response response#)
      (assert-response-status response# http-200-ok)
      (assert-response-status ping-response# http-503-service-unavailable)
-     (is (= "received-response" (get ping-response# :result)) (str ping-response))
+     (is (= "received-response" (get ping-response# :result)) (str ping-response#))
      (is (= {:exists? true :healthy? false :service-id service-id# :status "Failing"} service-state#))
      (is (= error-message# (deployment-error->str ~'waiter-url ~deployment-error))
          (formatted-service-state ~'waiter-url service-id#))))

--- a/waiter/integration/waiter/health_check_test.clj
+++ b/waiter/integration/waiter/health_check_test.clj
@@ -252,25 +252,3 @@
                 (is (= (str "Hello " (retrieve-username)) (-> backend-response :body str))))))
           (finally
             (delete-token-and-assert waiter-url token)))))))
-
-(deftest ^:parallel ^:integration-fast test-ping-deployment-error
-  (testing-using-waiter-url
-    (let [headers {:accept "application/json"
-           :x-waiter-cmd "INVALIDCOMMANDadfasdfadfasfdasfdasf"
-           :x-waiter-debug true
-           :x-waiter-name (rand-name)}
-          {:keys [headers] :as response} (make-kitchen-request waiter-url headers :method :post :path "/waiter-ping")
-          service-id (get headers "x-waiter-service-id")]
-      (with-service-cleanup
-        service-id
-        (let [{:keys [ping-response service-description service-state]}
-              (some-> response :body try-parse-json walk/keywordize-keys)
-              ping-response-body (some-> ping-response :body try-parse-json walk/keywordize-keys)
-              error-message (get-in ping-response-body [:waiter-error :message])]
-          (assert-waiter-response response)
-          (assert-response-status response http-200-ok)
-          (assert-response-status ping-response http-503-service-unavailable)
-          (is (= (service-id->service-description waiter-url service-id) service-description))
-          (is (= "received-response" (get ping-response :result)) (str ping-response))
-          (is (= {:exists? true :healthy? false :service-id service-id :status "Failing"} service-state))
-          (is (= error-message "Deployment error: Invalid startup command")))))))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1452,6 +1452,7 @@
    :not-found-handler-fn (pc/fnk [] handler/not-found-handler)
    :ping-service-handler (pc/fnk [[:daemons router-state-maintainer]
                                   [:routines make-inter-router-requests-async-fn]
+                                  [:settings health-check-config]
                                   [:state fallback-state-atom router-id user-agent-version]
                                   process-request-handler-fn process-request-wrapper-fn wrap-secure-request-fn]
                            (let [{{:keys [query-state-fn]} :maintainer} router-state-maintainer
@@ -1460,7 +1461,7 @@
                                            (fn inner-ping-service-handler [request]
                                              (let [retrieve-service-status-label-fn #(service/retrieve-service-status-label % (query-state-fn))
                                                    service-state-fn (partial descriptor/extract-service-state router-id retrieve-service-status-label-fn fallback-state-atom make-inter-router-requests-async-fn)]
-                                               (pr/ping-service user-agent process-request-handler-fn service-state-fn request))))]
+                                               (pr/ping-service user-agent process-request-handler-fn service-state-fn health-check-config request))))]
                              (wrap-secure-request-fn
                                (fn ping-service-handler [request]
                                  (-> request

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -951,7 +951,7 @@
                                      (assoc :body nil)
                                      (assoc :content-length 0)
                                      (update :headers assoc
-                                             "accept" "*/*"
+                                             "accept" "application/json;q=1.0, */*;q=0.9"
                                              "content-length" 0)))
             output-stream (ByteArrayOutputStream.)
             servlet-output-stream (proxy [ServletOutputStream] []

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -940,7 +940,7 @@
 (defn make-health-check-request
   "Makes a health check request to the backend using the specified proto and port from the descriptor.
    Returns the health check response from an arbitrary backend or the failure response."
-  [process-request-handler-fn idle-timeout-ms {:keys [descriptor] :as request} health-check-protocol health-check-accept-headers]
+  [process-request-handler-fn idle-timeout-ms {:keys [descriptor] :as request} health-check-protocol health-check-accept-header]
   (async/go
     (try
       (let [{:keys [service-description]} descriptor
@@ -951,7 +951,7 @@
                                      (assoc :body nil)
                                      (assoc :content-length 0)
                                      (update :headers assoc
-                                             "accept" health-check-accept-headers
+                                             "accept" health-check-accept-header
                                              "content-length" 0)))
             output-stream (ByteArrayOutputStream.)
             servlet-output-stream (proxy [ServletOutputStream] []
@@ -1000,14 +1000,14 @@
   "Performs a health check on an arbitrary instance of the service specified in the descriptor.
    If the service is not running, an instance will be started.
    The response body contains the following map: {:ping-response ..., :service-state ...}"
-  [user-agent process-request-handler-fn service-state-fn {:keys [health-check-accept-headers]} {:keys [descriptor headers] :as request}]
+  [user-agent process-request-handler-fn service-state-fn {:keys [health-check-accept-header]} {:keys [descriptor headers] :as request}]
   (async/go
     (try
       (let [{:keys [core-service-description service-description service-id]} descriptor
             request (assoc-in request [:headers "user-agent"] user-agent)
             idle-timeout-ms (Integer/parseInt (get headers "x-waiter-timeout" "300000"))
             health-check-protocol (scheduler/service-description->health-check-protocol service-description)
-            ping-response (async/<! (make-health-check-request process-request-handler-fn idle-timeout-ms request health-check-protocol health-check-accept-headers))]
+            ping-response (async/<! (make-health-check-request process-request-handler-fn idle-timeout-ms request health-check-protocol health-check-accept-header))]
         (let [{:strs [health-check-url]} service-description
               backend-protocol (hu/backend-protocol->http-version health-check-protocol)
               backend-scheme (hu/backend-proto->scheme health-check-protocol)

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -940,7 +940,7 @@
 (defn make-health-check-request
   "Makes a health check request to the backend using the specified proto and port from the descriptor.
    Returns the health check response from an arbitrary backend or the failure response."
-  [process-request-handler-fn idle-timeout-ms {:keys [descriptor] :as request} health-check-protocol]
+  [process-request-handler-fn idle-timeout-ms {:keys [descriptor] :as request} health-check-protocol health-check-headers-accept]
   (async/go
     (try
       (let [{:keys [service-description]} descriptor
@@ -951,7 +951,7 @@
                                      (assoc :body nil)
                                      (assoc :content-length 0)
                                      (update :headers assoc
-                                             "accept" "application/json;q=1.0, */*;q=0.9"
+                                             "accept" health-check-headers-accept
                                              "content-length" 0)))
             output-stream (ByteArrayOutputStream.)
             servlet-output-stream (proxy [ServletOutputStream] []
@@ -1000,14 +1000,14 @@
   "Performs a health check on an arbitrary instance of the service specified in the descriptor.
    If the service is not running, an instance will be started.
    The response body contains the following map: {:ping-response ..., :service-state ...}"
-  [user-agent process-request-handler-fn service-state-fn {:keys [descriptor headers] :as request}]
+  [user-agent process-request-handler-fn service-state-fn {:keys [health-check-headers-accept]} {:keys [descriptor headers] :as request}]
   (async/go
     (try
       (let [{:keys [core-service-description service-description service-id]} descriptor
             request (assoc-in request [:headers "user-agent"] user-agent)
             idle-timeout-ms (Integer/parseInt (get headers "x-waiter-timeout" "300000"))
             health-check-protocol (scheduler/service-description->health-check-protocol service-description)
-            ping-response (async/<! (make-health-check-request process-request-handler-fn idle-timeout-ms request health-check-protocol))]
+            ping-response (async/<! (make-health-check-request process-request-handler-fn idle-timeout-ms request health-check-protocol health-check-headers-accept))]
         (let [{:strs [health-check-url]} service-description
               backend-protocol (hu/backend-protocol->http-version health-check-protocol)
               backend-scheme (hu/backend-proto->scheme health-check-protocol)

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -940,7 +940,7 @@
 (defn make-health-check-request
   "Makes a health check request to the backend using the specified proto and port from the descriptor.
    Returns the health check response from an arbitrary backend or the failure response."
-  [process-request-handler-fn idle-timeout-ms {:keys [descriptor] :as request} health-check-protocol health-check-headers-accept]
+  [process-request-handler-fn idle-timeout-ms {:keys [descriptor] :as request} health-check-protocol health-check-accept-headers]
   (async/go
     (try
       (let [{:keys [service-description]} descriptor
@@ -951,7 +951,7 @@
                                      (assoc :body nil)
                                      (assoc :content-length 0)
                                      (update :headers assoc
-                                             "accept" health-check-headers-accept
+                                             "accept" health-check-accept-headers
                                              "content-length" 0)))
             output-stream (ByteArrayOutputStream.)
             servlet-output-stream (proxy [ServletOutputStream] []
@@ -1000,14 +1000,14 @@
   "Performs a health check on an arbitrary instance of the service specified in the descriptor.
    If the service is not running, an instance will be started.
    The response body contains the following map: {:ping-response ..., :service-state ...}"
-  [user-agent process-request-handler-fn service-state-fn {:keys [health-check-headers-accept]} {:keys [descriptor headers] :as request}]
+  [user-agent process-request-handler-fn service-state-fn {:keys [health-check-accept-headers]} {:keys [descriptor headers] :as request}]
   (async/go
     (try
       (let [{:keys [core-service-description service-description service-id]} descriptor
             request (assoc-in request [:headers "user-agent"] user-agent)
             idle-timeout-ms (Integer/parseInt (get headers "x-waiter-timeout" "300000"))
             health-check-protocol (scheduler/service-description->health-check-protocol service-description)
-            ping-response (async/<! (make-health-check-request process-request-handler-fn idle-timeout-ms request health-check-protocol health-check-headers-accept))]
+            ping-response (async/<! (make-health-check-request process-request-handler-fn idle-timeout-ms request health-check-protocol health-check-accept-headers))]
         (let [{:strs [health-check-url]} service-description
               backend-protocol (hu/backend-protocol->http-version health-check-protocol)
               backend-scheme (hu/backend-proto->scheme health-check-protocol)

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -52,7 +52,8 @@
                                            s/Keyword schema/require-symbol-factory-fn}
                                           schema/contains-kind-sub-map?)
    (s/required-key :git-version) s/Any
-   (s/required-key :health-check-config) {(s/required-key :health-check-timeout-ms) schema/positive-int
+   (s/required-key :health-check-config) {(s/required-key :health-check-headers-accept) schema/non-empty-string
+                                          (s/required-key :health-check-timeout-ms) schema/positive-int
                                           (s/required-key :failed-check-threshold) schema/positive-int}
    ;; TODO host belongs in server-options?
    (s/required-key :host) schema/non-empty-string
@@ -280,7 +281,8 @@
                              :min-hosts 2}
    :entitlement-config {:kind :simple
                         :simple {:factory-fn 'waiter.authorization/->SimpleEntitlementManager}}
-   :health-check-config {:health-check-timeout-ms 200
+   :health-check-config {:health-check-headers-accept "application/json;q=1.0, */*;q=0.9"
+                         :health-check-timeout-ms 200
                          :failed-check-threshold 5}
    :host "0.0.0.0"
    :hostname "localhost"

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -52,7 +52,7 @@
                                            s/Keyword schema/require-symbol-factory-fn}
                                           schema/contains-kind-sub-map?)
    (s/required-key :git-version) s/Any
-   (s/required-key :health-check-config) {(s/required-key :health-check-accept-headers) schema/non-empty-string
+   (s/required-key :health-check-config) {(s/required-key :health-check-accept-header) schema/non-empty-string
                                           (s/required-key :health-check-timeout-ms) schema/positive-int
                                           (s/required-key :failed-check-threshold) schema/positive-int}
    ;; TODO host belongs in server-options?
@@ -281,7 +281,7 @@
                              :min-hosts 2}
    :entitlement-config {:kind :simple
                         :simple {:factory-fn 'waiter.authorization/->SimpleEntitlementManager}}
-   :health-check-config {:health-check-accept-headers "application/json;q=1.0, */*;q=0.9"
+   :health-check-config {:health-check-accept-header "application/json;q=1.0, */*;q=0.9"
                          :health-check-timeout-ms 200
                          :failed-check-threshold 5}
    :host "0.0.0.0"

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -52,7 +52,7 @@
                                            s/Keyword schema/require-symbol-factory-fn}
                                           schema/contains-kind-sub-map?)
    (s/required-key :git-version) s/Any
-   (s/required-key :health-check-config) {(s/required-key :health-check-headers-accept) schema/non-empty-string
+   (s/required-key :health-check-config) {(s/required-key :health-check-accept-headers) schema/non-empty-string
                                           (s/required-key :health-check-timeout-ms) schema/positive-int
                                           (s/required-key :failed-check-threshold) schema/positive-int}
    ;; TODO host belongs in server-options?
@@ -281,7 +281,7 @@
                              :min-hosts 2}
    :entitlement-config {:kind :simple
                         :simple {:factory-fn 'waiter.authorization/->SimpleEntitlementManager}}
-   :health-check-config {:health-check-headers-accept "application/json;q=1.0, */*;q=0.9"
+   :health-check-config {:health-check-accept-headers "application/json;q=1.0, */*;q=0.9"
                          :health-check-timeout-ms 200
                          :failed-check-threshold 5}
    :host "0.0.0.0"


### PR DESCRIPTION
## Changes proposed in this PR

- prefer application/json in health request checks

## Why are we making these changes?

- Deployment errors are given in the ping response

