### PR TITLE
Fix soft delete nil index values

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1453,7 +1453,10 @@
                                                           :query-params {})
                 {index-body :body :as index-response} (list-tokens
                                                         waiter-url (retrieve-username) cookies {"include" ["deleted" "metadata"]})
-                token-index (first (try-parse-json index-body))]
+                token-index (->> index-body
+                                 try-parse-json
+                                 (filter (fn [cur-index] (= token (get cur-index "token"))))
+                                 first)]
             (assert-response-status response 200)
             (assert-response-status del-response 200)
             (is (= {"delete" token "hard-delete" false "success" true}

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1451,8 +1451,8 @@
                                                           :headers {"host" token}
                                                           :method :delete
                                                           :query-params {})
-                {index-body :body :as index-response} (list-tokens
-                                                        waiter-url (retrieve-username) cookies {"include" ["deleted" "metadata"]})
+                {index-body :body :as index-response}
+                (list-tokens waiter-url (retrieve-username) cookies {"include" ["deleted" "metadata"]})
                 token-index (->> index-body
                                  try-parse-json
                                  (filter (fn [cur-index] (= token (get cur-index "token"))))

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -176,7 +176,7 @@
                 owner-key (ensure-owner-key kv-store owner->owner-key owner)]
             (update-kv! kv-store owner-key (fn [index] (dissoc index token)))
             (when-not hard-delete
-              (let [{:keys [last-update-time maintenance] :as token-data} (kv/fetch kv-store token)
+              (let [{:strs [last-update-time maintenance] :as token-data} (kv/fetch kv-store token)
                     token-hash (sd/token-data->token-hash token-data)]
                 (update-kv! kv-store owner-key (fn [index]
                                                  (->> (make-index-entry token-hash true last-update-time maintenance)

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -2193,7 +2193,7 @@
                                "last-update-user" owner-1
                                "previous" token-data)]
       (is (= deleted-token-data (kv/fetch kv-store token)))
-      (is (= {token {:deleted true :etag (sd/token-data->token-hash deleted-token-data) :last-update-time nil :maintenance false}}
+      (is (= {token {:deleted true :etag (sd/token-data->token-hash deleted-token-data) :last-update-time (clock-millis) :maintenance false}}
              (list-index-entries-for-owner kv-store owner-1))))
 
     (let [service-parameter-template {"cpus" 2}

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -2106,7 +2106,13 @@
                "last-update-time" current-time
                "last-update-user" auth-user
                "previous" token-description)
-             (kv/fetch kv-store token))))
+             (kv/fetch kv-store token)))
+      (is (= {:deleted true
+              :last-update-time current-time
+              :maintenance false
+              :etag nil}
+             (-> (list-index-entries-for-owner kv-store owner)
+                 (get token)))))
 
     (testing "valid soft delete with up-to-date etag"
       (kv/store kv-store token token-description)
@@ -2119,7 +2125,13 @@
                "last-update-time" current-time
                "last-update-user" auth-user
                "previous" token-description)
-             (kv/fetch kv-store token))))
+             (kv/fetch kv-store token)))
+      (is (= {:deleted true
+              :last-update-time current-time
+              :maintenance false
+              :etag nil}
+             (-> (list-index-entries-for-owner kv-store owner)
+                 (get token)))))
 
     (testing "invalid soft delete"
       (kv/store kv-store token token-description)
@@ -2135,7 +2147,9 @@
       (is (= token-description (kv/fetch kv-store token)))
       (delete-service-description-for-token clock synchronize-fn kv-store history-length token owner auth-user
                                             :hard-delete true)
-      (is (nil? (kv/fetch kv-store token))))
+      (is (nil? (kv/fetch kv-store token)))
+      (is (nil? (-> (list-index-entries-for-owner kv-store owner)
+                    (get token)))))
 
     (testing "valid hard delete with up-to-date etag"
       (kv/store kv-store token token-description)
@@ -2143,7 +2157,9 @@
       (let [token-hash (sd/token-data->token-hash token-description)]
         (delete-service-description-for-token clock synchronize-fn kv-store history-length token owner auth-user
                                               :hard-delete true :version-hash token-hash))
-      (is (nil? (kv/fetch kv-store token))))
+      (is (nil? (kv/fetch kv-store token)))
+      (is (nil? (-> (list-index-entries-for-owner kv-store owner)
+                    (get token)))))
 
     (testing "invalid hard delete"
       (kv/store kv-store token token-description)


### PR DESCRIPTION
## Changes proposed in this PR

- `last-update-time` and `maintenance` are strings instead of keywords

## Why are we making these changes?

- causes index values on soft deleted tokens to be nil (e.g. `maintenance` defaults to a false value)


