### PR TITLE
adds flag to restrict k8s scheduler syncer-state output

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -848,7 +848,7 @@
 
   (state [_ include-flags]
     (cond-> {:supported-include-params ["auth-token-renewer" "authorizer" "service-id->failed-instances"
-                                        "syncer" "watch-state" "watch-state-details"]
+                                        "syncer" "syncer-details" "watch-state" "watch-state-details"]
              :type "KubernetesScheduler"}
       (contains? include-flags "auth-token-renewer")
       (assoc :auth-token-renewer (retrieve-auth-token-state-fn))
@@ -856,8 +856,11 @@
       (assoc :authorizer (authz/state authorizer))
       (contains? include-flags "service-id->failed-instances")
       (assoc :service-id->failed-instances @service-id->failed-instances-transient-store)
-      (contains? include-flags "syncer")
-      (assoc :syncer (retrieve-syncer-state-fn))
+      (or (contains? include-flags "syncer")
+          (contains? include-flags "syncer-details"))
+      (assoc :syncer (cond-> (retrieve-syncer-state-fn)
+                       (not (contains? include-flags "syncer-details"))
+                       (dissoc :service-id->health-check-context)))
       (or (contains? include-flags "watch-state")
           (contains? include-flags "watch-state-details"))
       (assoc :watch-state (cond-> @watch-state

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -688,14 +688,16 @@
       :syncer (retrieve-syncer-state-fn service-id)))
 
   (state [_ include-flags]
-    (cond-> {:supported-include-params ["id->service" "port->reservation" "syncer"]
+    (cond-> {:supported-include-params ["id->service" "port->reservation" "syncer" "syncer-details"]
              :type "ShellScheduler"}
       (contains? include-flags "id->service")
       (assoc :id->service @id->service-agent)
       (contains? include-flags "port->reservation")
       (assoc :port->reservation @port->reservation-atom)
-      (contains? include-flags "syncer")
-      (assoc :syncer (retrieve-syncer-state-fn))))
+      (or (contains? include-flags "syncer") (contains? include-flags "syncer-details"))
+      (assoc :syncer (cond-> (retrieve-syncer-state-fn)
+                       (not (contains? include-flags "syncer-details"))
+                       (dissoc :service-id->health-check-context)))))
 
   (validate-service [_ service-id]
     (let [{:strs [image]} (service-id->service-description-fn service-id)]

--- a/waiter/test/waiter/scheduler/cook_test.clj
+++ b/waiter/test/waiter/scheduler/cook_test.clj
@@ -859,24 +859,29 @@
         retrieve-syncer-state-fn (partial scheduler/retrieve-syncer-state @syncer-state-atom)
         cook-scheduler (create-cook-scheduler-helper
                          :retrieve-syncer-state-fn retrieve-syncer-state-fn
-                         :service-id->failed-instances-transient-store (atom {service-id [:failed-instances]}))]
+                         :service-id->failed-instances-transient-store (atom {service-id [:failed-instances]}))
+        supported-include-params ["authorizer" "service-id->failed-instances" "syncer" "syncer-details"]]
     (is (= {:failed-instances [:failed-instances]
             :syncer {:last-update-time :time}}
            (scheduler/service-id->state cook-scheduler service-id)))
-    (is (= {:supported-include-params ["authorizer" "service-id->failed-instances" "syncer"]
+    (is (= {:supported-include-params supported-include-params
             :type "CookScheduler"}
            (scheduler/state cook-scheduler #{})))
-    (is (= {:supported-include-params ["authorizer" "service-id->failed-instances" "syncer"]
-            :syncer {:last-update-time :time
-                     :service-id->health-check-context {}}
+    (is (= {:supported-include-params supported-include-params
+            :syncer {:last-update-time :time}
             :type "CookScheduler"}
            (scheduler/state cook-scheduler #{"syncer"})))
-    (is (= {:service-id->failed-instances {"service-id" [:failed-instances]}
-            :supported-include-params ["authorizer" "service-id->failed-instances" "syncer"]
+    (is (= {:supported-include-params supported-include-params
             :syncer {:last-update-time :time
                      :service-id->health-check-context {}}
             :type "CookScheduler"}
-           (scheduler/state cook-scheduler #{"authorizer" "service-id->failed-instances" "syncer"})))))
+           (scheduler/state cook-scheduler #{"syncer-details"})))
+    (is (= {:service-id->failed-instances {"service-id" [:failed-instances]}
+            :supported-include-params supported-include-params
+            :syncer {:last-update-time :time
+                     :service-id->health-check-context {}}
+            :type "CookScheduler"}
+           (scheduler/state cook-scheduler #{"authorizer" "service-id->failed-instances" "syncer" "syncer-details"})))))
 
 (deftest test-cook-scheduler
   (testing "Creating a CookScheduler"


### PR DESCRIPTION
## Changes proposed in this PR

- adds syncer details flag to scheduler state

## Why are we making these changes?

We want to restrict k8s watch state output when additional details (time-consuming to produce) are not needed.


