### PR TITLE
adds websocket upgrade requests to the request log

### DIFF
--- a/waiter/src/waiter/auth/authentication.clj
+++ b/waiter/src/waiter/auth/authentication.clj
@@ -413,4 +413,4 @@
     handler
     (fn send-ws-error [{:keys [^ServletUpgradeResponse upgrade-response]} status message]
       (.sendError upgrade-response status message)
-      false)))
+      status)))

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -84,9 +84,9 @@
     handler
     (fn prepare-https-redirect-ws-response [{:keys [^ServletUpgradeResponse upgrade-response] :as request}]
       (let [https-url (str "https://" (get-in request [:headers "host"]) (:uri request))]
-        (.setHeader upgrade-response "Location" https-url)
+        (.setHeader upgrade-response "location" https-url)
         (.sendError upgrade-response http-301-moved-permanently "https-redirect is enabled")
-        false))))
+        http-301-moved-permanently))))
 
 (defn async-make-request-helper
   "Helper function that returns a function that can invoke make-request-fn."

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -910,7 +910,7 @@
   [handler]
   (let [on-error (fn send-ws-error [{:keys [message status]} {^ServletUpgradeResponse upgrade-response :upgrade-response}]
                    (.sendError upgrade-response status message)
-                   false)]
+                   status)]
     (make-maintenance-mode handler on-error on-error)))
 
 (defn wrap-too-many-requests

--- a/waiter/src/waiter/status_codes.clj
+++ b/waiter/src/waiter/status_codes.clj
@@ -17,6 +17,7 @@
   (:import (org.eclipse.jetty.http HttpStatus)
            (org.eclipse.jetty.websocket.api StatusCode)))
 
+(def ^:const http-101-switching-protocols HttpStatus/SWITCHING_PROTOCOLS_101)
 (def ^:const http-200-ok HttpStatus/OK_200)
 (def ^:const http-201-created HttpStatus/CREATED_201)
 (def ^:const http-202-accepted HttpStatus/ACCEPTED_202)

