### PR TITLE
adds integration test for prompt GC of stale services

### DIFF
--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -1384,7 +1384,8 @@
                                 ;; (this stale-timeout-mins value is configured in the default token values :( )
                                 (let [{:strs [stale-timeout-mins]} (attach-token-defaults-fn {})]
                                   (t/minutes stale-timeout-mins)))]
-        (log/info service-id "that uses references went stale at" (du/date-to-str update-time))
+        (log/info service-id "that uses references went stale at" (du/date-to-str update-time)
+                  "and will be gc-ed in" (t/in-seconds gc-delay-duration) "seconds")
         (t/plus update-time gc-delay-duration))
       ;; when GC is enabled, use idle-timeout
       (pos? idle-timeout-mins)


### PR DESCRIPTION
## Changes proposed in this PR

- adds integration test for `stale-timeout-mins=0` and `fallback-period-secs=0`

## Why are we making these changes?

Integration test lets us verify prompt GC for stale services.
