### PR TITLE
Token Watch

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -1050,6 +1050,10 @@
                                           ;; or removed
                                           :channels-update-chan-buffer-size 1024
 
+                                          ;; Buffer size of the tokens-update-chan. The channel receives updates when
+                                          ;; tokens are created, updated, deleted (including index refresh endpoint)
+                                          :tokens-update-chan-buffer-size 1024
+
                                           ;; Time the tokens-watch-maintainer waits before fetching
                                           ;; the kv-store for up to date indexes and sending possible
                                           ;; missed events to listening watches

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -1040,7 +1040,20 @@
                                  ;; Stale services are detected by looking at the version of the
                                  ;; token used to create them, such services will have their idle timeout
                                  ;; reduced to stale-timeout-mins + fallback-period-secs.
-                                 "stale-timeout-mins" 15}}
+                                 "stale-timeout-mins" 15}
+
+                ;; Configures tokens-watch-maintainer which handles and updates watches
+                ;; for token events
+                :tokens-watch-maintainer {
+                                          ;; Buffer size of the tokens-watch-channels-update-chan
+                                          ;; The channel receives updates whenever a watch is added
+                                          ;; or removed
+                                          :channels-update-chan-buffer-size 1024
+
+                                          ;; Time the tokens-watch-maintainer waits before fetching
+                                          ;; the kv-store for up to date indexes and sending possible
+                                          ;; missed events to listening watches
+                                          :watch-refresh-timeout-ms 10000}}
 
  ;; Waiter supports making websocket connections to backends.
  ;; The maximum binary and text message sizes in the websocket request or response can be configured

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -1040,24 +1040,27 @@
                                  ;; Stale services are detected by looking at the version of the
                                  ;; token used to create them, such services will have their idle timeout
                                  ;; reduced to stale-timeout-mins + fallback-period-secs.
-                                 "stale-timeout-mins" 15}
+                                 "stale-timeout-mins" 15}}
 
-                ;; Configures tokens-watch-maintainer which handles and updates watches
+ ;; Waiter provides watch endpoints to listen on changes of a resource
+ ;; This configures various watch providers for different resources
+ :watch-config {
+                ;; Configures token-watch-maintainer which handles and updates watches
                 ;; for token events
-                :tokens-watch-maintainer {
-                                          ;; Buffer size of the tokens-watch-channels-update-chan
-                                          ;; The channel receives updates whenever a watch is added
-                                          ;; or removed
-                                          :channels-update-chan-buffer-size 1024
+                :tokens {
+                         ;; Buffer size of the tokens-watch-channels-update-chan
+                         ;; The channel receives updates whenever a watch is added
+                         ;; or removed
+                         :channels-update-chan-buffer-size 1024
 
-                                          ;; Buffer size of the tokens-update-chan. The channel receives updates when
-                                          ;; tokens are created, updated, deleted (including index refresh endpoint)
-                                          :tokens-update-chan-buffer-size 1024
+                         ;; Buffer size of the tokens-update-chan. The channel receives updates when
+                         ;; tokens are created, updated, deleted (including index refresh endpoint)
+                         :tokens-update-chan-buffer-size 1024
 
-                                          ;; Time the tokens-watch-maintainer waits before fetching
-                                          ;; the kv-store for up to date indexes and sending possible
-                                          ;; missed events to listening watches
-                                          :watch-refresh-timeout-ms 10000}}
+                         ;; Time the token-watch-maintainer waits before fetching
+                         ;; the kv-store for up to date indexes and sending possible
+                         ;; missed events to listening watches
+                         :watch-refresh-timeout-ms 10000}}
 
  ;; Waiter supports making websocket connections to backends.
  ;; The maximum binary and text message sizes in the websocket request or response can be configured

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1826,3 +1826,24 @@
                 (is (= (-> token-description (dissoc :token) (assoc :owner current-user)) parsed-description))))))
         (finally
           (delete-token-and-assert waiter-url token))))))
