### PR TITLE
CLI: fix maintenance start command trying to concatenate dictionary.

### DIFF
--- a/cli/waiter/subcommands/maintenance.py
+++ b/cli/waiter/subcommands/maintenance.py
@@ -65,7 +65,8 @@ def start_maintenance(clusters, args, enforce_cluster):
     json_body.update(update_doc)
     return_code, token_etag = _update_token(cluster, token_name, existing_token_etag, json_body)
     if return_code == 0:
-        print_info(f'Maintenance mode activated for {terminal.bold(token_name)} on cluster {terminal.bold(cluster)}.')
+        print_info(f'Maintenance mode activated for {terminal.bold(token_name)} on cluster '
+                   f'{terminal.bold(cluster["name"])}.')
         kill_services = False
         force_flag = False
         if kill_services_option == 'force_kill':


### PR DESCRIPTION
## Changes proposed in this PR

- fixes cli mainteannce start command bug where it improperly concatenates a dictionary

## Why are we making these changes?


