### PR TITLE
Gate k8s scheduler initialization on watch states

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -586,7 +586,7 @@
                                  :watch-connect-timeout-ms 10000
 
                                  ;; Determines, in milliseconds, how long to block scheduler initializaion waiting for initial watch state.
-                                 ;; When 0, the scheduler factory returns immidiately (maybe without initial Kubernetes scheduler state knowledge).
+                                 ;; When 0, the scheduler factory returns immediately (maybe without initial Kubernetes scheduler state knowledge).
                                  ;; Defaults to 2 minutes.
                                  :watch-init-timeout-ms 120000
 

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -585,6 +585,11 @@
                                  ;; Defaults to 10 seconds.
                                  :watch-connect-timeout-ms 10000
 
+                                 ;; Determines, in milliseconds, how long to block scheduler initializaion waiting for initial watch state.
+                                 ;; When 0, the scheduler factory returns immidiately (maybe without initial Kubernetes scheduler state knowledge).
+                                 ;; Defaults to 2 minutes.
+                                 :watch-init-timeout-ms 120000
+
                                  ;; Number of times to retry a watch before falling back to a global state query.
                                  ;; These retries only apply to a closed watch connection, not to connections returning an HTTP error code.
                                  ;; Defaults to 0 (one attempt, no retries) if not provided.

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -91,6 +91,7 @@
                                                                          "run-as-user" "myself"})
                                                             service-ids)
       :scheduler-name "dummy-scheduler"
+      :watch-init-timeout-ms 0
       :watch-state (atom nil)}
      (merge args)
      (update-in [:authorizer] utils/create-component)
@@ -1467,7 +1468,8 @@
                     :restart-kill-threshold 8
                     :service-id->deployment-error-cache {:threshold 5000
                                                          :ttl 60}
-                    :url "http://127.0.0.1:8001"}
+                    :url "http://127.0.0.1:8001"
+                    :watch-init-timeout-ms 0}
         base-config (merge context k8s-config)]
     (with-redefs [start-pods-watch! (constantly nil)
                   start-replicasets-watch! (constantly nil)]


### PR DESCRIPTION
## Changes proposed in this PR

Gate k8s scheduler initialization on watch states.

## Why are we making these changes?

Since the initial watch state is populated asynchronously, the scheduler can currently start without any knowledge of the current state of the services and instances in the target Kubernetes cluster.