### PR TITLE
consumes request stream asynchronously with reduced young gen memory pressure

### DIFF
--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -16,6 +16,7 @@
 (ns waiter.main
   (:gen-class)
   (:require [clj-time.core :as t]
+            [clojure.core.async :as async]
             [clojure.java.io :as io]
             [clojure.java.shell :as sh]
             [clojure.string :as str]
@@ -23,6 +24,7 @@
             [clojure.tools.logging :as log]
             [metrics.core :as mc]
             [metrics.jvm.core :as jvm-metrics]
+            [metrics.meters :as meters]
             [plumbing.core :as pc]
             [plumbing.graph :as graph]
             [qbits.jet.server :as server]
@@ -38,8 +40,7 @@
             [waiter.util.http-utils :as hu]
             [waiter.util.utils :as utils])
   (:import (clojure.core.async.impl.channels ManyToManyChannel)
-           (java.io IOException)
-           (javax.servlet ServletInputStream)
+           (javax.servlet ReadListener ServletInputStream)
            (org.eclipse.jetty.server AbstractConnector Server)))
 
 (defn retrieve-git-version []
@@ -64,15 +65,47 @@
   [handler]
   (fn [{:keys [body] :as request}]
     (let [{:keys [internal-protocol] :as response} (handler request)]
-      (when (and (instance? ServletInputStream body)
+      (if (and (instance? ServletInputStream body)
                  (not (.isFinished ^ServletInputStream body))
                  (not (instance? ManyToManyChannel response))
                  (not (hu/http2? internal-protocol)))
-        (try
-          (slurp body)
-          (catch IOException e
-            (log/error e "Unable to consume request stream"))))
-      response)))
+        (let [response-ch (async/promise-chan)
+              input-stream ^ServletInputStream body
+              bytes-counter-atom (atom 0)
+              throughput-meter-global (metrics/waiter-meter "streaming" "request-bytes")
+              throughput-iterations-meter-global (metrics/waiter-meter "streaming" "request-iterations")
+              complete-request-streaming (fn complete-request-streaming [throwable]
+                                           (if throwable
+                                             (log/error throwable "error after consuming" @bytes-counter-atom "bytes from request stream")
+                                             (log/info "successfully consumed" @bytes-counter-atom "bytes from request stream"))
+                                           (async/>!! response-ch response))
+              buffer-size 1024
+              buffer-bytes (byte-array buffer-size)]
+          (try
+            (.setReadListener
+              input-stream
+              (reify ReadListener
+                (onAllDataRead [_]
+                  (complete-request-streaming nil))
+                (onDataAvailable [_]
+                  (try
+                    (loop []
+                      (let [bytes-read (.read input-stream buffer-bytes)]
+                        (when (pos? bytes-read)
+                          (swap! bytes-counter-atom + bytes-read)
+                          (meters/mark! throughput-meter-global bytes-read)
+                          (meters/mark! throughput-iterations-meter-global))
+                        (when (and (utils/non-neg? bytes-read) (.isReady input-stream))
+                          (recur))))
+                    (catch Throwable throwable
+                      (complete-request-streaming throwable)
+                      (throw throwable))))
+                (onError [_ throwable]
+                  (complete-request-streaming throwable))))
+            (catch Throwable throwable
+              (complete-request-streaming throwable)))
+          response-ch)
+        response))))
 
 (defn- initialize-server-metrics
   "Initializes the gauge metrics for the server instance."

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -76,8 +76,8 @@
               throughput-iterations-meter-global (metrics/waiter-meter "streaming" "request-iterations")
               complete-request-streaming (fn complete-request-streaming [throwable]
                                            (if throwable
-                                             (log/error throwable "error after consuming" @bytes-counter-atom "bytes from request stream")
-                                             (log/info "successfully consumed" @bytes-counter-atom "bytes from request stream"))
+                                             (log/debug throwable "error after consuming" @bytes-counter-atom "bytes from request stream")
+                                             (log/debug "successfully consumed" @bytes-counter-atom "bytes from request stream"))
                                            (async/>!! response-ch response))
               buffer-size 1024
               buffer-bytes (byte-array buffer-size)]

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -65,10 +65,11 @@
   [handler]
   (fn [{:keys [body] :as request}]
     (let [{:keys [internal-protocol] :as response} (handler request)]
-      (if (and (instance? ServletInputStream body)
-                 (not (.isFinished ^ServletInputStream body))
-                 (not (instance? ManyToManyChannel response))
-                 (not (hu/http2? internal-protocol)))
+      (if-not (and (instance? ServletInputStream body)
+                   (not (.isFinished ^ServletInputStream body))
+                   (not (instance? ManyToManyChannel response))
+                   (not (hu/http2? internal-protocol)))
+        response
         (let [response-ch (async/promise-chan)
               input-stream ^ServletInputStream body
               bytes-counter-atom (atom 0)
@@ -104,8 +105,7 @@
                   (complete-request-streaming throwable))))
             (catch Throwable throwable
               (complete-request-streaming throwable)))
-          response-ch)
-        response))))
+          response-ch)))))
 
 (defn- initialize-server-metrics
   "Initializes the gauge metrics for the server instance."


### PR DESCRIPTION

## Changes proposed in this PR

- consumes request stream asynchronously with reduced young gen memory pressure

## Why are we making these changes?

The existing `slurp` is bad on two counts:
- uses blocking reads to read from the input stream
- generates a lot of short-lived objects and creates an unused string from the bytes consumed from the input stream


