### PR TITLE
adds support for ping/kill during maintenance stop/start

### DIFF
--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1437,21 +1437,53 @@ class WaiterCliTest(util.WaiterTest):
     def test_update_token_no_admin_mode(self):
         self.__test_create_update_token_admin_mode('update', self.token_name(), False)
 
-    def test_maintenance_start(self):
+    def run_maintenance_start_test(self, start_args='', ping_token=False):
         token_name = self.token_name()
-        token_fields = {'cpus': 0.1, 'mem': 128, 'cmd': 'foo'}
+        token_fields = util.minimal_service_description()
         custom_maintenance_message = "custom maintenance message"
         util.post_token(self.waiter_url, token_name, token_fields)
         try:
+            if ping_token:
+                cp = cli.ping(self.waiter_url, token_name)
+                self.assertEqual(0, cp.returncode, cp.stderr)
+                self.assertIn('Pinging token', cli.stdout(cp))
+                self.assertIn('successful', cli.stdout(cp))
+                util.wait_until_services_for_token(self.waiter_url, token_name, 1)
+                self.assertEqual(1, len(util.services_for_token(self.waiter_url, token_name)))
             cp = cli.maintenance('start', token_name, self.waiter_url,
-                                 maintenance_flags=f'"{custom_maintenance_message}"')
+                                 maintenance_flags=f'{start_args} "{custom_maintenance_message}"')
             self.assertEqual(0, cp.returncode, cp.stderr)
             token_data = util.load_token(self.waiter_url, token_name)
             self.assertEqual({'message': custom_maintenance_message}, token_data['maintenance'])
             for key, value in token_fields.items():
                 self.assertEqual(value, token_data[key])
+            if ping_token:
+                num_services = 1 if '--no-kill' in start_args else 0
+                self.assertEqual(num_services,
+                                 len(util.wait_until_services_for_token(self.waiter_url, token_name, num_services)))
         finally:
-            util.delete_token(self.waiter_url, token_name)
+            util.delete_token(self.waiter_url, token_name, kill_services=True)
+
+    def test_maintenance_start_basic(self):
+        self.run_maintenance_start_test()
+
+    def test_maintenance_start_no_service_ask_kill(self):
+        self.run_maintenance_start_test(start_args='--ask-kill')
+
+    def test_maintenance_start_no_service_force_kill(self):
+        self.run_maintenance_start_test(start_args='--force-kill')
+
+    def test_maintenance_start_no_service_no_kill(self):
+        self.run_maintenance_start_test(start_args='--no-kill')
+
+    def test_maintenance_start_ping_service_ask_kill(self):
+        self.run_maintenance_start_test(start_args='--ask-kill', ping_token=True)
+
+    def test_maintenance_start_ping_service_force_kill(self):
+        self.run_maintenance_start_test(start_args='--force-kill', ping_token=True)
+
+    def test_maintenance_start_ping_service_no_kill(self):
+        self.run_maintenance_start_test(start_args='--no-kill', ping_token=True)
 
     def test_maintenance_start_nonexistent_token(self):
         token_name = self.token_name()

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1466,21 +1466,44 @@ class WaiterCliTest(util.WaiterTest):
         self.__test_no_cluster(partial(cli.maintenance, 'start',
                                        maintenance_flags=f'"{custom_maintenance_message}"'))
 
-    def test_maintenance_stop(self):
+    def test_maintenance_stop_no_ping(self):
         token_name = self.token_name()
         token_fields = {'cpus': 0.1, 'mem': 128, 'cmd': 'foo'}
         custom_maintenance_message = "custom maintenance message"
         util.post_token(self.waiter_url, token_name,
                         {**token_fields, 'maintenance': {'message': custom_maintenance_message}})
         try:
-            cp = cli.maintenance('stop', token_name, self.waiter_url)
+            cp = cli.maintenance('stop', token_name, self.waiter_url, maintenance_flags='--no-ping')
             self.assertEqual(0, cp.returncode, cp.stderr)
