### PR TITLE
Drop managedFields from k8s objects

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -397,7 +397,9 @@
       (throw (ex-info "k8s watch connection failed"
                       {:watch-resource resource-name
                        :watch-response update-json}))
-      update-json)))
+      ;; Drop managedFields from response objects when present (much too verbose!)
+      ;; https://github.com/kubernetes/kubernetes/issues/90066#issuecomment-626828512
+      (utils/dissoc-in update-json [:object :metadata :managedFields]))))
 
 (defn api-request
   "Make an HTTP request to the Kubernetes API server using the configured authentication.


### PR DESCRIPTION
## Changes proposed in this PR

Drop managedFields metadata from k8s objects

## Why are we making these changes?

The managedFields metadata is not useful to us, and it's very verbose.

https://github.com/kubernetes/kubernetes/issues/90066#issuecomment-626828512