### PR TITLE
tags waiter error responses with an error class for the request-log

### DIFF
--- a/waiter/src/waiter/auth/kerberos.clj
+++ b/waiter/src/waiter/auth/kerberos.clj
@@ -27,6 +27,8 @@
             [waiter.util.utils :as utils])
   (:import (java.util.concurrent LinkedBlockingQueue ThreadPoolExecutor TimeUnit)))
 
+(def ^:const error-class-prestashed-tickets "waiter.PrestashedTickets")
+
 (defn get-opt-in-accounts
   "Returns the list of users whose tickets are prestashed on host"
   [host]
@@ -105,7 +107,7 @@
           [users chan] (async/alts!! [response-chan (async/timeout 1000)] :priority true)]
       (when (and (= response-chan chan) (not (contains? users run-as-user)))
         (throw (ex-info "No prestashed tickets available"
-                        {:error-class "waiter.PrestashedTickets"
+                        {:error-class error-class-prestashed-tickets
                          :message (utils/message :prestashed-tickets-not-available)
                          :service-id service-id
                          :status http-403-forbidden

--- a/waiter/src/waiter/auth/kerberos.clj
+++ b/waiter/src/waiter/auth/kerberos.clj
@@ -105,7 +105,8 @@
           [users chan] (async/alts!! [response-chan (async/timeout 1000)] :priority true)]
       (when (and (= response-chan chan) (not (contains? users run-as-user)))
         (throw (ex-info "No prestashed tickets available"
-                        {:message (utils/message :prestashed-tickets-not-available)
+                        {:error-class "waiter.PrestashedTickets"
+                         :message (utils/message :prestashed-tickets-not-available)
                          :service-id service-id
                          :status http-403-forbidden
                          :user run-as-user

--- a/waiter/src/waiter/auth/spnego.clj
+++ b/waiter/src/waiter/auth/spnego.clj
@@ -70,6 +70,7 @@
   [request]
   (log/info "triggering 401 negotiate for spnego authentication")
   (-> (response-http-401-unauthorized request "for negotiation")
+    (assoc :error-class "waiter.KerberosNegotiate")
     (assoc-in [:headers "www-authenticate"] (str/trim negotiate-prefix))))
 
 (defn response-http-401-unauthorized-spnego-disabled
@@ -84,7 +85,8 @@
   (log/info "triggering 503 unavailable for spnego authentication")
   (counters/inc! (metrics/waiter-counter "core" "response-status" "503"))
   (meters/mark! (metrics/waiter-meter "core" "response-status-rate" "503"))
-  (-> {:message "Too many Kerberos authentication requests"
+  (-> {:details {:error-class "waiter.KerberosQueueLength"}
+       :message "Too many Kerberos authentication requests"
        :status http-503-service-unavailable}
     (utils/data->error-response request)
     (cookies/cookies-response)))

--- a/waiter/test/waiter/auth/spnego_test.clj
+++ b/waiter/test/waiter/auth/spnego_test.clj
@@ -38,7 +38,7 @@
         auth-principal "user@test.com"
         standard-request {}
         standard-401-response {:body "Unauthorized"
-                               :error-class "waiter.KerberosNegotiate"
+                               :error-class error-class-kerberos-negotiate
                                :headers {"content-type" "text/plain"
                                          "www-authenticate" "Negotiate"}
                                :status http-401-unauthorized
@@ -61,7 +61,7 @@
         (with-redefs [too-many-pending-auth-requests? (constantly true)]
           (let [handler (require-gss request-handler thread-pool max-queue-length password)]
             (is (= {:body "Too many Kerberos authentication requests"
-                    :error-class "waiter.KerberosQueueLength"
+                    :error-class error-class-kerberos-queue-length
                     :headers {"content-type" "text/plain"}
                     :status http-503-service-unavailable
                     :waiter/response-source :waiter}

--- a/waiter/test/waiter/auth/spnego_test.clj
+++ b/waiter/test/waiter/auth/spnego_test.clj
@@ -38,6 +38,7 @@
         auth-principal "user@test.com"
         standard-request {}
         standard-401-response {:body "Unauthorized"
+                               :error-class "waiter.KerberosNegotiate"
                                :headers {"content-type" "text/plain"
                                          "www-authenticate" "Negotiate"}
                                :status http-401-unauthorized
@@ -60,6 +61,7 @@
         (with-redefs [too-many-pending-auth-requests? (constantly true)]
           (let [handler (require-gss request-handler thread-pool max-queue-length password)]
             (is (= {:body "Too many Kerberos authentication requests"
+                    :error-class "waiter.KerberosQueueLength"
                     :headers {"content-type" "text/plain"}
                     :status http-503-service-unavailable
                     :waiter/response-source :waiter}


### PR DESCRIPTION
## Changes proposed in this PR

- tags waiter error responses with an error class for the request-log

## Why are we making these changes?

Allows identifying sources of various error responses from the `waiter-error-class` in the request log.

