### PR TITLE
adds logging and connection metric to token watch connections

### DIFF
--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -23,6 +23,7 @@
             [plumbing.core :as pc]
             [schema.core :as s]
             [waiter.authorization :as authz]
+            [waiter.correlation-id :as cid]
             [waiter.kv :as kv]
             [waiter.service-description :as sd]
             [waiter.status-codes :refer :all]
@@ -638,12 +639,13 @@
 
 (defn handle-list-tokens-watch
   [index-filter-fn metadata-transducer-fn tokens-watch-channels-update-chan {:keys [ctrl] :as request}]
-  (let [watch-chan-xform
+  (let [correlation-id (cid/get-correlation-id)
+        watch-chan-xform
         (comp
           (map
             (fn event-filter [{:keys [object type] :as event}]
-              (log/info "received event from token-watch-maintainer daemon" {:type (:type event)})
-              (log/debug "full tokens event data received from daemon" {:event event})
+              (cid/cinfo correlation-id "received event from token-watch-maintainer daemon" {:type (:type event)})
+              (cid/cdebug correlation-id "full tokens event data received from daemon" {:event event})
               (case type
                 :INITIAL
                 (assoc event :object (->> object
@@ -666,13 +668,13 @@
                 (throw (ex-info "Invalid event type provided" {:event event})))))
           (map
             (fn [event]
-              (log/info "forwarding tokens event to client" {:type (:type event)})
-              (log/debug "full tokens event data being sent to client" {:event event})
+              (cid/cinfo correlation-id "forwarding tokens event to client" {:type (:type event)})
+              (cid/cdebug correlation-id "full tokens event data being sent to client" {:event event})
               (utils/clj->json event))))
         watch-chan-ex-handler-fn
         (fn watch-chan-ex-handler [e]
           (async/put! ctrl e)
-          (log/error e "Error during transformation of a token watch event"))
+          (cid/cerror correlation-id e "error during transformation of a token watch event"))
         watch-chan-buffer (async/buffer 1000)
         watch-chan (async/chan watch-chan-buffer watch-chan-xform watch-chan-ex-handler-fn)]
     (if (async/put! tokens-watch-channels-update-chan watch-chan)

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -677,6 +677,7 @@
           (cid/cerror correlation-id e "error during transformation of a token watch event"))
         watch-chan-buffer (async/buffer 1000)
         watch-chan (async/chan watch-chan-buffer watch-chan-xform watch-chan-ex-handler-fn)]
+    (log/info "created watch-chan" watch-chan)
     (if (async/put! tokens-watch-channels-update-chan watch-chan)
       (do
         (async/go


### PR DESCRIPTION
## Changes proposed in this PR

- adds logging to track watch channel
- adds correlation-id to token watch logs
- adds gauge to track token watch connections

## Why are we making these changes?

Additional logging will help with debugging in the future.

### Sample logs:
```
2021-02-18 08:30:08,286 INFO  waiter.core [qtp129682964-149] - [CID=b23452aa878a-21d047832f70fb20] request received: {:internal-protocol HTTP/1.1, :request-id b23452a88ae1-4ccd7e9a0d868da2-http, :remote-addr 127.0.0.1, :client-protocol HTTP/1.1, :headers {content-type application/json, accept application/json, referer http://localhost:9091/tokens, connection Keep-Alive, user-agent Apache-HttpClient/4.5.13 (Java/1.8.0_201), host localhost:9091, x-cid b23452aa878a-21d047832f70fb20}, :content-length nil, :content-type application/json, :character-encoding UTF-8, :uri /tokens, :query-string include=metadata&include=deleted&watch=true, :router-id r9091-b22c7285ce8d-186abd9641f02af2, :scheme :http, :request-method :get}
2021-02-18 08:30:08,288 INFO  waiter.token [qtp129682964-149] - [CID=b23452aa878a-21d047832f70fb20] created watch-chan #object[clojure.core.async.impl.channels.ManyToManyChannel 0x7796c410 clojure.core.async.impl.channels.ManyToManyChannel@7796c410]
2021-02-18 08:30:08,289 INFO  waiter.token [async-dispatch-21] - [CID=b23452aa878a-21d047832f70fb20] received event from token-watch-maintainer daemon {:type :INITIAL}
2021-02-18 08:30:08,289 INFO  waiter.token [async-dispatch-21] - [CID=b23452aa878a-21d047832f70fb20] forwarding tokens event to client {:type :INITIAL}
2021-02-18 08:30:08,629 INFO  waiter.token [async-dispatch-30] - [CID=b23452aa878a-21d047832f70fb20] received event from token-watch-maintainer daemon {:type :EVENTS}
2021-02-18 08:30:08,640 INFO  waiter.token [async-dispatch-30] - [CID=b23452aa878a-21d047832f70fb20] forwarding tokens event to client {:type :EVENTS}
2021-02-18 08:30:09,078 INFO  waiter.token [async-dispatch-43] - [CID=b23452aa878a-21d047832f70fb20] received event from token-watch-maintainer daemon {:type :EVENTS}
2021-02-18 08:30:09,078 INFO  waiter.token [async-dispatch-43] - [CID=b23452aa878a-21d047832f70fb20] forwarding tokens event to client {:type :EVENTS}
...
2021-02-18 08:30:19,476 INFO  waiter.token [async-dispatch-40] - [CID=b23452aa878a-21d047832f70fb20] received event from token-watch-maintainer daemon {:type :EVENTS}
2021-02-18 08:30:19,476 INFO  waiter.token [async-dispatch-40] - [CID=b23452aa878a-21d047832f70fb20] forwarding tokens event to client {:type :EVENTS}
2021-02-18 08:30:19,482 INFO  waiter.token [async-dispatch-37] - [CID=b23452aa878a-21d047832f70fb20] closing watch-chan, as ctrl channel in request has been triggered {:data [:qbits.jet.servlet/error #error {:cause Broken pipe ...}
...
2021-02-18 08:30:20,085 INFO  waiter.token-watch [async-dispatch-64] - [CID=token-watch-maintainer] removing closed watch-chan #object[clojure.core.async.impl.channels.ManyToManyChannel 0x7796c410 clojure.core.async.impl.channels.ManyToManyChannel@7796c410]
```


