### PR TITLE
CLI: choose correct cluster when updating token

### DIFF
--- a/cli/.waiter.json
+++ b/cli/.waiter.json
@@ -5,6 +5,11 @@
       "url": "http://127.0.0.1:9091/",
       "disabled": false,
       "default-for-create": true
+    },
+    {
+      "name": "WAITER2",
+      "url": "http://127.0.0.1:9092/",
+      "disabled": true
     }
   ],
   "metrics": {

--- a/cli/.waiter.json
+++ b/cli/.waiter.json
@@ -4,12 +4,20 @@
       "name": "WAITER1",
       "url": "http://127.0.0.1:9091/",
       "disabled": false,
-      "default-for-create": true
+      "default-for-create": true,
+      "sync-group": "group1"
     },
     {
       "name": "WAITER2",
       "url": "http://127.0.0.1:9191/",
-      "disabled": true
+      "disabled": true,
+      "sync-group": "group1"
+    },
+    {
+      "name": "WAITER3",
+      "url": "http://127.0.0.1:9291/",
+      "disabled": true,
+      "sync-group": "group2"
     }
   ],
   "metrics": {

--- a/cli/.waiter.json
+++ b/cli/.waiter.json
@@ -4,20 +4,7 @@
       "name": "WAITER1",
       "url": "http://127.0.0.1:9091/",
       "disabled": false,
-      "default-for-create": true,
-      "sync-group": "group1"
-    },
-    {
-      "name": "WAITER2",
-      "url": "http://127.0.0.1:9191/",
-      "disabled": true,
-      "sync-group": "group1"
-    },
-    {
-      "name": "WAITER3",
-      "url": "http://127.0.0.1:9291/",
-      "disabled": true,
-      "sync-group": "group2"
+      "default-for-create": true
     }
   ],
   "metrics": {

--- a/cli/.waiter.json
+++ b/cli/.waiter.json
@@ -8,7 +8,7 @@
     },
     {
       "name": "WAITER2",
-      "url": "http://127.0.0.1:9092/",
+      "url": "http://127.0.0.1:9191/",
       "disabled": true
     }
   ],

--- a/cli/integration/tests/waiter/test_cli_multi_cluster.py
+++ b/cli/integration/tests/waiter/test_cli_multi_cluster.py
@@ -232,6 +232,69 @@ class MultiWaiterCliTest(util.WaiterTest):
         finally:
             util.delete_token(self.waiter_url_2, token_name)
 
