### PR TITLE
Don't create deployment error if k8s 409 conflict

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -645,6 +645,7 @@
         (ss/try+
           (api-request request-url scheduler :body (utils/clj->json rs-spec) :request-method :post)
           (catch Object response
+            ; Don't create deployment error for http-409-conflict (replicaset already exists)
             (when-not (= (:status response) http-409-conflict)
               (let [deployment-error (create-service-deployment-error response response->deployment-error-msg-fn)]
                 (log/info "creating deployment error for service" {:deployment-error deployment-error

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -645,11 +645,12 @@
         (ss/try+
           (api-request request-url scheduler :body (utils/clj->json rs-spec) :request-method :post)
           (catch Object response
-            (let [deployment-error (create-service-deployment-error response response->deployment-error-msg-fn)]
-              (log/info "creating deployment error for service" {:deployment-error deployment-error
-                                                                 :service-id service-id})
-              (cu/cache-put! service-id->deployment-error-cache service-id deployment-error)
-              (ss/throw+ response))))
+            (when-not (= (:status response) http-409-conflict)
+              (let [deployment-error (create-service-deployment-error response response->deployment-error-msg-fn)]
+                (log/info "creating deployment error for service" {:deployment-error deployment-error
+                                                                   :service-id service-id})
+                (cu/cache-put! service-id->deployment-error-cache service-id deployment-error)))
+            (ss/throw+ response)))
         {:keys [k8s/replicaset-uid] :as service} (some-> response-json replicaset->Service)]
     (if service
       (cu/cache-evict service-id->deployment-error-cache service-id)


### PR DESCRIPTION
## Changes proposed in this PR

- When there is a collision and the replicaset already exists (409 k8s api response), don't create a service deployment error

## Why are we making these changes?

- this bug caused a regression in fallback behavior
