### PR TITLE
avoid reading entire request body into memory

### DIFF
--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -69,7 +69,11 @@
                  (not (instance? ManyToManyChannel response))
                  (not (hu/http2? internal-protocol)))
         (try
-          (slurp body)
+          (let [body-stream ^ServletInputStream body
+                buffer (byte-array 1024)]
+            ;; read until the request payload is fully consumed
+            (while (not (.isFinished body-stream))
+              (.read body-stream buffer)))
           (catch IOException e
             (log/error e "Unable to consume request stream"))))
       response)))


### PR DESCRIPTION
## Changes proposed in this PR

avoid reading entire request body into memory

## Why are we making these changes?

avoid allocating huge strings for request bodies that we don't actually use