+            stdout = cli.stdout(cp)
+            self.assertNotIn(f'Pinging token {token_name}', stdout)
+            self.assertNotIn(f'Ping successful', stdout)
             token_data = util.load_token(self.waiter_url, token_name)
             self.assertEqual(None, token_data.get('maintenance', None))
             for key, value in token_fields.items():
                 self.assertEqual(value, token_data[key])
         finally:
             util.delete_token(self.waiter_url, token_name)
+
+    def test_maintenance_stop_with_ping(self):
+        token_name = self.token_name()
+        token_fields = util.minimal_service_description()
+        custom_maintenance_message = "custom maintenance message"
+        util.post_token(self.waiter_url, token_name,
+                        {**token_fields, 'maintenance': {'message': custom_maintenance_message}})
+        try:
+            cp = cli.maintenance('stop', token_name, self.waiter_url)
+            stdout = cli.stdout(cp)
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            self.assertIn(f'Pinging token {token_name}', stdout)
+            self.assertIn('Ping successful', stdout)
+            token_data = util.load_token(self.waiter_url, token_name)
+            self.assertEqual(None, token_data.get('maintenance', None))
+            for key, value in token_fields.items():
+                self.assertEqual(value, token_data[key])
+            self.assertEqual(1, len(util.wait_until_services_for_token(self.waiter_url, token_name, 1)))
+        finally:
+            util.delete_token(self.waiter_url, token_name, kill_services=True)
 
     def test_maintenance_stop_no_cluster(self):
         self.__test_no_cluster(partial(cli.maintenance, 'stop'))

--- a/cli/waiter/action.py
+++ b/cli/waiter/action.py
@@ -156,7 +156,8 @@ def kill_service_on_cluster(cluster, service_id, timeout_seconds):
         print_error(message)
 
 
-def process_kill_request(clusters, token_name_or_service_id, is_service_id, force_flag, timeout_secs):
+def process_kill_request(clusters, token_name_or_service_id, is_service_id, force_flag, timeout_secs,
+                         no_service_result=False):
     """Kills the service(s) using the given token name or service-id.
     Returns False if no services can be found or if there was a failure in deleting any service.
     Returns True if all services using the token were deleted successfully."""
