### PR TITLE
log rotation every hour

### DIFF
--- a/waiter/resources/log4j.properties
+++ b/waiter/resources/log4j.properties
@@ -6,7 +6,7 @@ log4j.category.waiter=INFO
 log4j.appender.InfoAppender=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.InfoAppender.Threshold=INFO
 log4j.appender.InfoAppender.File=log/${waiter.logFilePrefix}waiter.log
-log4j.appender.InfoAppender.DatePattern='.'yyyy-MM-dd
+log4j.appender.InfoAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.InfoAppender.layout=org.apache.log4j.PatternLayout
 # CID will be replaced by the custom pattern layout configured in waiter.correlation-id/replace-pattern-layout-in-log4j-appenders
 log4j.appender.InfoAppender.layout.ConversionPattern=%d{ISO8601} %-5p %c [%t] - [CID] %m%n
@@ -14,7 +14,7 @@ log4j.appender.InfoAppender.layout.ConversionPattern=%d{ISO8601} %-5p %c [%t] - 
 log4j.appender.ErrorAppender=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.ErrorAppender.Threshold=ERROR
 log4j.appender.ErrorAppender.File=log/${waiter.logFilePrefix}waiter-error.log
-log4j.appender.ErrorAppender.DatePattern='.'yyyy-MM-dd
+log4j.appender.ErrorAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.ErrorAppender.layout=org.apache.log4j.PatternLayout
 # CID will be replaced by the custom pattern layout configured in waiter.correlation-id/replace-pattern-layout-in-log4j-appenders
 log4j.appender.ErrorAppender.layout.ConversionPattern=%d{ISO8601} %-5p %c [%t] - [CID] %m%n
@@ -25,7 +25,7 @@ log4j.additivity.RequestLog=false
 log4j.appender.RequestLogAppender=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.RequestLogAppender.Threshold=INFO
 log4j.appender.RequestLogAppender.File=log/${waiter.logFilePrefix}request.log
-log4j.appender.RequestLogAppender.DatePattern='.'yyyy-MM-dd
+log4j.appender.RequestLogAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.RequestLogAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.RequestLogAppender.layout.ConversionPattern=%m%n
 
@@ -35,7 +35,7 @@ log4j.additivity.Scheduler=false
 log4j.appender.SchedulerAppender=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.SchedulerAppender.Threshold=DEBUG
 log4j.appender.SchedulerAppender.File=log/${waiter.logFilePrefix}scheduler.log
-log4j.appender.SchedulerAppender.DatePattern='.'yyyy-MM-dd
+log4j.appender.SchedulerAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.SchedulerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.SchedulerAppender.layout.ConversionPattern=%d{ISO8601} %-5p %c [%t] - [CID] %m%n
 
@@ -45,6 +45,6 @@ log4j.additivity.InstanceTracker=false
 log4j.appender.InstanceAppender=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.InstanceAppender.Threshold=INFO
 log4j.appender.InstanceAppender.File=log/${waiter.logFilePrefix}instance.log
-log4j.appender.InstanceAppender.DatePattern='.'yyyy-MM-dd
+log4j.appender.InstanceAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.InstanceAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.InstanceAppender.layout.ConversionPattern=%m%n


### PR DESCRIPTION
## Changes proposed in this PR

- Set log rotation to every hour
- changes are based on these docs https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/DailyRollingFileAppender.html

## Why are we making these changes?

- Many request logs cause logs to use up lots of disk space.