+    def test_update_token_chooses_latest_configured_cluster(self):
+        config = {'clusters': [{'name': 'waiter1',
+                                'url': self.waiter_url_1,
+                                'default-for-create': True,
+                                'sync-group': 'staging clusters'},
+                               {'name': 'waiter2', 'url': self.waiter_url_2,
+                                'sync-group': 'staging clusters'}]}
+
+        cluster_1_name = util.retrieve_waiter_settings(self.waiter_url_1)['cluster-config']['name']
+        cluster_2_name = util.retrieve_waiter_settings(self.waiter_url_2)['cluster-config']['name']
+
+        # Create in cluster #1, then cluster #2
+        token_name = self.token_name()
+        util.post_token(self.waiter_url_1, token_name, util.minimal_service_description(cluster=cluster_1_name))
+        util.post_token(self.waiter_url_2, token_name, util.minimal_service_description(cluster=cluster_2_name))
+        try:
+            # Update using the CLI, which should update in cluster #2
+            with cli.temp_config_file(config) as path:
+                version = str(uuid.uuid4())
+                cp = cli.update(token_name=token_name, flags=f'--config {path}', update_flags=f'--version {version}')
+                self.assertEqual(0, cp.returncode, cp.stderr)
+                self.assertNotIn('waiter1', cli.stdout(cp))
+                self.assertIn('waiter2', cli.stdout(cp))
+                token_1 = util.load_token(self.waiter_url_1, token_name, expected_status_code=200)
+                token_2 = util.load_token(self.waiter_url_2, token_name, expected_status_code=200)
+                self.assertNotEqual(version, token_1['version'])
+                self.assertEqual(version, token_2['version'])
+        finally:
+            util.delete_token(self.waiter_url_1, token_name)
+            util.delete_token(self.waiter_url_2, token_name)
+
+
+    def test_update_token_multiple_sync_groups(self):
+        sync_group_1 = "sync-group-1"
+        sync_group_2 = "sync-group-2"
+        config = {'clusters': [{'name': 'waiter1',
+                                'url': self.waiter_url_1,
+                                'default-for-create': True,
+                                'sync-group': sync_group_1},
+                               {'name': 'waiter2', 'url': self.waiter_url_2,
+                                'sync-group': sync_group_2}]}
+
+        cluster_1_name = util.retrieve_waiter_settings(self.waiter_url_1)['cluster-config']['name']
+        cluster_2_name = util.retrieve_waiter_settings(self.waiter_url_2)['cluster-config']['name']
+
+        # Create in cluster #1, then cluster #2
+        token_name = self.token_name()
+        util.post_token(self.waiter_url_1, token_name, util.minimal_service_description(cluster=cluster_1_name))
+        util.post_token(self.waiter_url_2, token_name, util.minimal_service_description(cluster=cluster_2_name))
+        try:
+            # Update using the CLI, which should update in cluster #2
+            with cli.temp_config_file(config) as path:
+                version = str(uuid.uuid4())
+                cp = cli.update(token_name=token_name, flags=f'--config {path}', update_flags=f'--version {version}')
+                self.assertEqual(1, cp.returncode, cp.stderr)
+                self.assertIn('Could not infer the target cluster', cli.stderr(cp))
+                self.assertIn(sync_group_1, cli.stderr(cp))
+                self.assertIn(sync_group_2, cli.stderr(cp))
+        finally:
+            util.delete_token(self.waiter_url_1, token_name)
+            util.delete_token(self.waiter_url_2, token_name)
+
+
     def test_ping_via_token_cluster(self):
         # Create in cluster #1
         token_name = self.token_name()
@@ -301,3 +364,4 @@ class MultiWaiterCliTest(util.WaiterTest):
                     util.delete_token(self.waiter_url_2, token_name)
         finally:
             util.delete_token(self.waiter_url_1, token_name)
+

--- a/cli/integration/tests/waiter/test_cli_multi_cluster.py
+++ b/cli/integration/tests/waiter/test_cli_multi_cluster.py
@@ -23,6 +23,8 @@ class MultiWaiterCliTest(util.WaiterTest):
         self.waiter_url_1 = type(self).waiter_url_1
         self.waiter_url_2 = type(self).waiter_url_2
         self.logger = logging.getLogger(__name__)
