### PR TITLE
makes draining request bytes configurable

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -130,6 +130,11 @@
  :server-options {;; The timeout in ms for blocking I/O operations, default 15 minutes (in millis)
                   :blocking-timeout 900000
 
+                  ;; Drains request bytes before emitting a response, default is true (backward compatibility).
+                  ;; Some clients are sensitive to request bytes having streamed completely before receiving a response.
+                  ;; In such scnearios, we configure Waiter to drain all request bytes before emitting the response line.
+                  :drain-request-bytes true
+
                   ;; Whether or not to  enable secure HTTP2 transport, default false
                   :http2? false
 

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -148,17 +148,18 @@
                         options (merge (cond-> server-options
                                          (:ssl-port server-options) (assoc :ssl? true))
                                        websocket-config
-                                       {:ring-handler (-> (core/ring-handler-factory waiter-request?-fn handlers)
-                                                        (cors/wrap-cors-preflight
-                                                          cors-validator (:max-age cors-config) discover-service-parameters-fn waiter-request?-fn)
-                                                        core/wrap-error-handling
-                                                        (core/wrap-debug generate-log-url-fn)
-                                                        (core/attach-waiter-api-middleware waiter-request?-fn)
-                                                        (core/attach-server-header-middleware server-name)
-                                                        rlog/wrap-log
-                                                        core/correlation-id-middleware
-                                                        (core/wrap-request-info router-id support-info)
-                                                        consume-request-stream)
+                                       {:ring-handler (cond-> (-> (core/ring-handler-factory waiter-request?-fn handlers)
+                                                                (cors/wrap-cors-preflight
+                                                                  cors-validator (:max-age cors-config) discover-service-parameters-fn waiter-request?-fn)
+                                                                core/wrap-error-handling
+                                                                (core/wrap-debug generate-log-url-fn)
+                                                                (core/attach-waiter-api-middleware waiter-request?-fn)
+                                                                (core/attach-server-header-middleware server-name)
+                                                                rlog/wrap-log
+                                                                core/correlation-id-middleware
+                                                                (core/wrap-request-info router-id support-info))
+                                                        (get-in settings [:server-options :drain-request-bytes])
+                                                        (consume-request-stream))
                                         :websocket-acceptor websocket-request-acceptor
                                         :websocket-handler (-> (core/websocket-handler-factory handlers)
                                                              rlog/wrap-log

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -110,6 +110,7 @@
    (s/required-key :scheduler-syncer-interval-secs) schema/positive-int
    (s/required-key :server-options) {(s/optional-key :accept-queue-size) schema/non-negative-int
                                      (s/optional-key :blocking-timeout) schema/non-negative-int
+                                     (s/optional-key :drain-request-bytes) s/Bool
                                      (s/optional-key :http2?) s/Bool
                                      (s/optional-key :http2c?) s/Bool
                                      (s/optional-key :keystore) schema/non-empty-string
@@ -427,6 +428,7 @@
                     ;; We set it to a reasonably high 15 mins by default.
                     ;; The idle timeout is configured per request, so we do not explicitly configure it here.
                     :blocking-timeout 900000 ;; 15 minutes
+                    :drain-request-bytes true
                     :http2? false
                     :http2c? true
                     :keystore-scan-interval-secs (* 60 60 12)


### PR DESCRIPTION
## Changes proposed in this PR

- makes draining request bytes configurable

## Why are we making these changes?

Draining request bytes which we are going to discard is wasteful. Discarding such request bytes is actually preferable as it avoids keeping the server busy doing wasted work.

