### PR TITLE
Token Watch Maintainer uses token from KV-store for event generation

### DIFF
--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -248,7 +248,7 @@
 
   (defn get-token-index
     "Given a token, determine the correct index entry of the token. Returns nil if token doesn't exist."
-    [kv-store token & {:keys [refresh] :or {refresh false}}]
+    [kv-store token & {:keys [include refresh] :or {include #{} refresh false}}]
     (timers/start-stop-time!
       (metrics/waiter-timer "core" "token" "get-token-index" (get-refresh-metric-name refresh))
       (let [{:strs [deleted last-update-time maintenance owner] :as token-data} (kv/fetch kv-store token :refresh refresh)
@@ -256,7 +256,7 @@
         (when token-data
           (cond-> (make-index-entry token-hash deleted last-update-time maintenance)
                   (contains? include :owner) (assoc :owner owner)
-                  (contains? include :token) (assoc :token token)))))))
+                  (contains? include :token) (assoc :token token))))))
 
   (defn reindex-tokens
     "Reindex all tokens. `tokens` is a sequence of token maps.  Remove existing index entries.

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -251,10 +251,12 @@
     [kv-store token & {:keys [refresh] :or {refresh false}}]
     (timers/start-stop-time!
       (metrics/waiter-timer "core" "token" "get-token-index" (get-refresh-metric-name refresh))
-      (let [{:strs [deleted last-update-time maintenance] :as token-data} (kv/fetch kv-store token :refresh refresh)
+      (let [{:strs [deleted last-update-time maintenance owner] :as token-data} (kv/fetch kv-store token :refresh refresh)
             token-hash (sd/token-data->token-hash token-data)]
         (when token-data
-          (make-index-entry token-hash deleted last-update-time maintenance)))))
+          (cond-> (make-index-entry token-hash deleted last-update-time maintenance)
+                  (contains? include :owner) (assoc :owner owner)
+                  (contains? include :token) (assoc :token token)))))))
 
   (defn reindex-tokens
     "Reindex all tokens. `tokens` is a sequence of token maps.  Remove existing index entries.

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -246,6 +246,16 @@
     [kv-store]
     (into {} (kv/fetch kv-store token-owners-key)))
 
+  (defn get-token-index
+    "Given a token, determine the correct index entry of the token. Returns nil if token doesn't exist."
+    [kv-store token & {:keys [refresh] :or {refresh false}}]
+    (timers/start-stop-time!
+      (metrics/waiter-timer "core" "token" "get-token-index" (get-refresh-metric-name refresh))
+      (let [{:strs [deleted last-update-time maintenance] :as token-data} (kv/fetch kv-store token :refresh refresh)
+            token-hash (sd/token-data->token-hash token-data)]
+        (when token-data
+          (make-index-entry token-hash deleted last-update-time maintenance)))))
+
   (defn reindex-tokens
     "Reindex all tokens. `tokens` is a sequence of token maps.  Remove existing index entries.
      Writes new entries before deleting old ones to avoid intervening index queries from reading empty results."
@@ -264,10 +274,7 @@
               owner->index-entries (pc/map-vals
                                      (fn [tokens]
                                        (pc/map-from-keys
-                                         (fn [token]
-                                           (let [{:strs [deleted last-update-time maintenance] :as token-data} (kv/fetch kv-store token)
-                                                 token-hash (sd/token-data->token-hash token-data)]
-                                             (make-index-entry token-hash deleted last-update-time maintenance)))
+                                         (partial get-token-index kv-store)
                                          tokens))
                                      owner->tokens)
               owner->owner-key (pc/map-from-keys (fn [_] (new-owner-key)) (keys owner->index-entries))]
@@ -301,17 +308,7 @@
               outer-token->index
               (list-index-entries-for-owner-key kv-store owner-key :refresh refresh)))
           {}