+        self.waiter_1_cluster = util.retrieve_waiter_cluster_name(self.waiter_url_1)
+        self.waiter_2_cluster = util.retrieve_waiter_cluster_name(self.waiter_url_2)
 
     def __two_cluster_config(self):
         return {'clusters': [{'name': 'waiter1', 'url': self.waiter_url_1},
@@ -232,36 +234,59 @@ class MultiWaiterCliTest(util.WaiterTest):
         finally:
             util.delete_token(self.waiter_url_2, token_name)
 
-    def test_update_token_chooses_latest_configured_cluster(self):
-        config = {'clusters': [{'name': 'waiter1',
-                                'url': self.waiter_url_1,
-                                'default-for-create': True,
-                                'sync-group': 'staging clusters'},
-                               {'name': 'waiter2', 'url': self.waiter_url_2,
-                                'sync-group': 'staging clusters'}]}
-
-        cluster_1_name = util.retrieve_waiter_settings(self.waiter_url_1)['cluster-config']['name']
-        cluster_2_name = util.retrieve_waiter_settings(self.waiter_url_2)['cluster-config']['name']
-
-        # Create in cluster #1, then cluster #2
+    def _test_choose_latest_configured_cluster(self, cluster_test_configs, expected_updated_cluster_index):
+        config = {'clusters': cluster_test_configs}
         token_name = self.token_name()
-        util.post_token(self.waiter_url_1, token_name, util.minimal_service_description(cluster=cluster_1_name))
-        util.post_token(self.waiter_url_2, token_name, util.minimal_service_description(cluster=cluster_2_name))
+        expected_cluster_with_latest_token = cluster_test_configs[expected_updated_cluster_index]
+        # last token defined in the cluster_test_configs array will be the latest token
+        for cluster_test_config in cluster_test_configs:
+            util.post_token(cluster_test_config['url'], token_name, cluster_test_config['token-to-create'],
+                            update_mode_admin=True)
         try:
-            # Update using the CLI, which should update in cluster #2
             with cli.temp_config_file(config) as path:
                 version = str(uuid.uuid4())
                 cp = cli.update(token_name=token_name, flags=f'--config {path}', update_flags=f'--version {version}')
                 self.assertEqual(0, cp.returncode, cp.stderr)
-                self.assertNotIn('waiter1', cli.stdout(cp))
-                self.assertIn('waiter2', cli.stdout(cp))
-                token_1 = util.load_token(self.waiter_url_1, token_name, expected_status_code=200)
-                token_2 = util.load_token(self.waiter_url_2, token_name, expected_status_code=200)
-                self.assertNotEqual(version, token_1['version'])
-                self.assertEqual(version, token_2['version'])
+                self.assertIn(expected_cluster_with_latest_token['name'], cli.stdout(cp))
+                modified_token = util.load_token(expected_cluster_with_latest_token['url'], token_name,
+                                                 expected_status_code=200)
+                self.assertEqual(version, modified_token['version'])
+                for cluster_test_config in cluster_test_configs:
+                    waiter_url = cluster_test_config['url']
+                    if waiter_url != expected_cluster_with_latest_token['url']:
+                        not_modified_token = util.load_token(waiter_url, token_name, expected_status_code=200)
+                        print(not_modified_token)
+                        self.assertNotEqual(version, not_modified_token)
+                        self.assertNotIn(cluster_test_config['name'], cli.stdout(cp))
         finally:
-            util.delete_token(self.waiter_url_1, token_name)
-            util.delete_token(self.waiter_url_2, token_name)
+            for cluster_test_config in cluster_test_configs:
+                util.delete_token(cluster_test_config['url'], token_name)
+
+    def test_update_token_latest_configured_same_cluster(self):
+        sync_group_name = 'group_name'
+        cluster_test_configs = [{'name': 'waiter1',
+                                 'url': self.waiter_url_1,
+                                 'token-to-create': util.minimal_service_description(cluster=self.waiter_1_cluster),
+                                 'default-for-create': True,
+                                 'sync-group': sync_group_name},
+                                {'name': 'waiter2',
+                                 'url': self.waiter_url_2,
+                                 'token-to-create': util.minimal_service_description(cluster=self.waiter_2_cluster),
+                                 'sync-group': sync_group_name}]
+        self._test_choose_latest_configured_cluster(cluster_test_configs, 1)
+
+    def test_update_token_latest_configured_different_cluster(self):
+        sync_group_name = 'group_name'
+        cluster_test_configs = [{'name': 'waiter1',
+                                 'url': self.waiter_url_1,
+                                 'token-to-create': util.minimal_service_description(cluster=self.waiter_1_cluster),
+                                 'default-for-create': True,
+                                 'sync-group': sync_group_name},
+                                {'name': 'waiter2',
+                                 'url': self.waiter_url_2,
+                                 'token-to-create': util.minimal_service_description(cluster=self.waiter_1_cluster),
+                                 'sync-group': sync_group_name}]
+        self._test_choose_latest_configured_cluster(cluster_test_configs, 0)
 
     def test_update_token_multiple_sync_groups(self):
         sync_group_1 = "sync-group-1"
@@ -293,38 +318,6 @@ class MultiWaiterCliTest(util.WaiterTest):
             util.delete_token(self.waiter_url_1, token_name)
             util.delete_token(self.waiter_url_2, token_name)
 
-    def test_update_token_latest_configured_to_different_cluster(self):
-        sync_group_1 = "sync-group-1"
-        config = {'clusters': [{'name': 'waiter1',
-                                'url': self.waiter_url_1,
-                                'default-for-create': True,
-                                'sync-group': sync_group_1},
-                               {'name': 'waiter2', 'url': self.waiter_url_2,
-                                'sync-group': sync_group_1}]}
-
-        cluster_1_name = util.retrieve_waiter_settings(self.waiter_url_1)['cluster-config']['name']
-
-        # Create in cluster #1, then cluster #2
-        # note that the token in cluster #2 is the latest and has the cluster configured to cluster #1
-        token_name = self.token_name()
-        util.post_token(self.waiter_url_1, token_name, util.minimal_service_description(cluster=cluster_1_name))
-        util.post_token(self.waiter_url_2, token_name, util.minimal_service_description(cluster=cluster_1_name))
-        try:
-            # Update using the CLI, which should update in cluster #1 because the cluster configured is cluster #1
-            with cli.temp_config_file(config) as path:
-                version = str(uuid.uuid4())
-                cp = cli.update(token_name=token_name, flags=f'--config {path}', update_flags=f'--version {version}')
-                self.assertEqual(0, cp.returncode, cp.stderr)
-                self.assertNotIn('waiter2', cli.stdout(cp))
-                self.assertIn('waiter1', cli.stdout(cp))
-                token_1 = util.load_token(self.waiter_url_1, token_name, expected_status_code=200)
-                token_2 = util.load_token(self.waiter_url_2, token_name, expected_status_code=200)
-                self.assertNotEqual(version, token_2['version'])
-                self.assertEqual(version, token_1['version'])
-        finally:
-            util.delete_token(self.waiter_url_1, token_name)
-            util.delete_token(self.waiter_url_2, token_name)
-
     def test_update_token_multiple_sync_groups_no_conflict(self):
         sync_group_1 = "sync-group-1"
         sync_group_2 = "sync-group-2"
@@ -335,7 +328,6 @@ class MultiWaiterCliTest(util.WaiterTest):
                                {'name': 'waiter2', 'url': self.waiter_url_2,
                                 'sync-group': sync_group_2}]}
 
