### PR TITLE
provide better validation error message with user-metadata

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -729,7 +729,7 @@
                             (sd/validate-schema defaults max-constraints-schema initial-profile->defaults
                                                 {:allow-missing-required-fields? true})
                             ;; validate the profile's token parameters
-                            (token/validate-token-parameters defaults)
+                            (sd/validate-user-metadata-schema defaults)
                             defaults)))
    :query-service-maintainer-chan (pc/fnk [] (au/latest-chan)) ; TODO move to service-chan-maintainer
    :router-metrics-agent (pc/fnk [router-id] (metrics-sync/new-router-metrics-agent router-id {}))

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -229,8 +229,7 @@
                    (conj error-messages
                          (str key " "
                               (case key
-                                "origin-regex" "must be a valid regular expression"
-                                "target-path-regex" "must be a valid regular expression"
+                                ("origin-regex" "target-path-regex") "must be a valid regular expression"
                                 "methods" "must be a non-empty list of http methods (in upper-case)"
                                 "is not a valid key"))))
                  []

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -478,6 +478,7 @@
        (assoc parameter-key# (do ~error-message-body)))))
 
 (defn validate-user-metadata-schema
+  "Validates provided user-metadata of a token and throws an error with user readable validation issues."
   [user-metadata]
   (try
     (s/validate user-metadata-schema user-metadata)
@@ -507,7 +508,7 @@
                                          (attach-error-message-for-parameter
                                            parameter->issues
                                            :stale-timeout-mins
-                                           "stale-timeout-mins must be an integer between 0 240"))]
+                                           "stale-timeout-mins must be an integer between 0 and 240 (inclusive)"))]
         (throw (ex-info (str "Validation failed for token:\n" (str/join "\n" (vals parameter->error-message)))
                         {:failed-check (str parameter->issues) :status http-400-bad-request :log-level :warn}))))))
 

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -216,6 +216,38 @@
           (map? provided) {:bad-size (count provided)}
           :default {:bad-type provided})))))
 
+(defn generate-friendly-cors-rules-error-message
+  "If the provided cors-rules was invalid, attempt to generate a friendly error message."
+  [issue]
+  (when-let [cors-rules (get issue "cors-rules")]
+    (if (coll? cors-rules)
+      (->> cors-rules
+           (map
+             (fn [rule]
+               (reduce
+                 (fn [error-messages [key _]]
+                   (conj error-messages
+                         (str key " "
+                              (case key
+                                "origin-regex" "must be a valid regular expression"
+                                "target-path-regex" "must be a valid regular expression"
+                                "methods" "must be a non-empty list of http methods"
+                                "is not a valid key"))))
+                 []
+                 rule)))
+           (str/join ", ")
+           (str "cors-rules list has invalid items: "))
+      "cors-rules must be a list")))
+
+(defn generate-friendly-maintenance-error-message
+  "If the provided maintenance field was invalid, attempt to generate a friendly error message."
+  [issue]
+  (when-let [maintenance (get issue "maintenance")]
+    (cond
+      (get maintenance "message")
+      "maintenance message must be a non-empty string with length at most 512"
+      :else "maintenance must be a map")))
+
 (defn generate-friendly-environment-variable-error-message
   "If the provided metadata was invalid, attempt to generate a friendly error message. Return nil for unknown error."
   [issue]
@@ -444,6 +476,40 @@
      (cond-> ~parameter->error-message
        (contains? parameter->issues# parameter-name#)
        (assoc parameter-key# (do ~error-message-body)))))
+
+(defn validate-user-metadata-schema
+  [user-metadata]
+  (try
+    (s/validate user-metadata-schema user-metadata)
+    (catch Exception _
+      (let [parameter->issues (s/check user-metadata-schema user-metadata)
+            parameter->error-message (-> {}
+                                         (attach-error-message-for-parameter
+                                           parameter->issues
+                                           :cors-rules
+                                           (generate-friendly-cors-rules-error-message parameter->issues))
+                                         (attach-error-message-for-parameter
+                                           parameter->issues
+                                           :fallback-period-secs
+                                           "fallback-period-secs must be an integer between 0 and 86400 (inclusive)")
+                                         (attach-error-message-for-parameter
+                                           parameter->issues
+                                           :https-redirect
+                                           "https-redirect must be a boolean value")
+                                         (attach-error-message-for-parameter
+                                           parameter->issues
+                                           :maintenance
+                                           (generate-friendly-maintenance-error-message parameter->issues))
+                                         (attach-error-message-for-parameter
+                                           parameter->issues
+                                           :owner
+                                           "owner must be a non-empty string")
+                                         (attach-error-message-for-parameter
+                                           parameter->issues
+                                           :stale-timeout-mins
+                                           "stale-timeout-mins must be an integer between 0 240"))]
+        (throw (ex-info (str "Validation failed for token:\n" (str/join "\n" (vals parameter->error-message)))
+                        {:failed-check (str parameter->issues) :status http-400-bad-request :log-level :warn}))))))
 
 (defn validate-schema
   "Validates the provided service description template.

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -231,7 +231,7 @@
                               (case key
                                 "origin-regex" "must be a valid regular expression"
                                 "target-path-regex" "must be a valid regular expression"
-                                "methods" "must be a non-empty list of http methods"
+                                "methods" "must be a non-empty list of http methods (in upper-case)"
                                 "is not a valid key"))))
                  []
                  rule)))

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -59,13 +59,6 @@
                        :status 412
                        :token-metadata token-metadata})))))
 
-(defn validate-token-parameters
-  "Validates whether the user-specified token parameters are valid."
-  [user-metadata]
-  (when-let [user-metadata-check (s/check sd/user-metadata-schema user-metadata)]
-    (throw (ex-info "Validation failed for user metadata on token"
-                    {:failed-check (str user-metadata-check) :status http-400-bad-request :log-level :warn}))))
-
 (defn- get-refresh-metric-name
   [refresh]
   (if refresh "with-refresh" "without-refresh"))
@@ -481,7 +474,7 @@
       (throw (ex-info (str "No parameters provided for " token) {:status http-400-bad-request :log-level :warn})))
     (sd/validate-token token)
     (validate-service-description-fn new-service-parameter-template)
-    (validate-token-parameters new-user-metadata)
+    (sd/validate-user-metadata-schema new-user-metadata)
     (let [unknown-keys (-> new-token-data
                            keys
                            set


### PR DESCRIPTION
## Changes proposed in this PR

- Add validation error for token user metadata (e.g. "maintenance", "cors-rules", "owner")
- example cli output when putting invalid user metadata:
```
{ // token config
    "cors-rules": [{
        "target-path-regex": "",
        "methods": [], 
        "random-key": "testing" 
    }],
    "fallback-period-secs": 86401,
    "owner": "",
    "stale-timeout-mins": 241
}
```
![Screenshot from 2021-03-16 17-09-55](https://user-images.githubusercontent.com/8290559/111386614-7d39bc80-867a-11eb-96d5-4b46dde80a97.png)


## Why are we making these changes?

- Error message provided to user makes it unclear why validation failed when creating their token

