### PR TITLE
avoids logging stack trace for deployment errors

### DIFF
--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -739,9 +739,12 @@
 (defn handle-process-exception
   "Handles an error during process."
   [exception {:keys [descriptor] :as request}]
-  (log/error exception "error during process")
-  (track-process-error-metrics descriptor)
-  (utils/exception->response exception request))
+  (let [error-message (str (some-> exception .getMessage))]
+    (if (str/includes? error-message service/deployment-error-prefix)
+      (log/error "error during process" error-message)
+      (log/error exception "error during process" error-message))
+    (track-process-error-metrics descriptor)
+    (utils/exception->response exception request)))
 
 (let [process-timer (metrics/waiter-timer "core" "process")]
   (defn process

--- a/waiter/src/waiter/service.clj
+++ b/waiter/src/waiter/service.clj
@@ -33,6 +33,8 @@
 
 (def ^:const status-check-path "/status")
 
+(def ^:const deployment-error-prefix "Deployment error: ")
+
 ;;; Service instance ejecting, work-stealing, access and creation
 
 ;; Attempt to eject instances
@@ -265,13 +267,14 @@
                 (let [{:keys [service-deployment-error-details service-deployment-error-msg]} instance
                       {:keys [error-map error-message]}
                       (cond->
-                        {:error-map {:service-id service-id
+                        {:error-map {:log-level :info
+                                     :service-id service-id
                                      :status http-503-service-unavailable}
                          :error-message (utils/message instance)}
                         (and service-deployment-error-msg service-deployment-error-details)
                         (-> (assoc :error-message service-deployment-error-msg)
                             (update :error-map #(merge service-deployment-error-details %))))]
-                  (ex-info (str "Deployment error: " error-message) error-map))
+                  (ex-info (str deployment-error-prefix error-message) error-map))
                 (if-not (t/before? (t/now) expiry-time)
                   (do
                     ;; No instances were started in a reasonable amount of time


### PR DESCRIPTION
## Changes proposed in this PR

- avoids logging stack trace for deployment errors

## Why are we making these changes?

We wish to avoid stack traces for deployment errors as they can overwhelm the logs.

Example logs (no stack traces):
```
2021-04-14 15:37:54,549 ERROR waiter.process-request [async-dispatch-64] - [CID=test-waideperrtestesheachereqaut-43415-1618432668415] error during process Deployment error: Health check requires authentication
2021-04-14 15:37:54,550 INFO  waiter.util.utils [async-dispatch-64] - [CID=test-waideperrtestesheachereqaut-43415-1618432668415] Deployment error: Health check requires authentication
```