-        cluster_1_name = util.retrieve_waiter_settings(self.waiter_url_1)['cluster-config']['name']
         cluster_2_name = util.retrieve_waiter_settings(self.waiter_url_2)['cluster-config']['name']
 
         # Create in just cluster #2

--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -59,6 +59,10 @@ def retrieve_waiter_settings(waiter_url):
     return session.get(f'{waiter_url}/settings').json()
 
 
+def retrieve_waiter_cluster_name(waiter_url):
+    return retrieve_waiter_settings(waiter_url)['cluster-config']['name']
+
+
 def is_connection_error(exception):
     return isinstance(exception, requests.exceptions.ConnectionError)
 

--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -55,6 +55,10 @@ def retrieve_waiter_url(varname='WAITER_URL', value='http://localhost:9091'):
     return cook_url
 
 
+def retrieve_waiter_settings(waiter_url):
+    return session.get(f'{waiter_url}/settings').json()
+
+
 def is_connection_error(exception):
     return isinstance(exception, requests.exceptions.ConnectionError)
 
@@ -233,7 +237,7 @@ def load_file(file_format, path):
 
 def wait_until_routers(waiter_url, predicate):
     auth_cookie = {'x-waiter-auth': session.cookies['x-waiter-auth']}
-    max_wait_ms = session.get(f'{waiter_url}/settings').json()['scheduler-syncer-interval-secs'] * 2 * 1000
+    max_wait_ms = retrieve_waiter_settings(waiter_url)['scheduler-syncer-interval-secs'] * 2 * 1000
     routers = session.get(f'{waiter_url}/state/maintainer').json()['state']['routers']
     for _, router_url in routers.items():
         logging.debug(f'Waiting for at most {max_wait_ms}ms on {router_url}')

--- a/cli/waiter/cli.py
+++ b/cli/waiter/cli.py
@@ -114,9 +114,10 @@ def run(args, plugins):
             metrics.initialize(config_map)
             metrics.inc(f'command.{action}.runs')
             clusters = load_target_clusters(config_map, url, cluster)
+            enforce_clusters = (url or cluster) and True
             http_util.configure(config_map, plugins)
             args = {k: v for k, v in args.items() if v is not None}
