### PR TITLE
Token Watch API: Remove owner from internal index events and delete event

### DIFF
--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -87,7 +87,7 @@
   "Send an internal event to be processed by the tokens-watch-maintainer daemon process"
   [tokens-update-chan token]
   (log/info "sending internal index event" {:token token})
-  (async/put! tokens-update-chan token))
+  (async/put! tokens-update-chan {:token token}))
 
 (let [token-lock "TOKEN_LOCK"
       token-owners-key "^TOKEN_OWNERS"

--- a/waiter/src/waiter/token_watch.clj
+++ b/waiter/src/waiter/token_watch.clj
@@ -79,7 +79,7 @@
                         tokens-update-chan
                         (timers/start-stop-time!
                           (metrics/waiter-timer "core" "token-watch-maintainer" "token-update")
-                          (let [{:keys [owner token]} msg
+                          (let [token msg
                                 token-index-entry (token/get-token-index kv-store token :refresh true)
                                 local-token-index-entry (get token->index token)]
                             (if (= token-index-entry local-token-index-entry)
@@ -92,7 +92,7 @@
                                       [(make-index-event :UPDATE token-index-entry)
                                        (assoc-in current-state [:token->index token] token-index-entry)]
                                       ; index-entry doesn't exist then treat as DELETE
-                                      [(make-index-event :DELETE {:owner owner :token token})
+                                      [(make-index-event :DELETE {:token token})
                                        (assoc current-state :token->index (dissoc token->index token))])
                                     open-chans (->> [index-event]
                                                     (make-index-event :EVENTS)

--- a/waiter/src/waiter/token_watch.clj
+++ b/waiter/src/waiter/token_watch.clj
@@ -79,7 +79,7 @@
                         tokens-update-chan
                         (timers/start-stop-time!
                           (metrics/waiter-timer "core" "token-watch-maintainer" "token-update")
-                          (let [token msg
+                          (let [{:keys [token]} msg
                                 token-index-entry (token/get-token-index kv-store token :refresh true)
                                 local-token-index-entry (get token->index token)]
                             (if (= token-index-entry local-token-index-entry)

--- a/waiter/test/waiter/token_watch_test.clj
+++ b/waiter/test/waiter/token_watch_test.clj
@@ -185,7 +185,7 @@
         (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1"))
               expected-token->index {"token1" token-cur-index}]
           (assert-channels-next-message watch-chans (make-index-event :INITIAL []))
-          (send-internal-index-event tokens-update-chan "token1" (get token1-index :owner))
+          (send-internal-index-event tokens-update-chan "token1")
           (assert-channels-next-message watch-chans (make-aggregate-index-events (make-index-event :UPDATE token-cur-index)))
           (is (= {:last-update-time (clock)
                   :token->index expected-token->index
@@ -197,7 +197,7 @@
           synchronize-fn kv-store history-length limit-per-owner "token1" (assoc token1-service-desc "cpus" 2) token1-metadata)
         (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1"))
               expected-token->index {"token1" token-cur-index}]
-          (send-internal-index-event tokens-update-chan "token1" (get token1-index :owner))
+          (send-internal-index-event tokens-update-chan "token1")
           (assert-channels-next-message watch-chans (make-aggregate-index-events (make-index-event :UPDATE token-cur-index)))
           (is (= {:last-update-time (clock)
                   :token->index expected-token->index
@@ -205,15 +205,7 @@
                  (get-latest-state query-chan)))
 
           (testing "watch-channels doesn't send event if no changes in token-index-entry and current-state"
-            (send-internal-index-event tokens-update-chan "token1" (get token1-index :owner))
-            (assert-channels-no-new-message watch-chans 1000)
-            (is (= {:last-update-time (clock)
-                    :token->index expected-token->index
-                    :watch-count 10}
-                   (get-latest-state query-chan))))
-
-          (testing "faulty owner change events do not affect tokens-update-chan processing"
-            (send-internal-index-event tokens-update-chan "token1" "old-owner")
+            (send-internal-index-event tokens-update-chan "token1")
             (assert-channels-no-new-message watch-chans 1000)
             (is (= {:last-update-time (clock)
                     :token->index expected-token->index
@@ -227,7 +219,7 @@
                                                   :last-update-time (clock-millis)
                                                   :deleted true)
               expected-token->index {"token1" token-cur-index}]
-          (send-internal-index-event tokens-update-chan "token1" (get token1-index :owner))
+          (send-internal-index-event tokens-update-chan "token1")
           (assert-channels-next-message watch-chans (make-aggregate-index-events (make-index-event :UPDATE token-cur-index)))
           (is (= {:last-update-time (clock)
                   :token->index expected-token->index
@@ -237,18 +229,17 @@
       (testing "watch-channels get DELETE event for hard deleted tokens"
         (delete-service-description-for-token clock synchronize-fn kv-store history-length "token1"
                                               (get token1-index :owner) auth-user :hard-delete true)
-        (send-internal-index-event tokens-update-chan "token1" (get token1-index :owner))
+        (send-internal-index-event tokens-update-chan "token1")
         (assert-channels-next-message watch-chans
                                       (make-aggregate-index-events
-                                        (make-index-event :DELETE {:owner (get token1-index :owner)
-                                                                   :token "token1"})))
+                                        (make-index-event :DELETE {:token "token1"})))
         (is (= {:last-update-time (clock)
                 :token->index {}
                 :watch-count 10}
                (get-latest-state query-chan))))
 
       (testing "watch-channels doesn't send event if no changes in token-index-entry and current-state"
-        (send-internal-index-event tokens-update-chan "token1" (get token1-index :owner))
+        (send-internal-index-event tokens-update-chan "token1")
         (assert-channels-no-new-message watch-chans 1000)
         (is (= {:last-update-time (clock)
                 :token->index {}
@@ -419,7 +410,7 @@
                     (store-service-description-for-token
                       synchronize-fn kv-store history-length limit-per-owner "token1" token1-service-desc
                       (assoc token1-metadata "last-update-time" i))
-                    (send-internal-index-event tokens-update-chan "token1" (get token1-index :owner))
+                    (send-internal-index-event tokens-update-chan "token1")
                     (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1")
                                                               :last-update-time i)
                           expected-token->index {"token1" token-cur-index}]


### PR DESCRIPTION
## Changes proposed in this PR

- Remove owner from internal index events and delete events

## Why are we making these changes?

- Decrease tech debt
