### PR TITLE
adds referer request header to the request log

### DIFF
--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -31,7 +31,7 @@
   "Convert a request into a context suitable for logging."
   [{:keys [client-protocol headers internal-protocol query-string remote-addr request-id
            request-method request-time server-port uri] :as request}]
-  (let [{:strs [content-length content-type host origin user-agent x-cid x-forwarded-for]} headers
+  (let [{:strs [content-length content-type host origin referer user-agent x-cid x-forwarded-for]} headers
         remote-address (or x-forwarded-for remote-addr)]
     (cond-> {:cid x-cid
              :host host
@@ -46,6 +46,7 @@
       remote-address (assoc :remote-addr remote-address)
       content-length (assoc :request-content-length content-length)
       content-type (assoc :request-content-type content-type)
+      referer (assoc :referer referer)
       request-time (assoc :request-time (du/date-to-str request-time))
       server-port (assoc :server-port server-port)
       user-agent (assoc :user-agent user-agent))))

--- a/waiter/test/waiter/request_log_test.clj
+++ b/waiter/test/waiter/request_log_test.clj
@@ -25,7 +25,7 @@
                            "content-type" "application/json"
                            "host" "host"
                            "origin" "www.origin.org"
-                           "referer" "https://test.com/headers"
+                           "referer" "https://test.com/referer"
                            "user-agent" "test-user-agent"
                            "x-cid" "123"}
                  :internal-protocol "HTTP/1.1"
@@ -45,7 +45,7 @@
             :origin "www.origin.org"
             :path "/"
             :query-string "a=1"
-            :referer "https://test.com/headers"
+            :referer "https://test.com/referer"
             :remote-addr "127.0.0.1"
             :request-content-length "20"
             :request-content-type "application/json"

--- a/waiter/test/waiter/request_log_test.clj
+++ b/waiter/test/waiter/request_log_test.clj
@@ -25,6 +25,7 @@
                            "content-type" "application/json"
                            "host" "host"
                            "origin" "www.origin.org"
+                           "referer" "https://test.com/headers"
                            "user-agent" "test-user-agent"
                            "x-cid" "123"}
                  :internal-protocol "HTTP/1.1"
@@ -44,6 +45,7 @@
             :origin "www.origin.org"
             :path "/"
             :query-string "a=1"
+            :referer "https://test.com/headers"
             :remote-addr "127.0.0.1"
             :request-content-length "20"
             :request-content-type "application/json"


### PR DESCRIPTION
## Changes proposed in this PR

- adds referer request header to the request log

## Why are we making these changes?

The Referer request header contains the address of the page making the request. It allows identifying sources of traffic to a service.

