### PR TITLE
classifies client timeouts as 408 request timeout error

### DIFF
--- a/waiter/src/waiter/status_codes.clj
+++ b/waiter/src/waiter/status_codes.clj
@@ -34,6 +34,7 @@
 (def ^:const http-403-forbidden HttpStatus/FORBIDDEN_403)
 (def ^:const http-404-not-found HttpStatus/NOT_FOUND_404)
 (def ^:const http-405-method-not-allowed HttpStatus/METHOD_NOT_ALLOWED_405)
+(def ^:const http-408-request-timeout HttpStatus/REQUEST_TIMEOUT_408)
 (def ^:const http-409-conflict HttpStatus/CONFLICT_409)
 (def ^:const http-410-gone HttpStatus/GONE_410)
 (def ^:const http-415-unsupported-media-type HttpStatus/UNSUPPORTED_MEDIA_TYPE_415)

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -580,6 +580,10 @@
          (classify-error (EofException. "reset"))))
   (is (= [:instance-error nil http-504-gateway-timeout "java.util.concurrent.TimeoutException"]
          (classify-error (TimeoutException. "timeout"))))
+  (is (=[:client-error "Timeout receiving bytes from client" http-408-request-timeout "java.util.concurrent.TimeoutException"]
+         (let [timeout-exception (TimeoutException. "timeout")]
+           (.addSuppressed timeout-exception (Throwable. "HttpInput idle timeout"))
+           (classify-error timeout-exception))))
   (is (= [:client-error "Failed to upgrade to websocket connection" http-400-bad-request "org.eclipse.jetty.websocket.api.UpgradeException"]
          (classify-error (UpgradeException. nil http-400-bad-request "websocket upgrade failed"))))
   (is (= [:instance-error nil http-502-bad-gateway "java.lang.Exception"]


### PR DESCRIPTION
## Changes proposed in this PR

- classifies client timeouts as 408 request timeout error

## Why are we making these changes?

Request timeout due to client not responding with data should be a 408 response.


