### PR TITLE
adds keystore file hot-reload support

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -45,7 +45,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20200801_013034-g6cffb81"
+                 [twosigma/jet "0.7.10-20210124_190414-gc884701"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -45,7 +45,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20210124_190414-gc884701"
+                 [twosigma/jet "0.7.10-20210126_171807-gea4b804"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]


### PR DESCRIPTION
twosigma-jet PR: https://github.com/twosigma/jet/pull/51

## Changes proposed in this PR

- monitors and reloads the keystore file registered with the SslContextFactory

## Why are we making these changes?

Certificates (and the KeyStore file) can be short-lived and a hot-reload of the KeyStore file in the SSLContext is required without a Jetty server restart. With this change, the Jetty server now monitors the directory of the KeyStore file specified in the SslContextFactory and reloads the SslContextFactory if any changes are detected to the KeyStore file.

### Logs confirming keystore file being picked up

The logs below confirm the `KeyStoreScanner` bean being added and running at intervals (configured at 60 secs in this example).
Also, the scanner picks up changes to the keystore file and reloads it.

```
2021-01-25 23:48:05,551 DEBUG org.eclipse.jetty.util.component.ContainerLifeCycle [main] -  KeyStoreScanner@6ad7f96c{STOPPED} added {Scanner@637f9a24{STOPPED},AUTO}
2021-01-25 23:48:05,551 DEBUG org.eclipse.jetty.util.component.ContainerLifeCycle [main] -  Server@7d7caa3a{STOPPED}[9.4.31.v20200723] added {KeyStoreScanner@6ad7f96c{STOPPED},AUTO}
2021-01-25 23:48:05,584 DEBUG org.eclipse.jetty.util.component.AbstractLifeCycle [main] -  starting KeyStoreScanner@6ad7f96c{STOPPED}
2021-01-25 23:48:05,584 DEBUG org.eclipse.jetty.util.component.AbstractLifeCycle [main] -  starting Scanner@637f9a24{STOPPED}
2021-01-25 23:48:05,584 DEBUG org.eclipse.jetty.util.Scanner [main] -  Scanner start: rprtExists=false, depth=1, rprtDirs=false, interval=60, filter=null, scannables={/Users/shamsimam/projects/github-projects/twosigma-waiter/waiter/resources/certs=IncludeExcludeSet@2773cea7{i=[],ip=SELF,e=[],ep=SELF}}
2021-01-25 23:48:05,588 DEBUG org.eclipse.jetty.util.Scanner [main] -  scan accepted /Users/shamsimam/projects/github-projects/twosigma-waiter/waiter/resources/certs/keystore mod=1611639443941
2021-01-25 23:48:05,588 DEBUG org.eclipse.jetty.util.Scanner [main] -  scan accepted /Users/shamsimam/projects/github-projects/twosigma-waiter/waiter/resources/certs/waiter.crt mod=1611639573994
2021-01-25 23:48:05,589 DEBUG org.eclipse.jetty.util.Scanner [main] -  scan accepted /Users/shamsimam/projects/github-projects/twosigma-waiter/waiter/resources/certs/waiter.key mod=1611639503053
2021-01-25 23:48:05,589 DEBUG org.eclipse.jetty.util.Scanner [main] -  scan accepted /Users/shamsimam/projects/github-projects/twosigma-waiter/waiter/resources/certs/commands.txt mod=1611639656522
2021-01-25 23:48:05,589 DEBUG org.eclipse.jetty.util.Scanner [main] -  scan accepted /Users/shamsimam/projects/github-projects/twosigma-waiter/waiter/resources/certs/waiter.csr mod=1611639621228
2021-01-25 23:48:05,590 DEBUG org.eclipse.jetty.util.component.AbstractLifeCycle [main] -  STARTED @34542ms Scanner@637f9a24{STARTED}
2021-01-25 23:48:05,591 DEBUG org.eclipse.jetty.util.component.AbstractLifeCycle [main] -  STARTED @34542ms KeyStoreScanner@6ad7f96c{STARTED}
...
2021-01-25 23:53:08,600 DEBUG org.eclipse.jetty.util.Scanner [Scanner-0] -  scan accepted /Users/shamsimam/projects/github-projects/twosigma-waiter/waiter/resources/certs/keystore mod=1611640273584
2021-01-25 23:53:08,601 DEBUG org.eclipse.jetty.util.Scanner [Scanner-0] -  scan accepted /Users/shamsimam/projects/github-projects/twosigma-waiter/waiter/resources/certs/waiter.crt mod=1611639573994
2021-01-25 23:53:08,601 DEBUG org.eclipse.jetty.util.Scanner [Scanner-0] -  scan accepted /Users/shamsimam/projects/github-projects/twosigma-waiter/waiter/resources/certs/waiter.key mod=1611640342060
2021-01-25 23:53:08,601 DEBUG org.eclipse.jetty.util.Scanner [Scanner-0] -  scan accepted /Users/shamsimam/projects/github-projects/twosigma-waiter/waiter/resources/certs/commands.txt mod=1611639656522
2021-01-25 23:53:08,601 DEBUG org.eclipse.jetty.util.Scanner [Scanner-0] -  scan accepted /Users/shamsimam/projects/github-projects/twosigma-waiter/waiter/resources/certs/waiter.csr mod=1611639621228
2021-01-25 23:53:08,601 DEBUG org.eclipse.jetty.util.Scanner [Scanner-0] -  scanned [/Users/shamsimam/projects/github-projects/twosigma-waiter/waiter/resources/certs]: {/Users/shamsimam/projects/github-projects/twosigma-waiter/waiter/resources/certs/keystore=CHANGED, /Users/shamsimam/projects/github-projects/twosigma-waiter/waiter/resources/certs/waiter.key=CHANGED}
2021-01-25 23:53:08,602 DEBUG org.eclipse.jetty.util.ssl.KeyStoreScanner [Scanner-0] -  changed /Users/shamsimam/projects/github-projects/twosigma-waiter/waiter/resources/certs/keystore
2021-01-25 23:53:08,602 DEBUG org.eclipse.jetty.util.ssl.KeyStoreScanner [Scanner-0] -  reloading keystore file /Users/shamsimam/projects/github-projects/twosigma-waiter/waiter/resources/certs/keystore
```

