### PR TITLE
configures queue timeout to control wait time for ping from CLI

### DIFF
--- a/cli/waiter/action.py
+++ b/cli/waiter/action.py
@@ -20,10 +20,13 @@ def ping_on_cluster(cluster, timeout, wait_for_request, token_name, service_exis
     def perform_ping():
         status = None
         try:
+            default_queue_timeout_millis = 300000
             timeout_seconds = timeout if wait_for_request else 5
+            timeout_millis = timeout_seconds * 1000
             headers = {
+                'X-Waiter-Queue-Timeout': str(max(default_queue_timeout_millis, timeout_millis)),
                 'X-Waiter-Token': token_name,
-                'X-Waiter-Timeout': str(timeout_seconds * 1000)
+                'X-Waiter-Timeout': str(timeout_millis)
             }
             read_timeout = timeout_seconds if wait_for_request else (timeout_seconds + 5)
             resp = http_util.get(cluster, '/waiter-ping', headers=headers, read_timeout=read_timeout)


### PR DESCRIPTION
## Changes proposed in this PR

- configures queue timeout to control wait time for ping from CLI

## Why are we making these changes?

The timeout, when issuing a ping, needs to include the delay in reserving an instance rather than on exclusive upon the delay in receiving a response from the backend. We rely on the timeout (`read_timeout`) on the client-side (the CLI) to terminate the request when the ping takes too long and report the error.

## Example logs

### Old implementation erroring out at 5 minutes
```
$ time waiter ping --timeout 900 cli_test_ping_timeout_20210225T091851_oYA4DPDe
Pinging token cli_test_ping_timeout_20210225T091851_oYA4DPDe in http://127.0.0.1:9091...
Ping responded with non-200 status 503.
After 300 seconds, no instance available to handle request. Check that your service is able to start properly!

real    5m5.619s
```

### New implementation running the specified duration
```
$ time waiter --url 'http://127.0.0.1:9091' ping --timeout 900 cli_test_ping_timeout_20210225T091851_oYA4DPDe
Pinging token cli_test_ping_timeout_20210225T091851_oYA4DPDe in http://127.0.0.1:9091...
Ping successful.
Service is currently Running.

real    13m21.197s
```



