### PR TITLE
adds support for configuring timeouts for k8s watch connections

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -559,10 +559,18 @@
                                  ;; The URL used below is the default proxy URL bound to by the `kubectl proxy` command:
                                  :url "http://localhost:8001"
 
+                                 ;; Determines, in milliseconds, the timeout until a connection is established.
+                                 ;; Defaults to 10 seconds.
+                                 :watch-connect-timeout-ms 10000
+
                                  ;; Number of times to retry a watch before falling back to a global state query.
                                  ;; These retries only apply to a closed watch connection, not to connections returning an HTTP error code.
                                  ;; Defaults to 0 (one attempt, no retries) if not provided.
-                                 :watch-retries 10}
+                                 :watch-retries 10
+
+                                 ;; Defines, in milliseconds, the maximum period of inactivity between two consecutive data packets on watch connections.
+                                 ;; Defaults to 15 minutes.
+                                 :watch-socket-timeout-ms 900000}
 
                     ;; :kind :marathon uses Marathon (https://mesosphere.github.io/marathon/) for scheduling instances:
                     ;:kind :marathon

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -1931,7 +1931,9 @@
         ;; which lets us test the watch-retries behavior here
         pods-watch-query-count (atom 0)
         pods-watch-stream (make-watch-stream pods-watch-updates watch-update-signals)
-        pods-watch-query-fn (fn pods-watch-query-fn [_ watch-url]
+        pods-watch-query-fn (fn pods-watch-query-fn [resource-name watch-url request-options]
+                              (is (= "Pods" resource-name))
+                              (is (empty? request-options))
                               (swap! pods-watch-query-count inc)
                               (let [last-resource-version (->> watch-url
                                                                (re-find #"(?<=[&?]resourceVersion=)\d+")


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for configuring connection and idle timeouts for k8s watch connections

## Why are we making these changes?

Watch connection support should self-heal if the connection goes bad. Using the idle timeout allows the watch connection to fail and then be reconnected.
