### PR TITLE
Cli display deployment error

### DIFF
--- a/cli/waiter/subcommands/ping.py
+++ b/cli/waiter/subcommands/ping.py
@@ -38,7 +38,7 @@ def ping_on_cluster(cluster, timeout, wait_for_request, token_name, service_exis
                             ping_response_waiter_error = json.loads(ping_response['body'])['waiter-error']['message']
                             print_error(ping_response_waiter_error)
                         except KeyError:
-                            pass
+                            logging.debug('Ping response body does not contain waiter-error message.')
                         result = False
                 elif ping_response_result == 'timed-out':
                     if wait_for_request:

--- a/cli/waiter/subcommands/ping.py
+++ b/cli/waiter/subcommands/ping.py
@@ -37,6 +37,8 @@ def ping_on_cluster(cluster, timeout, wait_for_request, token_name, service_exis
                         try:
                             ping_response_waiter_error = json.loads(ping_response['body'])['waiter-error']['message']
                             print_error(ping_response_waiter_error)
+                        except json.JSONDecodeError:
+                            logging.debug('Ping response is not in json format, cannot display waiter-error message.')
                         except KeyError:
                             logging.debug('Ping response body does not contain waiter-error message.')
                         result = False

--- a/cli/waiter/subcommands/ping.py
+++ b/cli/waiter/subcommands/ping.py
@@ -1,4 +1,5 @@
 import logging
+import json
 
 from waiter import http_util, terminal
 from waiter.format import format_status
@@ -33,6 +34,11 @@ def ping_on_cluster(cluster, timeout, wait_for_request, token_name, service_exis
                         result = True
                     else:
                         print_error(f'Ping responded with non-200 status {ping_response_status}.')
+                        try:
+                            ping_response_waiter_error = json.loads(ping_response['body'])['waiter-error']['message']
+                            print_error(ping_response_waiter_error)
+                        except KeyError:
+                            pass
                         result = False
                 elif ping_response_result == 'timed-out':
                     if wait_for_request:

--- a/waiter/integration/waiter/health_check_test.clj
+++ b/waiter/integration/waiter/health_check_test.clj
@@ -252,25 +252,3 @@
                 (is (= (str "Hello " (retrieve-username)) (-> backend-response :body str))))))
           (finally
             (delete-token-and-assert waiter-url token)))))))
-
-(deftest ^:parallel ^:integration-fast test-ping-deployment-error
-  (testing-using-waiter-url
-    (let [headers {:accept "application/json"
-           :x-waiter-cmd "INVALIDCOMMANDadfasdfadfasfdasfdasf"
-           :x-waiter-debug true
-           :x-waiter-name (rand-name)}
-          {:keys [headers] :as response} (make-kitchen-request waiter-url headers :method :post :path "/waiter-ping")
-          service-id (get headers "x-waiter-service-id")]
-      (with-service-cleanup
-        service-id
-        (let [{:keys [ping-response service-description service-state]}
-              (some-> response :body try-parse-json walk/keywordize-keys)
-              ping-response-body (some-> ping-response :body try-parse-json walk/keywordize-keys)
-              error-message (get-in ping-response-body [:waiter-error :message])]
-          (assert-waiter-response response)
-          (assert-response-status response http-200-ok)
-          (assert-response-status ping-response http-503-service-unavailable)
-          (is (= (service-id->service-description waiter-url service-id) service-description))
-          (is (= "received-response" (get ping-response :result)) (str ping-response))
-          (is (= {:exists? true :healthy? false :service-id service-id :status "Failing"} service-state))
-          (is (= error-message "Deployment error: Invalid startup command")))))))


### PR DESCRIPTION
## Changes proposed in this PR

- display the deployment error given by /waiter-ping
- example of an invalid startup command deployment error
![Screenshot from 2020-12-17 09-51-09](https://user-images.githubusercontent.com/8290559/102510692-8603fd80-404d-11eb-93c2-340191184bc6.png)


## Why are we making these changes?

- users can now easily see deployment related errors when pinging through the cli