-            result = actions[action]['run-function'](clusters, args, config_path)
+            result = actions[action]['run-function'](clusters, args, config_path, enforce_clusters)
             logging.debug(f'result: {result}')
             if result == 0:
                 metrics.inc(f'command.{action}.result.success')

--- a/cli/waiter/cli.py
+++ b/cli/waiter/cli.py
@@ -114,10 +114,10 @@ def run(args, plugins):
             metrics.initialize(config_map)
             metrics.inc(f'command.{action}.runs')
             clusters = load_target_clusters(config_map, url, cluster)
-            enforce_clusters = (url or cluster) and True
+            enforce_cluster = (url or cluster) and True
             http_util.configure(config_map, plugins)
             args = {k: v for k, v in args.items() if v is not None}
-            result = actions[action]['run-function'](clusters, args, config_path, enforce_clusters)
+            result = actions[action]['run-function'](clusters, args, config_path, enforce_cluster)
             logging.debug(f'result: {result}')
             if result == 0:
                 metrics.inc(f'command.{action}.result.success')

--- a/cli/waiter/querying.py
+++ b/cli/waiter/querying.py
@@ -172,7 +172,7 @@ def _get_latest_cluster(clusters, query_result):
         provided_cluster_names.append(cluster_config_name)
         if cluster_name_goal.upper() == cluster_config_name.upper():
             return c