+
+(deftest ^:parallel ^:integration-fast test-tokens-watch-maintainer
+  (testing-using-waiter-url
+    (let [{:keys [body] :as response} (get-tokens-watch-maintainer-state waiter-url)
+          {:strs [router-id state]} (try-parse-json body)
+          router-url (router-endpoint waiter-url router-id)]
+      (testing "no query parameters provide entire state"
+        (assert-response-status response 200)
+        (is (= (set (keys state))
+               #{"token->token-index" "watches-count"})))
+      (testing "include only watches-count"
+        (let [{:keys [body]} (get-tokens-watch-maintainer-state router-url :query-params "include=watches-count")
+              {:strs [state]} (try-parse-json body)]
+          (is (= (set (keys state))
+                 #{"watches-count"}))))
+      (testing "include multiple fields"
+        (let [{:keys [body]} (get-tokens-watch-maintainer-state
+                               router-url :query-params "include=watches-count&include=token->token-index")
+              {:strs [state]} (try-parse-json body)]
+          (is (= (set (keys state))
+                 #{"token->token-index" "watches-count"})))))))

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1826,30 +1826,3 @@
                 (is (= (-> token-description (dissoc :token) (assoc :owner current-user)) parsed-description))))))
         (finally
           (delete-token-and-assert waiter-url token))))))
-
-(deftest ^:parallel ^:integration-fast test-tokens-watch-maintainer
-  (testing-using-waiter-url
-    (let [{:keys [cookies]} (make-request waiter-url "/waiter-auth")
-          {:keys [body] :as response} (get-tokens-watch-maintainer-state waiter-url)
-          {:strs [router-id state]} (try-parse-json body)
-          router-url (router-endpoint waiter-url router-id)]
-      (testing "no query parameters provide entire state"
-        (assert-response-status response 200)
-        (is (= (set (keys state))
-               #{"token->token-index" "watches-count"})))
-      (testing "include only watches-count"
-        (let [{:keys [body] :as response}
-              (get-tokens-watch-maintainer-state router-url :query-params "include=watches-count" :cookies cookies)
-              {:strs [state]} (try-parse-json body)]
-          (assert-response-status response 200)
-          (is (= (set (keys state))
-                 #{"watches-count"}))))
-      (testing "include multiple fields"
-        (let [{:keys [body] :as response}
-              (get-tokens-watch-maintainer-state router-url
-                                                 :query-params "include=watches-count&include=token->token-index"
-                                                 :cookies cookies)
-              {:strs [state]} (try-parse-json body)]
-          (assert-response-status response 200)
-          (is (= (set (keys state))
-                 #{"token->token-index" "watches-count"})))))))

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1829,7 +1829,8 @@
 
 (deftest ^:parallel ^:integration-fast test-tokens-watch-maintainer
   (testing-using-waiter-url
-    (let [{:keys [body] :as response} (get-tokens-watch-maintainer-state waiter-url)
+    (let [{:keys [cookies]} (make-request waiter-url "/waiter-auth")
+          {:keys [body] :as response} (get-tokens-watch-maintainer-state waiter-url)
           {:strs [router-id state]} (try-parse-json body)
           router-url (router-endpoint waiter-url router-id)]
       (testing "no query parameters provide entire state"
@@ -1837,13 +1838,18 @@
         (is (= (set (keys state))
                #{"token->token-index" "watches-count"})))
       (testing "include only watches-count"
-        (let [{:keys [body]} (get-tokens-watch-maintainer-state router-url :query-params "include=watches-count")
+        (let [{:keys [body] :as response}
+              (get-tokens-watch-maintainer-state router-url :query-params "include=watches-count" :cookies cookies)
               {:strs [state]} (try-parse-json body)]
+          (assert-response-status response 200)
           (is (= (set (keys state))
                  #{"watches-count"}))))
       (testing "include multiple fields"
-        (let [{:keys [body]} (get-tokens-watch-maintainer-state
-                               router-url :query-params "include=watches-count&include=token->token-index")
+        (let [{:keys [body] :as response}
+              (get-tokens-watch-maintainer-state router-url
+                                                 :query-params "include=watches-count&include=token->token-index"
+                                                 :cookies cookies)
               {:strs [state]} (try-parse-json body)]
+          (assert-response-status response 200)
           (is (= (set (keys state))
                  #{"token->token-index" "watches-count"})))))))

--- a/waiter/integration/waiter/token_watch_integration_test.clj
+++ b/waiter/integration/waiter/token_watch_integration_test.clj
@@ -302,7 +302,7 @@
               (assert-watch-token-index-entry watch token-2 entry)
               (delete-token-and-assert waiter-url token-2 :hard-delete false)
               (assert-watch-token-index-entry-does-not-change watch token-2 entry)
-              (stop-watches [watch]))
+              (stop-watch watch))
             (finally
               (delete-token-and-assert waiter-url token-1)
               (delete-token-and-assert waiter-url token-2)))))

--- a/waiter/integration/waiter/token_watch_integration_test.clj
+++ b/waiter/integration/waiter/token_watch_integration_test.clj
@@ -67,10 +67,10 @@
           (is (await-goal-response-for-all-routers goal-fn watch-state-request-fn router_urls))))
 
       (testing "updating a token reflects change in token-watch-state"
-        (let [token (create-token-name waiter-url ".")
-              last-update-time (System/currentTimeMillis)
+        (let [last-update-time (System/currentTimeMillis)
               response (post-token waiter-url
                                    {:token token :cpus 2 :last-update-time last-update-time}
+                                   :headers {"if-match" (token->etag waiter-url token)}
                                    :query-params {"update-mode" "admin"})
               goal-fn (fn [{:keys [body] :as response}]
                         (let [{:strs [state]} (try-parse-json body)]

--- a/waiter/integration/waiter/token_watch_integration_test.clj
+++ b/waiter/integration/waiter/token_watch_integration_test.clj
@@ -3,7 +3,6 @@
             [clojure.set :as set]
             [clojure.test :refer :all]
             [waiter.status-codes :refer :all]
-            [waiter.util.async-utils :as au]
             [waiter.util.client-tools :refer :all]))
 
 (defn- await-goal-response-for-all-routers
@@ -107,3 +106,202 @@
                           (assert-response-status response 200)
                           (nil? (get-in state ["token->index" token]))))]
           (is (await-goal-response-for-all-routers goal-fn watch-state-request-fn router_urls)))))))
+
+(defn- start-watch
+  [router-url cookies & {:keys [query-params] :or {query-params {"include" ["metadata", "deleted"]
+                                                                 "watch" "true"}}}]
+  (let [{:keys [body error]} (make-request router-url "/tokens"
+                                           :cookies cookies
+                                           :fold-chunked-response? false
+                                           :query-params query-params)
+        token->index-atom (atom {})
+        query-state-fn (fn [] @token->index-atom)
+        exit-chan (async/promise-chan)
+        go-chan
+        (async/go-loop [token->index @token->index-atom]
+          (reset! token->index-atom token->index)
+          (let [[msg chan] (async/alts! [body exit-chan] :priority true)
+                next-token->index
+                (condp = chan
+                  body
+                  (when (some? msg)
+                    (let [{:strs [object type]} (try-parse-json msg)]
+                      (case type
+                        "INITIAL"
+                        (reduce
+                          (fn [token->index index]
+                            (assoc token->index (get index "token") index))
+                          {}
+                          object)
+
+                        "EVENTS"
+                        (reduce
+                          (fn [token->index {:strs [object type]}]
+                            (case type
+                              "UPDATE"
+                              (assoc token->index (get object "token") object)
+                              "DELETE"
+                              (dissoc token->index (get object "token") object)
+                              (throw (ex-info "Unknown event type received in EVENTS object" {:event object}))))
+                          token->index
+                          object)
+                        (throw (ex-info "Unknown event type received from watch" {:event msg})))))
+
+                  exit-chan
+                  (do
+                    (async/close! body)
+                    false))]
+            (when next-token->index
+              (recur next-token->index))))]
+    {:exit-chan exit-chan
+     :error-chan error
+     :go-chan go-chan
+     :query-state-fn query-state-fn}))
+
+(defn- start-watches
+  [router-urls cookies]
+  (mapv
+    #(start-watch % cookies)
+    router-urls))
+
+(defn- stop-watch
+  [{:keys [exit-chan go-chan]}]
+  (async/close! exit-chan)
+  (async/<!! go-chan))
+
+(defn- stop-watches
+  [watches]
+  (doseq [watch watches]
+    (stop-watch watch)))
+
+(defmacro assert-watch-token-index-entry
+  [watch token entry]
+  `(let [watch# ~watch
+         token# ~token
+         entry# ~entry
+         query-state-fn# (:query-state-fn watch#)]
+     (is (wait-for
+           #(= (get (query-state-fn#) token#)
+               entry#)
+           :interval 1 :timeout 5))))
+
+(defmacro assert-watches-token-index-entry
+  [watches token entry]
+  `(let [watches# ~watches
+         token# ~token
+         entry# ~entry]
+     (doseq [watch# watches#]
+       (assert-watch-token-index-entry watch# token# entry#))))
+
+(defn- get-token-index
+  [waiter-url token &
+   {:keys [cookies headers query-params] :or {cookies [] headers {} query-params {}}}]
+  (let [{:keys [body] :as index-response}
+        (make-request waiter-url "/tokens" :query-params {"include" ["metadata", "deleted"]} :cookies cookies)]
+    (assert-response-status index-response 200)
+    (->> body
+         try-parse-json
+         (filter #(= token (get % "token")))
+         first)))
+
+(deftest ^:parallel ^:integration-fast test-token-watch-maintainer-watches
+  (testing-using-waiter-url
+    (let [routers (routers waiter-url)
+          router-urls (vals routers)
+          {:keys [cookies]} (make-request waiter-url "/waiter-auth")]
+
+      (testing "watch stream gets initial list of tokens"
+        (let [token-name (create-token-name waiter-url ".")
+              response (post-token waiter-url (assoc (kitchen-params) :token token-name) :cookies cookies)
+              watches (start-watches router-urls cookies)]
+          (assert-response-status response 200)
+          (try
+            (let [entry (get-token-index waiter-url token-name :cookies cookies)]
+              (assert-watches-token-index-entry watches token-name entry))
+            (finally
+              (stop-watches watches)
+              (delete-token-and-assert waiter-url token-name)))))
+
+      (testing "stream receives index UPDATE (create, update, soft-delete) events for all routers"
+        (let [token-name (create-token-name waiter-url ".")
+              watches (start-watches router-urls cookies)]
+          (assert-watches-token-index-entry watches token-name nil)
+          (try
+            (let [response (post-token waiter-url (assoc (kitchen-params) :token token-name) :cookies cookies)
+                  entry (get-token-index waiter-url token-name :cookies cookies)]
+              (assert-response-status response 200)
+              (assert-watches-token-index-entry watches token-name entry))
+            (let [response (post-token waiter-url (assoc (kitchen-params) :token token-name
+                                                                          :version "updated-version")
+                                       :cookies cookies)
+                  entry (get-token-index waiter-url token-name :cookies cookies)]
+              (assert-response-status response 200)
+              (assert-watches-token-index-entry watches token-name entry))
+            (delete-token-and-assert waiter-url token-name :hard-delete false)
+            (let [entry (get-token-index waiter-url token-name :cookies cookies)]
+              (assert-watches-token-index-entry watches token-name entry))
+            (finally
+              (stop-watches watches)
+              (delete-token-and-assert waiter-url token-name)))))
+
+      (testing "stream receives DELETE events for all routers"
+        (let [token-name (create-token-name waiter-url ".")
+              response (post-token waiter-url (assoc (kitchen-params) :token token-name) :cookies cookies)
+              watches (start-watches router-urls cookies)]
+          (assert-response-status response 200)
+          (try
+            (let [entry (get-token-index waiter-url token-name :cookies cookies)]
+              (assert-watches-token-index-entry watches token-name entry)
+              (delete-token-and-assert waiter-url token-name)
+              (assert-watches-token-index-entry watches token-name nil))
+            (finally
+              (stop-watches watches)))))
+
+      (testing "stream does not include soft deleted token events without include=deleted query param"
+        (let [token-1 (create-token-name waiter-url ".")
+              token-2 (create-token-name waiter-url ".")
+              res-1 (post-token waiter-url (assoc (kitchen-params) :token token-1) :cookies cookies)
+              res-2 (post-token waiter-url (assoc (kitchen-params) :token token-2) :cookies cookies)]
+          (assert-response-status res-1 200)
+          (assert-response-status res-2 200)
+          (try
+            (delete-token-and-assert waiter-url token-1 :hard-delete false)
+            (let [entry (get-token-index waiter-url token-2 :cookies cookies)
+                  watch (start-watch waiter-url cookies :query-params {"include" "metadata" "watch" "true"})]
+              (assert-watch-token-index-entry watch token-1 nil)
+              (assert-watch-token-index-entry watch token-2 entry)
+              (delete-token-and-assert waiter-url token-2 :hard-delete false)
+              (async/<!! (async/timeout 4000))
+              (assert-watch-token-index-entry watch token-2 entry)
+              (stop-watches [watch]))
+            (finally
+              (delete-token-and-assert waiter-url token-1)
+              (delete-token-and-assert waiter-url token-2)))))
+
+      (testing "stream does not include metadata in events without include=metadata query param"
+        (let [token-1 (create-token-name waiter-url ".")
+              token-2 (create-token-name waiter-url ".")
+              res-1 (post-token waiter-url (assoc (kitchen-params) :token token-1) :cookies cookies)
+              res-2 (post-token waiter-url (assoc (kitchen-params) :token token-2) :cookies cookies)]
+          (assert-response-status res-1 200)
+          (assert-response-status res-2 200)
+          (try
+            (let [watch (start-watch waiter-url cookies :query-params {"watch" "true"})]
+              (assert-watch-token-index-entry watch token-1 {"token" token-1
+                                                             "owner" (retrieve-username)
+                                                             "maintenance" false})
+              (assert-watch-token-index-entry watch token-2 {"token" token-2
+                                                             "owner" (retrieve-username)
+                                                             "maintenance" false})
+              (post-token waiter-url (assoc (kitchen-params) :token token-1 :version "update-1"))
+              (async/<!! (async/timeout 4000))
+              (assert-watch-token-index-entry watch token-1 {"token" token-1
+                                                             "owner" (retrieve-username)
+                                                             "maintenance" false})
+              (assert-watch-token-index-entry watch token-2 {"token" token-2
+                                                             "owner" (retrieve-username)
+                                                             "maintenance" false})
+              (stop-watch watch))
+            (finally
+              (delete-token-and-assert waiter-url token-1)
+              (delete-token-and-assert waiter-url token-2))))))))

--- a/waiter/integration/waiter/token_watch_integration_test.clj
+++ b/waiter/integration/waiter/token_watch_integration_test.clj
@@ -1,0 +1,110 @@
+(ns waiter.token-watch-integration-test
+  (:require [clojure.core.async :as async]
+            [clojure.set :as set]
+            [clojure.test :refer :all]
+            [waiter.status-codes :refer :all]
+            [waiter.util.async-utils :as au]
+            [waiter.util.client-tools :refer :all]))
+
+(defn await-goal-response-for-all-routers
+  "Returns true if the goal-response-fn was satisfied with the response from request-fn for all routers before
+  timeout-ms by polling every interval-ms."
+  [goal-response-fn request-fn router-urls timeout-ms interval-ms]
+  (let [timeout-ch (async/timeout timeout-ms)
+        timer-ch (au/timer-chan interval-ms)]
+    (loop []
+      (let [[_ ch] (async/alts!! [timer-ch timeout-ch] :priority true)
+            responses (for [router-url router-urls]
+                        (request-fn router-url))]
+        (cond
+          (every? goal-response-fn responses) true
+          (= ch timeout-ch) false
+          :else (recur))))))
+
+(deftest ^:parallel ^:integration-fast test-token-watch-maintainer
+  (testing-using-waiter-url
+    (let [{:keys [cookies]} (make-request waiter-url "/waiter-auth")
+          routers (routers waiter-url)
+          router_urls (vals routers)
+          {:keys [body] :as response} (get-token-watch-maintainer-state waiter-url)
+          {:strs [router-id state]} (try-parse-json body)
+          watch-state-request-fn (fn [router-url]
+                                   (get-token-watch-maintainer-state router-url
+                                                                     :query-params "include=token-index-map"
+                                                                     :cookies cookies))
+          token (create-token-name waiter-url ".")
+          router-url (router-endpoint waiter-url router-id)
+          default-state-fields #{"last-update-time" "watch-count"}]
+
+      (testing "no query parameters provide default state fields"
+        (assert-response-status response 200)
+        (is (= (set (keys state))
+               default-state-fields)))
+
+      (testing "include token-index-map map"
+        (let [{:keys [body] :as response}
+              (get-token-watch-maintainer-state router-url :query-params "include=token-index-map" :cookies cookies)
+              {:strs [state]} (try-parse-json body)]
+          (assert-response-status response 200)
+          (is (= (set (keys state))
+                 (set/union default-state-fields #{"token-index-map"})))))
+
+      (testing "creating token reflects change in token-watch-state"
+        (let [last-update-time (System/currentTimeMillis)
+              response (post-token waiter-url
+                                   {:token token :cpus 1 :last-update-time last-update-time}
+                                   :query-params {"update-mode" "admin"})
+              goal-fn (fn [{:keys [body] :as response}]
+                        (let [{:strs [state]} (try-parse-json body)]
+                          (assert-response-status response 200)
+                          (= (get-in state ["token-index-map" token])
+                             {"deleted" false
+                              "etag" (token->etag waiter-url token)
+                              "last-update-time" last-update-time
+                              "maintenance" false
+                              "owner" (retrieve-username)
+                              "token" token})))]
+          (assert-response-status response 200)
+          (is (await-goal-response-for-all-routers goal-fn watch-state-request-fn router_urls 5000 100))))
+
+      (testing "updating a token reflects change in token-watch-state"
+        (let [token (create-token-name waiter-url ".")
+              last-update-time (System/currentTimeMillis)
+              response (post-token waiter-url
+                                   {:token token :cpus 2 :last-update-time last-update-time}
+                                   :query-params {"update-mode" "admin"})
+              goal-fn (fn [{:keys [body] :as response}]
+                        (let [{:strs [state]} (try-parse-json body)]
+                          (assert-response-status response 200)
+                          (= (get-in state ["token-index-map" token])
+                             {"deleted" false
+                              "etag" (token->etag waiter-url token)
+                              "last-update-time" last-update-time
+                              "maintenance" false
+                              "owner" (retrieve-username)
+                              "token" token})))]
+          (assert-response-status response 200)
+          (is (await-goal-response-for-all-routers goal-fn watch-state-request-fn router_urls 5000 100))))
+
+      (testing "soft deleting a token reflects change in token-watch-state"
+        (let [_ (delete-token-and-assert waiter-url token :hard-delete false)
+              goal-fn (fn [{:keys [body] :as response}]
+                        (let [{:strs [state]} (try-parse-json body)]
+                          (assert-response-status response 200)
+                          (= (-> state
+                                 (get-in ["token-index-map" token])
+                                 (dissoc "last-update-time"))
+                             {"deleted" true
+                              "etag" nil
+                              "maintenance" false
+                              "owner" (retrieve-username)
+                              "token" token})))]
+          (is (await-goal-response-for-all-routers goal-fn watch-state-request-fn router_urls 5000 100))))
+
+      (testing "hard deleting a token reflects change in token-watch-state"
+        (let [_ (delete-token-and-assert waiter-url token)
+              goal-fn (fn [{:keys [body] :as response}]
+                        (let [{:strs [state]} (try-parse-json body)]
+                          (assert-response-status response 200)
+                          (nil? (get-in state ["token-index-map" token]))))]
+          (is (await-goal-response-for-all-routers goal-fn watch-state-request-fn router_urls 5000 100)))))))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1775,11 +1775,14 @@
                                clock synchronize-fn kv-store token-cluster-calculator token-root history-length limit-per-owner
                                waiter-hostnames entitlement-manager make-inter-router-requests-sync-fn validate-service-description-fn
                                attach-service-defaults-fn tokens-update-chan request)))))
-   :token-list-handler-fn (pc/fnk [[:state entitlement-manager kv-store]
+   :token-list-handler-fn (pc/fnk [[:daemons token-watch-maintainer]
+                                   [:state entitlement-manager kv-store]
                                    wrap-secure-request-fn]
-                            (wrap-secure-request-fn
-                              (fn token-handler-fn [request]
-                                (token/handle-list-tokens-request kv-store entitlement-manager request))))
+                            (let [{:keys [tokens-watch-channels-update-chan]} token-watch-maintainer]
+                              (wrap-secure-request-fn
+                                (fn token-handler-fn [request]
+                                  (token/handle-list-tokens-request kv-store entitlement-manager
+                                                                    tokens-watch-channels-update-chan request)))))
    :token-owners-handler-fn (pc/fnk [[:state kv-store]
                                      wrap-secure-request-fn]
                               (wrap-secure-request-fn

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -769,7 +769,9 @@
    :token-cluster-calculator (pc/fnk [[:settings [:cluster-config name] [:token-config cluster-calculator]]]
                                (utils/create-component
                                  cluster-calculator :context {:default-cluster name}))
-   :tokens-update-chan (pc/fnk [] (au/latest-chan))
+   :tokens-update-chan (pc/fnk [[:settings
+                                 [:token-config [:tokens-watch-maintainer tokens-update-chan-buffer-size]]]]
+                         (async/chan tokens-update-chan-buffer-size))
    :tokens-watch-channels-update-chan (pc/fnk [[:settings
                                                 [:token-config [:tokens-watch-maintainer channels-update-chan-buffer-size]]]]
                                         (async/chan channels-update-chan-buffer-size))

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -809,7 +809,7 @@
                                                           "fallback" "gc-broken-services" "gc-services" "gc-transient-metrics" "interstitial"
                                                           "jwt-auth-server" "kv-store" "launch-metrics" "leader" "local-usage"
                                                           "maintainer" "router-metrics" "scheduler" "service-description-builder"
-                                                          "service-maintainer" "statsd" "work-stealing"]
+                                                          "service-maintainer" "statsd" "token-watch-maintainer" "work-stealing"]
                                                          (pc/map-from-keys make-url))
                                            :router-id router-id
                                            :routers routers}))
@@ -891,18 +891,15 @@
        :leader-id (leader-id-fn)})
     router-id request))
 
-(defn get-tokens-watch-maintainer-state
-  "Using the query-state-fn, pass include-flags to get the tokens-watch-maintainer-state and return
+(defn get-token-watch-maintainer-state
+  "Using the query-state-fn, pass include-flags to get the token-watch-maintainer-state and return
   streaming response"
   [router-id query-state-fn request]
   (try
     (let [{:strs [include]} (-> request ru/query-params-request :query-params)
-          include-flags (if (string? include) #{include} (set include))
-          state (if (nil? include)
-                  (query-state-fn)
-                  (query-state-fn include-flags))]
+          include-flags (if (string? include) #{include} (set include))]
       (utils/clj->streaming-json-response {:router-id router-id
-                                           :state state}))
+                                           :state (query-state-fn include-flags)}))
     (catch Exception ex
       (utils/exception->response ex request))))
 

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -891,6 +891,21 @@
        :leader-id (leader-id-fn)})
     router-id request))
 
+(defn get-tokens-watch-maintainer-state
+  "Using the query-state-fn, pass include-flags to get the tokens-watch-maintainer-state and return
+  streaming response"
+  [router-id query-state-fn request]
+  (try
+    (let [{:strs [include]} (-> request ru/query-params-request :query-params)
+          include-flags (if (string? include) #{include} (set include))
+          state (if (nil? include)
+                  (query-state-fn)
+                  (query-state-fn include-flags))]
+      (utils/clj->streaming-json-response {:router-id router-id
+                                           :state state}))
+    (catch Exception ex
+      (utils/exception->response ex request))))
+
 (defn get-router-metrics-state
   "Outputs the router metrics state."
   [router-id router-metrics-state-fn request]

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -178,7 +178,11 @@
                                    (s/required-key :limit-per-owner) schema/positive-int
                                    (s/required-key :token-defaults) {(s/required-key "fallback-period-secs") schema/non-negative-int
                                                                      (s/required-key "https-redirect") s/Bool
-                                                                     (s/required-key "stale-timeout-mins") schema/non-negative-int}}
+                                                                     (s/required-key "stale-timeout-mins") schema/non-negative-int}
+                                   (s/required-key :tokens-watch-maintainer) {(s/required-key :channels-update-chan-buffer-size)
+                                                                              schema/non-negative-int
+                                                                              (s/required-key :watch-refresh-timeout-ms)
+                                                                              schema/non-negative-int}}
    (s/required-key :waiter-principal) schema/non-empty-string
    (s/required-key :websocket-config) {(s/required-key :ws-max-binary-message-size) schema/positive-int
                                        (s/required-key :ws-max-text-message-size) schema/positive-int}
@@ -470,7 +474,9 @@
                   :limit-per-owner 1000
                   :token-defaults {"fallback-period-secs" (-> 5 t/minutes t/in-seconds)
                                    "https-redirect" false
-                                   "stale-timeout-mins" 15}}
+                                   "stale-timeout-mins" 15}
+                  :tokens-watch-maintainer {:channels-update-chan-buffer-size 1024
+                                            :watch-refresh-timeout-ms 10000}}
    :websocket-config {:ws-max-binary-message-size (* 1024 1024 40)
                       :ws-max-text-message-size (* 1024 1024 40)}
    :work-stealing {:max-in-flight-offers 4000

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -178,13 +178,10 @@
                                    (s/required-key :limit-per-owner) schema/positive-int
                                    (s/required-key :token-defaults) {(s/required-key "fallback-period-secs") schema/non-negative-int
                                                                      (s/required-key "https-redirect") s/Bool
-                                                                     (s/required-key "stale-timeout-mins") schema/non-negative-int}
-                                   (s/required-key :tokens-watch-maintainer) {(s/required-key :channels-update-chan-buffer-size)
-                                                                              schema/non-negative-int
-                                                                              (s/required-key :tokens-update-chan-buffer-size)
-                                                                              schema/non-negative-int
-                                                                              (s/required-key :watch-refresh-timeout-ms)
-                                                                              schema/non-negative-int}}
+                                                                     (s/required-key "stale-timeout-mins") schema/non-negative-int}}
+   (s/required-key :watch-config) {(s/required-key :tokens) {(s/required-key :channels-update-chan-buffer-size) schema/non-negative-int
+                                                             (s/required-key :tokens-update-chan-buffer-size) schema/non-negative-int
+                                                             (s/required-key :watch-refresh-timeout-ms) schema/non-negative-int}}
    (s/required-key :waiter-principal) schema/non-empty-string
    (s/required-key :websocket-config) {(s/required-key :ws-max-binary-message-size) schema/positive-int
                                        (s/required-key :ws-max-text-message-size) schema/positive-int}
@@ -476,10 +473,10 @@
                   :limit-per-owner 1000
                   :token-defaults {"fallback-period-secs" (-> 5 t/minutes t/in-seconds)
                                    "https-redirect" false
-                                   "stale-timeout-mins" 15}
-                  :tokens-watch-maintainer {:channels-update-chan-buffer-size 1024
-                                            :tokens-update-chan-buffer-size 1024
-                                            :watch-refresh-timeout-ms 10000}}
+                                   "stale-timeout-mins" 15}}
+   :watch-config {:tokens {:channels-update-chan-buffer-size 1024
+                           :tokens-update-chan-buffer-size 1024
+                           :watch-refresh-timeout-ms 10000}}
    :websocket-config {:ws-max-binary-message-size (* 1024 1024 40)
                       :ws-max-text-message-size (* 1024 1024 40)}
    :work-stealing {:max-in-flight-offers 4000

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -181,6 +181,8 @@
                                                                      (s/required-key "stale-timeout-mins") schema/non-negative-int}
                                    (s/required-key :tokens-watch-maintainer) {(s/required-key :channels-update-chan-buffer-size)
                                                                               schema/non-negative-int
+                                                                              (s/required-key :tokens-update-chan-buffer-size)
+                                                                              schema/non-negative-int
                                                                               (s/required-key :watch-refresh-timeout-ms)
                                                                               schema/non-negative-int}}
    (s/required-key :waiter-principal) schema/non-empty-string
@@ -476,6 +478,7 @@
                                    "https-redirect" false
                                    "stale-timeout-mins" 15}
                   :tokens-watch-maintainer {:channels-update-chan-buffer-size 1024
+                                            :tokens-update-chan-buffer-size 1024
                                             :watch-refresh-timeout-ms 10000}}
    :websocket-config {:ws-max-binary-message-size (* 1024 1024 40)
                       :ws-max-text-message-size (* 1024 1024 40)}

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -674,9 +674,9 @@
         watch-chan-buffer (async/buffer 1000)
         watch-chan (async/chan watch-chan-buffer watch-chan-xform watch-chan-ex-handler-fn)]
     (async/go
-      (async/<! ctrl)
-      (log/info "closing watch-chan, as ctrl channel in request has been triggered")
-      (async/close! watch-chan))
+      (let [data (async/<! ctrl)]
+        (log/info "closing watch-chan, as ctrl channel in request has been triggered" {:data data})
+        (async/close! watch-chan)))
     (async/put! tokens-watch-channels-update-chan watch-chan)
     (utils/attach-waiter-source
       {:body watch-chan

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -15,19 +15,24 @@
 ;;
 (ns waiter.token
   (:require [clj-time.coerce :as tc]
+            [clj-time.core :as t]
+            [clojure.core.async :as async]
             [clojure.data :as data]
             [clojure.set :as set]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
+            [metrics.timers :as timers]
             [plumbing.core :as pc]
             [schema.core :as s]
             [waiter.authorization :as authz]
             [waiter.kv :as kv]
+            [waiter.metrics :as metrics]
             [waiter.service-description :as sd]
             [waiter.status-codes :refer :all]
             [waiter.util.date-utils :as du]
             [waiter.util.ring-utils :as ru]
-            [waiter.util.utils :as utils])
+            [waiter.util.utils :as utils]
+            [waiter.util.async-utils :as au])
   (:import (org.joda.time DateTime)))
 
 (def ^:const ANY-USER "*")
@@ -181,6 +186,7 @@
                 (update-kv! kv-store owner-key (fn [index]
                                                  (->> (make-index-entry token-hash true last-update-time maintenance)
                                                       (assoc index token))))))))
+
         ; Don't bother removing owner from token-owners, even if they have no tokens now
         (log/info "deleted token for" token))))
 
@@ -205,10 +211,10 @@
 
   (defn list-index-entries-for-owner
     "List all tokens for a given user."
-    [kv-store owner]
-    (let [owner->owner-key (kv/fetch kv-store token-owners-key)]
+    [kv-store owner & {:keys [refresh] :or {refresh false}}]
+    (let [owner->owner-key (kv/fetch kv-store token-owners-key :refresh refresh)]
       (if-let [owner-key (get owner->owner-key owner)]
-        (kv/fetch kv-store owner-key)
+        (kv/fetch kv-store owner-key :refresh refresh)
         (log/info "no owner-key found for owner" owner))))
 
   (defn list-token-owners
@@ -719,3 +725,119 @@
                                              :status http-405-method-not-allowed})))
     (catch Exception ex
       (utils/exception->response ex req))))
+
+(defn make-index-event
+  [type object]
+  {:object object :type type})
+
+(defn start-tokens-watch-maintainer
+  [kv-store tokens-update-chan tokens-watch-channels-update-chan watch-refresh-timeout-ms exit-chan]
+  (let [tokens-event-chan (au/latest-chan)
+        tokens-event-mult (async/mult tokens-event-chan)
+        query-chan (async/chan)
+        get-token->token-index-fn (fn []
+                                    (->> kv-store
+                                         list-token-owners
+                                         (reduce
+                                           (fn [current-token-index-map owner]
+                                             (reduce
+                                               (fn [inner-token-index-map [token entry]]
+                                                 (->> (assoc entry :owner owner :token token)
+                                                      (assoc inner-token-index-map token)))
+                                               current-token-index-map
+                                               (list-index-entries-for-owner kv-store owner :refresh true)))
+                                           {})))
+        state-atom (atom {:token->token-index (get-token->token-index-fn)
+                          :watches-count 0})
+        go-chan
+        (async/go
+          (try
+            (loop [{:keys [token->token-index watches-count] :as current-state} @state-atom
+                   watch-refresh-timeout-chan (async/timeout watch-refresh-timeout-ms)]
+              (reset! state-atom current-state)
+              (let [[msg current-chan]
+                    (async/alts! [exit-chan tokens-update-chan tokens-watch-channels-update-chan
+                                  watch-refresh-timeout-chan query-chan]
+                                 :priority true)
+                    [next-state next-watch-refresh-timeout-chan]
+                    (condp = current-chan
+                      exit-chan
+                      (do
+                        (log/warn "Stopping tokens-watch-maintainer")
+                        (when (not= :exit msg)
+                          (throw (ex-info "Stopping router-state maintainer" {:time (t/now) :reason msg}))))
+
+                      tokens-update-chan
+                      (timers/start-stop-time!
+                        (metrics/waiter-timer "core" "tokens-watch-maintainer" "process-tokens-update")
+                        (let [{:keys [token owner]} msg
+                              token-index-entry (some-> (list-index-entries-for-owner kv-store owner :refresh true)
+                                                        (get token)
+                                                        (assoc :owner owner :token token))
+                              [event next-state]
+                              (when (not= token-index-entry (get token->token-index token))
+                                (if token-index-entry
+                                  [(make-index-event "UPDATE" token-index-entry)
+                                   (assoc-in current-state [:token->token-index token] token-index-entry)]
+                                  [(make-index-event "DELETE" {:owner owner :token token})
+                                   (assoc current-state :token->token-index (dissoc token->token-index token))]))]
+                          (if event
+                            (do
+                              (async/>! tokens-event-chan event)
+                              [next-state watch-refresh-timeout-chan])
+                            [current-state watch-refresh-timeout-chan])))
+
+                      tokens-watch-channels-update-chan
+                      (timers/start-stop-time!
+                        (metrics/waiter-timer "core" "tokens-watch-maintainer" "process-tokens-channels-update")
+                        (let [{:keys [channel-event watch-chan]} msg
+                              next-state (case channel-event
+                                           :add (do
+                                                  (async/put! watch-chan (or (vals token->token-index) '()))
+                                                  (async/tap tokens-event-mult watch-chan)
+                                                  (update current-state :watches-count inc))
+                                           :remove (update current-state :watches-count dec)
+                                           (throw (ex-info "Invalid tokens-watch-channels-update-chan event" {:event msg})))]
+                          (log/info "Tokens-watch-maintainer watch count changed!" {:previous-count watches-count
+                                                                                    :new-count (get next-state :watches-count)})
+                          [next-state watch-refresh-timeout-chan]))
+
+                      watch-refresh-timeout-chan
+                      (timers/start-stop-time!
+                        (metrics/waiter-timer "core" "tokens-watch-maintainer" "refresh")
+                        (let [next-token->index (get-token->token-index-fn)
+                              [only-old-indexes only-next-indexes _] (data/diff token->token-index next-token->index)]
+                          ; if token in old-indexes and not in only-next-indexes, then those token indexes were deleted
+                          (doseq [[token {:keys [owner]}] only-old-indexes]
+                            (when-not (contains? only-next-indexes token)
+                              (async/>! tokens-event-chan (make-index-event "DELETE" {:owner owner :token token}))))
+                          ; if token in only-next-indexes, it has been updated (soft-delete included)
+                          (doseq [[token _] only-next-indexes]
+                            (async/>! tokens-event-chan (make-index-event "UPDATE" (get next-token->index token))))
+                          (if (and (nil? only-old-indexes) (nil? only-next-indexes))
+                            (log/info "Tokens-watch-maintainer found no differences in kv-store and current-state")
+                            (log/info "Tokens-watch-maintainer found some differences in kv-store and current-state"
+                                      {:only-in-current only-old-indexes :only-in-next only-next-indexes}))
+                          [(assoc current-state :token->token-index next-token->index)
+                           (async/timeout watch-refresh-timeout-ms)]))
+
+                      query-chan
+                      (let [response-chan msg]
+                        (async/put! response-chan current-state)
+                        [current-state watch-refresh-timeout-chan]))]
+                (if (and next-state next-watch-refresh-timeout-chan)
+                  (recur next-state next-watch-refresh-timeout-chan)
+                  (log/info "Stopping tokens-watch-maintainer as next loop values are nil"))))
+            (catch Exception e
+              (log/error e "Fatal error in tokens-watch-maintainer"))))]
+    {:go-chan go-chan
+     :query-chan query-chan
+     :query-state-fn (fn tokens-watch-query-state-fn
+                       ([] @state-atom)
+                       ([include-flags]
+                        (let [state @state-atom]
+                          (cond-> {}
+                                  (contains? include-flags "token->token-index")
+                                  (assoc :token->token-index (get state :token->token-index))
+                                  (contains? include-flags "watches-count")
+                                  (assoc :watches-count (get state :watches-count))))))}))

--- a/waiter/src/waiter/token_watch.clj
+++ b/waiter/src/waiter/token_watch.clj
@@ -93,7 +93,9 @@
                                       ; index-entry doesn't exist then treat as DELETE
                                       [(make-index-event :DELETE {:owner owner :token token})
                                        (assoc current-state :token->index (dissoc token->index token))])
-                                    open-chans (send-event-to-channels! watch-chans index-event)]
+                                    open-chans (->> [index-event]
+                                                    (make-index-event :EVENTS)
+                                                    (send-event-to-channels! watch-chans))]
                                 (assoc next-state :watch-chans open-chans)))))
 
                         tokens-watch-channels-update-chan

