### PR TITLE
Add more token watch logs and correlate them throughout event flow

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1371,7 +1371,7 @@
                               [:state clock kv-store]]
                              (let [watch-refresh-timer-chan (au/timer-chan watch-refresh-timeout-ms)]
                                (token-watch/start-token-watch-maintainer
-                                 kv-store clock tokens-update-chan-buffer-size channels-update-chan-buffer-size watch-refresh-timer-chan utils/unique-identifier)))})
+                                 kv-store clock tokens-update-chan-buffer-size channels-update-chan-buffer-size watch-refresh-timer-chan)))})
 
 (def request-handlers
   {:app-name-handler-fn (pc/fnk [service-id-handler-fn]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1369,9 +1369,11 @@
                                 [:tokens channels-update-chan-buffer-size tokens-update-chan-buffer-size
                                  watch-refresh-timeout-ms]]]
                               [:state clock kv-store]]
-                             (let [watch-refresh-timer-chan (au/timer-chan watch-refresh-timeout-ms)]
+                             (let [watch-refresh-timer-chan (au/timer-chan watch-refresh-timeout-ms)
+                                   cid-factory-fn (fn create-watch-cid []
+                                                    (str "token-watch-maintainer" "." (utils/unique-identifier)))]
                                (token-watch/start-token-watch-maintainer
-                                 kv-store clock tokens-update-chan-buffer-size channels-update-chan-buffer-size watch-refresh-timer-chan)))})
+                                 kv-store clock tokens-update-chan-buffer-size channels-update-chan-buffer-size watch-refresh-timer-chan cid-factory-fn)))})
 
 (def request-handlers
   {:app-name-handler-fn (pc/fnk [service-id-handler-fn]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1369,11 +1369,9 @@
                                 [:tokens channels-update-chan-buffer-size tokens-update-chan-buffer-size
                                  watch-refresh-timeout-ms]]]
                               [:state clock kv-store]]
