### PR TITLE
always includes service-id in service-state for waiter-ping output

### DIFF
--- a/waiter/integration/waiter/health_check_test.clj
+++ b/waiter/integration/waiter/health_check_test.clj
@@ -37,7 +37,7 @@
             (str ping-response))
         (is (= "get" (get-in ping-response [:headers :x-kitchen-request-method])) (str ping-response))
         (if (utils/param-contains? query-params "exclude" "service-state")
-          (is (= {:result "excluded"} service-state))
+          (is (= {:result "excluded" :service-id service-id} service-state))
           (is (= {:exists? true :healthy? true :service-id service-id :status "Running"} service-state))))
       (do
         (is (= "timed-out" (get ping-response :result)) (str ping-response))

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -1037,7 +1037,8 @@
         (let [request-params (-> request ru/query-params-request :query-params)
               exclude-service-state (utils/param-contains? request-params "exclude" "service-state")
               service-state (if exclude-service-state
-                              {:result :excluded}
+                              {:result :excluded
+                               :service-id service-id}
                               (fa/<? (service-state-fn service-id (:result ping-response))))]
           (merge
             (dissoc ping-response [:body :error-chan :headers :request :result :status :trailers])


### PR DESCRIPTION
## Changes proposed in this PR

- always includes service-id in service-state for waiter-ping output

## Why are we making these changes?

We would like to identify the service by service-id from ping output.


