### PR TITLE
makes draining request bytes buffer size configurable

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -130,6 +130,11 @@
  :server-options {;; The timeout in ms for blocking I/O operations, default 15 minutes (in millis)
                   :blocking-timeout 900000
 
+                  ;; The buffer size used while draining request bytes before emitting a response, the default is 16384.
+                  ;; Draining request bytes is necessary for clients that are sensitive to request being streamed completely before receiving a response.
+                  ;; Waiter, conservatively, drains all request bytes before emitting the response line.
+                  :drain-request-buffer-size 16384
+
                   ;; Whether or not to  enable secure HTTP2 transport, default false
                   :http2? false
 

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -110,6 +110,7 @@
    (s/required-key :scheduler-syncer-interval-secs) schema/positive-int
    (s/required-key :server-options) {(s/optional-key :accept-queue-size) schema/non-negative-int
                                      (s/optional-key :blocking-timeout) schema/non-negative-int
+                                     (s/optional-key :drain-request-buffer-size) schema/positive-int
                                      (s/optional-key :http2?) s/Bool
                                      (s/optional-key :http2c?) s/Bool
                                      (s/optional-key :keystore) schema/non-empty-string
@@ -427,6 +428,7 @@
                     ;; We set it to a reasonably high 15 mins by default.
                     ;; The idle timeout is configured per request, so we do not explicitly configure it here.
                     :blocking-timeout 900000 ;; 15 minutes
+                    :drain-request-buffer-size 16384
                     :http2? false
                     :http2c? true
                     :keystore-scan-interval-secs (* 60 60 12)


### PR DESCRIPTION
## Changes proposed in this PR

- makes draining request bytes buffer size configurable

## Why are we making these changes?

Reduces the number of iterations required to drain a request and hence the associated overheads (e.g. reporting metrics) associated with reading bytes in individual iterations.