-                             (let [watch-refresh-timer-chan (au/timer-chan watch-refresh-timeout-ms)
-                                   cid-factory-fn (fn create-watch-cid []
-                                                    (str "token-watch-maintainer" "." (utils/unique-identifier)))]
+                             (let [watch-refresh-timer-chan (au/timer-chan watch-refresh-timeout-ms)]
                                (token-watch/start-token-watch-maintainer
-                                 kv-store clock tokens-update-chan-buffer-size channels-update-chan-buffer-size watch-refresh-timer-chan cid-factory-fn)))})
+                                 kv-store clock tokens-update-chan-buffer-size channels-update-chan-buffer-size watch-refresh-timer-chan utils/unique-identifier)))})
 
 (def request-handlers
   {:app-name-handler-fn (pc/fnk [service-id-handler-fn]

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -674,9 +674,8 @@
             watch-chan-xform
             (comp
               (map
-                (fn event-filter [{:keys [object type] :as event}]
-                  (cid/cinfo correlation-id "received event from token-watch-maintainer daemon" {:type (:type event)
-                                                                                                 :token-sample (first (:object event))})
+                (fn event-filter [{:keys [id object type] :as event}]
+                  (cid/cinfo correlation-id "received event from token-watch-maintainer daemon" {:id id})
                   (cid/cdebug correlation-id "full tokens event data received from daemon" {:event event})
                   (case type
                     :INITIAL
@@ -699,9 +698,10 @@
                     :EVENTS (not-empty object)
                     (throw (ex-info "Invalid event type provided" {:event event})))))
               (map
-                (fn [event]
-                  (cid/cinfo correlation-id "forwarding tokens event to client" {:type (:type event)
-                                                                                 :token-sample (first (:object event))})
+                (fn [{:keys [id object type] :as event}]
+                  (cid/cinfo correlation-id "forwarding tokens event to client"
+                             (case type :INITIAL {:id id :object-count (count object) :object-sample (first object) :type type}
+                                        :EVENTS event))
                   (cid/cdebug correlation-id "full tokens event data being sent to client" {:event event})
                   (utils/clj->json event))))
             watch-chan-ex-handler-fn

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -80,7 +80,7 @@
   "Send an internal event to be processed by the tokens-watch-maintainer daemon process"
   [tokens-update-chan token]
   (log/info "sending internal index event" {:token token})
-  (async/put! tokens-update-chan {:token token :cid (cid/get-correlation-id)}))
+  (async/put! tokens-update-chan {:cid (cid/get-correlation-id) :token token}))
 
 (let [token-lock "TOKEN_LOCK"
       token-owners-key "^TOKEN_OWNERS"

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -675,7 +675,8 @@
             (comp
               (map
                 (fn event-filter [{:keys [object type] :as event}]
-                  (cid/cinfo correlation-id "received event from token-watch-maintainer daemon" {:type (:type event)})
+                  (cid/cinfo correlation-id "received event from token-watch-maintainer daemon" {:type (:type event)
+                                                                                                 :token-sample (first (:object event))})
                   (cid/cdebug correlation-id "full tokens event data received from daemon" {:event event})
                   (case type
                     :INITIAL
@@ -699,7 +700,8 @@
                     (throw (ex-info "Invalid event type provided" {:event event})))))
               (map
                 (fn [event]
-                  (cid/cinfo correlation-id "forwarding tokens event to client" {:type (:type event)})
+                  (cid/cinfo correlation-id "forwarding tokens event to client" {:type (:type event)
+                                                                                 :token-sample (first (:object event))})
                   (cid/cdebug correlation-id "full tokens event data being sent to client" {:event event})
                   (utils/clj->json event))))
             watch-chan-ex-handler-fn

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -80,7 +80,7 @@
   "Send an internal event to be processed by the tokens-watch-maintainer daemon process"
   [tokens-update-chan token]
   (log/info "sending internal index event" {:token token})
-  (async/put! tokens-update-chan {:token token}))
+  (async/put! tokens-update-chan {:token token :x-cid (cid/get-correlation-id)}))
 
 (let [token-lock "TOKEN_LOCK"
       token-owners-key "^TOKEN_OWNERS"

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -80,7 +80,7 @@
   "Send an internal event to be processed by the tokens-watch-maintainer daemon process"
   [tokens-update-chan token]
   (log/info "sending internal index event" {:token token})
-  (async/put! tokens-update-chan {:token token :x-cid (cid/get-correlation-id)}))
+  (async/put! tokens-update-chan {:token token :cid (cid/get-correlation-id)}))
 
 (let [token-lock "TOKEN_LOCK"
       token-owners-key "^TOKEN_OWNERS"

--- a/waiter/src/waiter/token_watch.clj
+++ b/waiter/src/waiter/token_watch.clj
@@ -42,8 +42,7 @@
   [kv-store clock tokens-update-chan-buffer-size channels-update-chan-buffer-size watch-refresh-timer-chan]
   (cid/with-correlation-id
     "token-watch-maintainer"
-    (let [cid-factory-fn utils/unique-identifier
-          exit-chan (async/promise-chan)
+    (let [exit-chan (async/promise-chan)
           tokens-update-chan-buffer (async/buffer tokens-update-chan-buffer-size)
           tokens-update-chan (async/chan tokens-update-chan-buffer)
           tokens-watch-channels-update-chan-buffer (async/buffer channels-update-chan-buffer-size)
@@ -68,7 +67,7 @@
             (try
               (loop [{:keys [token->index watch-chans] :as current-state} @state-atom]
                 (reset! state-atom current-state)
-                (let [external-event-cid (cid-factory-fn)
+                (let [external-event-cid (utils/unique-identifier)
                       [msg current-chan]
                       (async/alts! [exit-chan tokens-update-chan tokens-watch-channels-update-chan
                                     watch-refresh-timer-chan query-chan]

--- a/waiter/src/waiter/token_watch.clj
+++ b/waiter/src/waiter/token_watch.clj
@@ -39,10 +39,11 @@
 (defn start-token-watch-maintainer
   "Starts daemon thread that maintains token watches and process/filters internal token events to be streamed to
   clients through the watch handlers. Returns map of various channels and state functions to control the daemon."
-  [kv-store clock tokens-update-chan-buffer-size channels-update-chan-buffer-size watch-refresh-timer-chan cid-factory-fn]
+  [kv-store clock tokens-update-chan-buffer-size channels-update-chan-buffer-size watch-refresh-timer-chan]
   (cid/with-correlation-id
     "token-watch-maintainer"
-    (let [exit-chan (async/promise-chan)
+    (let [cid-factory-fn utils/unique-identifier
+          exit-chan (async/promise-chan)
           tokens-update-chan-buffer (async/buffer tokens-update-chan-buffer-size)
           tokens-update-chan (async/chan tokens-update-chan-buffer)
           tokens-watch-channels-update-chan-buffer (async/buffer channels-update-chan-buffer-size)

--- a/waiter/src/waiter/token_watch.clj
+++ b/waiter/src/waiter/token_watch.clj
@@ -86,7 +86,7 @@
                           (let [{:keys [token cid] :as internal-event} msg]
                             (cid/with-correlation-id
                               (str "token-watch-maintainer" "." cid "." external-event-cid)
-                              (log/info "token-watch-maintainer received an internal index event" internal-event)
+                              (log/info "received an internal index event" internal-event)
                               (let [token-index-entry (token/get-token-index kv-store token :refresh true)
                                     local-token-index-entry (get token->index token)]
                                 (if (= token-index-entry local-token-index-entry)
@@ -101,7 +101,7 @@
                                           ; index-entry doesn't exist then treat as DELETE
                                           [(make-index-event :DELETE {:token token})
                                            (assoc current-state :token->index (dissoc token->index token))])
-                                        _ (log/info "token-watch-maintainer sending a token event to watches" {:event index-event})
+                                        _ (log/info "sending a token event to watches" {:event index-event})
                                         open-chans (->> (make-index-event :EVENTS [index-event] :id external-event-cid)
                                                         (send-event-to-channels! watch-chans))]
                                     (assoc next-state :watch-chans open-chans)))))))
@@ -149,7 +149,7 @@
                                 (meters/mark! (metrics/waiter-meter "core" "token-watch-maintainer" "refresh-sync-rate"))
                                 (meters/mark! (metrics/waiter-meter "core" "token-watch-maintainer" "refresh-sync-count")
                                               (count events))
-                                (log/info "token-watch-maintainer found some differences in kv-store and current-state"
+                                (log/info "found some differences in kv-store and current-state"
                                           {:only-in-current only-old-indexes
                                            :only-in-next only-next-indexes
                                            :token-count (count token->index)}))

--- a/waiter/src/waiter/token_watch.clj
+++ b/waiter/src/waiter/token_watch.clj
@@ -39,7 +39,7 @@
 (defn start-token-watch-maintainer
   "Starts daemon thread that maintains token watches and process/filters internal token events to be streamed to
   clients through the watch handlers. Returns map of various channels and state functions to control the daemon."
-  [kv-store clock tokens-update-chan-buffer-size channels-update-chan-buffer-size watch-refresh-timer-chan]
+  [kv-store clock tokens-update-chan-buffer-size channels-update-chan-buffer-size watch-refresh-timer-chan cid-factory-fn]
   (cid/with-correlation-id
     "token-watch-maintainer"
     (let [exit-chan (async/promise-chan)
@@ -109,7 +109,7 @@
                         (timers/start-stop-time!
                           (metrics/waiter-timer "core" "token-watch-maintainer" "channel-update")
                           (cid/with-correlation-id
-                            (str "token-watch-maintainer" "." (utils/unique-identifier))
+                            (cid-factory-fn)
                             (log/info "received watch-chan" msg)
                             (let [watch-chan msg
                                   initial-event
@@ -126,7 +126,7 @@
                         (timers/start-stop-time!
                           (metrics/waiter-timer "core" "token-watch-maintainer" "refresh")
                           (cid/with-correlation-id
-                            (str "token-watch-maintainer" "." (utils/unique-identifier))
+                            (cid-factory-fn)
                             (log/info "refresh starting...")
                             (let [next-token->index (token/get-token->index kv-store :refresh true)
                                   [only-old-indexes only-next-indexes _] (data/diff token->index next-token->index)

--- a/waiter/src/waiter/token_watch.clj
+++ b/waiter/src/waiter/token_watch.clj
@@ -7,12 +7,15 @@
             [metrics.timers :as timers]
             [waiter.correlation-id :as cid]
             [waiter.metrics :as metrics]
-            [waiter.token :as token]))
+            [waiter.token :as token]
+            [waiter.util.utils :as utils]))
 
 (defn make-index-event
   "Create an event for watch endpoints"
-  [type object]
-  {:object object :type type})
+  [type object & {:keys [id]}]
+  (cond->
+    {:object object :type type}
+    id (assoc :id id)))
 
 (defn send-event-to-channels!
   "Given a list of watch channels and the event to send to each channel, send the event in a non blocking fashion and
@@ -79,74 +82,79 @@
                         tokens-update-chan
                         (timers/start-stop-time!
                           (metrics/waiter-timer "core" "token-watch-maintainer" "token-update")
-                          (let [{:keys [token x-cid] :as internal-event} msg
-                                token-index-entry (token/get-token-index kv-store token :refresh true)
-                                local-token-index-entry (get token->index token)]
-                            (log/info "token-watch-maintainer received an internal index event" internal-event)
-                            (if (= token-index-entry local-token-index-entry)
-                              ; There is no change detected, so no event to be reported
-                              current-state
-                              (let [[index-event next-state]
-                                    (if (some? token-index-entry)
-                                      ; If index-entry retrieved from kv-store exists then treat as UPDATE
-                                      ; (includes token creation and soft deletion)
-                                      [(make-index-event :UPDATE token-index-entry)
-                                       (assoc-in current-state [:token->index token] token-index-entry)]
-                                      ; index-entry doesn't exist then treat as DELETE
-                                      [(make-index-event :DELETE {:token token})
-                                       (assoc current-state :token->index (dissoc token->index token))])
-                                    _ (log/info "token-watch-maintainer sending a token event to watches" {:event index-event})
-                                    open-chans (->> [index-event]
-                                                    (make-index-event :EVENTS)
-                                                    (send-event-to-channels! watch-chans))]
-                                (assoc next-state :watch-chans open-chans)))))
+                          (let [{:keys [token x-cid] :as internal-event} msg]
+                            (cid/with-correlation-id
+                              (str "token-watch-maintainer" "." x-cid)
+                              (log/info "token-watch-maintainer received an internal index event" internal-event)
+                              (let [token-index-entry (token/get-token-index kv-store token :refresh true)
+                                    local-token-index-entry (get token->index token)]
+                                (if (= token-index-entry local-token-index-entry)
+                                  ; There is no change detected, so no event to be reported
+                                  current-state
+                                  (let [[index-event next-state]
+                                        (if (some? token-index-entry)
+                                          ; If index-entry retrieved from kv-store exists then treat as UPDATE
+                                          ; (includes token creation and soft deletion)
+                                          [(make-index-event :UPDATE token-index-entry)
+                                           (assoc-in current-state [:token->index token] token-index-entry)]
+                                          ; index-entry doesn't exist then treat as DELETE
+                                          [(make-index-event :DELETE {:token token})
+                                           (assoc current-state :token->index (dissoc token->index token))])
+                                        _ (log/info "token-watch-maintainer sending a token event to watches" {:event index-event})
+                                        open-chans (->> (make-index-event :EVENTS [index-event] :id x-cid)
+                                                        (send-event-to-channels! watch-chans))]
+                                    (assoc next-state :watch-chans open-chans)))))))
 
                         tokens-watch-channels-update-chan
                         (timers/start-stop-time!
                           (metrics/waiter-timer "core" "token-watch-maintainer" "channel-update")
-                          (log/info "received watch-chan" msg)
-                          (let [watch-chan msg
-                                initial-event
-                                (timers/start-stop-time!
-                                  (metrics/waiter-timer "core" "token-watch-maintainer" "channel-update-build-event")
-                                  (make-index-event :INITIAL (doall (or (vals token->index) []))))]
-                            (timers/start-stop-time!
-                              (metrics/waiter-timer "core" "token-watch-maintainer" "channel-update-forward-event")
-                              (async/put! watch-chan initial-event))
-                            (log/info "finished sending initial event")
-                            (assoc current-state :watch-chans (conj watch-chans watch-chan))))
+                          (cid/with-correlation-id
+                            (str "token-watch-maintainer" "." (utils/unique-identifier))
+                            (log/info "received watch-chan" msg)
+                            (let [watch-chan msg
+                                  initial-event
+                                  (timers/start-stop-time!
+                                    (metrics/waiter-timer "core" "token-watch-maintainer" "channel-update-build-event")
+                                    (make-index-event :INITIAL (doall (or (vals token->index) [])) :id (cid/get-correlation-id)))]
+                              (timers/start-stop-time!
+                                (metrics/waiter-timer "core" "token-watch-maintainer" "channel-update-forward-event")
+                                (async/put! watch-chan initial-event))
+                              (log/info "finished sending initial event")
+                              (assoc current-state :watch-chans (conj watch-chans watch-chan)))))
 
                         watch-refresh-timer-chan
                         (timers/start-stop-time!
                           (metrics/waiter-timer "core" "token-watch-maintainer" "refresh")
-                          (log/info "refresh starting...")
-                          (let [next-token->index (token/get-token->index kv-store :refresh true)
-                                [only-old-indexes only-next-indexes _] (data/diff token->index next-token->index)
-                                ; if token in old-indexes and not in only-next-indexes, then those token indexes were deleted
-                                delete-events
-                                (for [[token {:keys [owner]}] only-old-indexes
-                                      :when (not (contains? only-next-indexes token))]
-                                  (make-index-event :DELETE {:owner owner :token token}))
-                                ; if token in only-next-indexes, it has been updated (soft-delete, and creation included)
-                                update-events
-                                (for [[token _] only-next-indexes]
-                                  (make-index-event :UPDATE (get next-token->index token)))
-                                events (concat delete-events update-events)
-                                ; send events event if empty, which will serve as a heartbeat
-                                open-chans
-                                (send-event-to-channels! watch-chans (make-index-event :EVENTS events))]
-                            (when (not-empty events)
-                              (counters/inc! (metrics/waiter-counter "core" "token-watch-maintainer" "refresh-sync"))
-                              (meters/mark! (metrics/waiter-meter "core" "token-watch-maintainer" "refresh-sync-rate"))
-                              (meters/mark! (metrics/waiter-meter "core" "token-watch-maintainer" "refresh-sync-count")
-                                            (count events))
-                              (log/info "token-watch-maintainer found some differences in kv-store and current-state"
-                                        {:only-in-current only-old-indexes
-                                         :only-in-next only-next-indexes
-                                         :token-count (count token->index)}))
-                            (log/info "refresh ended.")
-                            (assoc current-state :token->index next-token->index
-                                                 :watch-chans open-chans)))
+                          (cid/with-correlation-id
+                            (str "token-watch-maintainer" "." (utils/unique-identifier))
+                            (log/info "refresh starting...")
+                            (let [next-token->index (token/get-token->index kv-store :refresh true)
+                                  [only-old-indexes only-next-indexes _] (data/diff token->index next-token->index)
+                                  ; if token in old-indexes and not in only-next-indexes, then those token indexes were deleted
+                                  delete-events
+                                  (for [[token {:keys [owner]}] only-old-indexes
+                                        :when (not (contains? only-next-indexes token))]
+                                    (make-index-event :DELETE {:owner owner :token token}))
+                                  ; if token in only-next-indexes, it has been updated (soft-delete, and creation included)
+                                  update-events
+                                  (for [[token _] only-next-indexes]
+                                    (make-index-event :UPDATE (get next-token->index token)))
+                                  events (concat delete-events update-events)
+                                  ; send events event if empty, which will serve as a heartbeat
+                                  open-chans
+                                  (send-event-to-channels! watch-chans (make-index-event :EVENTS events :id (cid/get-correlation-id)))]
+                              (when (not-empty events)
+                                (counters/inc! (metrics/waiter-counter "core" "token-watch-maintainer" "refresh-sync"))
+                                (meters/mark! (metrics/waiter-meter "core" "token-watch-maintainer" "refresh-sync-rate"))
+                                (meters/mark! (metrics/waiter-meter "core" "token-watch-maintainer" "refresh-sync-count")
+                                              (count events))
+                                (log/info "token-watch-maintainer found some differences in kv-store and current-state"
+                                          {:only-in-current only-old-indexes
+                                           :only-in-next only-next-indexes
+                                           :token-count (count token->index)}))
+                              (log/info "refresh ended.")
+                              (assoc current-state :token->index next-token->index
+                                                   :watch-chans open-chans))))
 
                         query-chan
                         (let [{:keys [response-chan include-flags]} msg]

--- a/waiter/src/waiter/token_watch.clj
+++ b/waiter/src/waiter/token_watch.clj
@@ -82,9 +82,9 @@
                         tokens-update-chan
                         (timers/start-stop-time!
                           (metrics/waiter-timer "core" "token-watch-maintainer" "token-update")
-                          (let [{:keys [token x-cid] :as internal-event} msg]
+                          (let [{:keys [token cid] :as internal-event} msg]
                             (cid/with-correlation-id
-                              (str "token-watch-maintainer" "." x-cid)
+                              (str "token-watch-maintainer" "." cid)
                               (log/info "token-watch-maintainer received an internal index event" internal-event)
                               (let [token-index-entry (token/get-token-index kv-store token :refresh true)
                                     local-token-index-entry (get token->index token)]
@@ -101,7 +101,7 @@
                                           [(make-index-event :DELETE {:token token})
                                            (assoc current-state :token->index (dissoc token->index token))])
                                         _ (log/info "token-watch-maintainer sending a token event to watches" {:event index-event})
-                                        open-chans (->> (make-index-event :EVENTS [index-event] :id x-cid)
+                                        open-chans (->> (make-index-event :EVENTS [index-event] :id cid)
                                                         (send-event-to-channels! watch-chans))]
                                     (assoc next-state :watch-chans open-chans)))))))
 

--- a/waiter/test/waiter/token_watch_test.clj
+++ b/waiter/test/waiter/token_watch_test.clj
@@ -17,14 +17,12 @@
   (:require [clj-time.core :as t]
             [clojure.core.async :as async]
             [clojure.test :refer :all]
-            [waiter.correlation-id :as cid]
             [waiter.kv :as kv]
             [waiter.service-description :as sd]
             [waiter.status-codes :refer :all]
             [waiter.test-helpers :refer :all]
             [waiter.token :refer :all]
-            [waiter.token-watch :refer :all]
-            [waiter.util.utils :as utils])
+            [waiter.token-watch :refer :all])
   (:import (org.joda.time DateTime)))
 
 (def ^:const history-length 5)

--- a/waiter/test/waiter/token_watch_test.clj
+++ b/waiter/test/waiter/token_watch_test.clj
@@ -122,14 +122,8 @@
       stop-token-watch-maintainer (fn [go-chan exit-chan]
                                     (async/>!! exit-chan :exit)
                                     (async/<!! go-chan))
-      make-aggregate-index-events (fn [object & {:keys [id]}]
-                                    (make-index-event :EVENTS [object] :id id))
-      token-watch-test-cid "token-watch-test"
-      test-cid-factory-fn (constantly token-watch-test-cid)
-      send-internal-index-event-fn (fn [tokens-update-chan token]
-                                     (cid/with-correlation-id
-                                       token-watch-test-cid
-                                       (send-internal-index-event tokens-update-chan token)))
+      make-aggregate-index-events (fn [object]
+                                    (make-index-event :EVENTS [object]))
       auth-user "auth-user"
       token1-metadata {"cluster" "c1" "last-update-time" 1000 "owner" "owner1"}
       token1-service-desc {"cpus" 1}
@@ -201,7 +195,7 @@
         (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1"))
               expected-token->index {"token1" token-cur-index}]
           (assert-channels-next-event watch-chans (make-index-event :INITIAL []))
-          (send-internal-index-event-fn tokens-update-chan "token1")
+          (send-internal-index-event tokens-update-chan "token1")
           (assert-channels-next-event watch-chans (make-aggregate-index-events (make-index-event :UPDATE token-cur-index)))
           (is (= {:last-update-time (clock)
                   :token->index expected-token->index
@@ -213,7 +207,7 @@
           synchronize-fn kv-store history-length limit-per-owner "token1" (assoc token1-service-desc "cpus" 2) token1-metadata)
         (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1"))
               expected-token->index {"token1" token-cur-index}]
-          (send-internal-index-event-fn tokens-update-chan "token1")
+          (send-internal-index-event tokens-update-chan "token1")
           (assert-channels-next-event watch-chans (make-aggregate-index-events (make-index-event :UPDATE token-cur-index)))
           (is (= {:last-update-time (clock)
                   :token->index expected-token->index
@@ -221,7 +215,7 @@
                  (get-latest-state query-chan)))
 
           (testing "watch-channels doesn't send event if no changes in token-index-entry and current-state"
-            (send-internal-index-event-fn tokens-update-chan "token1")
+            (send-internal-index-event tokens-update-chan "token1")
             (assert-channels-no-new-message watch-chans 1000)
             (is (= {:last-update-time (clock)
                     :token->index expected-token->index
@@ -235,7 +229,7 @@
                                                   :last-update-time (clock-millis)
                                                   :deleted true)
               expected-token->index {"token1" token-cur-index}]
-          (send-internal-index-event-fn tokens-update-chan "token1")
+          (send-internal-index-event tokens-update-chan "token1")
           (assert-channels-next-event watch-chans (make-aggregate-index-events (make-index-event :UPDATE token-cur-index)))
           (is (= {:last-update-time (clock)
                   :token->index expected-token->index
@@ -245,7 +239,7 @@
       (testing "watch-channels get DELETE event for hard deleted tokens"
         (delete-service-description-for-token clock synchronize-fn kv-store history-length "token1"
                                               (get token1-index :owner) auth-user :hard-delete true)
-        (send-internal-index-event-fn tokens-update-chan "token1")
+        (send-internal-index-event tokens-update-chan "token1")
         (assert-channels-next-event watch-chans
                                     (make-aggregate-index-events
                                       (make-index-event :DELETE {:token "token1"})))
@@ -255,7 +249,7 @@
                (get-latest-state query-chan))))
 
       (testing "watch-channels doesn't send event if no changes in token-index-entry and current-state"
-        (send-internal-index-event-fn tokens-update-chan "token1")
+        (send-internal-index-event tokens-update-chan "token1")
         (assert-channels-no-new-message watch-chans 1000)
         (is (= {:last-update-time (clock)
                 :token->index {}
@@ -423,7 +417,7 @@
                     (store-service-description-for-token
                       synchronize-fn kv-store history-length limit-per-owner "token1" token1-service-desc
                       (assoc token1-metadata "last-update-time" i))
-                    (send-internal-index-event-fn tokens-update-chan "token1")
+                    (send-internal-index-event tokens-update-chan "token1")
                     (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1")
                                                               :last-update-time i)
                           expected-token->index {"token1" token-cur-index}]

--- a/waiter/test/waiter/token_watch_test.clj
+++ b/waiter/test/waiter/token_watch_test.clj
@@ -165,9 +165,7 @@
           _ (store-service-description-for-token
               synchronize-fn kv-store history-length limit-per-owner "token1" token1-service-desc token1-metadata)
           {:keys [exit-chan go-chan query-chan tokens-watch-channels-update-chan]}
-          (with-redefs
-            [utils/unique-identifier test-cid-factory-fn]
-            (start-token-watch-maintainer kv-store clock 1 1 (async/chan)))
+          (start-token-watch-maintainer kv-store clock 1 1 (async/chan))
           token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1"))
           expected-token->index {"token1" token-cur-index}]
       (is (= {:last-update-time (clock)
@@ -192,9 +190,7 @@
     (let [kv-store (kv/->LocalKeyValueStore (atom {}))
           watch-chans (create-watch-chans 10)
           {:keys [exit-chan go-chan tokens-update-chan query-chan tokens-watch-channels-update-chan]}
-          (with-redefs
-            [utils/unique-identifier test-cid-factory-fn]
-            (start-token-watch-maintainer kv-store clock 1 1 (async/chan)))]
+          (start-token-watch-maintainer kv-store clock 1 1 (async/chan))]
 
       (testing "watch-channels get UPDATE event for added tokens"
         (add-watch-chans tokens-watch-channels-update-chan watch-chans)
@@ -274,9 +270,7 @@
           watch-chans-1 (create-watch-chans 10)
           watch-chans-2 (create-watch-chans 10)
           {:keys [exit-chan go-chan tokens-watch-channels-update-chan query-chan]}
-          (with-redefs
-            [utils/unique-identifier test-cid-factory-fn]
-            (start-token-watch-maintainer kv-store clock 1 1 watch-refresh-timer-chan))]
+          (start-token-watch-maintainer kv-store clock 1 1 watch-refresh-timer-chan)]
       (is (= {:last-update-time (clock)
               :token->index {}
               :watch-count 0}
@@ -318,9 +312,7 @@
           watch-chans (create-watch-chans 10)
           watch-refresh-timer-chan (async/chan)
           {:keys [exit-chan go-chan tokens-watch-channels-update-chan query-chan]}
-          (with-redefs
-            [utils/unique-identifier test-cid-factory-fn]
-            (start-token-watch-maintainer kv-store clock 1 1 watch-refresh-timer-chan))]
+          (start-token-watch-maintainer kv-store clock 1 1 watch-refresh-timer-chan)]
       (is (= {:last-update-time (clock)
               :token->index {}
               :watch-count 0}
@@ -413,9 +405,7 @@
   (deftest test-start-token-watch-maintainer-slow-channel
     (let [kv-store (kv/->LocalKeyValueStore (atom {}))
           {:keys [exit-chan go-chan tokens-update-chan tokens-watch-channels-update-chan query-chan]}
-          (with-redefs
-            [utils/unique-identifier test-cid-factory-fn]
-            (start-token-watch-maintainer kv-store clock 1 1 (async/chan)))]
+          (start-token-watch-maintainer kv-store clock 1 1 (async/chan))]
 
       (testing "sending 5000 internal events does not halt daemon process with a slow watch-channel"
         (let [buffer-size 1
@@ -454,9 +444,7 @@
   (deftest test-start-token-watch-maintainer-buffer-state
     (let [kv-store (kv/->LocalKeyValueStore (atom {}))
           {:keys [exit-chan go-chan tokens-update-chan tokens-watch-channels-update-chan query-state-fn]}
-          (with-redefs
-            [utils/unique-identifier test-cid-factory-fn]
-            (start-token-watch-maintainer kv-store clock 1000 1000 (async/chan)))
+          (start-token-watch-maintainer kv-store clock 1000 1000 (async/chan))
           expected-buffer-count 123]
       (stop-token-watch-maintainer go-chan exit-chan)
 

--- a/waiter/test/waiter/token_watch_test.clj
+++ b/waiter/test/waiter/token_watch_test.clj
@@ -116,11 +116,11 @@
                                     (async/<!! go-chan))
       make-aggregate-index-events (fn [object & {:keys [id]}]
                                     (make-index-event :EVENTS [object] :id id))
-      token-watch-test-x-cid "token-watch-test"
-      token-watch-cid-factory-fn (constantly token-watch-test-x-cid)
+      token-watch-test-cid "token-watch-test"
+      token-watch-cid-factory-fn (constantly token-watch-test-cid)
       send-internal-index-event-fn (fn [tokens-update-chan token]
                                      (cid/with-correlation-id
-                                       token-watch-test-x-cid
+                                       token-watch-test-cid
                                        (send-internal-index-event tokens-update-chan token)))
       auth-user "auth-user"
       token1-metadata {"cluster" "c1" "last-update-time" 1000 "owner" "owner1"}
@@ -147,7 +147,7 @@
                 :token->index {}
                 :watch-count 10}
                (get-latest-state query-chan)))
-        (assert-channels-next-message watch-chans (make-index-event :INITIAL [] :id token-watch-test-x-cid)))
+        (assert-channels-next-message watch-chans (make-index-event :INITIAL [] :id token-watch-test-cid)))
 
       (stop-token-watch-maintainer go-chan exit-chan)))
 
@@ -191,10 +191,10 @@
           synchronize-fn kv-store history-length limit-per-owner "token1" token1-service-desc token1-metadata)
         (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1"))
               expected-token->index {"token1" token-cur-index}]
-          (assert-channels-next-message watch-chans (make-index-event :INITIAL [] :id token-watch-test-x-cid))
+          (assert-channels-next-message watch-chans (make-index-event :INITIAL [] :id token-watch-test-cid))
           (send-internal-index-event-fn tokens-update-chan "token1")
           (assert-channels-next-message watch-chans (make-aggregate-index-events (make-index-event :UPDATE token-cur-index)
-                                                                                 :id token-watch-test-x-cid))
+                                                                                 :id token-watch-test-cid))
           (is (= {:last-update-time (clock)
                   :token->index expected-token->index
                   :watch-count 10}
@@ -207,7 +207,7 @@
               expected-token->index {"token1" token-cur-index}]
           (send-internal-index-event-fn tokens-update-chan "token1")
           (assert-channels-next-message watch-chans (make-aggregate-index-events (make-index-event :UPDATE token-cur-index)
-                                                                                 :id token-watch-test-x-cid))
+                                                                                 :id token-watch-test-cid))
           (is (= {:last-update-time (clock)
                   :token->index expected-token->index
                   :watch-count 10}
@@ -230,7 +230,7 @@
               expected-token->index {"token1" token-cur-index}]
           (send-internal-index-event-fn tokens-update-chan "token1")
           (assert-channels-next-message watch-chans (make-aggregate-index-events (make-index-event :UPDATE token-cur-index)
-                                                                                 :id token-watch-test-x-cid))
+                                                                                 :id token-watch-test-cid))
           (is (= {:last-update-time (clock)
                   :token->index expected-token->index
                   :watch-count 10}
@@ -243,7 +243,7 @@
         (assert-channels-next-message watch-chans
                                       (make-aggregate-index-events
                                         (make-index-event :DELETE {:token "token1"})
-                                        :id token-watch-test-x-cid))
+                                        :id token-watch-test-cid))
         (is (= {:last-update-time (clock)
                 :token->index {}
                 :watch-count 10}
@@ -277,13 +277,13 @@
                 :token->index {}
                 :watch-count 10}
                (get-latest-state query-chan)))
-        (assert-channels-next-message watch-chans-1 (make-index-event :INITIAL [] :id token-watch-test-x-cid))
+        (assert-channels-next-message watch-chans-1 (make-index-event :INITIAL [] :id token-watch-test-cid))
         (add-watch-chans tokens-watch-channels-update-chan watch-chans-2)
         (is (= {:last-update-time (clock)
                 :token->index {}
                 :watch-count 20}
                (get-latest-state query-chan)))
-        (assert-channels-next-message watch-chans-2 (make-index-event :INITIAL [] :id token-watch-test-x-cid)))
+        (assert-channels-next-message watch-chans-2 (make-index-event :INITIAL [] :id token-watch-test-cid)))
 
       (testing "watch-count should decrement when daemon process is refreshed"
         (remove-watch-chans watch-chans-1)
@@ -321,7 +321,7 @@
                (get-latest-state query-chan))))
 
       (add-watch-chans tokens-watch-channels-update-chan watch-chans)
-      (assert-channels-next-message watch-chans (make-index-event :INITIAL [] :id token-watch-test-x-cid))
+      (assert-channels-next-message watch-chans (make-index-event :INITIAL [] :id token-watch-test-cid))
 
       (testing "refresh-timeout should update current-state and watchers if token is added to kv-store"
         (store-service-description-for-token
@@ -335,7 +335,7 @@
                  (get-latest-state query-chan)))
           (assert-channels-next-message watch-chans (make-aggregate-index-events
                                                       (make-index-event :UPDATE token-cur-index)
-                                                      :id token-watch-test-x-cid))))
+                                                      :id token-watch-test-cid))))
 
       (testing "refresh-timeout should update current-state and watchers if token is out of date"
         (store-service-description-for-token
@@ -350,7 +350,7 @@
                  (get-latest-state query-chan)))
           (assert-channels-next-message watch-chans (make-aggregate-index-events
                                                       (make-index-event :UPDATE token-cur-index)
-                                                      :id token-watch-test-x-cid))))
+                                                      :id token-watch-test-cid))))
 
       (testing "refresh-timeout should update current-state and watchers if token is soft deleted"
         (delete-service-description-for-token clock synchronize-fn kv-store history-length "token1"
@@ -366,7 +366,7 @@
                  (get-latest-state query-chan)))
           (assert-channels-next-message watch-chans (make-aggregate-index-events
                                                       (make-index-event :UPDATE token-cur-index)
-                                                      :id token-watch-test-x-cid))))
+                                                      :id token-watch-test-cid))))
 
       (testing "refresh-timeout should update current-state and watchers if token is hard deleted"
         (delete-service-description-for-token clock synchronize-fn kv-store history-length "token1"
@@ -380,7 +380,7 @@
                                                     (make-index-event :DELETE
                                                                       {:owner (get token1-index :owner)
                                                                        :token "token1"})
-                                                    :id token-watch-test-x-cid)))
+                                                    :id token-watch-test-cid)))
 
       (stop-token-watch-maintainer go-chan exit-chan)))
 
