### PR TITLE
marks instances as expired when they have been ejected too many times

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -793,6 +793,11 @@
                    ;; failures and eject-backoff-base-time-ms (milliseconds):
                    :eject-backoff-base-time-ms 10000
 
+                   ;; Ejected instances that are consistently failing requests despite being deemed as healthy
+                   ;; by health checks are marked as expired when the number of consecutive failed requests
+                   ;; reaches the expiry-threshold.
+                   :expiry-threshold 5
+
                    ;; Killed instances are ejected for max-eject-time-ms (milliseconds):
                    :max-eject-time-ms 300000}
 

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -30,6 +30,7 @@
                                              s/Keyword schema/require-symbol-factory-fn}
                                             schema/contains-kind-sub-map?)
    (s/required-key :ejection-config) {(s/required-key :eject-backoff-base-time-ms) schema/positive-int
+                                      (s/required-key :expiry-threshold) schema/positive-int
                                       (s/required-key :max-eject-time-ms) schema/positive-int}
    (s/required-key :cors-config) (s/constrained
                                    {:kind s/Keyword
@@ -273,6 +274,7 @@
                  :max-age 3600
                  :token-parameter {:factory-fn 'waiter.cors/token-parameter-based-validator}}
    :ejection-config {:eject-backoff-base-time-ms 10000
+                     :expiry-threshold 5
                      :max-eject-time-ms 300000}
    ;; To be considered part of the same cluster, routers need to
    ;; 1. have the same leader-latch-path to participate in leadership election

--- a/waiter/src/waiter/state/ejection_expiry.clj
+++ b/waiter/src/waiter/state/ejection_expiry.clj
@@ -1,0 +1,66 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns waiter.state.ejection-expiry
+  (:require [clojure.set :as set]
+            [plumbing.core :as pc]))
+
+(defrecord EjectionExpiryTracker
+  [failure-threshold service-id->instance-ids-atom])
+
+(defn tracker-state
+  "Returns the state of the tracker."
+  [{:keys [failure-threshold service-id->instance-ids-atom]} include-flags]
+  (cond-> {:failure-threshold failure-threshold
+           :supported-include-params ["service-details"]}
+    (contains? include-flags "service-details")
+    (assoc :service-id->instance-ids (pc/map-vals vec (deref service-id->instance-ids-atom)))))
+
+(defn instance-expired?
+  "Returns true if the instance is being tracked as expired due to consecutively failed requests."
+  [{:keys [service-id->instance-ids-atom]} service-id instance-id]
+  (contains? (get @service-id->instance-ids-atom service-id) instance-id))
+
+(defn select-services!
+  "Stops tracking services not in the provided service-ids."
+  [{:keys [service-id->instance-ids-atom]} service-ids]
+  (swap! service-id->instance-ids-atom select-keys service-ids))
+
+(defn- update-service-id->instance-ids
+  "Helper function to clear empty entries from service-id->instance-ids map."
+  [service-id->instance-ids service-id new-instance-ids]
+  (if (empty? new-instance-ids)
+    (dissoc service-id->instance-ids service-id)
+    (assoc service-id->instance-ids service-id new-instance-ids)))
+
+(defn select-instances!
+  "Stops tracking services not in the provided service-ids."
+  [{:keys [service-id->instance-ids-atom]} service-id instance-ids]
+  (swap! service-id->instance-ids-atom
+         (fn inner-select-instances! [service-id->instance-ids]
+           (let [cur-instance-ids (get service-id->instance-ids service-id)
+                 new-instance-ids (set/intersection cur-instance-ids (set instance-ids))]
+             (update-service-id->instance-ids service-id->instance-ids service-id new-instance-ids)))))
+
+(defn track-consecutive-failures!
+  "Determines if the provided instance should be tracked for expiry based on whether the consecutive failures
+   has reached the configured failure threshold."
+  [{:keys [failure-threshold service-id->instance-ids-atom]} service-id instance-id consecutive-failures]
+  (swap! service-id->instance-ids-atom
+         (fn inner-track-consecutive-failures! [service-id->instance-ids]
+           (let [cur-instance-ids (get service-id->instance-ids service-id)
+                 transform (if (and consecutive-failures (>= consecutive-failures failure-threshold)) conj disj)
+                 new-instance-ids (transform (or cur-instance-ids #{}) instance-id)]
+             (update-service-id->instance-ids service-id->instance-ids service-id new-instance-ids)))))

--- a/waiter/test/waiter/state/ejection_expiry_test.clj
+++ b/waiter/test/waiter/state/ejection_expiry_test.clj
@@ -1,0 +1,126 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns waiter.state.ejection-expiry-test
+  (:require [clojure.test :refer :all]
+            [waiter.state.ejection-expiry :refer :all]
+            [plumbing.core :as pc]))
+
+(deftest test-tracker-state
+  (let [failure-threshold 10
+        service-id->instance-ids-atom (atom {"S1" #{"S1.A"}
+                                             "S2" #{"S2.A" "S2.B"}
+                                             "S3" #{"S3.A" "S3.B" "S3.C"}})
+        tracker (->EjectionExpiryTracker failure-threshold service-id->instance-ids-atom)]
+    (is (= {:failure-threshold failure-threshold
+            :supported-include-params ["service-details"]}
+           (tracker-state tracker #{})))
+    (is (= {:failure-threshold failure-threshold
+            :service-id->instance-ids (pc/map-vals vec @service-id->instance-ids-atom)
+            :supported-include-params ["service-details"]}
+           (tracker-state tracker #{"service-details"})))))
+
+(deftest test-instance-expired?
+  (let [failure-threshold 10
+        service-id->instance-ids-atom (atom {"S1" #{"S1.A"}
+                                             "S2" #{"S2.A" "S2.B"}
+                                             "S3" #{"S3.A" "S3.B" "S3.C"}})
+        tracker (->EjectionExpiryTracker failure-threshold service-id->instance-ids-atom)]
+
+    (is (not (instance-expired? tracker "S0" "S0.A")))
+
+    (is (instance-expired? tracker "S1" "S1.A"))
+    (is (not (instance-expired? tracker "S1" "S1.B")))
+
+    (is (instance-expired? tracker "S2" "S2.A"))
+    (is (instance-expired? tracker "S2" "S2.B"))
+    (is (not (instance-expired? tracker "S2" "S2.C")))))
+
+(deftest test-select-services!
+  (let [failure-threshold 10
+        service-id->instance-ids-atom (atom {"S0" #{}
+                                             "S1" #{"S1.A"}
+                                             "S2" #{"S2.A" "S2.B"}
+                                             "S3" #{"S3.A" "S3.B" "S3.C"}})
+        tracker (->EjectionExpiryTracker failure-threshold service-id->instance-ids-atom)]
+
+    (select-services! tracker ["S1" "S3" "S5" "S7"])
+
+    (is (= {"S1" #{"S1.A"}
+            "S3" #{"S3.A" "S3.B" "S3.C"}}
+           @service-id->instance-ids-atom))))
+
+(deftest test-select-instances!
+  (let [failure-threshold 10
+        service-id->instance-ids-atom (atom {"S1" #{"S1.A"}
+                                             "S2" #{"S2.A" "S2.B"}
+                                             "S3" #{"S3.A" "S3.B" "S3.C"}})
+        tracker (->EjectionExpiryTracker failure-threshold service-id->instance-ids-atom)]
+
+    (select-instances! tracker "S1" [])
+    (select-instances! tracker "S2" ["S2.B" "S2.D" "S2.F"])
+
+    (is (= {"S2" #{"S2.B"}
+            "S3" #{"S3.A" "S3.B" "S3.C"}}
+           @service-id->instance-ids-atom))))
+
+(deftest test-track-consecutive-failures!
+  (let [failure-threshold 10
+        service-id->instance-ids-atom (atom {"S1" #{"S1.A"}
+                                             "S2" #{"S2.A" "S2.B"}
+                                             "S3" #{"S3.A" "S3.B" "S3.C"}})
+        tracker (->EjectionExpiryTracker failure-threshold service-id->instance-ids-atom)]
+
+    (track-consecutive-failures! tracker "S0" "S0.A" 8)
+    (is (= {"S1" #{"S1.A"}
+            "S2" #{"S2.A" "S2.B"}
+            "S3" #{"S3.A" "S3.B" "S3.C"}}
+           @service-id->instance-ids-atom))
+
+    (track-consecutive-failures! tracker "S0" "S0.A" 18)
+    (is (= {"S0" #{"S0.A"}
+            "S1" #{"S1.A"}
+            "S2" #{"S2.A" "S2.B"}
+            "S3" #{"S3.A" "S3.B" "S3.C"}}
+           @service-id->instance-ids-atom))
+
+    (track-consecutive-failures! tracker "S2" "S2.A" 8)
+    (is (= {"S0" #{"S0.A"}
+            "S1" #{"S1.A"}
+            "S2" #{"S2.B"}
+            "S3" #{"S3.A" "S3.B" "S3.C"}}
+           @service-id->instance-ids-atom))
+
+    (track-consecutive-failures! tracker "S2" "S2.A" 4)
+    (is (= {"S0" #{"S0.A"}
+            "S1" #{"S1.A"}
+            "S2" #{"S2.B"}
+            "S3" #{"S3.A" "S3.B" "S3.C"}}
+           @service-id->instance-ids-atom))
+
+    (track-consecutive-failures! tracker "S2" "S2.A" 18)
+    (is (= {"S0" #{"S0.A"}
+            "S1" #{"S1.A"}
+            "S2" #{"S2.A" "S2.B"}
+            "S3" #{"S3.A" "S3.B" "S3.C"}}
+           @service-id->instance-ids-atom))
+
+    (track-consecutive-failures! tracker "S2" "S2.B" 5)
+    (is (= {"S0" #{"S0.A"}
+            "S1" #{"S1.A"}
+            "S2" #{"S2.A"}
+            "S3" #{"S3.A" "S3.C" "S3.B"}}
+           @service-id->instance-ids-atom))))
+


### PR DESCRIPTION
## Changes proposed in this PR

- marks instances as expired when they have been ejected too many times

## Why are we making these changes?

Waiter has additional knowledge from failed requests than that available from the health checks provided by the scheduler. As a result, if it detected an instance that is failing consecutive requests, it can mark the instance as expired and put it up as a candidate for replacement.

<img width="1058" alt="Screen Shot 2021-02-25 at 3 46 34 AM" src="https://user-images.githubusercontent.com/6611249/109134933-2f393500-771c-11eb-9332-c615d37cb394.png">


### Example logs:

Script causing an instance to always fail requests:
```
$ for i in `seq 1 20`; do curl -H'x-waiter-token: cli_test_ping_timeout_20210225T104810_yfASqbdJ' -H'x-kitchen-act-busy: true' 'http://127.0.0.1:9091/hello'; echo; done
...
```

Confirming that instances are being marked as expired and are being replaced by the auto-scaler, notice that the `num-expired-healthy-instances` count keeps changing.

```
2021-02-25 10:48:13,735 INFO  waiter.state.maintainer [async-dispatch-28] - [CID=router-state-maintainer] update-healthy-instances: w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05 has {:num-unhealthy-instance-ids 0, :service-id w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05, :num-expired-healthy-instances 0, :num-expired-unhealthy-instances 0, :num-healthy-instances 1} New healthy instances: ["w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05.159496a7c407c-1ccec905470c0e61"].  
2021-02-25 10:49:13,762 INFO  waiter.state.maintainer [async-dispatch-35] - [CID=router-state-maintainer] update-healthy-instances: w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05 has {:num-unhealthy-instance-ids 0, :service-id w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05, :num-expired-healthy-instances 0, :num-expired-unhealthy-instances 0, :num-healthy-instances 1} New healthy instances: ["w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05.15957678ef2dd-50463b2488f4ab13"].  
2021-02-25 11:00:54,120 INFO  waiter.state.maintainer [async-dispatch-53] - [CID=router-state-maintainer] update-healthy-instances: w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05 has {:num-unhealthy-instance-ids 0, :service-id w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05, :num-expired-healthy-instances 1, :num-expired-unhealthy-instances 0, :num-healthy-instances 2} New healthy instances: ["w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05.159fa03b130e7-3eef94ea21441edd"].  
2021-02-25 11:00:59,125 INFO  waiter.state.maintainer [async-dispatch-33] - [CID=router-state-maintainer] update-healthy-instances: w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05 has {:num-unhealthy-instance-ids 0, :service-id w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05, :num-expired-healthy-instances 0, :num-expired-unhealthy-instances 0, :num-healthy-instances 1}  Removed healthy instances: ["w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05.15957678ef2dd-50463b2488f4ab13"]. 
2021-02-25 11:03:34,207 INFO  waiter.state.maintainer [async-dispatch-52] - [CID=router-state-maintainer] update-healthy-instances: w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05 has {:num-unhealthy-instance-ids 0, :service-id w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05, :num-expired-healthy-instances 1, :num-expired-unhealthy-instances 0, :num-healthy-instances 2} New healthy instances: ["w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05.15a1f4989d731-4b81562cb595798c"].  
2021-02-25 11:03:39,212 INFO  waiter.state.maintainer [async-dispatch-33] - [CID=router-state-maintainer] update-healthy-instances: w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05 has {:num-unhealthy-instance-ids 0, :service-id w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05, :num-expired-healthy-instances 0, :num-expired-unhealthy-instances 0, :num-healthy-instances 1}  Removed healthy instances: ["w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05.159fa03b130e7-3eef94ea21441edd"]. 
2021-02-25 11:06:14,311 INFO  waiter.state.maintainer [async-dispatch-50] - [CID=router-state-maintainer] update-healthy-instances: w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05 has {:num-unhealthy-instance-ids 0, :service-id w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05, :num-expired-healthy-instances 1, :num-expired-unhealthy-instances 0, :num-healthy-instances 2} New healthy instances: ["w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05.15a4490e9bc47-38c802d8a20ab41d"].  
2021-02-25 11:06:19,315 INFO  waiter.state.maintainer [async-dispatch-46] - [CID=router-state-maintainer] update-healthy-instances: w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05 has {:num-unhealthy-instance-ids 0, :service-id w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05, :num-expired-healthy-instances 0, :num-expired-unhealthy-instances 0, :num-healthy-instances 1}  Removed healthy instances: ["w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05.15a1f4989d731-4b81562cb595798c"]. 
2021-02-25 11:08:54,396 INFO  waiter.state.maintainer [async-dispatch-29] - [CID=router-state-maintainer] update-healthy-instances: w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05 has {:num-unhealthy-instance-ids 0, :service-id w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05, :num-expired-healthy-instances 1, :num-expired-unhealthy-instances 0, :num-healthy-instances 2} New healthy instances: ["w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05.15a69d6e6e209-124024b95e03888b"].  
2021-02-25 11:08:59,396 INFO  waiter.state.maintainer [async-dispatch-35] - [CID=router-state-maintainer] update-healthy-instances: w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05 has {:num-unhealthy-instance-ids 0, :service-id w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05, :num-expired-healthy-instances 0, :num-expired-unhealthy-instances 0, :num-healthy-instances 1}  Removed healthy instances: ["w9091-servicem6fwhcbn5q-0929d1bb3d942ae8f66a3fbebf55df05.15a4490e9bc47-38c802d8a20ab41d"].
```

Router state confirming that the instance is being tracked as expired:

<img width="852" alt="Screen Shot 2021-02-25 at 11 44 15 AM" src="https://user-images.githubusercontent.com/6611249/109194250-da6ade00-775e-11eb-90ed-44095f0811f3.png">

<img width="1104" alt="Screen Shot 2021-02-25 at 11 44 06 AM" src="https://user-images.githubusercontent.com/6611249/109194253-db037480-775e-11eb-81c4-3a9dde82ceec.png">


