### PR TITLE
configures the scanning interval to detect changes to and reload the keystore

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -138,6 +138,8 @@
 
                   ;; When SSL is enabled, the keystore to use for SSL connections
                   :keystore "/path/to/keystore.p12"
+                  ;; When SSL is enabled, the scanning interval to detect changes to and reload the keystore
+                  :keystore-scan-interval-secs 43200
                   ;; When SSL is enabled, the format of keystore
                   :keystore-type "pkcs12"
                   ;; When SSL is enabled, the password to the keystore

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -112,6 +112,7 @@
                                      (s/optional-key :http2?) s/Bool
                                      (s/optional-key :http2c?) s/Bool
                                      (s/optional-key :keystore) schema/non-empty-string
+                                     (s/optional-key :keystore-scan-interval-secs) schema/positive-int
                                      (s/optional-key :keystore-type) schema/non-empty-string
                                      (s/optional-key :key-password) schema/non-empty-string
                                      (s/optional-key :max-threads) schema/positive-int
@@ -423,6 +424,7 @@
                     :blocking-timeout 900000 ;; 15 minutes
                     :http2? false
                     :http2c? true
+                    :keystore-scan-interval-secs (* 60 60 12)
                     :max-threads 200
                     :request-header-size 32768
                     :response-header-size 8192


### PR DESCRIPTION
## Changes proposed in this PR

- explicitly configures the scanning interval to detect changes to and reload the keystore

## Why are we making these changes?

We wish the keystore of the SSL certificates to be reloaded as it changes.

## Related PR

- https://github.com/twosigma/waiter/pull/1274
- https://github.com/twosigma/jet/pull/51