-    raise Exception(f'The token is configured in cluster {cluster_name_goal} which is not provided.' +
+    raise Exception(f'The token is configured in cluster {cluster_name_goal}, which is not provided.' +
                     f' The following clusters were provided: {", ".join(provided_cluster_names)}.')
 
 

--- a/cli/waiter/querying.py
+++ b/cli/waiter/querying.py
@@ -204,6 +204,8 @@ def get_target_cluster_from_token(clusters, token_name, enforce_cluster):
             sync_groups_set.add(sync_group)
             cluster_names.add(cluster)
         if len(sync_groups_set) > 1:
-            raise Exception(f'There are multiple cluster groups that contain a description for this token: ' +
-                            f'groups-{sync_groups_set} clusters-{cluster_names}')
+            raise Exception('Could not infer the target cluster for this operation because there are multiple cluster '
+                            f'groups that contain a description for this token: groups-{sync_groups_set} '
+                            f'clusters-{cluster_names}.'
+                            '\nConsider specifying with the --cluster flag which cluster you are targeting.')
         return _get_latest_cluster(clusters, query_result)

--- a/cli/waiter/querying.py
+++ b/cli/waiter/querying.py
@@ -196,7 +196,6 @@ def get_target_cluster_from_token(clusters, token_name, enforce_cluster):
         for cluster in list(query_result['clusters'].keys()):
             cluster_config = next(c for c in clusters if c['name'] == cluster)
             sync_group = cluster_config.get('sync-group', False)
-
             # consider clusters that don't have a configured sync-group as in their own unique group
             if not sync_group:
                 sync_group = sync_group_count

--- a/cli/waiter/subcommands/delete.py
+++ b/cli/waiter/subcommands/delete.py
@@ -49,7 +49,7 @@ def delete_token_on_cluster(cluster, token_name, token_etag):
         print_error(message)
 
 
-def delete(clusters, args, _):
+def delete(clusters, args, _, __):
     """Deletes the token with the given token name."""
     guard_no_cluster(clusters)
     token_name = args.get('token')[0]

--- a/cli/waiter/subcommands/init.py
+++ b/cli/waiter/subcommands/init.py
@@ -23,7 +23,7 @@ DEFAULTS = {
 }
 
 
-def init_token_json(_, args, __):
+def init_token_json(_, args, __, ___):
     """Creates (or updates) a Waiter token"""
     logging.debug('args: %s' % args)
     file = os.path.abspath(args.pop('file'))

--- a/cli/waiter/subcommands/kill.py
+++ b/cli/waiter/subcommands/kill.py
@@ -41,7 +41,7 @@ def kill_service_on_cluster(cluster, service_id, timeout_seconds):
         print_error(message)
 
 
-def kill(clusters, args, _):
+def kill(clusters, args, _, __):
     """Kills the service(s) using the given token name."""
     guard_no_cluster(clusters)
     token_name_or_service_id = args.get('token-or-service-id')

--- a/cli/waiter/subcommands/maintenance.py
+++ b/cli/waiter/subcommands/maintenance.py
@@ -4,7 +4,7 @@ import requests
 
 from waiter import terminal, http_util
 from waiter.token_post import process_post_result, post_failed_message
-from waiter.querying import get_cluster_with_token, get_token
+from waiter.querying import get_target_cluster_from_token, get_token
 from waiter.util import guard_no_cluster, logging, print_info
 
 
@@ -14,7 +14,7 @@ def _is_token_in_maintenance_mode(token_data):
 
 def _get_existing_token_data(clusters, token_name, enforce_cluster):
     guard_no_cluster(clusters)
-    cluster = get_cluster_with_token(clusters, token_name, enforce_cluster)
+    cluster = get_target_cluster_from_token(clusters, token_name, enforce_cluster)
     existing_token_data, existing_token_etag = get_token(cluster, token_name)
     return cluster, existing_token_data, existing_token_etag
 

--- a/cli/waiter/subcommands/maintenance.py
+++ b/cli/waiter/subcommands/maintenance.py
@@ -12,9 +12,9 @@ def _is_token_in_maintenance_mode(token_data):
     return 'maintenance' in token_data
 
 
-def _get_existing_token_data(clusters, token_name, enforce_clusters):
+def _get_existing_token_data(clusters, token_name, enforce_cluster):
     guard_no_cluster(clusters)
-    cluster = get_cluster_with_token(clusters, token_name, enforce_clusters)
+    cluster = get_cluster_with_token(clusters, token_name, enforce_cluster)
     existing_token_data, existing_token_etag = get_token(cluster, token_name)
     return cluster, existing_token_data, existing_token_etag
 
@@ -40,30 +40,30 @@ def _update_token(cluster, token_name, existing_token_etag, body):
         print_info(f'{message}\n')
 
 
-def check_maintenance(clusters, args, enforce_clusters):
+def check_maintenance(clusters, args, enforce_cluster):
     """Checks if a token is in maintenance mode and displays the result. Returns 0 if the token is in maintenance mode
     and returns 1 if the token is NOT in maintenance mode."""
     token_name = args['token']
-    _, existing_token_data, existing_token_etag = _get_existing_token_data(clusters, token_name, enforce_clusters)
+    _, existing_token_data, existing_token_etag = _get_existing_token_data(clusters, token_name, enforce_cluster)
     maintenance_mode_active = _is_token_in_maintenance_mode(existing_token_data)
     print_info(f'{token_name} is {"" if maintenance_mode_active else "not "}in maintenance mode')
     return 0 if maintenance_mode_active else 1
 
 
-def start_maintenance(clusters, args, enforce_clusters):
+def start_maintenance(clusters, args, enforce_cluster):
     """Sets the token in maintenance mode by updating the token user metadata fields"""
     token_name = args['token']
-    cluster, existing_token_data, existing_token_etag = _get_existing_token_data(clusters, token_name, enforce_clusters)
+    cluster, existing_token_data, existing_token_etag = _get_existing_token_data(clusters, token_name, enforce_cluster)
     json_body = existing_token_data
     update_doc = {"maintenance": {"message": args['message']}}
     json_body.update(update_doc)
     return _update_token(cluster, token_name, existing_token_etag, json_body)
 
 
-def stop_maintenance(clusters, args, enforce_clusters):
+def stop_maintenance(clusters, args, enforce_cluster):
     """Stops maintenance mode for a token by deleting the 'maintenance' user metadata field in the token data"""
     token_name = args['token']
-    cluster, existing_token_data, existing_token_etag = _get_existing_token_data(clusters, token_name, enforce_clusters)
+    cluster, existing_token_data, existing_token_etag = _get_existing_token_data(clusters, token_name, enforce_cluster)
     maintenance_mode_active = _is_token_in_maintenance_mode(existing_token_data)
     if not maintenance_mode_active:
         raise Exception("Token is not in maintenance mode")
@@ -72,7 +72,7 @@ def stop_maintenance(clusters, args, enforce_clusters):
     return _update_token(cluster, token_name, existing_token_etag, json_body)
 
 
-def maintenance(parser, clusters, args, _, enforce_clusters):
+def maintenance(parser, clusters, args, _, enforce_cluster):
     """Calls the sub action for maintenance command. If no sub action is provided then displays the help message."""
     logging.debug('args: %s' % args)
     sub_func = args.get('sub_func', None)
@@ -80,7 +80,7 @@ def maintenance(parser, clusters, args, _, enforce_clusters):
         parser.print_help()
         return 0
     else:
-        return sub_func(clusters, args, enforce_clusters)
+        return sub_func(clusters, args, enforce_cluster)
 
 
 def register_check(add_parser):

--- a/cli/waiter/subcommands/maintenance.py
+++ b/cli/waiter/subcommands/maintenance.py
@@ -12,9 +12,9 @@ def _is_token_in_maintenance_mode(token_data):
     return 'maintenance' in token_data
 
 
-def _get_existing_token_data(clusters, token_name):
+def _get_existing_token_data(clusters, token_name, enforce_clusters):
     guard_no_cluster(clusters)
-    cluster = get_cluster_with_token(clusters, token_name)
+    cluster = get_cluster_with_token(clusters, token_name, enforce_clusters)
     existing_token_data, existing_token_etag = get_token(cluster, token_name)
     return cluster, existing_token_data, existing_token_etag
 
@@ -40,30 +40,30 @@ def _update_token(cluster, token_name, existing_token_etag, body):
         print_info(f'{message}\n')
 
 
-def check_maintenance(clusters, args):
+def check_maintenance(clusters, args, enforce_clusters):
     """Checks if a token is in maintenance mode and displays the result. Returns 0 if the token is in maintenance mode
     and returns 1 if the token is NOT in maintenance mode."""
     token_name = args['token']
-    _, existing_token_data, existing_token_etag = _get_existing_token_data(clusters, token_name)
+    _, existing_token_data, existing_token_etag = _get_existing_token_data(clusters, token_name, enforce_clusters)
     maintenance_mode_active = _is_token_in_maintenance_mode(existing_token_data)
     print_info(f'{token_name} is {"" if maintenance_mode_active else "not "}in maintenance mode')
     return 0 if maintenance_mode_active else 1
 
 
-def start_maintenance(clusters, args):
+def start_maintenance(clusters, args, enforce_clusters):
     """Sets the token in maintenance mode by updating the token user metadata fields"""
     token_name = args['token']
-    cluster, existing_token_data, existing_token_etag = _get_existing_token_data(clusters, token_name)
+    cluster, existing_token_data, existing_token_etag = _get_existing_token_data(clusters, token_name, enforce_clusters)
     json_body = existing_token_data
     update_doc = {"maintenance": {"message": args['message']}}
     json_body.update(update_doc)
     return _update_token(cluster, token_name, existing_token_etag, json_body)
 
 
-def stop_maintenance(clusters, args):
+def stop_maintenance(clusters, args, enforce_clusters):
     """Stops maintenance mode for a token by deleting the 'maintenance' user metadata field in the token data"""
     token_name = args['token']
-    cluster, existing_token_data, existing_token_etag = _get_existing_token_data(clusters, token_name)
+    cluster, existing_token_data, existing_token_etag = _get_existing_token_data(clusters, token_name, enforce_clusters)
     maintenance_mode_active = _is_token_in_maintenance_mode(existing_token_data)
     if not maintenance_mode_active:
         raise Exception("Token is not in maintenance mode")
@@ -72,7 +72,7 @@ def stop_maintenance(clusters, args):
     return _update_token(cluster, token_name, existing_token_etag, json_body)
 
 
-def maintenance(parser, clusters, args, _):
+def maintenance(parser, clusters, args, _, enforce_clusters):
     """Calls the sub action for maintenance command. If no sub action is provided then displays the help message."""
     logging.debug('args: %s' % args)
     sub_func = args.get('sub_func', None)
@@ -80,7 +80,7 @@ def maintenance(parser, clusters, args, _):
         parser.print_help()
         return 0
     else:
-        return sub_func(clusters, args)
+        return sub_func(clusters, args, enforce_clusters)
 
 
 def register_check(add_parser):

--- a/cli/waiter/subcommands/ping.py
+++ b/cli/waiter/subcommands/ping.py
@@ -119,7 +119,7 @@ def ping_service_on_cluster(cluster, service_id, timeout, wait_for_request):
                            f'^SERVICE-ID#{service_id}', lambda: service_is_active(cluster, service_id))
 
 