--- a/waiter/src/waiter/token_watch.clj
+++ b/waiter/src/waiter/token_watch.clj
@@ -143,7 +143,6 @@
                     (recur (assoc next-state :last-update-time (clock)))
                     (log/info "Stopping token-watch-maintainer as next loop values are nil"))))
               (catch Exception e
-                (clojure.stacktrace/print-stack-trace e)
                 (log/error e "Fatal error in token-watch-maintainer")
                 (System/exit 1))))]
       (metrics/waiter-gauge #(count tokens-update-chan-buffer)

--- a/waiter/src/waiter/token_watch.clj
+++ b/waiter/src/waiter/token_watch.clj
@@ -55,9 +55,9 @@
                       (contains? include-flags "token->index")
                       (assoc :token->index token->index)
                       (contains? include-flags "buffer-state")
-                      (assoc :buffer-state {:update-chan-count (count tokens-update-chan-buffer)
+                      (assoc :buffer-state {:update-chan-count (.count tokens-update-chan-buffer)
                                             :watch-channels-update-chan-count
-                                            (count tokens-watch-channels-update-chan-buffer)}))))
+                                            (.count tokens-watch-channels-update-chan-buffer)}))))
           go-chan
           (async/go
             (try

--- a/waiter/src/waiter/token_watch.clj
+++ b/waiter/src/waiter/token_watch.clj
@@ -1,0 +1,151 @@
+(ns waiter.token-watch
+  (:require [clojure.core.async :as async]
+            [clojure.data :as data]
+            [clojure.tools.logging :as log]
+            [metrics.counters :as counters]
+            [metrics.meters :as meters]
+            [metrics.timers :as timers]
+            [waiter.correlation-id :as cid]
+            [waiter.metrics :as metrics]
+            [waiter.token :as tkn]
+            [waiter.util.async-utils :as au]))
+
+(defn send-event-to-channels
+  "Given a list of watch channels and the event to send to each channel, send the event in a non blocking fashion and
+  close channels that error the async/put! operation. Returns a list of closed channels."
+  [watch-chans event]
+  (for [watch-chan watch-chans
+        :when
+        (try
+          (not (async/put! watch-chan event))
+          (catch AssertionError e
+            (log/error e "closing watch-chan due to error")
+            (async/close! watch-chan)
+            true))]
+    watch-chan))
+
+(defn start-token-watch-maintainer
+  "Starts daemon thread that maintains token watches and process/filters internal token events to be streamed to
+  clients through the watch handlers. Returns map of various channels and state functions to control the daemon."
+  [kv-store clock tokens-update-chan-buffer-size channels-update-chan-buffer-size watch-refresh-timer-chan]
+  (cid/with-correlation-id
+    "token-watch-maintainer"
+    (let [exit-chan (async/promise-chan)
+          tokens-update-chan-buffer (async/buffer tokens-update-chan-buffer-size)
+          tokens-update-chan (async/chan tokens-update-chan-buffer)
+          tokens-watch-channels-update-chan-buffer (async/buffer channels-update-chan-buffer-size)
+          tokens-watch-channels-update-chan (async/chan tokens-watch-channels-update-chan-buffer)
+          query-chan (async/chan)
+          state-atom (atom {:last-update-time (clock)
+                            :token-index-map (tkn/get-token-index-map kv-store :refresh true)
+                            :watch-chans #{}})
+          query-state-fn
+          (fn tokens-watch-query-state-fn
+            [include-flags]
+            (let [{:keys [last-update-time token-index-map watch-chans]} @state-atom]
+              (cond-> {:last-update-time last-update-time
+                       :watch-count (count watch-chans)}
+                      (contains? include-flags "token-index-map")
+                      (assoc :token-index-map token-index-map)
+                      (contains? include-flags "buffer-state")
+                      (assoc :buffer-state {:update-chan-count (count tokens-update-chan-buffer)
+                                            :watch-channels-update-chan-count
+                                            (count tokens-watch-channels-update-chan-buffer)}))))
+          go-chan
+          (async/go
+            (try
+              (loop [{:keys [token-index-map watch-chans] :as current-state} @state-atom]
+                (reset! state-atom current-state)
+                (let [[msg current-chan]
+                      (async/alts! [exit-chan tokens-update-chan tokens-watch-channels-update-chan
+                                    watch-refresh-timer-chan query-chan]
+                                   :priority true)
+                      next-state
+                      (condp = current-chan
+                        exit-chan
+                        (do
+                          (log/warn "Stopping token-watch-maintainer")
+                          (when (not= :exit msg)
+                            (throw (ex-info "Stopping router-state maintainer" {:time (clock) :reason msg}))))
+
+                        tokens-update-chan
+                        (timers/start-stop-time!
+                          (metrics/waiter-timer "core" "token-watch-maintainer" "process-tokens-update")
+                          (let [{:keys [token owner]} msg
+                                token-index-entry (tkn/get-token-index kv-store token owner :refresh true)
+                                local-token-index-entry (get token-index-map token)]
+                            (cond
+                              ; There is no change detected, so no event to be reported
+                              (= token-index-entry local-token-index-entry)
+                              current-state
+                              ; If index-entry retrieved from kv-store exists then treat as UPDATE (includes token creation)
+                              (some? token-index-entry)
+                              (let [closed-chans (send-event-to-channels watch-chans (tkn/make-index-event :UPDATE token-index-entry))]
+                                (-> current-state
+                                    (assoc-in [:token-index-map token] token-index-entry)
+                                    (assoc :watch-chans (apply disj watch-chans closed-chans))))
+                              :else
+                              (let [event-obj {:owner owner :token token}
+                                    closed-chans (send-event-to-channels watch-chans (tkn/make-index-event :DELETE event-obj))]
+                                (-> current-state
+                                    (assoc :token-index-map (dissoc token-index-map token))
+                                    (assoc :watch-chans (apply disj watch-chans closed-chans)))))))
+
+                        tokens-watch-channels-update-chan
+                        (timers/start-stop-time!
+                          (metrics/waiter-timer "core" "token-watch-maintainer" "process-tokens-channels-update")
+                          (let [watch-chan msg]
+                            (async/put! watch-chan (tkn/make-index-event :INITIAL (or (vals token-index-map) [])))
+                            (assoc current-state :watch-chans (conj watch-chans watch-chan))))
+
+                        watch-refresh-timer-chan
+                        (timers/start-stop-time!
+                          (metrics/waiter-timer "core" "token-watch-maintainer" "refresh")
+                          (let [next-token-index-map (tkn/get-token-index-map kv-store :refresh true)
+                                [only-old-indexes only-next-indexes _] (data/diff token-index-map next-token-index-map)
+                                ; if token in old-indexes and not in only-next-indexes, then those token indexes were deleted
+                                delete-events
+                                (for [[token {:keys [owner]}] only-old-indexes
+                                      :when (not (contains? only-next-indexes token))]
+                                  (tkn/make-index-event :DELETE {:owner owner :token token}))
+                                ; if token in only-next-indexes, it has been updated (soft-delete, and creation included)
+                                update-events
+                                (for [[token _] only-next-indexes]
+                                  (tkn/make-index-event :UPDATE (get next-token-index-map token)))
+                                events (concat delete-events update-events)
+                                ; send events event if empty, which will serve as a heartbeat
+                                closed-chans
+                                (send-event-to-channels watch-chans (tkn/make-index-event :EVENTS events))]
+                            (when (not-empty events)
+                              (counters/inc! (metrics/waiter-counter "core" "token-watch-maintainer" "refresh-sync"))
+                              (meters/mark! (metrics/waiter-meter "core" "token-watch-maintainer" "refresh-sync-rate"))
+                              (meters/mark! (metrics/waiter-meter "core" "token-watch-maintainer" "refresh-sync-count")
+                                            (count events))
+                              (log/info "token-watch-maintainer found some differences in kv-store and current-state"
+                                        {:only-in-current only-old-indexes
+                                         :only-in-next only-next-indexes
+                                         :token-count (count token-index-map)}))
+                            (assoc current-state :token-index-map next-token-index-map
+                                                 :watch-chans (apply disj watch-chans closed-chans))))
+
+                        query-chan
+                        (let [{:keys [response-chan include-flags]} msg]
+                          (async/put! response-chan (query-state-fn include-flags))
+                          current-state))]
+                  (if next-state
+                    (recur (assoc next-state :last-update-time (clock)))
+                    (log/info "Stopping token-watch-maintainer as next loop values are nil"))))
+              (catch Exception e
+                (clojure.stacktrace/print-stack-trace e)
+                (log/error e "Fatal error in token-watch-maintainer")
+                (System/exit 1))))]
+      (metrics/waiter-gauge #(count tokens-update-chan-buffer)
+                            "core" "token-watch-maintainer" "update-chan-count")
+      (metrics/waiter-gauge #(count tokens-watch-channels-update-chan-buffer)
+                            "core" "token-watch-maintainer" "watch-channels-update-chan-count")
+      {:exit-chan exit-chan
+       :go-chan go-chan
+       :query-chan query-chan
+       :query-state-fn query-state-fn
+       :tokens-update-chan tokens-update-chan
+       :tokens-watch-channels-update-chan tokens-watch-channels-update-chan})))

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -1139,9 +1139,9 @@
     (log/debug "retrieved token" token ":" (:body token-response))
     token-response))
 
-(defn get-tokens-watch-maintainer-state
+(defn get-token-watch-maintainer-state
   [waiter-url & {:keys [cookies query-params]}]
-  (make-request waiter-url "/state/tokens-watch-maintainer"
+  (make-request waiter-url "/state/token-watch-maintainer"
                 :cookies cookies
                 :query-params query-params
                 :method :get))

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -1139,6 +1139,12 @@
     (log/debug "retrieved token" token ":" (:body token-response))
     token-response))
 
+(defn get-tokens-watch-maintainer-state
+  [waiter-url & {:keys [query-params]}]
+  (make-request waiter-url "/state/tokens-watch-maintainer"
+                :query-params query-params
+                :method :get))
+
 (defmacro with-service-cleanup
   "Ensures a service is cleaned up."
   [service-id & body]

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -1140,8 +1140,9 @@
     token-response))
 
 (defn get-tokens-watch-maintainer-state
-  [waiter-url & {:keys [query-params]}]
+  [waiter-url & {:keys [cookies query-params]}]
   (make-request waiter-url "/state/tokens-watch-maintainer"
+                :cookies cookies
                 :query-params query-params
                 :method :get))
 

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -780,3 +780,10 @@
   [principal]
   (when principal
     (first (str/split principal #"@" 2))))
+
+(defn chan-to-seq!!
+  "Takes a channel and returns a lazy sequence of channel messages"
+  [c]
+  (lazy-seq
+    (when-some [v (async/<!! c)]
+      (cons v (chan-to-seq!! c)))))

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -16,6 +16,7 @@
 (ns waiter.token-test
   (:require [clj-time.coerce :as tc]
             [clj-time.core :as t]
+            [clojure.core.async :as async]
             [clojure.data.json :as json]
             [clojure.string :as str]
             [clojure.test :refer :all]
@@ -367,10 +368,12 @@
           (is (empty? (sd/fetch-core kv-store service-id-1)))))
 
       (testing "test:list-tokens"
-        (let [{:keys [body status]}
+        (let [token-watch-channels-update-chan (async/chan)
+              {:keys [body status]}
               (handle-list-tokens-request
                 kv-store
                 entitlement-manager
+                token-watch-channels-update-chan
                 {:authorization/user auth-user
                  :query-string "include=metadata"
                  :request-method :get})
@@ -382,7 +385,8 @@
                    "maintenance" false
                    "owner" "tu1"
                    "token" token}]
-                 (json/read-str body)))))
+                 (json/read-str body)))
+          (is (nil? (async/poll! token-watch-channels-update-chan)))))
 
       (testing "post:new-service-description-different-owner"
         (let [token (str token "-tu")
@@ -2356,7 +2360,8 @@
                               (authorized? [_ _ _ _] (throw (UnsupportedOperationException. "unexpected call"))))
         handle-list-tokens-request (wrap-handler-json-response handle-list-tokens-request)
         last-update-time-seed (clock-millis)
-        token->token-hash (fn [token] (sd/token-data->token-hash (kv/fetch kv-store token)))]
+        token->token-hash (fn [token] (sd/token-data->token-hash (kv/fetch kv-store token)))
+        token-watch-channels-update-chan (async/chan)]
     (store-service-description-for-token
       synchronize-fn kv-store history-length limit-per-owner "token1"
       {"cpus" 1 "idle-timeout-mins" 0 "mem" 1024}
@@ -2394,7 +2399,7 @@
       {"allowed-params" #{"P1" "P2"} "env" {"E1" "v0" "P1" "v1" "P2" "v2"} "cpus" 4 "mem" 1024}
       {"cluster" "c1" "last-update-time" (- last-update-time-seed 3000) "maintenance" {"message" "msg1"} "owner" "owner3"})
     (let [request {:query-string "include=metadata" :request-method :get}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
       (is (= #{{"deleted" false
                 "etag" (token->token-hash "token1")
@@ -2444,9 +2449,10 @@
                 "maintenance" true
                 "owner" "owner3"
                 "token" "token9"}}
-             (set (json/read-str body)))))
+             (set (json/read-str body))))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [request {:query-string "include=metadata&include=deleted" :request-method :get}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
       (is (= #{{"deleted" false
                 "etag" (token->token-hash "token1")
@@ -2502,9 +2508,10 @@
                 "maintenance" true
                 "owner" "owner3"
                 "token" "token9"}}
-             (set (json/read-str body)))))
+             (set (json/read-str body))))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [request {:request-method :get}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
       (is (= #{{"maintenance" false "owner" "owner1" "token" "token1"}
                {"maintenance" false "owner" "owner1" "token" "token2"}
@@ -2514,13 +2521,14 @@
                {"maintenance" false "owner" "owner3" "token" "token7"}
                {"maintenance" false "owner" "owner3" "token" "token8"}
                {"maintenance" true "owner" "owner3" "token" "token9"}}
-             (set (json/read-str body)))))
+             (set (json/read-str body))))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [entitlement-manager (reify authz/EntitlementManager
                                 (authorized? [_ subject action resource]
                                   (is (= :manage action))
                                   (str/starts-with? (:user resource) subject)))]
       (let [request {:query-string "can-manage-as-user=owner" :request-method :get}
-            {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+            {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
         (is (= http-200-ok status))
         (is (= #{{"maintenance" false "owner" "owner1" "token" "token1"}
                  {"maintenance" false "owner" "owner1" "token" "token2"}
@@ -2530,30 +2538,34 @@
                  {"maintenance" false "owner" "owner3" "token" "token7"}
                  {"maintenance" false "owner" "owner3" "token" "token8"}
                  {"maintenance" true "owner" "owner3" "token" "token9"}}
-               (set (json/read-str body)))))
+               (set (json/read-str body))))
+        (is (nil? (async/poll! token-watch-channels-update-chan))))
       (let [request {:query-string "can-manage-as-user=owner1" :request-method :get}
-            {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+            {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
         (is (= http-200-ok status))
         (is (= #{{"maintenance" false "owner" "owner1" "token" "token1"}
                  {"maintenance" false "owner" "owner1" "token" "token2"}}
-               (set (json/read-str body)))))
+               (set (json/read-str body))))
+        (is (nil? (async/poll! token-watch-channels-update-chan))))
       (let [request {:query-string "can-manage-as-user=owner2" :request-method :get}
-            {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+            {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
         (is (= http-200-ok status))
         (is (= #{{"maintenance" false "owner" "owner2" "token" "token3"}}
                (set (json/read-str body)))))
       (let [request {:query-string "can-manage-as-user=test" :request-method :get}
-            {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+            {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
         (is (= http-200-ok status))
-        (is (= #{} (set (json/read-str body))))))
+        (is (= #{} (set (json/read-str body))))
+        (is (nil? (async/poll! token-watch-channels-update-chan)))))
     (let [request {:query-string "owner=owner1" :request-method :get}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
       (is (= #{{"maintenance" false "owner" "owner1" "token" "token1"}
                {"maintenance" false "owner" "owner1" "token" "token2"}}
-             (set (json/read-str body)))))
+             (set (json/read-str body))))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [request {:query-string "owner=owner1&include=metadata" :request-method :get}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
       (is (= #{{"deleted" false
                 "etag" (token->token-hash "token1")
@@ -2567,21 +2579,24 @@
                 "maintenance" false
                 "owner" "owner1"
                 "token" "token2"}}
-             (set (json/read-str body)))))
+             (set (json/read-str body))))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [request {:query-string "owner=does-not-exist" :request-method :get}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
-      (is (= [] (json/read-str body))))
+      (is (= [] (json/read-str body)))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [request {:headers {"accept" "application/json"}
                    :request-method :post}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)
           json-response (try (json/read-str body)
                              (catch Exception _
                                (is (str "Failed to parse body as JSON:\n" body))))]
       (is (= http-405-method-not-allowed status))
-      (is json-response))
+      (is json-response)
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [request {:request-method :get :query-string "owner=owner2&include=metadata"}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
       (is (= #{{"deleted" false
                 "etag" (token->token-hash "token3")
@@ -2589,9 +2604,10 @@
                 "maintenance" false
                 "owner" "owner2"
                 "token" "token3"}}
-             (set (json/read-str body)))))
+             (set (json/read-str body))))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [request {:request-method :get :query-string "owner=owner2&include=metadata&include=deleted"}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
       (is (= #{{"deleted" false
                 "etag" (token->token-hash "token3")
@@ -2605,68 +2621,78 @@
                 "maintenance" false
                 "owner" "owner2"
                 "token" "token4"}}
-             (set (json/read-str body)))))
+             (set (json/read-str body))))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [request {:request-method :get :query-string "cpus=1"}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
       (is (= #{{"maintenance" false "owner" "owner1" "token" "token1"}}
-             (set (json/read-str body)))))
+             (set (json/read-str body))))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [request {:request-method :get :query-string "mem=2048"}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
       (is (= #{{"maintenance" false "owner" "owner1" "token" "token2"}
                {"maintenance" false "owner" "owner2" "token" "token3"}
                {"maintenance" false "owner" "owner3" "token" "token5"}
                {"maintenance" false "owner" "owner3" "token" "token6"}}
-             (set (json/read-str body)))))
+             (set (json/read-str body))))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [request {:request-method :get :query-string "cluster=c1&mem=2048"}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
       (is (= #{{"maintenance" false "owner" "owner1" "token" "token2"}
                {"maintenance" false "owner" "owner3" "token" "token5"}
                {"maintenance" false "owner" "owner3" "token" "token6"}}
-             (set (json/read-str body)))))
+             (set (json/read-str body))))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [request {:request-method :get :query-string "cluster=c2&mem=2048"}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
       (is (= #{{"maintenance" false "owner" "owner2" "token" "token3"}}
-             (set (json/read-str body)))))
+             (set (json/read-str body))))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [request {:request-method :get :query-string "include=deleted&mem=2048"}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
       (is (= #{{"maintenance" false "owner" "owner1" "token" "token2"}
                {"maintenance" false "owner" "owner2" "token" "token3"}
                {"maintenance" false "owner" "owner2" "token" "token4"}
                {"maintenance" false "owner" "owner3" "token" "token5"}
                {"maintenance" false "owner" "owner3" "token" "token6"}}
-             (set (json/read-str body)))))
+             (set (json/read-str body))))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [request {:request-method :get :query-string "idle-timeout-mins=0"}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
       (is (= #{{"maintenance" false "owner" "owner1" "token" "token1"}
                {"maintenance" false "owner" "owner3" "token" "token6"}}
-             (set (json/read-str body)))))
+             (set (json/read-str body))))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [request {:request-method :get :query-string "idle-timeout-mins=0&include=deleted"}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
       (is (= #{{"maintenance" false "owner" "owner1" "token" "token1"}
                {"maintenance" false "owner" "owner2" "token" "token4"}
                {"maintenance" false "owner" "owner3" "token" "token6"}}
-             (set (json/read-str body)))))
+             (set (json/read-str body))))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [request {:request-method :get :query-string "cluster=c1&idle-timeout-mins=0"}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
       (is (= #{{"maintenance" false "owner" "owner1" "token" "token1"}
                {"maintenance" false "owner" "owner3" "token" "token6"}}
-             (set (json/read-str body)))))
+             (set (json/read-str body))))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [request {:request-method :get :query-string "run-as-requester=true"}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
       (is (= #{{"maintenance" false "owner" "owner3" "token" "token5"}
                {"maintenance" false "owner" "owner3" "token" "token6"}}
-             (set (json/read-str body)))))
+             (set (json/read-str body))))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [request {:request-method :get :query-string "run-as-requester=false"}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
       (is (= #{{"maintenance" false "owner" "owner1" "token" "token1"}
                {"maintenance" false "owner" "owner1" "token" "token2"}
@@ -2674,15 +2700,17 @@
                {"maintenance" false "owner" "owner3" "token" "token7"}
                {"maintenance" false "owner" "owner3" "token" "token8"}
                {"maintenance" true "owner" "owner3" "token" "token9"}}
-             (set (json/read-str body)))))
+             (set (json/read-str body))))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [request {:request-method :get :query-string "requires-parameters=true"}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
       (is (= #{{"maintenance" false "owner" "owner3" "token" "token7"}
                {"maintenance" false "owner" "owner3" "token" "token8"}}
-             (set (json/read-str body)))))
+             (set (json/read-str body))))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [request {:request-method :get :query-string "requires-parameters=false"}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
       (is (= #{{"maintenance" false "owner" "owner1" "token" "token1"}
                {"maintenance" false "owner" "owner1" "token" "token2"}
@@ -2690,16 +2718,19 @@
                {"maintenance" false "owner" "owner3" "token" "token5"}
                {"maintenance" false "owner" "owner3" "token" "token6"}
                {"maintenance" true "owner" "owner3" "token" "token9"}}
-             (set (json/read-str body)))))
+             (set (json/read-str body))))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [request {:request-method :get :query-string "cluster=c2&idle-timeout-mins=0"}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
-      (is (empty? (set (json/read-str body)))))
+      (is (empty? (set (json/read-str body))))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [request {:request-method :get :query-string "idle-timeout-mins=5"}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
       (is (= #{{"maintenance" false "owner" "owner2" "token" "token3"}}
-             (set (json/read-str body)))))
+             (set (json/read-str body))))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [request {:headers {"accept" "application/json"}
                    :request-method :get}
           {:keys [body]} (handle-list-token-owners-request kv-store request)
@@ -2707,12 +2738,13 @@
       (is (some #(= "owner1" %) owner-map-keys) "Should have had a key 'owner1'")
       (is (some #(= "owner2" %) owner-map-keys) "Should have had a key 'owner2'"))
     (let [request {:request-method :get :query-string "maintenance=true"}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
       (is (= #{{"maintenance" true "owner" "owner3" "token" "token9"}}
-             (set (json/read-str body)))))
+             (set (json/read-str body))))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))
     (let [request {:request-method :get :query-string "maintenance=false"}
-          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager request)]
+          {:keys [body status]} (handle-list-tokens-request kv-store entitlement-manager token-watch-channels-update-chan request)]
       (is (= http-200-ok status))
       (is (= #{{"maintenance" false "owner" "owner1" "token" "token1"}
                {"maintenance" false "owner" "owner1" "token" "token2"}
@@ -2721,4 +2753,5 @@
                {"maintenance" false "owner" "owner3" "token" "token6"}
                {"maintenance" false "owner" "owner3" "token" "token7"}
                {"maintenance" false "owner" "owner3" "token" "token8"}}
-             (set (json/read-str body)))))))
+             (set (json/read-str body))))
+      (is (nil? (async/poll! token-watch-channels-update-chan))))))

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -16,6 +16,7 @@
 (ns waiter.token-test
   (:require [clj-time.coerce :as tc]
             [clj-time.core :as t]
+            [clojure.core.async :as async]
             [clojure.data.json :as json]
             [clojure.string :as str]
             [clojure.test :refer :all]
@@ -28,7 +29,8 @@
             [waiter.test-helpers :refer :all]
             [waiter.token :refer :all]
             [waiter.util.date-utils :as du]
-            [waiter.util.utils :as utils])
+            [waiter.util.utils :as utils]
+            [waiter.util.async-utils :as au])
   (:import (clojure.lang ExceptionInfo)
            (java.io StringBufferInputStream)
            (org.joda.time DateTime)))
