### PR TITLE
adds support for streaming timeout on token watch

### DIFF
--- a/waiter/integration/waiter/token_watch_integration_test.clj
+++ b/waiter/integration/waiter/token_watch_integration_test.clj
@@ -113,13 +113,11 @@
           (is (await-goal-response-for-all-routers goal-fn watch-state-request-fn router_urls)))))))
 
 (defn- start-watch
-  [router-url cookies & {:keys [query-params] :or {query-params {"include" ["metadata", "deleted"]
+  [router-url cookies & {:keys [query-params] :or {query-params {"include" ["deleted" "metadata"]
                                                                  "watch" "true"}}}]
-  (let [{:keys [body error] :as request} (make-request router-url "/tokens"
-                                                       :async? true
-                                                       :cookies cookies
-                                                       :query-params query-params)
-        _ (assert-response-status request 200)
+  (let [{:keys [body error headers] :as response}
+        (make-request router-url "/tokens" :async? true :cookies cookies :query-params query-params)
+        _ (assert-response-status response 200)
         json-objects (->> body
                           utils/chan-to-seq!!
                           (map (fn [chunk] (-> chunk .getBytes ByteArrayInputStream.)))
@@ -166,6 +164,7 @@
     {:exit-fn exit-fn
      :error-chan error
      :go-chan go-chan
+     :headers headers
      :query-state-fn query-state-fn
      :router-url router-url}))
 
@@ -386,3 +385,22 @@
             (finally
               (delete-token-and-assert waiter-url token-1)
               (delete-token-and-assert waiter-url token-2))))))))
+
+(deftest ^:parallel ^:integration-fast test-token-watch-streaming-timeout
+  (testing-using-waiter-url
+    (let [{:keys [cookies]} (make-request waiter-url "/waiter-auth")
+          streaming-timeout-ms 5000
+          start-time-epoch-ms (System/currentTimeMillis)
+          {:keys [exit-fn go-chan headers query-state-fn]}
+          (start-watch waiter-url cookies :query-params {"include" ["metadata"]
+                                                         "name" "test-token-watch-streaming-timeout"
+                                                         "streaming-timeout" (str streaming-timeout-ms)
+                                                         "watch" "true"})
+          _ (async/alts!! [go-chan (async/timeout (* 2 streaming-timeout-ms))] :priority true)
+          end-time-epoch-ms (System/currentTimeMillis)
+          elapsed-time-ms (- end-time-epoch-ms start-time-epoch-ms)
+          _ (exit-fn)
+          assertion-message (str {:elapsed-time-ms elapsed-time-ms
+                                  :headers headers})]
+      (is (empty? (query-state-fn)) assertion-message)
+      (is (<= streaming-timeout-ms elapsed-time-ms (+ streaming-timeout-ms 1000)) assertion-message))))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1776,13 +1776,15 @@
                                waiter-hostnames entitlement-manager make-inter-router-requests-sync-fn validate-service-description-fn
                                attach-service-defaults-fn tokens-update-chan request)))))
    :token-list-handler-fn (pc/fnk [[:daemons token-watch-maintainer]
+                                   [:settings [:instance-request-properties streaming-timeout-ms]]
                                    [:state entitlement-manager kv-store]
                                    wrap-secure-request-fn]
                             (let [{:keys [tokens-watch-channels-update-chan]} token-watch-maintainer]
                               (wrap-secure-request-fn
                                 (fn token-handler-fn [request]
-                                  (token/handle-list-tokens-request kv-store entitlement-manager
-                                                                    tokens-watch-channels-update-chan request)))))
+                                  (token/handle-list-tokens-request
+                                    kv-store entitlement-manager streaming-timeout-ms tokens-watch-channels-update-chan
+                                    request)))))
    :token-owners-handler-fn (pc/fnk [[:state kv-store]
                                      wrap-secure-request-fn]
                               (wrap-secure-request-fn


### PR DESCRIPTION

## Changes proposed in this PR

- adds support for streaming timeout on token watch

## Why are we making these changes?

Limits the duration of open connections without response bytes being streamed.

### Sample logs:
```
2021-02-18 15:29:20,556 INFO  waiter.core [qtp826082556-197] - [CID=c914b08081d3-154e13e2bc38cc71] request received: {:internal-protocol HTTP/1.1, :request-id c914b077cbb4-3a57253631f593d6-http, :remote-addr 127.0.0.1, :client-protocol HTTP/1.1, :headers {content-type application/json, accept application/json, referer http://localhost:9091/tokens, connection Keep-Alive, user-agent Apache-HttpClient/4.5.13 (Java/1.8.0_201), host localhost:9091, x-cid c914b08081d3-154e13e2bc38cc71}, :content-length nil, :content-type application/json, :character-encoding UTF-8, :uri /tokens, :query-string include=metadata&include=deleted&watch=true, :router-id r9091-c9064759429a-645710962e35218a, :scheme :http, :request-method :get}
2021-02-18 15:29:20,576 INFO  waiter.token [qtp826082556-197] - [CID=c914b08081d3-154e13e2bc38cc71] request will use streaming timeout of 20000 ms
2021-02-18 15:29:20,582 INFO  waiter.token [qtp826082556-197] - [CID=c914b08081d3-154e13e2bc38cc71] created watch-chan #object[clojure.core.async.impl.channels.ManyToManyChannel 0x41646779 clojure.core.async.impl.channels.ManyToManyChannel@41646779]
2021-02-18 15:29:20,587 INFO  waiter.token [async-dispatch-43] - [CID=c914b08081d3-154e13e2bc38cc71] received event from token-watch-maintainer daemon {:type :INITIAL}
2021-02-18 15:29:20,589 INFO  waiter.token [async-dispatch-43] - [CID=c914b08081d3-154e13e2bc38cc71] forwarding tokens event to client {:type :INITIAL}
2021-02-18 15:29:29,477 INFO  waiter.token [async-dispatch-44] - [CID=c914b08081d3-154e13e2bc38cc71] received event from token-watch-maintainer daemon {:type :EVENTS}
2021-02-18 15:29:30,875 INFO  waiter.token [async-dispatch-38] - [CID=c914b08081d3-154e13e2bc38cc71] received event from token-watch-maintainer daemon {:type :EVENTS}
2021-02-18 15:29:30,879 INFO  waiter.token [async-dispatch-38] - [CID=c914b08081d3-154e13e2bc38cc71] forwarding tokens event to client {:type :EVENTS}
2021-02-18 15:29:37,679 INFO  waiter.token [async-dispatch-31] - [CID=c914b08081d3-154e13e2bc38cc71] received event from token-watch-maintainer daemon {:type :EVENTS}
2021-02-18 15:29:37,680 INFO  waiter.token [async-dispatch-31] - [CID=c914b08081d3-154e13e2bc38cc71] forwarding tokens event to client {:type :EVENTS}
2021-02-18 15:29:39,485 INFO  waiter.token [async-dispatch-30] - [CID=c914b08081d3-154e13e2bc38cc71] received event from token-watch-maintainer daemon {:type :EVENTS}
2021-02-18 15:29:49,489 INFO  waiter.token [async-dispatch-55] - [CID=c914b08081d3-154e13e2bc38cc71] received event from token-watch-maintainer daemon {:type :EVENTS}
2021-02-18 15:29:57,683 INFO  waiter.token [async-dispatch-23] - [CID=c914b08081d3-154e13e2bc38cc71] closing watch-chan due to streaming timeout
2021-02-18 15:29:57,685 INFO  waiter.token [async-dispatch-51] - [CID=c914b08081d3-154e13e2bc38cc71] closing watch-chan as ctrl channel has been triggered {:data nil}

2021-02-18 16:18:34,795 INFO  waiter.core [qtp826082556-197] - [CID=cbc48b5949b1-e5216c45b540cfa] request received: {:internal-protocol HTTP/1.1, :request-id cbc48b53f117-4d0bd9ebd12142be-http, :remote-addr 127.0.0.1, :client-protocol HTTP/1.1, :headers {content-type application/json, accept application/json, referer http://localhost:9091/tokens, connection Keep-Alive, user-agent Apache-HttpClient/4.5.13 (Java/1.8.0_201), host localhost:9091, x-cid cbc48b5949b1-e5216c45b540cfa}, :content-length nil, :content-type application/json, :character-encoding UTF-8, :uri /tokens, :query-string include=metadata&include=deleted&streaming-timeout=3500&watch=true, :router-id r9091-cbbde8ce872b-2e621234cccb17ec, :scheme :http, :request-method :get}
2021-02-18 16:18:34,804 INFO  waiter.token [qtp826082556-197] - [CID=cbc48b5949b1-e5216c45b540cfa] request will use streaming timeout of 3500 ms
2021-02-18 16:18:34,806 INFO  waiter.token [qtp826082556-197] - [CID=cbc48b5949b1-e5216c45b540cfa] created watch-chan #object[clojure.core.async.impl.channels.ManyToManyChannel 0x2a65b75 clojure.core.async.impl.channels.ManyToManyChannel@2a65b75]
2021-02-18 16:18:34,808 INFO  waiter.token [async-dispatch-62] - [CID=cbc48b5949b1-e5216c45b540cfa] received event from token-watch-maintainer daemon {:type :INITIAL}
2021-02-18 16:18:34,814 INFO  waiter.token [async-dispatch-62] - [CID=cbc48b5949b1-e5216c45b540cfa] forwarding tokens event to client {:type :INITIAL}
2021-02-18 16:18:37,283 INFO  waiter.token [async-dispatch-20] - [CID=cbc48b5949b1-e5216c45b540cfa] received event from token-watch-maintainer daemon {:type :EVENTS}
2021-02-18 16:18:38,324 INFO  waiter.token [async-dispatch-58] - [CID=cbc48b5949b1-e5216c45b540cfa] closing watch-chan due to streaming timeout 3500 ms
2021-02-18 16:18:38,332 INFO  waiter.token [async-dispatch-64] - [CID=cbc48b5949b1-e5216c45b540cfa] closing watch-chan as ctrl channel has been triggered {:data nil}
```