@@ -436,7 +436,7 @@
 
           (testing "channel is closed and no longer can have messages put! to it, but can still read"
             (is (not (async/put! slow-chan "temp")))
-            (is (= { :id token-watch-test-x-cid :object [] :type :INITIAL}
+            (is (= { :id token-watch-test-cid :object [] :type :INITIAL}
                    (async/<!! slow-chan))))))
 
       (stop-token-watch-maintainer go-chan exit-chan)))

--- a/waiter/test/waiter/token_watch_test.clj
+++ b/waiter/test/waiter/token_watch_test.clj
@@ -17,13 +17,13 @@
   (:require [clj-time.core :as t]
             [clojure.core.async :as async]
             [clojure.test :refer :all]
+            [waiter.correlation-id :as cid]
             [waiter.kv :as kv]
             [waiter.service-description :as sd]
             [waiter.status-codes :refer :all]
             [waiter.test-helpers :refer :all]
             [waiter.token :refer :all]
-            [waiter.token-watch :refer :all]
-            [waiter.correlation-id :as cid])
+            [waiter.token-watch :refer :all])
   (:import (org.joda.time DateTime)))
 
 (def ^:const history-length 5)


### PR DESCRIPTION
## Changes proposed in this PR

- internal index event uses cid (this comes from inter router request, or local token edit request)
- token-watch-maintainer uses the cid from the internal index event for logging and puts the cid in the outer event object
- token-watch-maintainer creates a cid when doing refresh events, or initial event
- handler-lists-tokens-watch only logs the id before processing and logs extra event information when forwarding the event to a client

## Why are we making these changes?
- This gives better visibility into what tokens are in what events
- correlates the initial token edit request with the event being sent to clients makes it easier to relate logs while debugging

