### PR TITLE
add maintenance custom filter

### DIFF
--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -616,10 +616,15 @@
                                                (let [search-parameter-values (cond
                                                                                (string? raw-param) #{raw-param}
                                                                                :else (set raw-param))]
-                                                 (fn [token-parameters]
-                                                   (and (contains? token-parameters parameter-name)
-                                                        (contains? search-parameter-values
-                                                                   (str (get token-parameters parameter-name)))))))]
+                                                 (case parameter-name
+                                                   "maintenance"
+                                                   (fn [token-parameters]
+                                                     (= (contains? token-parameters parameter-name)
+                                                        (Boolean/parseBoolean raw-param)))
+                                                   (fn [token-parameters]
+                                                     (and (contains? token-parameters parameter-name)
+                                                          (contains? search-parameter-values
+                                                                     (str (get token-parameters parameter-name))))))))]
              (->> owners
                   (map
                     (fn [owner]

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -601,8 +601,8 @@
       :get (let [{:strs [can-manage-as-user] :as request-params} (-> req ru/query-params-request :query-params)
                  include-deleted (utils/param-contains? request-params "include" "deleted")
                  show-metadata (utils/param-contains? request-params "include" "metadata")
-                 filter-maintenance (when (contains? request-params "maintenance")
-                                       (utils/request-flag request-params "maintenance"))
+                 should-filter-maintenance? (contains? request-params "maintenance")
+                 maintenance-active? (utils/request-flag request-params "maintenance")
                  include-run-as-requester (when (contains? request-params "run-as-requester")
                                             (utils/request-flag request-params "run-as-requester"))
                  include-requires-parameters (when (contains? request-params "requires-parameters")
@@ -631,8 +631,8 @@
                                (or include-deleted (not (:deleted entry)))))
                            (filter
                              (fn list-tokens-maintenance-predicate [[_ entry]]
-                               (or (nil? filter-maintenance)
-                                   (= (-> entry :maintenance true?) filter-maintenance))))
+                               (or (not should-filter-maintenance?)
+                                   (= (-> entry :maintenance true?) maintenance-active?))))
                            (filter
                              (fn list-tokens-auth-predicate [[token _]]
                                (or (nil? can-manage-as-user)

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -2689,8 +2689,19 @@
           owner-map-keys (keys (json/read-str body))]
       (is (some #(= "owner1" %) owner-map-keys) "Should have had a key 'owner1'")
       (is (some #(= "owner2" %) owner-map-keys) "Should have had a key 'owner2'"))
-    (let [request {:request-method :get :query-string "maintenance={\"message\" \"msg1\"}"}
+    (let [request {:request-method :get :query-string "maintenance=true"}
           {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
       (is (= http-200-ok status))
       (is (= #{{"maintenance" true "owner" "owner3" "token" "token9"}}
+             (set (json/read-str body)))))
+    (let [request {:request-method :get :query-string "maintenance=false"}
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+      (is (= http-200-ok status))
+      (is (= #{{"maintenance" false "owner" "owner1" "token" "token1"}
+               {"maintenance" false "owner" "owner1" "token" "token2"}
+               {"maintenance" false "owner" "owner2" "token" "token3"}
+               {"maintenance" false "owner" "owner3" "token" "token5"}
+               {"maintenance" false "owner" "owner3" "token" "token6"}
+               {"maintenance" false "owner" "owner3" "token" "token7"}
+               {"maintenance" false "owner" "owner3" "token" "token8"}}
              (set (json/read-str body)))))))


### PR DESCRIPTION
## Changes proposed in this PR

- allows "maintenance=true" and "maintenance=false" to be query parameters on "/tokens" endpoint

## Why are we making these changes?

- makes it easier to see all tokens in maintenance mode

