### PR TITLE
adds support for overriding value from file in arguments

### DIFF
--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -1,15 +1,12 @@
-import argparse
-import json
 import logging
-import sys
 import os
 from enum import Enum
 
 import requests
 
 from waiter import terminal, http_util
-from waiter.querying import get_token, query_token, get_target_cluster_from_token
 from waiter.data_format import load_data
+from waiter.querying import get_token, query_token, get_target_cluster_from_token
 from waiter.util import FALSE_STRINGS, print_info, response_message, TRUE_STRINGS, guard_no_cluster, str2bool
 
 BOOL_STRINGS = TRUE_STRINGS + FALSE_STRINGS
@@ -166,11 +163,9 @@ def add_token_flags(parser):
 
 def add_override_flags(parser):
     """Adds the arguments override file values flags to the given parser"""
-    override_group = parser.add_mutually_exclusive_group(required=False)
-    override_group.add_argument('--override', action='store_true', dest='override',
-                                help='Allow overriding values in input file with values from CLI arguments. '
-                                     'Overriding values is disallowed by default.')
-    override_group.add_argument('--no-override', action='store_false', dest='override', help=argparse.SUPPRESS)
+    parser.add_argument('--override', action='store_true', default=False, dest='override',
+                        help='Allow overriding values in input file with values from CLI arguments. '
+                             'Overriding values is disallowed by default.')
 
 
 def register_argument_parser(add_parser, action):

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -168,7 +168,7 @@ def add_override_flags(parser):
     """Adds the arguments override file values flags to the given parser"""
     override_group = parser.add_mutually_exclusive_group(required=False)
     override_group.add_argument('--override', action='store_true', dest='override',
-                                help='Allow overriding values in file with values from other arguments. '
+                                help='Allow overriding values in input file with values from CLI arguments. '
                                      'Overriding values is disallowed by default.')
     override_group.add_argument('--no-override', action='store_false', dest='override', help=argparse.SUPPRESS)
 


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for overriding value from file in arguments during token create and update

## Why are we making these changes?

Not being able to override values from one provided ina file is sometimes surprising to users. We preserve the current behavior as the default and introduce a new `--override` flag to allow users to pass in values they intend to override.

### Sample output

#### Help text
```
$ waiter create -h
usage: waiter create [-h] [--name NAME] [--owner OWNER] [--version VERSION] [--cmd CMD] [--cmd-type CMD-TYPE] [--cpus CPUS] [--mem MEM] [--ports PORTS] [--json JSON | --yaml YAML | --input INPUT] [--override] [token]
...
  --input INPUT         provide the data in a JSON/YAML file
  --override            Allow overriding values in file with values from other arguments. Overriding values is disallowed by default.
```

#### Usage
```
$ waiter create test-token --cpus 2 --json integration/foo.json
You cannot specify the same parameter in both an input file and token field flags at the same time (cpus) without specifying the --override flag.

$ waiter create test-token --no-override --cpus 2 --json integration/foo.json
You cannot specify the same parameter in both an input file and token field flags at the same time (cpus) without specifying the --override flag.

$ waiter create test-token --no-override --override --cpus 2 --json integration/foo.json
...
waiter create: error: argument --override: not allowed with argument --no-override

$ waiter create test-token --override --cpus 2 --json integration/foo.json
Attempting to create token on WAITER1...
Successfully created test-token.

$ waiter create test-token --cpus 2 --json integration/foo.json
You cannot specify the token name both as an argument and in the input file without specifying the --override flag.

$ waiter --verbose create test-token --override --cpus 2 --json integration/foo.json
...
2021-01-28 08:34:38,670 [DEBUG] [root] Will use token name (test-token) from args and skip token specified in file(my-token)
...
No changes detected for test-token.
2021-01-28 08:34:38,692 [DEBUG] [root] result: 0
```