-          owner->owner-key))))
-
-  (defn get-token-index
-    "Given a token and owner, return the token index entry with the token and owner as added fields.
-     Specifying :refresh true will refresh the owner's index cache and get the most up to date index entry."
-    [kv-store token owner & {:keys [refresh] :or {refresh false}}]
-    (timers/start-stop-time!
-      (metrics/waiter-timer "core" "token" "get-token-index" (get-refresh-metric-name refresh))
-      (some-> (list-index-entries-for-owner kv-store owner :refresh refresh)
-              (get token)
-              (assoc :owner owner :token token)))))
+          owner->owner-key)))))
 
 (defprotocol ClusterCalculator
   (get-default-cluster [this]

--- a/waiter/src/waiter/token_watch.clj
+++ b/waiter/src/waiter/token_watch.clj
@@ -80,9 +80,9 @@
                         (timers/start-stop-time!
                           (metrics/waiter-timer "core" "token-watch-maintainer" "token-update")
                           (let [{:keys [owner token]} msg
-                                token-index-entry (some-> kv-store
-                                                          (token/get-token-index token :refresh true)
-                                                          (assoc :owner owner :token token))
+                                token-index-entry (token/get-token-index kv-store token
+                                                                         :include #{:token :owner}
+                                                                         :refresh true)
                                 local-token-index-entry (get token->index token)]
                             (if (= token-index-entry local-token-index-entry)
                               ; There is no change detected, so no event to be reported

--- a/waiter/src/waiter/token_watch.clj
+++ b/waiter/src/waiter/token_watch.clj
@@ -80,9 +80,7 @@
                         (timers/start-stop-time!
                           (metrics/waiter-timer "core" "token-watch-maintainer" "token-update")
                           (let [{:keys [owner token]} msg
-                                token-index-entry (token/get-token-index kv-store token
-                                                                         :include #{:token :owner}
-                                                                         :refresh true)
+                                token-index-entry (token/get-token-index kv-store token :refresh true)
                                 local-token-index-entry (get token->index token)]
                             (if (= token-index-entry local-token-index-entry)
                               ; There is no change detected, so no event to be reported

--- a/waiter/src/waiter/token_watch.clj
+++ b/waiter/src/waiter/token_watch.clj
@@ -79,8 +79,10 @@
                         tokens-update-chan
                         (timers/start-stop-time!
                           (metrics/waiter-timer "core" "token-watch-maintainer" "token-update")
-                          (let [{:keys [token owner]} msg
-                                token-index-entry (token/get-token-index kv-store token owner :refresh true)
+                          (let [{:keys [owner token]} msg
+                                token-index-entry (some-> kv-store
+                                                          (token/get-token-index token :refresh true)
+                                                          (assoc :owner owner :token token))
                                 local-token-index-entry (get token->index token)]
                             (if (= token-index-entry local-token-index-entry)
                               ; There is no change detected, so no event to be reported

--- a/waiter/test/waiter/token_watch_test.clj
+++ b/waiter/test/waiter/token_watch_test.clj
@@ -210,6 +210,14 @@
             (is (= {:last-update-time (clock)
                     :token->index expected-token->index
                     :watch-count 10}
+                   (get-latest-state query-chan))))
+
+          (testing "faulty owner change events do not affect tokens-update-chan processing"
+            (send-internal-index-event tokens-update-chan "token1" "old-owner")
+            (assert-channels-no-new-message watch-chans 1000)
+            (is (= {:last-update-time (clock)
+                    :token->index expected-token->index
+                    :watch-count 10}
                    (get-latest-state query-chan))))))
 
       (testing "watch-channels get UPDATE event for soft deleted tokens"
@@ -246,6 +254,7 @@
                 :token->index {}
                 :watch-count 10}
                (get-latest-state query-chan))))
+
       (stop-token-watch-maintainer go-chan exit-chan)))
 
   (deftest test-start-token-watch-maintainer-watch-count


### PR DESCRIPTION
## Changes proposed in this PR

- use token for event generation instead of owner-index

## Why are we making these changes?

- fixes possible race condition when user changes owner index very quickly