-def ping(clusters, args, _):
+def ping(clusters, args, _, __):
     """Pings the token with the given token name."""
     guard_no_cluster(clusters)
     token_name_or_service_id = args.get('token-or-service-id')

--- a/cli/waiter/subcommands/show.py
+++ b/cli/waiter/subcommands/show.py
@@ -110,7 +110,7 @@ def tabulate_token(cluster_name, token, token_name, services, token_etag):
         f'{service_table}'
 
 
-def show(clusters, args, _):
+def show(clusters, args, _, __):
     """Prints info for the token with the given token name."""
     guard_no_cluster(clusters)
     as_json = args.get('json')

--- a/cli/waiter/subcommands/tokens.py
+++ b/cli/waiter/subcommands/tokens.py
@@ -29,7 +29,7 @@ def print_as_table(query_result):
     print(token_table)
 
 
-def tokens(clusters, args, _):
+def tokens(clusters, args, _, __):
     """Prints info for the tokens owned by the given user."""
     guard_no_cluster(clusters)
     as_json = args.get('json')

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -73,7 +73,7 @@ def create_or_update(cluster, token_name, token_fields, admin_mode, action):
         print_info(f'{message}\n')
 
 
-def create_or_update_token(clusters, args, _, action):
+def create_or_update_token(clusters, args, _, enforce_clusters, action):
     """Creates (or updates) a Waiter token"""
     guard_no_cluster(clusters)
     logging.debug('args: %s' % args)

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -7,7 +7,7 @@ from enum import Enum
 import requests
 
 from waiter import terminal, http_util