--- a/waiter/src/waiter/websocket.clj
+++ b/waiter/src/waiter/websocket.clj
@@ -97,8 +97,8 @@
   [server-name handler]
   (fn websocket-request-acceptor [^ServletUpgradeRequest request ^ServletUpgradeResponse response]
     (let [request-headers (->> (.getHeaders request)
-                            (pc/map-vals #(str/join "," %))
-                            (pc/map-keys str/lower-case))
+                               (pc/map-vals #(str/join "," %))
+                               (pc/map-keys str/lower-case))
           request-id (str "ws-" (utils/unique-identifier))
           correlation-id (or (get request-headers "x-cid") request-id)
           method (some-> request .getMethod str/lower-case keyword)

--- a/waiter/src/waiter/websocket.clj
+++ b/waiter/src/waiter/websocket.clj
@@ -32,6 +32,7 @@
             [waiter.headers :as headers]
             [waiter.metrics :as metrics]
             [waiter.middleware :as middleware]
+            [waiter.request-log :as rlog]
             [waiter.scheduler :as scheduler]
             [waiter.statsd :as statsd]
             [waiter.status-codes :refer :all]
@@ -48,16 +49,58 @@
 ;; https://tools.ietf.org/html/rfc6455#section-7.4
 (def ^:const server-termination-on-unexpected-condition websocket-1011-server-error)
 
+(def ^:const attr-auth-method "ws/auth-method")
+(def ^:const attr-auth-principal "ws/auth-principal")
+(def ^:const attr-waiter-token "ws/waiter-token")
+
+(defn successful-upgrade?
+  "Returns true if the status is 101 indicating the upgrade request was successful."
+  [status]
+  (and (integer? status)
+       (= http-101-switching-protocols status)))
+
+(defn get-upgrade-request-attribute
+  "Returns an Object containing the value of the attribute, or nil if the attribute does not exist."
+  [^UpgradeRequest upgrade-request attribute-name]
+  (when (instance? ServletUpgradeRequest upgrade-request)
+    (.getServletAttribute ^ServletUpgradeRequest upgrade-request attribute-name)))
+
+(defn set-upgrade-request-attribute!
+  "Stores an attribute in this request."
+  [^UpgradeRequest upgrade-request attribute-name attribute-value]
+  (when (instance? ServletUpgradeRequest upgrade-request)
+    (.setServletAttribute ^ServletUpgradeRequest upgrade-request attribute-name attribute-value)))
+
+(defn log-websocket-upgrade!
+  "Publishes the result of an upgrade request to the request log."
+  [{:keys [upgrade-request upgrade-response] :as request} response-status]
+  (let [response-headers (->> (.getHeaders upgrade-response)
+                          (pc/map-vals #(str/join "," %))
+                          (pc/map-keys str/lower-case))
+        auth-method (get-upgrade-request-attribute upgrade-request attr-auth-method)
+        auth-principal (get-upgrade-request-attribute upgrade-request attr-auth-principal)
+        waiter-token (get-upgrade-request-attribute upgrade-request attr-waiter-token)
+        response (cond->
+                   {:headers response-headers
+                    :request-type "websocket-upgrade"
+                    :waiter-api-call? false}
+                   ;; do not output status for 101 as further processing in Jetty may still fail the request
+                   (not (successful-upgrade? response-status)) (assoc :status response-status)
+                   auth-method (assoc :authorization/method auth-method)
+                   auth-principal (assoc :authorization/principal auth-principal)
+                   waiter-token (assoc :waiter/token waiter-token))]
+    (rlog/log-request! request response)))
+
 (defn make-websocket-request-acceptor
   "Takes a handler and returns a websocket-request-acceptor handler function that takes a special request and response
   object provided on websocket upgrade. It creates a generic request map from the two objects and passes it to the handler"
   [server-name handler]
   (fn websocket-request-acceptor [^ServletUpgradeRequest request ^ServletUpgradeResponse response]
     (let [request-headers (->> (.getHeaders request)
-                               (pc/map-vals #(str/join "," %))
-                               (pc/map-keys str/lower-case))
-          correlation-id (or (get request-headers "x-cid")
-                             (str "ws-" (utils/unique-identifier)))
+                            (pc/map-vals #(str/join "," %))
+                            (pc/map-keys str/lower-case))
+          request-id (str "ws-" (utils/unique-identifier))
+          correlation-id (or (get request-headers "x-cid") request-id)
           method (some-> request .getMethod str/lower-case keyword)
           scheme (some-> request .getRequestURI .getScheme keyword)
           uri (some-> request .getRequestURI .getPath)]
@@ -72,13 +115,31 @@
                    :uri uri})
         (.setHeader response "server" server-name)
         (.setHeader response "x-cid" correlation-id)
-        (let [handler-request {:headers request-headers
+        (let [handler-request {:client-protocol (some->> request .getProtocolVersion (str "WS/"))
+                               :headers (assoc request-headers "x-cid" correlation-id)
+                               :internal-protocol (some-> request .getHttpVersion)
+                               :query-string (some-> request .getQueryString)
+                               :remote-addr (some-> request .getRemoteAddress)
+                               :request-id request-id
                                :request-method method
+                               :request-time (t/now)
                                :scheme scheme
+                               :server-port (some-> request .getLocalPort)
                                :upgrade-request request
                                :upgrade-response response
-                               :uri uri}]
-          (handler handler-request))))))
+                               :uri uri}
+              response-status (handler handler-request)]
+          (log-websocket-upgrade! handler-request response-status)
+          (successful-upgrade? response-status))))))
+
+(defn wrap-service-discovery-data
+  "Middleware that stores service discovery data inside the ServletUpgradeRequest before passing the request map to the next handler."
+  [handler]
+  (fn wrap-service-discovery-data-handler
+    [{:keys [upgrade-request] :as request}]
+    (when-let [token (get-in request [:waiter-discovery :token])]
+      (set-upgrade-request-attribute! upgrade-request attr-waiter-token token))
+    (handler request)))
 
 (defn request-authenticator
   "Authenticates the request using the x-waiter-auth cookie.
@@ -90,19 +151,24 @@
                               (when (= auth/AUTH-COOKIE-NAME (.getName cookie))
                                 (.getValue cookie)))
                             (seq (.getCookies request)))