@@ -2721,3 +2723,241 @@
                {"maintenance" false "owner" "owner3" "token" "token7"}
                {"maintenance" false "owner" "owner3" "token" "token8"}}
              (set (json/read-str body)))))))
+
+(defmacro assert-channels-no-new-message
+  [chans timeout-ms]
+  `(let [chans# ~chans
+         timeout-ms# ~timeout-ms
+         timeout-chan# (async/timeout timeout-ms#)
+         [_# res-chan#] (-> chans#
+                            (conj timeout-chan#)
+                            (async/alts!! :priority true))]
+     (is (= res-chan# timeout-chan#))))
+
+(defmacro assert-channels-next-message-with-fn
+  [chans msg-fn]
+  `(let [chans# ~chans
+         msg-fn# ~msg-fn
+         res# (for [chan# chans#] (async/<!! chan#))]
+     (is (every? msg-fn# res#))))
+
+(defmacro assert-channels-next-message
+  "Assert that list of channels next message"
+  [chans msg]
+  `(let [chans# ~chans
+         msg# ~msg]
+     (assert-channels-next-message-with-fn chans# #(= % msg#))))
+
+(let [get-token-hash (fn [kv-store token] (sd/token-data->token-hash (kv/fetch kv-store token)))
+      get-latest-state (fn [query-chan]
+                         (let [temp-chan (async/chan)]
+                           (async/>!! query-chan temp-chan)
+                           (async/<!! temp-chan)))
+      create-watch-chans (fn []
+                           (for [_ (range 10)]
+                             (async/chan)))
+      add-watch-chans (fn [tokens-watch-channels-update-chan watch-chans]
+                        (doseq [chan watch-chans]
+                          (async/put! tokens-watch-channels-update-chan {:channel-event :add :watch-chan chan})))
+      remove-watch-chans (fn [tokens-watch-channels-update-chan watch-chans]
+                           (doseq [chan watch-chans]
+                             (async/put! tokens-watch-channels-update-chan {:channel-event :remove :watch-chan chan})))
+      stop-tokens-watch-maintainer (fn [go-chan exit-chan]
+                                     (async/>!! exit-chan :exit)
+                                     (async/<!! go-chan))
+      auth-user "auth-user"
+      token1-metadata {"cluster" "c1" "last-update-time" 1000 "owner" "owner1"}
+      token1-service-desc {"cpus" 1}
+      token1-index {:deleted false
+                    :last-update-time (get token1-metadata "last-update-time")
+                    :maintenance false
+                    :owner (get token1-metadata "owner")
+                    :token "token1"}]
+  (deftest test-start-tokens-watch-maintainer-empty-starting-state
+    (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+          watch-chans (create-watch-chans)
+          exit-chan (async/chan 1)
+          tokens-update-chan (au/latest-chan)
+          tokens-watch-channels-update-chan (async/chan)
+          watch-refresh-timeout-ms 10000
+          {:keys [go-chan query-chan]}
+          (start-tokens-watch-maintainer kv-store tokens-update-chan tokens-watch-channels-update-chan watch-refresh-timeout-ms exit-chan)]
+      (is (= {:token->token-index {} :watches-count 0} (get-latest-state query-chan)))
+      (testing "watch-channels should receive empty list of tokens"
+        (add-watch-chans tokens-watch-channels-update-chan watch-chans)
+        (is (= {:token->token-index {} :watches-count 10} (get-latest-state query-chan)))
+        (assert-channels-next-message watch-chans '()))
+      (stop-tokens-watch-maintainer go-chan exit-chan)))
+  (deftest test-start-tokens-watch-maintainer-non-empty-starting-state
+    (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+          watch-chans (create-watch-chans)
+          exit-chan (async/chan 1)
+          tokens-update-chan (au/latest-chan)
+          tokens-watch-channels-update-chan (async/chan)
+          watch-refresh-timeout-ms 10000
+          _ (store-service-description-for-token
+              synchronize-fn kv-store history-length limit-per-owner "token1" token1-service-desc token1-metadata)
+          {:keys [go-chan query-chan]}
+          (start-tokens-watch-maintainer kv-store tokens-update-chan tokens-watch-channels-update-chan watch-refresh-timeout-ms exit-chan)
+          token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1"))
+          expected-token->token-index {"token1" token-cur-index}]
+      (is (= {:token->token-index expected-token->token-index :watches-count 0}
+             (get-latest-state query-chan)))
+      (testing "watch-channels should receive starting list of tokens"
+        (add-watch-chans tokens-watch-channels-update-chan watch-chans)
+        (is (= {:token->token-index expected-token->token-index :watches-count 10} (get-latest-state query-chan)))
+        (assert-channels-next-message-with-fn watch-chans
+                                              #(= #{token-cur-index}
+                                                  (set %))))
+      (stop-tokens-watch-maintainer go-chan exit-chan)))
+  (deftest test-start-tokens-watch-maintainer-watch-channels-updates
+    (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+          watch-chans (create-watch-chans)
+          exit-chan (async/chan 1)
+          tokens-update-chan (au/latest-chan)
+          tokens-watch-channels-update-chan (async/chan)
+          watch-refresh-timeout-ms 10000
+          {:keys [go-chan query-chan]}
+          (start-tokens-watch-maintainer kv-store tokens-update-chan tokens-watch-channels-update-chan watch-refresh-timeout-ms exit-chan)]
+      (testing "watch-channels get UPDATE event for added tokens"
+        (add-watch-chans tokens-watch-channels-update-chan watch-chans)
+        (is (= {:token->token-index {} :watches-count 10}
+               (get-latest-state query-chan)))
+        (store-service-description-for-token
+          synchronize-fn kv-store history-length limit-per-owner "token1" token1-service-desc token1-metadata)
+        (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1"))
+              expected-token->token-index {"token1" token-cur-index}]
+          (async/>!! tokens-update-chan {:owner (get token1-index :owner) :token "token1"})
+          (assert-channels-next-message watch-chans '())
+          (assert-channels-next-message watch-chans (make-index-event "UPDATE" token-cur-index))
+          (is (= {:token->token-index expected-token->token-index :watches-count 10} (get-latest-state query-chan)))))
+      (testing "watch-channels get UPDATE event for modified tokens"
+        (store-service-description-for-token
+          synchronize-fn kv-store history-length limit-per-owner "token1" (assoc token1-service-desc "cpus" 2) token1-metadata)
+        (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1"))
+              expected-token->token-index {"token1" token-cur-index}]
+          (async/>!! tokens-update-chan {:owner (get token1-index :owner) :token "token1"})
+          (assert-channels-next-message watch-chans (make-index-event "UPDATE" token-cur-index))
+          (is (= {:token->token-index expected-token->token-index :watches-count 10} (get-latest-state query-chan)))
+          (testing "watch-channels doesn't send event if no changes in token-index-entry and current-state"
+            (async/>!! tokens-update-chan {:owner (get token1-index :owner) :token "token1"})
+            (assert-channels-no-new-message watch-chans 1000)
+            (is (= {:token->token-index expected-token->token-index :watches-count 10} (get-latest-state query-chan))))))
+      (testing "watch-channels get UPDATE event for soft deleted tokens"
+        (delete-service-description-for-token clock synchronize-fn kv-store history-length "token1"
+                                              (get token1-index :owner) auth-user)
+        (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1")
+                                                  :last-update-time (clock-millis)
+                                                  :deleted true)
+              expected-token->token-index {"token1" token-cur-index}]
+          (async/>!! tokens-update-chan {:owner (get token1-index :owner) :token "token1"})
+          (assert-channels-next-message watch-chans (make-index-event "UPDATE" token-cur-index))
+          (is (= {:token->token-index expected-token->token-index :watches-count 10} (get-latest-state query-chan)))))
+      (testing "watch-channels get DELETE event for hard deleted tokens"
+        (delete-service-description-for-token clock synchronize-fn kv-store history-length "token1"
+                                              (get token1-index :owner) auth-user :hard-delete true)
+        (async/>!! tokens-update-chan {:owner (get token1-index :owner) :token "token1"})
+        (assert-channels-next-message watch-chans (make-index-event "DELETE" {:owner (get token1-index :owner)
+                                                                              :token "token1"}))
+        (is (= {:token->token-index {} :watches-count 10} (get-latest-state query-chan))))
+      (testing "watch-channels doesn't send event if no changes in token-index-entry and current-state"
+        (async/>!! tokens-update-chan {:owner (get token1-index :owner) :token "token1"})
+        (assert-channels-no-new-message watch-chans 1000)
+        (is (= {:token->token-index {} :watches-count 10} (get-latest-state query-chan))))
+      (stop-tokens-watch-maintainer go-chan exit-chan)))
+  (deftest test-start-tokens-watch-maintainer-watch-count
+    (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+          watch-chans (create-watch-chans)
+          exit-chan (async/chan 1)
+          tokens-update-chan (au/latest-chan)
+          tokens-watch-channels-update-chan (async/chan)
+          watch-refresh-timeout-ms 10000
+          {:keys [go-chan query-chan]}
+          (start-tokens-watch-maintainer kv-store tokens-update-chan tokens-watch-channels-update-chan watch-refresh-timeout-ms exit-chan)]
+      (is (= {:token->token-index {} :watches-count 0}
+             (get-latest-state query-chan)))
+      (testing "watch-count should increment when channels are added"
+        (add-watch-chans tokens-watch-channels-update-chan watch-chans)
+        (is (= {:token->token-index {} :watches-count 10} (get-latest-state query-chan)))
+        (assert-channels-next-message watch-chans '())
+        (add-watch-chans tokens-watch-channels-update-chan watch-chans)
+        (is (= {:token->token-index {} :watches-count 20} (get-latest-state query-chan)))
+        (assert-channels-next-message watch-chans '()))
+      (testing "watch-count should decrement when notified"
+        (remove-watch-chans tokens-watch-channels-update-chan watch-chans)
+        (is (= {:token->token-index {} :watches-count 10} (get-latest-state query-chan)))
+        (remove-watch-chans tokens-watch-channels-update-chan watch-chans)
+        (is (= {:token->token-index {} :watches-count 0} (get-latest-state query-chan))))
+      (stop-tokens-watch-maintainer go-chan exit-chan)))
+  (deftest test-start-tokens-watch-maintainer-refresh-timeout
+    (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+          watch-chans (create-watch-chans)
+          exit-chan (async/chan 1)
+          tokens-update-chan (au/latest-chan)
+          tokens-watch-channels-update-chan (async/chan)
+          watch-refresh-timeout-ms 2000
+          test-refresh-timeout-ms-buffer (+ watch-refresh-timeout-ms 500)
+          {:keys [go-chan query-chan]}
+          (start-tokens-watch-maintainer kv-store tokens-update-chan tokens-watch-channels-update-chan
+                                         watch-refresh-timeout-ms exit-chan)]
+      (is (= {:token->token-index {} :watches-count 0}
+             (get-latest-state query-chan)))
+      (testing "refresh-timeout should not update if there are no changes in kv-store"
+        (Thread/sleep test-refresh-timeout-ms-buffer)
+        (is (= {:token->token-index {} :watches-count 0}
+               (get-latest-state query-chan))))
+      (add-watch-chans tokens-watch-channels-update-chan watch-chans)
+      (assert-channels-next-message watch-chans '())
+      (testing "refresh-timeout should update current-state and watchers if token is added to kv-store"
+        (store-service-description-for-token
+          synchronize-fn kv-store history-length limit-per-owner "token1" token1-service-desc token1-metadata)
+        (Thread/sleep test-refresh-timeout-ms-buffer)
+        (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1"))
+              expected-token->token-index {"token1" token-cur-index}]
+          (is (= {:token->token-index expected-token->token-index :watches-count 10}
+                 (get-latest-state query-chan)))
+          (assert-channels-next-message watch-chans (make-index-event "UPDATE" token-cur-index))))
+      (testing "refresh-timeout should update current-state and watchers if token is out of date"
+        (store-service-description-for-token
+          synchronize-fn kv-store history-length limit-per-owner "token1" (assoc token1-service-desc "cpus" 2)
+          token1-metadata)
+        (Thread/sleep test-refresh-timeout-ms-buffer)
+        (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1"))
+              expected-token->token-index {"token1" token-cur-index}]
+          (is (= {:token->token-index expected-token->token-index :watches-count 10}
+                 (get-latest-state query-chan)))
+          (assert-channels-next-message watch-chans (make-index-event "UPDATE" token-cur-index))))
+      (testing "refresh-timeout should update current-state and watchers if token is soft deleted"
+        (delete-service-description-for-token clock synchronize-fn kv-store history-length "token1"
+                                              (get token1-index :owner) auth-user)
+        (Thread/sleep test-refresh-timeout-ms-buffer)
+        (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1")
+                                                  :last-update-time (clock-millis)
+                                                  :deleted true)
+              expected-token->token-index {"token1" token-cur-index}]
+          (is (= {:token->token-index expected-token->token-index :watches-count 10}
+                 (get-latest-state query-chan)))
+          (assert-channels-next-message watch-chans (make-index-event "UPDATE" token-cur-index))))
+      (testing "refresh-timeout should update current-state and watchers if token is hard deleted"
+        (delete-service-description-for-token clock synchronize-fn kv-store history-length "token1"
+                                              (get token1-index :owner) auth-user :hard-delete true)
+        (Thread/sleep test-refresh-timeout-ms-buffer)
+        (is (= {:token->token-index {} :watches-count 10} (get-latest-state query-chan)))
+        (assert-channels-next-message watch-chans (make-index-event "DELETE" {:owner (get token1-index :owner)
+                                                                              :token "token1"})))
+      (stop-tokens-watch-maintainer go-chan exit-chan)))
+  (deftest test-start-tokens-watch-maintainer-query-state
+    (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+          exit-chan (async/chan 1)
+          tokens-update-chan (au/latest-chan)
+          tokens-watch-channels-update-chan (async/chan)
+          watch-refresh-timeout-ms 10000
+          {:keys [go-chan query-state-fn]}
+          (start-tokens-watch-maintainer kv-store tokens-update-chan tokens-watch-channels-update-chan watch-refresh-timeout-ms exit-chan)]
+      (testing "query-state-fn provides current state"
+        (is (= {:token->token-index {} :watches-count 0}
+               (query-state-fn))))
+      (testing "query-state-fn respects include-flags"
+        (is (= {:token->token-index {}}
+               (query-state-fn #{"token->token-index"}))))
+      (stop-tokens-watch-maintainer go-chan exit-chan))))

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -2828,13 +2828,12 @@
 
     (testing "when tokens-watch-channels-update-chan is closed an error is thrown and ctrl is closed"
       (let [ctrl-chan (async/chan)
-            tokens-watch-channels-update-chan (async/chan)]
-        (async/close! tokens-watch-channels-update-chan)
-        (try
-          (handle-list-tokens-watch index-filter-fn no-change-transducer-fn tokens-watch-channels-update-chan
-                                    {:ctrl ctrl-chan})
-          (catch Exception e
-            (is (= (.getMessage e) "tokens-watch-channels-update-chan is closed!"))))))
+            tokens-watch-channels-update-chan (async/chan)
+            _ (async/close! tokens-watch-channels-update-chan)
+            {:keys [status]}
+            (handle-list-tokens-watch index-filter-fn no-change-transducer-fn tokens-watch-channels-update-chan
+                                      {:ctrl ctrl-chan})]
+        (is (= http-500-internal-server-error status))))
 
     (testing "empty aggregate events (:type :EVENTS) are filtered out by default"
       (let [{:keys [body status]}

--- a/waiter/test/waiter/token_watch_test.clj
+++ b/waiter/test/waiter/token_watch_test.clj
@@ -73,8 +73,8 @@
 
     (testing "sending basic event to channels"
       (let [chans (create-watch-chans 10)
-            closed-chans (send-event-to-channels! chans event)]
-        (is (= #{} closed-chans))
+            open-chans (send-event-to-channels! chans event)]
+        (is (= (set chans) open-chans))
         (assert-channels-next-message chans event)))
 
     (testing "sending basic event to mix of open and closed channels"
@@ -82,8 +82,8 @@
             open-chans (create-watch-chans 10)
             chans (conj open-chans closed-chan)
             _ (async/close! closed-chan)
-            result-closed-chans (send-event-to-channels! chans event)]
-        (is (= #{closed-chan} result-closed-chans))
+            result-open-chans (send-event-to-channels! chans event)]
+        (is (= (set open-chans) result-open-chans))
         (assert-channels-next-message open-chans event)))
 
     (testing "sending event to a channel with maxed out put! buffer (1024 messages) will close the buffer"
@@ -91,8 +91,8 @@
             _ (dotimes [i 1024] (async/put! filled-chan i))
             open-chans (create-watch-chans 10)
             chans (conj open-chans filled-chan)
-            result-closed-chans (send-event-to-channels! chans event)]
-        (is (= #{filled-chan} result-closed-chans))
+            result-open-chans (send-event-to-channels! chans event)]
+        (is (= (set open-chans) result-open-chans))
         (assert-channels-next-message open-chans event)))))
 
 (let [get-token-hash (fn [kv-store token] (sd/token-data->token-hash (kv/fetch kv-store token)))

--- a/waiter/test/waiter/token_watch_test.clj
+++ b/waiter/test/waiter/token_watch_test.clj
@@ -424,4 +424,29 @@
             (is (= {:object [], :type :INITIAL}
                    (async/<!! slow-chan))))))
 
-      (stop-token-watch-maintainer go-chan exit-chan))))
+      (stop-token-watch-maintainer go-chan exit-chan)))
+
+  (deftest test-start-token-watch-maintainer-buffer-state
+    (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+          {:keys [exit-chan go-chan tokens-update-chan tokens-watch-channels-update-chan query-state-fn]}
+          (start-token-watch-maintainer kv-store clock 1000 1000 (async/chan))
+          expected-buffer-count 123]
+      (stop-token-watch-maintainer go-chan exit-chan)
+
+      (testing "state provides correct current buffer count for tokens-update-chan"
+        (dotimes [_ expected-buffer-count]
+          (async/put! tokens-update-chan (async/chan)))
+        (is (= {:buffer-state {:update-chan-count expected-buffer-count
+                               :watch-channels-update-chan-count 0}
+                :last-update-time (clock)
+                :watch-count 0}
+               (query-state-fn #{"buffer-state"}))))
+
+      (testing "state provides correct current buffer count for tokens-watch-channels-update-chan"
+        (dotimes [_ expected-buffer-count]
+          (async/put! tokens-watch-channels-update-chan (async/chan)))
+        (is (= {:buffer-state {:update-chan-count expected-buffer-count
+                               :watch-channels-update-chan-count expected-buffer-count}
+                :last-update-time (clock)
+                :watch-count 0}
+               (query-state-fn #{"buffer-state"})))))))

--- a/waiter/test/waiter/token_watch_test.clj
+++ b/waiter/test/waiter/token_watch_test.clj
@@ -1,0 +1,427 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns waiter.token-watch-test
+  (:require [clj-time.core :as t]
+            [clojure.core.async :as async]
+            [clojure.test :refer :all]
+            [waiter.kv :as kv]
+            [waiter.service-description :as sd]
+            [waiter.status-codes :refer :all]
+            [waiter.test-helpers :refer :all]
+            [waiter.token :refer :all]
+            [waiter.token-watch :refer :all])
+  (:import (org.joda.time DateTime)))
+
+(def ^:const history-length 5)
+(def ^:const limit-per-owner 10)
+
+(let [lock (Object.)]
+  (defn- synchronize-fn
+    [_ f]
+    (locking lock
+      (f))))
+
+(let [current-time (t/now)]
+  (defn- clock [] current-time)
+
+  (defn- clock-millis [] (.getMillis ^DateTime (clock))))
+
+(defmacro assert-channels-no-new-message
+  [chans timeout-ms]
+  `(let [chans# ~chans
+         timeout-ms# ~timeout-ms
+         timeout-chan# (async/timeout timeout-ms#)
+         [_# res-chan#] (-> chans#
+                            (conj timeout-chan#)
+                            (async/alts!! :priority true))]
+     (is (= res-chan# timeout-chan#))))
+
+(defmacro assert-channels-next-message-with-fn
+  [chans msg-fn]
+  `(let [chans# ~chans
+         msg-fn# ~msg-fn
+         res# (for [chan# chans#] (async/<!! chan#))]
+     (is (every? msg-fn# res#))))
+
+(defmacro assert-channels-next-message
+  "Assert that list of channels next message"
+  [chans msg]
+  `(let [chans# ~chans
+         msg# ~msg]
+     (assert-channels-next-message-with-fn chans# #(= % msg#))))
+
+(defn- create-watch-chans
+  [x]
+  (for [_ (range x)]
+    (async/chan (async/sliding-buffer 1024))))
+
+(deftest test-send-event-to-channels
+  (let [event {:event :DELETE :object {:owner "owner1" :token "token1"}}]
+
+    (testing "sending basic event to channels"
+      (let [chans (create-watch-chans 10)
+            closed-chans (send-event-to-channels chans event)]
+        (is (= [] closed-chans))
+        (assert-channels-next-message chans event)))
+
+    (testing "sending basic event to mix of open and closed channels"
+      (let [closed-chan (async/chan 1)
+            open-chans (create-watch-chans 10)
+            chans (conj open-chans closed-chan)
+            _ (async/close! closed-chan)
+            result-closed-chans (send-event-to-channels chans event)]
+        (is (= [closed-chan] result-closed-chans))
+        (assert-channels-next-message open-chans event)))
+
+    (testing "sending event to a channel with maxed out put! buffer (1024 messages) will close the buffer"
+      (let [filled-chan (async/chan)
+            _ (dotimes [i 1024] (async/put! filled-chan i))
+            open-chans (create-watch-chans 10)
+            chans (conj open-chans filled-chan)
+            result-closed-chans (send-event-to-channels chans event)]
+        (is (= [filled-chan] result-closed-chans))
+        (assert-channels-next-message open-chans event)))))
+
+(let [get-token-hash (fn [kv-store token] (sd/token-data->token-hash (kv/fetch kv-store token)))
+      get-latest-state (fn [query-chan]
+                         (let [temp-chan (async/promise-chan)]
+                           (async/>!! query-chan {:include-flags #{"token-index-map"}
+                                                  :response-chan temp-chan})
+                           (async/<!! temp-chan)))
+      add-watch-chans (fn [tokens-watch-channels-update-chan watch-chans]
+                        (doseq [chan watch-chans]
+                          (async/put! tokens-watch-channels-update-chan chan)))
+      remove-watch-chans (fn [watch-chans]
+                           (doseq [chan watch-chans]
+                             (async/close! chan)))
+      trigger-token-watch-refresh (fn [watch-refresh-timer-chan]
+                                    (async/>!! watch-refresh-timer-chan {}))
+      stop-token-watch-maintainer (fn [go-chan exit-chan]
+                                    (async/>!! exit-chan :exit)
+                                    (async/<!! go-chan))
+      auth-user "auth-user"
+      token1-metadata {"cluster" "c1" "last-update-time" 1000 "owner" "owner1"}
+      token1-service-desc {"cpus" 1}
+      token1-index {:deleted false
+                    :last-update-time (get token1-metadata "last-update-time")
+                    :maintenance false
+                    :owner (get token1-metadata "owner")
+                    :token "token1"}]
+
+  (deftest test-start-token-watch-maintainer-empty-starting-state
+    (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+          watch-chans (create-watch-chans 10)
+          {:keys [exit-chan go-chan query-chan tokens-watch-channels-update-chan]}
+          (start-token-watch-maintainer kv-store clock 1 1 (async/chan))]
+      (is (= {:last-update-time (clock)
+              :token-index-map {}
+              :watch-count 0}
+             (get-latest-state query-chan)))
+
+      (testing "watch-channels should receive empty list of tokens"
+        (add-watch-chans tokens-watch-channels-update-chan watch-chans)
+        (is (= {:last-update-time (clock)
+                :token-index-map {}
+                :watch-count 10}
+               (get-latest-state query-chan)))
+        (assert-channels-next-message watch-chans (make-index-event :INITIAL [])))
+
+      (stop-token-watch-maintainer go-chan exit-chan)))
+
+  (deftest test-start-token-watch-maintainer-non-empty-starting-state
+    (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+          watch-chans (create-watch-chans 10)
+          _ (store-service-description-for-token
+              synchronize-fn kv-store history-length limit-per-owner "token1" token1-service-desc token1-metadata)
+          {:keys [exit-chan go-chan query-chan tokens-watch-channels-update-chan]}
+          (start-token-watch-maintainer kv-store clock 1 1 (async/chan))
+          token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1"))
+          expected-token-index-map {"token1" token-cur-index}]
+      (is (= {:last-update-time (clock)
+              :token-index-map expected-token-index-map
+              :watch-count 0}
+             (get-latest-state query-chan)))
+
+      (testing "watch-channels should receive starting list of tokens"
+        (add-watch-chans tokens-watch-channels-update-chan watch-chans)
+        (is (= {:last-update-time (clock) :token-index-map expected-token-index-map :watch-count 10}
+               (get-latest-state query-chan)))
+        (assert-channels-next-message-with-fn watch-chans
+                                              #(and (= #{token-cur-index}
+                                                       (set (get % :object)))
+                                                    (= :INITIAL
+                                                       (get % :type)))))
+
+      (stop-token-watch-maintainer go-chan exit-chan)))
+
+  (deftest test-start-token-watch-maintainer-watch-channels-updates
+    (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+          watch-chans (create-watch-chans 10)
+          {:keys [exit-chan go-chan tokens-update-chan query-chan tokens-watch-channels-update-chan]}
+          (start-token-watch-maintainer kv-store clock 1 1 (async/chan))]
+
+      (testing "watch-channels get UPDATE event for added tokens"
+        (add-watch-chans tokens-watch-channels-update-chan watch-chans)
+        (is (= {:last-update-time (clock) :token-index-map {} :watch-count 10}
+               (get-latest-state query-chan)))
+        (store-service-description-for-token
+          synchronize-fn kv-store history-length limit-per-owner "token1" token1-service-desc token1-metadata)
+        (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1"))
+              expected-token-index-map {"token1" token-cur-index}]
+          (assert-channels-next-message watch-chans (make-index-event :INITIAL []))
+          (send-internal-index-event tokens-update-chan "token1" (get token1-index :owner))
+          (assert-channels-next-message watch-chans (make-index-event :UPDATE token-cur-index))
+          (is (= {:last-update-time (clock)
+                  :token-index-map expected-token-index-map
+                  :watch-count 10}
+                 (get-latest-state query-chan)))))
+
+      (testing "watch-channels get UPDATE event for modified tokens"
+        (store-service-description-for-token
+          synchronize-fn kv-store history-length limit-per-owner "token1" (assoc token1-service-desc "cpus" 2) token1-metadata)
+        (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1"))
+              expected-token-index-map {"token1" token-cur-index}]
+          (send-internal-index-event tokens-update-chan "token1" (get token1-index :owner))
+          (assert-channels-next-message watch-chans (make-index-event :UPDATE token-cur-index))
+          (is (= {:last-update-time (clock)
+                  :token-index-map expected-token-index-map
+                  :watch-count 10}
+                 (get-latest-state query-chan)))
+
+          (testing "watch-channels doesn't send event if no changes in token-index-entry and current-state"
+            (send-internal-index-event tokens-update-chan "token1" (get token1-index :owner))
+            (assert-channels-no-new-message watch-chans 1000)
+            (is (= {:last-update-time (clock)
+                    :token-index-map expected-token-index-map
+                    :watch-count 10}
+                   (get-latest-state query-chan))))))
+
+      (testing "watch-channels get UPDATE event for soft deleted tokens"
+        (delete-service-description-for-token clock synchronize-fn kv-store history-length "token1"
+                                              (get token1-index :owner) auth-user)
+        (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1")
+                                                  :last-update-time (clock-millis)
+                                                  :deleted true)
+              expected-token-index-map {"token1" token-cur-index}]
+          (send-internal-index-event tokens-update-chan "token1" (get token1-index :owner))
+          (assert-channels-next-message watch-chans (make-index-event :UPDATE token-cur-index))
+          (is (= {:last-update-time (clock)
+                  :token-index-map expected-token-index-map
+                  :watch-count 10}
+                 (get-latest-state query-chan)))))
+
+      (testing "watch-channels get DELETE event for hard deleted tokens"
+        (delete-service-description-for-token clock synchronize-fn kv-store history-length "token1"
+                                              (get token1-index :owner) auth-user :hard-delete true)
+        (send-internal-index-event tokens-update-chan "token1" (get token1-index :owner))
+        (assert-channels-next-message watch-chans
+                                      (make-index-event :DELETE {:owner (get token1-index :owner)
+                                                                 :token "token1"}))
+        (is (= {:last-update-time (clock)
+                :token-index-map {}
+                :watch-count 10}
+               (get-latest-state query-chan))))
+
+      (testing "watch-channels doesn't send event if no changes in token-index-entry and current-state"
+        (send-internal-index-event tokens-update-chan "token1" (get token1-index :owner))
+        (assert-channels-no-new-message watch-chans 1000)
+        (is (= {:last-update-time (clock)
+                :token-index-map {}
+                :watch-count 10}
+               (get-latest-state query-chan))))
+      (stop-token-watch-maintainer go-chan exit-chan)))
+
+  (deftest test-start-token-watch-maintainer-watch-count
+    (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+          watch-refresh-timer-chan (async/chan)
+          watch-chans-1 (create-watch-chans 10)
+          watch-chans-2 (create-watch-chans 10)
+          {:keys [exit-chan go-chan tokens-watch-channels-update-chan query-chan]}
+          (start-token-watch-maintainer kv-store clock 1 1 watch-refresh-timer-chan)]
+      (is (= {:last-update-time (clock)
+              :token-index-map {}
+              :watch-count 0}
+             (get-latest-state query-chan)))
+
+      (testing "watch-count should increment when channels are added"
+        (add-watch-chans tokens-watch-channels-update-chan watch-chans-1)
+        (is (= {:last-update-time (clock)
+                :token-index-map {}
+                :watch-count 10}
+               (get-latest-state query-chan)))
+        (assert-channels-next-message watch-chans-1 (make-index-event :INITIAL []))
+        (add-watch-chans tokens-watch-channels-update-chan watch-chans-2)
+        (is (= {:last-update-time (clock)
+                :token-index-map {}
+                :watch-count 20}
+               (get-latest-state query-chan)))
+        (assert-channels-next-message watch-chans-2 (make-index-event :INITIAL [])))
+
+      (testing "watch-count should decrement when daemon process is refreshed"
+        (remove-watch-chans watch-chans-1)
+        (trigger-token-watch-refresh watch-refresh-timer-chan)
+        (get-latest-state query-chan)
+        (is (= {:last-update-time (clock)
+                :token-index-map {}
+                :watch-count 10}
+               (get-latest-state query-chan)))
+        (remove-watch-chans watch-chans-2)
+        (trigger-token-watch-refresh watch-refresh-timer-chan)
+        (is (= {:last-update-time (clock)
+                :token-index-map {}
+                :watch-count 0}
+               (get-latest-state query-chan))))
+
+      (stop-token-watch-maintainer go-chan exit-chan)))
+
+  (deftest test-start-token-watch-maintainer-refresh-timeout
+    (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+          watch-chans (create-watch-chans 10)
+          watch-refresh-timer-chan (async/chan)
+          {:keys [exit-chan go-chan tokens-watch-channels-update-chan query-chan]}
+          (start-token-watch-maintainer kv-store clock 1 1 watch-refresh-timer-chan)]
+      (is (= {:last-update-time (clock)
+              :token-index-map {}
+              :watch-count 0}
+             (get-latest-state query-chan)))
+
+      (testing "refresh-timeout should not update if there are no changes in kv-store"
+        (trigger-token-watch-refresh watch-refresh-timer-chan)
+        (is (= {:last-update-time (clock)
+                :token-index-map {}
+                :watch-count 0}
+               (get-latest-state query-chan))))
+
+      (add-watch-chans tokens-watch-channels-update-chan watch-chans)
+      (assert-channels-next-message watch-chans (make-index-event :INITIAL []))
+
+      (testing "refresh-timeout should update current-state and watchers if token is added to kv-store"
+        (store-service-description-for-token
+          synchronize-fn kv-store history-length limit-per-owner "token1" token1-service-desc token1-metadata)
+        (trigger-token-watch-refresh watch-refresh-timer-chan)
+        (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1"))
+              expected-token-index-map {"token1" token-cur-index}]
+          (is (= {:last-update-time (clock)
+                  :token-index-map expected-token-index-map
+                  :watch-count 10}
+                 (get-latest-state query-chan)))
+          (assert-channels-next-message watch-chans
+                                        (->> (make-index-event :UPDATE token-cur-index)
+                                             list
+                                             (make-index-event :EVENTS)))))
+
+      (testing "refresh-timeout should update current-state and watchers if token is out of date"
+        (store-service-description-for-token
+          synchronize-fn kv-store history-length limit-per-owner "token1" (assoc token1-service-desc "cpus" 2)
+          token1-metadata)
+        (trigger-token-watch-refresh watch-refresh-timer-chan)
+        (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1"))
+              expected-token-index-map {"token1" token-cur-index}]
+          (is (= {:last-update-time (clock)
+                  :token-index-map expected-token-index-map
+                  :watch-count 10}
+                 (get-latest-state query-chan)))
+          (assert-channels-next-message watch-chans (->> (make-index-event :UPDATE token-cur-index)
+                                                         list
+                                                         (make-index-event :EVENTS)))))
+
+      (testing "refresh-timeout should update current-state and watchers if token is soft deleted"
+        (delete-service-description-for-token clock synchronize-fn kv-store history-length "token1"
+                                              (get token1-index :owner) auth-user)
+        (trigger-token-watch-refresh watch-refresh-timer-chan)
+        (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1")
+                                                  :last-update-time (clock-millis)
+                                                  :deleted true)
+              expected-token-index-map {"token1" token-cur-index}]
+          (is (= {:last-update-time (clock)
+                  :token-index-map expected-token-index-map
+                  :watch-count 10}
+                 (get-latest-state query-chan)))
+          (assert-channels-next-message watch-chans (->> (make-index-event :UPDATE token-cur-index)
+                                                         list
+                                                         (make-index-event :EVENTS)))))
+
+      (testing "refresh-timeout should update current-state and watchers if token is hard deleted"
+        (delete-service-description-for-token clock synchronize-fn kv-store history-length "token1"
+                                              (get token1-index :owner) auth-user :hard-delete true)
+        (trigger-token-watch-refresh watch-refresh-timer-chan)
+        (is (= {:last-update-time (clock)
+                :token-index-map {}
+                :watch-count 10}
+               (get-latest-state query-chan)))
+        (assert-channels-next-message watch-chans (->> (make-index-event :DELETE {:owner (get token1-index :owner)
+                                                                                  :token "token1"})
+                                                       list
+                                                       (make-index-event :EVENTS))))
+
+      (stop-token-watch-maintainer go-chan exit-chan)))
+
+  (deftest test-start-token-watch-maintainer-query-state
+    (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+          {:keys [exit-chan go-chan query-state-fn]}
+          (start-token-watch-maintainer kv-store clock 1 1 (async/chan))]
+
+      (testing "query-state-fn provides current state with default fields"
+        (is (= {:last-update-time (clock)
+                :watch-count 0}
+               (query-state-fn #{}))))
+
+      (testing "query-state-fn respects include-flags"
+        (is (= {:buffer-state {:update-chan-count 0
+                               :watch-channels-update-chan-count 0}
+                :last-update-time (clock)
+                :token-index-map {}
+                :watch-count 0}
+               (query-state-fn #{"token-index-map" "buffer-state"}))))
+
+      (stop-token-watch-maintainer go-chan exit-chan)))
+
+  (deftest test-start-token-watch-maintainer-slow-channel
+    (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+          {:keys [exit-chan go-chan tokens-update-chan tokens-watch-channels-update-chan query-chan]}
+          (start-token-watch-maintainer kv-store clock 1 1 (async/chan))]
+
+      (testing "sending 5000 internal events does not halt daemon process with a slow watch-channel"
+        (let [buffer-size 1
+              slow-chan (async/chan buffer-size)
+              msg-count 5000]
+          (async/put! tokens-watch-channels-update-chan slow-chan)
+          (is (= {:last-update-time (clock)
+                  :token-index-map {}
+                  :watch-count 1}
+                 (get-latest-state query-chan)))
+          (is (every?
+                true?
+                (for [i (range msg-count)]
+                  (do
+                    (store-service-description-for-token
+                      synchronize-fn kv-store history-length limit-per-owner "token1" token1-service-desc
+                      (assoc token1-metadata "last-update-time" i))
+                    (send-internal-index-event tokens-update-chan "token1" (get token1-index :owner))
+                    (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1")
+                                                              :last-update-time i)
+                          expected-token-index-map {"token1" token-cur-index}]
+                      (= {:last-update-time (clock)
+                          :token-index-map expected-token-index-map}
+                         (dissoc (get-latest-state query-chan)
+                                 :watch-count)))))))
+
+          (testing "channel is closed and no longer can have messages put! to it, but can still read"
+            (is (not (async/put! slow-chan "temp")))
+            (is (= {:object [], :type :INITIAL}
+                   (async/<!! slow-chan))))))
+
+      (stop-token-watch-maintainer go-chan exit-chan))))

--- a/waiter/test/waiter/token_watch_test.clj
+++ b/waiter/test/waiter/token_watch_test.clj
@@ -44,10 +44,11 @@
   `(let [chans# ~chans
          timeout-ms# ~timeout-ms
          timeout-chan# (async/timeout timeout-ms#)
-         [_# res-chan#] (-> chans#
+         [msg# res-chan#] (-> chans#
                             (conj timeout-chan#)
                             (async/alts!! :priority true))]
-     (is (= res-chan# timeout-chan#))))
+     (is (= res-chan# timeout-chan#)
+         (str "Expected no message from channel instead got: " msg#))))
 
 (defmacro assert-channels-next-message-with-fn
   [chans msg-fn]


### PR DESCRIPTION
## Changes proposed in this PR

- add daemon process to maintain local map of token->index and broker messages to listeners
- add handler for `/state/tokens-watch-maintainer` to query the state of the maintainer
- example (no query parameters)
![Screenshot from 2021-02-02 11-28-16](https://user-images.githubusercontent.com/8290559/106638851-ed1c3980-6549-11eb-89a9-0321c0112d8e.png)
- example with include query parameters
![Screenshot from 2021-02-02 11-29-21](https://user-images.githubusercontent.com/8290559/106638857-ee4d6680-6549-11eb-9d7b-f114fc64c086.png)
- request log for `/tokens?watch-true`
![Screenshot from 2021-02-11 08-48-33](https://user-images.githubusercontent.com/8290559/107652293-0d34b280-6c46-11eb-9767-171f7bf1fdee.png)



## Why are we making these changes?
- This token watch can be used by clients who want to maintain a local replica of the overall token index state