-from waiter.querying import get_token, query_token
+from waiter.querying import get_token, query_token, get_target_cluster_from_token
 from waiter.data_format import load_data
 from waiter.util import FALSE_STRINGS, print_info, response_message, TRUE_STRINGS, guard_no_cluster, str2bool
 
@@ -73,7 +73,7 @@ def create_or_update(cluster, token_name, token_fields, admin_mode, action):
         print_info(f'{message}\n')
 
 
-def create_or_update_token(clusters, args, _, enforce_clusters, action):
+def create_or_update_token(clusters, args, _, enforce_cluster, action):
     """Creates (or updates) a Waiter token"""
     guard_no_cluster(clusters)
     logging.debug('args: %s' % args)
@@ -115,13 +115,12 @@ def create_or_update_token(clusters, args, _, enforce_clusters, action):
         elif num_default_create_clusters > 1:
             raise Exception('You have "default-for-create" set to true for more than one cluster.')
         else:
-            cluster = default_for_create[0]
             query_result = query_token(clusters, token_name)
             if query_result['count'] > 0:
-                cluster_names_with_token = list(query_result['clusters'].keys())
-                if cluster['name'] not in cluster_names_with_token:
-                    cluster = next(c for c in clusters if c['name'] == cluster_names_with_token[0])
-                    logging.debug(f'token already exists in: {cluster}')
+                cluster = get_target_cluster_from_token(clusters, token_name, enforce_cluster)
+                logging.debug(f'token already exists in: {cluster}')
+            else:
+                cluster = default_for_create[0]
     else:
         cluster = clusters[0]
 


### PR DESCRIPTION
## Changes proposed in this PR

- using the most up to date token description, use the "cluster" field to get the appropriate cluster configuration for sending the POST request to.
- This modifies the behavior of maintenance, create, and update subcommands
- ping was left out because it would break current test cases "test_federated_ping", which expects to ping multiple cluster tokens

## Why are we making these changes?
- users may have their token in a secondary cluster but the current code will update the token as the first cluster configured.