-          auth-cookie-valid? (and auth-cookie
-                                  (-> auth-cookie
-                                      (URLDecoder/decode "UTF-8")
-                                      (auth/decode-auth-cookie password)
-                                      auth/decoded-auth-valid?))]
-      (when-not auth-cookie-valid?
-        (log/info "failed to authenticate" {:auth-cookie auth-cookie})
-        (.sendForbidden response "Unauthorized"))
-      auth-cookie-valid?)
+          decoded-auth-cookie (and auth-cookie
+                                   (-> auth-cookie
+                                     (URLDecoder/decode "UTF-8")
+                                     (auth/decode-auth-cookie password)))
+          auth-cookie-valid? (auth/decoded-auth-valid? decoded-auth-cookie)]
+      (if auth-cookie-valid?
+        (let [[auth-principal _ _] decoded-auth-cookie]
+          (set-upgrade-request-attribute! request attr-auth-method "cookie")
+          (set-upgrade-request-attribute! request attr-auth-principal auth-principal)
+          http-101-switching-protocols)
+        (do
+          (log/info "failed to authenticate" {:auth-cookie auth-cookie})
+          (.sendForbidden response "Unauthorized")
+          http-403-forbidden)))
     (catch Throwable e
       (log/error e "error while authenticating websocket request")
       (.sendError response http-500-internal-server-error (.getMessage e))
-      false)))
+      http-500-internal-server-error)))
 
 (defn request-subprotocol-acceptor
   "Associates a subprotocol (when present) in the request with the response.
@@ -114,19 +180,19 @@
       (condp = (count sec-websocket-protocols)
         0 (do
             (log/info "no subprotocols provided, accepting upgrade request")
-            true)
+            http-101-switching-protocols)
         1 (let [accepted-subprotocol (first sec-websocket-protocols)]
             (log/info "accepting websocket subprotocol" accepted-subprotocol)
             (.setAcceptedSubProtocol response accepted-subprotocol)
-            true)
+            http-101-switching-protocols)
         (do
           (log/info "rejecting websocket due to presence of multiple subprotocols" sec-websocket-protocols)
           (.sendError response http-500-internal-server-error (str "waiter does not yet support multiple subprotocols in websocket requests: " sec-websocket-protocols))
-          false)))
+          http-500-internal-server-error)))
     (catch Throwable th
       (log/error th "error while selecting subprotocol for websocket request")
       (.sendError response http-500-internal-server-error (.getMessage th))
-      false)))
+      http-500-internal-server-error)))
 
 (defn inter-router-request-middleware
   "Attaches a dummy x-waiter-auth cookie into the request to enable mimic-ing auth in inter-router websocket requests."

--- a/waiter/test/waiter/auth/authenticator_test.clj
+++ b/waiter/test/waiter/auth/authenticator_test.clj
@@ -463,8 +463,8 @@
                    :waiter-discovery {:token-metadata {}
                                       :token "token"
                                       :waiter-headers {"x-waiter-authentication" "value"}}}
-          success? (handler request)]
-      (is (false? success?))
+          response-status (handler request)]
+      (is (= http-400-bad-request response-status))
       (is (= http-400-bad-request (.getStatusCode upgrade-response)))
       (is (str/includes? (.getStatusReason upgrade-response) "An authentication parameter is not supported for on-the-fly headers"))))
 
@@ -477,7 +477,7 @@
                                       :token-metadata {}
                                       :token "token"
                                       :waiter-headers {"x-waiter-run-as-user" "test-user"}}}