@@ -165,14 +166,14 @@ def process_kill_request(clusters, token_name_or_service_id, is_service_id, forc
         num_services = query_result['count']
         if num_services == 0:
             print_no_data(clusters)
-            return False
+            return no_service_result
     else:
         query_result = query_services(clusters, token_name_or_service_id)
         num_services = query_result['count']
         if num_services == 0:
             clusters_text = ' / '.join([terminal.bold(c['name']) for c in clusters])
             print(f'There are no services using token {terminal.bold(token_name_or_service_id)} in {clusters_text}.')
-            return False
+            return no_service_result
         elif num_services > 1:
             print(f'There are {num_services} services using token {terminal.bold(token_name_or_service_id)}:')
 

--- a/cli/waiter/subcommands/maintenance.py
+++ b/cli/waiter/subcommands/maintenance.py
@@ -1,11 +1,13 @@
+import argparse
 from functools import partial
 
 import requests
 
 from waiter import terminal, http_util
-from waiter.token_post import process_post_result, post_failed_message
+from waiter.action import ping_token_on_cluster
 from waiter.querying import get_target_cluster_from_token, get_token
-from waiter.util import guard_no_cluster, logging, print_info
+from waiter.token_post import post_failed_message, process_post_result
+from waiter.util import check_positive, guard_no_cluster, logging, print_info
 
 
 def _is_token_in_maintenance_mode(token_data):
@@ -27,17 +29,19 @@ def _update_token(cluster, token_name, existing_token_etag, body):
     try:
         resp = http_util.post(cluster, 'token', body, params=params, headers=headers)
         process_post_result(resp)
-        return 0
+        token_etag = resp.headers.get('ETag', None)
+        return 0, token_etag
     except requests.exceptions.ReadTimeout as rt:
         logging.exception(rt)
         print_info(terminal.failed(
             f'Encountered read timeout with {cluster_name} ({cluster_url}). The operation may have completed.'))
-        return 1
+        return 1, None
     except IOError as ioe:
         logging.exception(ioe)
         reason = f'Cannot connect to {cluster_name} ({cluster_url})'
         message = post_failed_message(cluster_name, reason)
         print_info(f'{message}\n')
+        return 1, None
 
 
 def check_maintenance(clusters, args, enforce_cluster):
@@ -57,19 +61,35 @@ def start_maintenance(clusters, args, enforce_cluster):
     json_body = existing_token_data
     update_doc = {"maintenance": {"message": args['message']}}
     json_body.update(update_doc)
-    return _update_token(cluster, token_name, existing_token_etag, json_body)
+    return_code, _ = _update_token(cluster, token_name, existing_token_etag, json_body)
+    return return_code
 
 
 def stop_maintenance(clusters, args, enforce_cluster):
     """Stops maintenance mode for a token by deleting the 'maintenance' user metadata field in the token data"""
     token_name = args['token']
+    ping_token = args.pop('ping_token', True)
+    timeout = args.pop('timeout', 300)
+    wait_for_ping = True
     cluster, existing_token_data, existing_token_etag = _get_existing_token_data(clusters, token_name, enforce_cluster)
     maintenance_mode_active = _is_token_in_maintenance_mode(existing_token_data)
     if not maintenance_mode_active:
         raise Exception("Token is not in maintenance mode")
     json_body = existing_token_data
     json_body.pop("maintenance")
-    return _update_token(cluster, token_name, existing_token_etag, json_body)
+    return_code, token_etag = _update_token(cluster, token_name, existing_token_etag, json_body)
+    if return_code == 0:
+        if ping_token:
+            if token_etag:
+                success = ping_token_on_cluster(cluster, token_name, timeout, wait_for_ping, token_etag)
+                return 0 if success else 1
+            else:
+                logging.debug(f'Not pinging token {token_name} in {cluster} as token ETag is missing.')
+        else:
+            logging.debug(f'Skipped pinging token {token_name} in {cluster}.')
+            return 0
+    else:
+        return return_code
 
 
 def maintenance(parser, clusters, args, _, enforce_cluster):
@@ -94,8 +114,16 @@ def register_check(add_parser):
 
 def register_stop(add_parser):
     """Registers the maintenance stop parser"""
-    parser = add_parser('stop', help='Stop maintenance mode for a token. Requests to the token will be handled '
-                                     'normally.')
+    parser = add_parser('stop', help='Stop maintenance mode for a token. '
+                                     'Requests to the token will be handled normally.'
+                                     'By default, also ping the token to ensure a running service.')
+    ping_group = parser.add_mutually_exclusive_group(required=False)
+    ping_group.add_argument('--no-ping', action='store_false', dest='ping_token',
+                            help='Skip pinging the token. Pinging the token is enabled by default.')
+    ping_group.add_argument('--ping', action='store_true', dest='ping_token',
+                            help='Ping the token after stopping maintenance.')
+    parser.add_argument('--timeout', '-t', default=300, help='read timeout (in seconds) for ping request',
+                        type=check_positive)
     parser.add_argument('token')
     parser.set_defaults(sub_func=stop_maintenance)
 

--- a/cli/waiter/subcommands/maintenance.py
+++ b/cli/waiter/subcommands/maintenance.py
@@ -81,6 +81,7 @@ def start_maintenance(clusters, args, enforce_cluster):
                 return 0 if success else 1
             else:
                 logging.debug(f'Not killing services for token {token_name} in {cluster} as token ETag is missing.')
+                return 1
         else:
             logging.debug(f'Skipped killing services for token {token_name} in {cluster}.')
             return 0
@@ -108,6 +109,7 @@ def stop_maintenance(clusters, args, enforce_cluster):
                 return 0 if success else 1
             else:
                 logging.debug(f'Not pinging token {token_name} in {cluster} as token ETag is missing.')
+                return 1
         else:
             logging.debug(f'Skipped pinging token {token_name} in {cluster}.')
             return 0
@@ -159,7 +161,7 @@ def register_start(add_parser):
                              "By default, also kill the token's currently running services.")
     kill_group = parser.add_mutually_exclusive_group(required=False)
     kill_group.add_argument('--ask-kill', action='store_const', const='ask_kill', dest='kill_services',
-                            help="Ask before killing the token's currently running services.")
+                            help="Ask before killing if there are multiple running services accessed by the token.")
     kill_group.add_argument('--force-kill', action='store_const', const='force_kill', dest='kill_services',
                             help="Force kill the token's currently running services. "
                                  "Killing the token's services is enabled by default.")


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for ping during maintenance stop
- adds support for service kill during maintenance start

