### PR TITLE
adds flag to restrict k8s scheduler watch-state output

### DIFF
--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -38,7 +38,7 @@
               (let [{:keys [body] :as response} (make-request router-url "/state/scheduler"
                                                               :cookies cookies
                                                               :method :get
-                                                              :query-params {"include" ["components" "watch-state"]})
+                                                              :query-params {"include" ["components" "watch-state-details"]})
                     _ (assert-response-status response http-200-ok)
                     body-json (-> body str try-parse-json)
                     watch-state-json (get-watch-state body-json)
@@ -64,7 +64,7 @@
             {:keys [body] :as response} (make-request router-url "/state/scheduler"
                                                       :cookies cookies
                                                       :method :get
-                                                      :query-params {"include" ["components" "watch-state"]})
+                                                      :query-params {"include" ["components" "watch-state-details"]})
             _ (assert-response-status response http-200-ok)
             body-json (-> body str try-parse-json)
             watch-state-json (get-watch-state body-json)
@@ -80,7 +80,7 @@
           (let [{:keys [body] :as response} (make-request router-url "/state/scheduler"
                                                           :cookies cookies
                                                           :method :get
-                                                          :query-params {"include" ["components" "watch-state"]})
+                                                          :query-params {"include" ["components" "watch-state-details"]})
                 _ (assert-response-status response http-200-ok)
                 body-json (-> body str try-parse-json)
                 watch-state-json (get-watch-state body-json)
@@ -233,7 +233,7 @@
       (let [{:keys [body] :as response} (make-request router-url "/state/scheduler"
                                                       :cookies cookies
                                                       :method :get
-                                                      :query-params {"include" ["components" "watch-state"]})
+                                                      :query-params {"include" ["components" "watch-state-details"]})
             _ (assert-response-status response http-200-ok)
             body-json (-> body str try-parse-json)
             watch-state-json (get-watch-state body-json)


### PR DESCRIPTION
## Changes proposed in this PR

- adds flag to restrict watch-state output

## Why are we making these changes?

We want to restrict k8s watch state output when additional details (time consuming to produce) are not needed.
