### PR TITLE
add logging for changes in maintenance mode of a token

### DIFF
--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -554,12 +554,12 @@
                               nil)
                             limit-per-owner)]
           (if
-            (contains? overriding-token-data :maintenance)
-            (if (contains? overridden-token-data :maintenance)
-              (log/info "updating maintenance mode for token" {})
-              (log/info "starting maintenance mode for token" {}))
-            (when (contains? overriden-token-data :maintenance)
-              (log/info "stopping maintenance mode for token" {})))
+            (contains? overriding-token-data "maintenance")
+            (if (contains? overridden-token-data "maintenance")
+              (log/info "updating maintenance mode for token" {:token token})
+              (log/info "starting maintenance mode for token" {:token token}))
+            (when (contains? overridden-token-data "maintenance")
+              (log/info "stopping maintenance mode for token" {:token token})))
           (store-service-description-for-token
             synchronize-fn kv-store history-length token-limit token new-service-parameter-template new-token-metadata
             :version-hash version-hash)

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -553,8 +553,7 @@
                               (log/info "will not enforce count limit on owner tokens in admin mode" {:owner owner})
                               nil)
                             limit-per-owner)]
-          (if
-            (contains? overriding-token-data "maintenance")
+          (if (contains? overriding-token-data "maintenance")
             (if (contains? overridden-token-data "maintenance")
               (log/info "updating maintenance mode for token" {:token token})
               (log/info "starting maintenance mode for token" {:token token}))

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -15,6 +15,7 @@
 ;;
 (ns waiter.token
   (:require [clj-time.coerce :as tc]
+            [clojure.data :as data]
             [clojure.set :as set]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
@@ -538,7 +539,8 @@
           new-user-editable-token-data (-> (merge new-service-parameter-template new-token-metadata)
                                            (select-keys sd/token-user-editable-keys))
           existing-token-description (sd/token->token-description kv-store token :include-deleted false)
-          existing-editable-token-data (token-description->editable-token-parameters existing-token-description)]
+          existing-editable-token-data (token-description->editable-token-parameters existing-token-description)
+          [overridden-token-data overriding-token-data _] (data/diff existing-editable-token-data new-user-editable-token-data)]
       (if (and (not admin-mode?)
                (= existing-editable-token-data new-user-editable-token-data))
         (-> (utils/clj->json-response
@@ -551,6 +553,13 @@
                               (log/info "will not enforce count limit on owner tokens in admin mode" {:owner owner})
                               nil)
                             limit-per-owner)]
+          (if
+            (contains? overriding-token-data :maintenance)
+            (if (contains? overridden-token-data :maintenance)
+              (log/info "updating maintenance mode for token" {})
+              (log/info "starting maintenance mode for token" {}))
+            (when (contains? overriden-token-data :maintenance)
+              (log/info "stopping maintenance mode for token" {})))
           (store-service-description-for-token
             synchronize-fn kv-store history-length token-limit token new-service-parameter-template new-token-metadata
             :version-hash version-hash)


### PR DESCRIPTION
## Changes proposed in this PR

- Logs whenever maintenance mode starts, stops, or updates.
- Does not log if there were not changes to maintenance mode.

Log screen shot examples:
![Screenshot from 2020-12-21 16-13-15](https://user-images.githubusercontent.com/8290559/102827584-71ef3180-43a8-11eb-8300-012280b38250.png)
![Screenshot from 2020-12-21 16-14-39](https://user-images.githubusercontent.com/8290559/102827587-73205e80-43a8-11eb-9a5f-21d00f4a80d1.png)
![Screenshot from 2020-12-21 16-16-52](https://user-images.githubusercontent.com/8290559/102827593-74518b80-43a8-11eb-8f14-304fdd93271d.png)


## Why are we making these changes?

- better visibility on maintenance mode and metrics of its usage

