### PR TITLE
CORS access-control-request-headers is optional

### DIFF
--- a/waiter/src/waiter/cors.clj
+++ b/waiter/src/waiter/cors.clj
@@ -42,14 +42,13 @@
 (defn preflight-request?
   "Determines if a request is a CORS preflight request.
    A CORS preflight request is a CORS request that checks to see if the CORS protocol is understood.
-   It is an OPTIONS request, using three HTTP request headers:
-   Access-Control-Request-Method, Access-Control-Request-Headers, and the Origin header.
+   It is an OPTIONS request with two required HTTP request headers:
+   Access-Control-Request-Method and Origin
    Source: https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request"
   [{:keys [headers request-method] :as request}]
   (and (= :options request-method)
        (contains? headers "origin")
-       (contains? headers "access-control-request-method")
-       (contains? headers "access-control-request-headers")))
+       (contains? headers "access-control-request-method")))
 
 (defn wrap-cors-preflight
   "Preflight request handling middleware.
@@ -81,7 +80,7 @@
             (let [{:strs [access-control-request-headers]} headers]
               (utils/attach-waiter-source
                 {:headers {"access-control-allow-credentials" "true"
-                           "access-control-allow-headers" access-control-request-headers
+                           "access-control-allow-headers" (or access-control-request-headers "*")
                            "access-control-allow-methods" (str/join ", " (or allowed-methods schema/http-methods))
                            "access-control-allow-origin" origin
                            "access-control-max-age" (str max-age)}

--- a/waiter/test/waiter/cors_test.clj
+++ b/waiter/test/waiter/cors_test.clj
@@ -221,9 +221,9 @@
                                           "access-control-request-method" "DELETE"
                                           "origin" "doesnt.matter"}
                                 :request-method :get})))
-  (is (not (preflight-request? {:headers {"access-control-request-method" "DELETE"
-                                          "origin" "doesnt.matter"}
-                                :request-method :options})))
+  (is (preflight-request? {:headers {"access-control-request-method" "DELETE"
+                                     "origin" "doesnt.matter"}
+                           :request-method :options}))
   (is (not (preflight-request? {:headers {"access-control-request-headers" "x-test-header"
                                           "origin" "doesnt.matter"}
                                 :request-method :options})))


### PR DESCRIPTION
## Changes proposed in this PR

Make `access-control-request-headers` header optional on CORS preflight requests.

## Why are we making these changes?

Requiring the header was a bug. The MDN documentation is not very clear on this, but a careful reading of the linked spec shows that this header is not required if no custom headers are being sent with the CORS request.