-          success? (handler request)]
-      (is (false? success?))
+          response-status (handler request)]
+      (is (= http-400-bad-request response-status))
       (is (= http-400-bad-request (.getStatusCode upgrade-response)))
       (is (str/includes? (.getStatusReason upgrade-response) "An authentication disabled token may not be combined with on-the-fly headers")))))

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -175,10 +175,10 @@
                                       :token "token.localtest.me"
                                       :token-metadata {"https-redirect" true}
                                       :waiter-headers {}}}
-          success? (handler request)]
-      (is (false? success?))
+          response-status (handler request)]
+      (is (= http-301-moved-permanently response-status))
       (is (= http-301-moved-permanently (.getStatusCode upgrade-response)))
-      (is (= "https://token.localtest.me" (.getHeader upgrade-response "Location")))
+      (is (= "https://token.localtest.me" (.getHeader upgrade-response "location")))
       (is (= "https-redirect is enabled" (.getStatusReason upgrade-response)))))
 
   (testing "returns 301 with proper url if ws and https-redirect is true and uri is set"
@@ -193,10 +193,10 @@
                                       :token "token.localtest.me"
                                       :token-metadata {"https-redirect" true}
                                       :waiter-headers {}}}
-          success? (handler request)]
-      (is (false? success?))
+          response-status (handler request)]
+      (is (= http-301-moved-permanently response-status))
       (is (= http-301-moved-permanently (.getStatusCode upgrade-response)))
-      (is (= "https://token.localtest.me/random/uri/path" (.getHeader upgrade-response "Location")))
+      (is (= "https://token.localtest.me/random/uri/path" (.getHeader upgrade-response "location")))
       (is (= "https-redirect is enabled" (.getStatusReason upgrade-response)))))
 
   (testing "passes on to next handler if wss and https-redirect is true"

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -429,8 +429,8 @@
                    :waiter-discovery {:token-metadata {"maintenance" {"message" maintenance-message}}
                                       :token "token"
                                       :waiter-headers {}}}
-          success? (handler request)]
-      (is (false? success?))
+          response-status (handler request)]
+      (is (= http-503-service-unavailable response-status))
       (is (= http-503-service-unavailable (.getStatusCode upgrade-response)))
       (is (str/includes? (.getStatusReason upgrade-response) maintenance-message))))
 
@@ -441,8 +441,8 @@
                    :waiter-discovery {:token-metadata {}
                                       :token "token"
                                       :waiter-headers {"x-waiter-maintenance" "some value"}}}
-          success? (handler request)]
-      (is (false? success?))
+          response-status (handler request)]
+      (is (= http-400-bad-request response-status))
       (is (= http-400-bad-request (.getStatusCode upgrade-response)))
       (is (str/includes? (.getStatusReason upgrade-response) "The maintenance parameter is not supported for on-the-fly requests"))))
 

--- a/waiter/test/waiter/websocket_test.clj
+++ b/waiter/test/waiter/websocket_test.clj
@@ -80,7 +80,7 @@
                                                 (is (= cookie-value in-cookie))
                                                 (is (= password in-password))
                                                 nil)]
-          (is (not (request-authenticator password request response)))
+          (is (= http-403-forbidden (request-authenticator password request response)))
           (is (= http-403-forbidden (.getStatusCode response)))
           (is (= "Unauthorized" (.getStatusReason response))))))
 
@@ -92,7 +92,7 @@
                                                 (is (= cookie-value in-cookie))
                                                 (is (= password in-password))
                                                 nil)]
-          (is (not (request-authenticator password request response)))
+          (is (= http-403-forbidden (request-authenticator password request response)))
           (is (= http-403-forbidden (.getStatusCode response)))
           (is (= "Unauthorized" (.getStatusReason response))))))
 
@@ -104,7 +104,7 @@
                                                 (is (= cookie-value in-cookie))
                                                 (is (= password in-password))
                                                 (throw (Exception. "Test-Exception")))]
