### PR TITLE
renders nil keys while rendering maps as json

### DIFF
--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -161,7 +161,7 @@
   [k]
   (cond
     (keyword? k) (keyword->str k)
-    (nil? k) (throw (Exception. "JSON object properties may not be nil"))
+    (nil? k) "_nil_"
     :else (str k)))
 
 (defn stringify-elements

--- a/waiter/test/waiter/util/utils_test.clj
+++ b/waiter/test/waiter/util/utils_test.clj
@@ -120,6 +120,12 @@
         (is (= expected-json-response-headers headers))
         (is (not (nil? body)))))
 
+    (testing "should convert map with nil keys"
+      (let [{:keys [body headers status]} (clj->json-response {nil 1 "two" 2 "" 3})]
+        (is (= http-200-ok status))
+        (is (= expected-json-response-headers headers))
+        (is (not (nil? body)))))
+
     (testing "should convert regex patterns to strings"
       (is (= (json/write-str {"bar" "foo"}) (:body (clj->json-response {:bar #"foo"}))))
       (is (= (json/write-str {"bar" ["foo" "baz"] "foo/bar" "baz"} :escape-slash false)
@@ -395,7 +401,7 @@
       (is (= '(("foo" "bar")) (stringify-elements :k [[#"foo" "bar"]])))
       (is (= '(("foo" "bar") ("baz" "qux")) (stringify-elements :k [[#"foo" "bar"] [#"baz" "qux"]]))))
 
-    (testing "should convert symbols to strings, inlcuding their namespace"
+    (testing "should convert symbols to strings, including their namespace"
       (is (= "waiter.cors/pattern-based-validator" (stringify-elements :k 'waiter.cors/pattern-based-validator))))
 
     (testing "NaN and Infinity"


### PR DESCRIPTION
## Changes proposed in this PR

- renders nil keys while rendering maps as json

## Why are we making these changes?

We should avoid throwing error while rendering a JSON response. This causes the streaming response to abort.