## Why are we making these changes?

In addition to configuring maintenance mode, we would like to kill/ping running services for the token when enabling/disabling maintenance. The new behaviors are added as default options and can be disabled by CLI flags.

## CLI output

### help flag

```
$ waiter maintenance start -h
usage: waiter maintenance start [-h] [--ask-kill | --force-kill | --no-kill] token message
...
optional arguments:
  -h, --help    show this help message and exit
  --ask-kill    Ask before killing if there are multiple running services accessed by the token.
  --force-kill  Force kill the token's currently running services. Killing the token's services is enabled by default.
  --no-kill     Skip killing the token's currently running services.


$ waiter maintenance stop -h
usage: waiter maintenance stop [-h] [--no-ping | --ping] [--timeout TIMEOUT] token
...
  --no-ping             Skip pinging the token. Pinging the token is enabled by default.
  --ping                Ping the token after stopping maintenance.
  --timeout TIMEOUT, -t TIMEOUT
                        read timeout (in seconds) for ping request
```

### maintenance start

```
$ waiter --url 'http://localhost:9091' maintenance start test-token 'foo'
Successfully updated test-token.
Killing service w9091-servicegocjaybjge-7b9c39faa28efd0a7870207764751865 in http://localhost:9091...
Successfully killed w9091-servicegocjaybjge-7b9c39faa28efd0a7870207764751865 in http://localhost:9091.


$ waiter --url 'http://localhost:9091' maintenance start --no-kill test-token 'foo2'
Successfully updated test-token.


$ waiter --url 'http://localhost:9091' maintenance start --ask-kill test-token 'foo2'
No changes detected for test-token.
Killing service w9091-servicegocjaybjge-7b9c39faa28efd0a7870207764751865 in http://localhost:9091...
Successfully killed w9091-servicegocjaybjge-7b9c39faa28efd0a7870207764751865 in http://localhost:9091.


$ waiter --url 'http://localhost:9091' maintenance start --ask-kill test-token 'foo3'
Successfully updated test-token.
There are 2 services using token test-token:

=== http://localhost:9091 / w9091-servicegocjaybjge-e6c73b60d4c75ca0da89a4114b335226 ===
...
Kill service in http://localhost:9091? y
Killing service w9091-servicegocjaybjge-e6c73b60d4c75ca0da89a4114b335226 in http://localhost:9091...
Successfully killed w9091-servicegocjaybjge-e6c73b60d4c75ca0da89a4114b335226 in http://localhost:9091.

=== http://localhost:9091 / w9091-servicegocjaybjge-7b9c39faa28efd0a7870207764751865 ===
...
Kill service in http://localhost:9091? y
Killing service w9091-servicegocjaybjge-7b9c39faa28efd0a7870207764751865 in http://localhost:9091...
Successfully killed w9091-servicegocjaybjge-7b9c39faa28efd0a7870207764751865 in http://localhost:9091.


$ waiter --url 'http://localhost:9091' maintenance start --ask-kill test-token 'foo4'
Successfully updated test-token.
There are 2 services using token test-token:
=== http://localhost:9091 / w9091-servicegocjaybjge-d0e8ba3b23e5173d806d473f2b55d883 ===
...
Kill service in http://localhost:9091? n

=== http://localhost:9091 / w9091-servicegocjaybjge-e6c73b60d4c75ca0da89a4114b335226 ===
...
Kill service in http://localhost:9091? y
Killing service w9091-servicegocjaybjge-e6c73b60d4c75ca0da89a4114b335226 in http://localhost:9091...
Successfully killed w9091-servicegocjaybjge-e6c73b60d4c75ca0da89a4114b335226 in http://localhost:9091.
```

### maintenance stop

```
$ waiter --url 'http://localhost:9091' maintenance stop test-token 
Successfully updated test-token.
Pinging token test-token in http://localhost:9091...
Ping successful.
Service is currently Running.


$ waiter --url 'http://localhost:9091' maintenance stop --no-ping test-token 
Successfully updated test-token.
```