-          (is (not (request-authenticator password request response)))
+          (is (= http-500-internal-server-error (request-authenticator password request response)))
           (is (= http-500-internal-server-error (.getStatusCode response)))
           (is (= "Test-Exception" (.getStatusReason response))))))))
 
@@ -125,7 +125,7 @@
     (testing "sec-websocket-protocol:multiple"
       (let [request (reified-upgrade-request {:headers {"sec-websocket-protocol" ["foo" "bar"]}})
             response (reified-upgrade-response)]
-        (is (not (request-subprotocol-acceptor request response)))
+        (is (= http-500-internal-server-error (request-subprotocol-acceptor request response)))
         (is (= http-500-internal-server-error (.getStatusCode response)))
         (is (= "waiter does not yet support multiple subprotocols in websocket requests: [\"foo\" \"bar\"]"
                (.getStatusReason response)))))
@@ -133,7 +133,7 @@
     (testing "sec-websocket-protocol:exception"
       (let [request (reified-upgrade-request {:headers {"sec-websocket-protocol" (Object.)}})
             response (reified-upgrade-response)]
-        (is (not (request-subprotocol-acceptor request response)))
+        (is (= http-500-internal-server-error (request-subprotocol-acceptor request response)))
         (is (= http-500-internal-server-error (.getStatusCode response)))
         (is (= "Don't know how to create ISeq from: java.lang.Object"
                (.getStatusReason response)))))))


### PR DESCRIPTION
## Changes proposed in this PR

- adds websocket upgrade requests to the request log

## Why are we making these changes?

We would like to be able to track from the request log results for websocket upgrade requests

### Example logs

Successful upgrade:
```
  {
    "authentication-method": "cookie",
    "cid": "ws-e07c6a182bc6-184d2e44230b8e76",
    "client-protocol": "WS/13",
    "host": "127.0.0.1:9091",
    "internal-protocol": "HTTP/1.1",
    "method": "GET",
    "path": "/websocket-auth",
    "principal": "shamsimam",
    "query-string": "foo=bar",
    "remote-addr": "127.0.0.1",
    "request-id": "ws-e07c6a182bc6-184d2e44230b8e76",
    "request-time": "2021-01-14T04:33:20.554Z",
    "request-type": "websocket-upgrade",
    "scheme": "ws",
    "server": "waiter/1ee073e",
    "server-port": 9091,
    "user-agent": "Jetty/9.4.31.v20200723",
    "waiter-api": false
  }
```

Unauthenticated upgrade request:
```
  {
    "cid": "ws-e07ef4179262-1aa8f97cbb2e9b1e",
    "client-protocol": "WS/13",
    "host": "127.0.0.1:9091",
    "internal-protocol": "HTTP/1.1",
    "method": "GET",
    "path": "/websocket-unauth",
    "remote-addr": "127.0.0.1",
    "request-id": "ws-e07ef4179262-1aa8f97cbb2e9b1e",
    "request-time": "2021-01-14T04:33:31.458Z",
    "request-type": "websocket-upgrade",
    "scheme": "ws",
    "server": "waiter/1ee073e",
    "server-port": 9091,
    "status": 403,
    "user-agent": "Jetty/9.4.31.v20200723",
    "waiter-api": false
  }
```

Maintenance mode upgrade request:
```
  {
    "cid": "ws-e0658651dd20-450290e771705e0a",
    "client-protocol": "WS/13",
    "host": "127.0.0.1:9091",
    "internal-protocol": "HTTP/1.1",
    "method": "GET",
    "path": "/websocket-auth",
    "remote-addr": "127.0.0.1",
    "request-id": "ws-e0658651dd20-450290e771705e0a",
    "request-time": "2021-01-14T04:31:42.246Z",
    "request-type": "websocket-upgrade",
    "scheme": "ws",
    "server": "waiter/1ee073e",
    "server-port": 9091,
    "status": 503,
    "token": "token-waiwebinttestesreqmaimod246724823284741",
    "user-agent": "Jetty/9.4.31.v20200723",
    "waiter-api": false
  }
```


