### PR TITLE
removes www-authenticate header checks on backend responses

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -305,6 +305,14 @@
             (is (= "chunked" (get-in body-json ["request-info" "headers" "transfer-encoding"])))
             (is (= test-trailers (get-in body-json ["request-info" "trailers"]))))))
 
+      (testing "401-response-without-www-authenticate"
+        (log/info "Basic test for 401 response without www-authenticate header")
+        (let [request-headers (assoc request-headers :accept "text/plain")
+              {:keys [body] :as response} (make-kitchen-request waiter-url request-headers :path "/bad-status?status=401")]
+          (assert-response-status response http-401-unauthorized)
+          (assert-backend-response response)
+          (is (str/includes? (str body) "Hello World"))))
+
       (delete-service waiter-url service-id))))
 
 (deftest ^:parallel ^:integration-fast test-basic-service-validation-from-on-the-fly-headers

--- a/waiter/src/waiter/util/http_utils.clj
+++ b/waiter/src/waiter/util/http_utils.clj
@@ -26,7 +26,7 @@
   (:import (java.net URI)
            (java.util ArrayList)
            (org.apache.commons.codec.binary Base64)
-           (org.eclipse.jetty.client HttpClient)
+           (org.eclipse.jetty.client HttpClient WWWAuthenticationProtocolHandler)
            (org.eclipse.jetty.client.api Authentication$Result Request)
            (org.eclipse.jetty.http HttpField HttpHeader)
            (org.eclipse.jetty.http2.client HTTP2Client)
@@ -127,6 +127,8 @@
         (http/client (cond-> (select-keys config [:client-name :follow-redirects? :request-buffer-size :response-buffer-size :transport])
                        (some? conn-timeout) (assoc :connect-timeout conn-timeout)
                        (some? socket-timeout) (assoc :idle-timeout socket-timeout)))]
+    ;; disable checks on www-authenticate header on 401 responses
+    (some-> client .getProtocolHandlers (.remove WWWAuthenticationProtocolHandler/NAME))
     (when clear-content-decoders
       (.clear (.getContentDecoderFactories client)))
     (.setCookieStore client (HttpCookieStore$Empty.))


### PR DESCRIPTION
## Changes proposed in this PR

- removes www-authenticate header checks on backend responses

## Why are we making these changes?

We should avoid triggering exceptions on 401 responses generated by the backend e.g. when www-authenticate header is missing and eject backends. This particular exception is generated by the WWWAuthenticationProtocolHandler class added by default in the [list of protocol handlers](https://github.com/ganqing2017/jetty/blob/79b822339c3940679ac69a51eaed21b7af3e71c1/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java#L225). 

Example from logs of exception **before** the fix:
```
2020-12-31 09:34:31,501 INFO  waiter.process-request [async-dispatch-64] - [CID=test-wbttbf-12a67deaa90db-4da18f60ec847f49] process request to 127.0.0.1:9091 at path /bad-status
2020-12-31 09:34:31,503 INFO  waiter.process-request [async-dispatch-5] - [CID=test-wbttbf-12a67deaa90db-4da18f60ec847f49] suggested instance: w9091-wbttbf328090157960637-f2784dca56f2426d880506520daa0525.12a65e41cb143-96e803d972
92dfb 127.0.0.8 10500
2020-12-31 09:34:31,504 INFO  waiter.process-request [async-dispatch-5] - [CID=test-wbttbf-12a67deaa90db-4da18f60ec847f49] connecting to http://127.0.0.8:10500/bad-status using HTTP/1.1
2020-12-31 09:34:31,505 INFO  waiter.process-request [qtp1492877109-200] - [CID=test-wbttbf-12a67deaa90db-4da18f60ec847f49] streamed 0 bytes from request input stream
2020-12-31 09:34:31,515 INFO  waiter.process-request [async-dispatch-11] - [CID=test-wbttbf-12a67deaa90db-4da18f60ec847f49] backend response status: 401 and headers: {server BaseHTTP/0.6 Python/3.7.2, date Thu, 31 Dec 2020 15:34
:31 GMT, connection close, content-type text/plain, x-cid test-wbttbf-12a67deaa90db-4da18f60ec847f49, content-length 11}
2020-12-31 09:34:31,520 INFO  waiter.process-request [async-dispatch-19] - [CID=test-wbttbf-12a67deaa90db-4da18f60ec847f49] exception occurred while streaming response for w9091-wbttbf328090157960637-f2784dca56f2426d880506520daa
0525
clojure.lang.ExceptionInfo: error occurred after streaming 11 bytes in response {}
        at waiter.process_request$stream_http_response$fn__39714$state_machine__11550__auto____39775$fn__39781.invoke(process_request.clj:488)
        at waiter.process_request$stream_http_response$fn__39714$state_machine__11550__auto____39775.invoke(process_request.clj:488)
        at clojure.core.async.impl.ioc_macros$run_state_machine.invokeStatic(ioc_macros.clj:978)
        at clojure.core.async.impl.ioc_macros$run_state_machine.invoke(ioc_macros.clj:977)
        at clojure.core.async.impl.ioc_macros$run_state_machine_wrapped.invokeStatic(ioc_macros.clj:982)
        at clojure.core.async.impl.ioc_macros$run_state_machine_wrapped.invoke(ioc_macros.clj:980)
        at clojure.core.async.impl.ioc_macros$take_BANG_$fn__11568.invoke(ioc_macros.clj:991)
        at clojure.core.async.impl.channels.ManyToManyChannel$fn__5517.invoke(channels.clj:265)
        at clojure.lang.AFn.run(AFn.java:22)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at clojure.core.async.impl.concurrent$counted_thread_factory$reify__5321$fn__5322.invoke(concurrent.clj:29)
        at clojure.lang.AFn.run(AFn.java:22)
        at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: org.eclipse.jetty.client.HttpResponseException: HTTP protocol violation: Authentication challenge without WWW-Authenticate header
        at org.eclipse.jetty.client.AuthenticationProtocolHandler$AuthenticationListener.onComplete(AuthenticationProtocolHandler.java:163)
        at org.eclipse.jetty.client.ResponseNotifier.notifyComplete(ResponseNotifier.java:218)
        at org.eclipse.jetty.client.ResponseNotifier.notifyComplete(ResponseNotifier.java:210)
        at org.eclipse.jetty.client.HttpReceiver.terminateResponse(HttpReceiver.java:530)
        at org.eclipse.jetty.client.HttpReceiver.terminateResponse(HttpReceiver.java:510)
        at org.eclipse.jetty.client.HttpReceiver.responseSuccess(HttpReceiver.java:473)
        at org.eclipse.jetty.client.http.HttpReceiverOverHTTP.messageComplete(HttpReceiverOverHTTP.java:340)
        at org.eclipse.jetty.http.HttpParser.handleContentMessage(HttpParser.java:580)
        at org.eclipse.jetty.http.HttpParser.parseContent(HttpParser.java:1697)
        at org.eclipse.jetty.http.HttpParser.parseNext(HttpParser.java:1526)
        at org.eclipse.jetty.client.http.HttpReceiverOverHTTP.parse(HttpReceiverOverHTTP.java:199)
        at org.eclipse.jetty.client.http.HttpReceiverOverHTTP.process(HttpReceiverOverHTTP.java:138)
        at org.eclipse.jetty.client.http.HttpReceiverOverHTTP.receive(HttpReceiverOverHTTP.java:75)
        at org.eclipse.jetty.client.http.HttpChannelOverHTTP.receive(HttpChannelOverHTTP.java:133)
        at org.eclipse.jetty.client.http.HttpConnectionOverHTTP.onFillable(HttpConnectionOverHTTP.java:156)
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
        at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:336)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:313)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:171)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:129)
        at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:375)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:806)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:938)
        ... 1 more
2020-12-31 09:34:31,523 INFO  waiter.process-request [async-dispatch-19] - [CID=test-wbttbf-12a67deaa90db-4da18f60ec847f49] org.eclipse.jetty.client.HttpResponseException HTTP protocol violation: Authentication challenge without
 WWW-Authenticate header identified as :instance-error
2020-12-31 09:34:31,524 INFO  waiter.process-request [async-dispatch-19] - [CID=test-wbttbf-12a67deaa90db-4da18f60ec847f49] clojure.lang.ExceptionInfo error occurred after streaming 11 bytes in response identified as :instance-e
rror
2020-12-31 09:34:31,524 INFO  waiter.process-request [async-dispatch-19] - [CID=test-wbttbf-12a67deaa90db-4da18f60ec847f49] sending poison pill to response channel
2020-12-31 09:34:31,526 INFO  waiter.process-request [async-dispatch-16] - [CID=test-wbttbf-12a67deaa90db-4da18f60ec847f49] done processing request :instance-error
2020-12-31 09:34:31,528 INFO  waiter.state.responder [async-dispatch-50] - [CID=test-wbttbf-12a67deaa90db-4da18f60ec847f49] w9091-wbttbf328090157960637-f2784dca56f2426d880506520daa0525.12a65e41cb143-96e803d97292dfb with status :
instance-error has 1 consecutive failures
2020-12-31 09:34:31,529 INFO  waiter.state.responder [async-dispatch-50] - [CID=test-wbttbf-12a67deaa90db-4da18f60ec847f49] ejecting instance w9091-wbttbf328090157960637-f2784dca56f2426d880506520daa0525.12a65e41cb143-96e803d9729
2dfb for 10000.0 ms.
```

Logs **after** the fix showing no exception being reported in the logs:
```
2020-12-31 09:30:27,830 INFO  waiter.process-request [async-dispatch-55] - [CID=test-wbttbf-12a2f22682894-4e825dfaba13590d] process request to 127.0.0.1:9091 at path /bad-status
2020-12-31 09:30:27,833 INFO  waiter.process-request [async-dispatch-18] - [CID=test-wbttbf-12a2f22682894-4e825dfaba13590d] suggested instance: w9091-wbttbf327846087741780-91e541ec2c54109cf1e18f23892e9126.12a2d071e92ac-785214074
9cbfc3 127.0.0.5 10500
2020-12-31 09:30:27,834 INFO  waiter.process-request [async-dispatch-18] - [CID=test-wbttbf-12a2f22682894-4e825dfaba13590d] connecting to http://127.0.0.5:10500/bad-status using HTTP/1.1
2020-12-31 09:30:27,835 INFO  waiter.process-request [qtp13676036-200] - [CID=test-wbttbf-12a2f22682894-4e825dfaba13590d] streamed 0 bytes from request input stream
2020-12-31 09:30:27,841 INFO  waiter.process-request [async-dispatch-3] - [CID=test-wbttbf-12a2f22682894-4e825dfaba13590d] backend response status: 401 and headers: {server BaseHTTP/0.6 Python/3.7.2, date Thu, 31 Dec 2020 15:30:
27 GMT, connection close, content-type text/plain, x-cid test-wbttbf-12a2f22682894-4e825dfaba13590d, content-length 11}
2020-12-31 09:30:27,843 INFO  waiter.process-request [async-dispatch-45] - [CID=test-wbttbf-12a2f22682894-4e825dfaba13590d] 11 bytes streamed in response
2020-12-31 09:30:27,843 INFO  waiter.process-request [async-dispatch-19] - [CID=test-wbttbf-12a2f22682894-4e825dfaba13590d] done processing request :success
```

