### PR TITLE
ensures termination of responder go block in unit tests

### DIFF
--- a/waiter/test/waiter/state/responder_test.clj
+++ b/waiter/test/waiter/state/responder_test.clj
@@ -377,10 +377,10 @@
         (when (not= expected-counter-value actual-counter-value)
           (println (first *testing-vars*) ":" counter-name "expected:" expected-counter-value "actual:" actual-counter-value))
         (is (= expected-counter-value actual-counter-value)
-            (str "Mismatch in" counter-name "counter value. Expected: " expected-counter-value " Actual: " actual-counter-value)))))
+            (str "Mismatch in " counter-name " counter value. Expected: " expected-counter-value " Actual: " actual-counter-value)))))
 
   (defn- check-state-fn [query-state-chan expected-state]
-    (Thread/sleep 1) ; allow previous chaneel messages to get processed
+    (Thread/sleep 1) ; allow previous channel messages to get processed
     (let [query-state-response-chan (async/promise-chan)]
       (async/>!! query-state-chan {:cid "cid" :response-chan query-state-response-chan :service-id service-id})
       (let [actual-state (async/<!! query-state-response-chan)
@@ -517,9 +517,17 @@
         (metrics/reset-counter work-stealing-received-in-flight-counter
                                (+ (count (:work-stealing-queue initial-state)) (count (:request-id->work-stealer initial-state)))))
       ;; start the service-chan-responder
-      (start-service-chan-responder
-        ejection-expiry-tracker service-id trigger-uneject-process-fn timeout-config channel-config initial-state)
-      (assoc channel-config :trigger-uneject-process-atom trigger-uneject-process-atom)))
+      (let [go-chan (start-service-chan-responder
+                      ejection-expiry-tracker service-id trigger-uneject-process-fn timeout-config channel-config initial-state)]
+        (assoc channel-config
+          :go-chan go-chan
+          :trigger-uneject-process-atom trigger-uneject-process-atom))))
+
+  (defn- exit-service-chan-responder
+    "Sends exit signal via exit-chan and then waits for the responder go-block to terminate."
+    [{:keys [exit-chan go-chan]}]
+    (async/>!! exit-chan :exit)
+    (async/<!! go-chan))
 
   (let [instance-h1 {:id "s1.h1" :started-at (DateTime. 10000)}
         instance-h2 {:id "s1.h2" :started-at (DateTime. 20000)}
@@ -540,8 +548,8 @@
                            "s1.u2" instance-u2
                            "s1.u3" instance-u3}]
 
-    (deftest test-start-service-chan-responder-simple-state-updates
-      (let [{:keys [exit-chan query-state-chan update-state-chan]}
+    (deftest test-simple-state-updates
+      (let [{:as responder-chans :keys [query-state-chan update-state-chan]}
             (launch-service-chan-responder 0 {})]
         ; update state and verify whether state changes are reflected correctly
         (let [update-state {:healthy-instances [instance-h1 instance-h2 instance-h3]
@@ -584,10 +592,10 @@
                                           :sorted-instance-ids ["s1.h1" "s1.u1" "s1.h2" "s1.h3"
                                                                 "s1.u3" "s1.h4" "s1.h5"]
                                           :work-stealing-queue (make-queue [])})
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-deployment-errors ; tests to make sure deployment errors are updated correctly
-      (let [{:keys [exit-chan query-state-chan reserve-instance-chan update-state-chan]}
+    (deftest test-deployment-errors ; tests to make sure deployment errors are updated correctly
+      (let [{:as responder-chans :keys [query-state-chan reserve-instance-chan update-state-chan]}
             (launch-service-chan-responder 0 {})]
         (doseq [deployment-error [:authentication-required :bad-startup-command :health-check-misconfigured :not-enough-memory nil]]
           ; update state and verify whether state changes are reflected correctly
@@ -625,10 +633,10 @@
                                             :load-balancing :oldest
                                             :request-id->work-stealer {}
                                             :work-stealing-queue (make-queue [])}))
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-exclude-expired-instance
-      (let [{:keys [exit-chan query-state-chan update-state-chan]}
+    (deftest test-exclude-expired-instance
+      (let [{:as responder-chans :keys [query-state-chan update-state-chan]}
             (launch-service-chan-responder 0 {})]
         ; update state and verify whether state changes are reflected correctly
         (let [update-state {:healthy-instances [instance-h1 instance-h2 instance-h3]
@@ -666,10 +674,10 @@
                                           :request-id->work-stealer {}
                                           :sorted-instance-ids ["s1.h1" "s1.u1" "s1.h2" "s1.h4" "s1.h5"]
                                           :work-stealing-queue (make-queue [])})
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-eject-expired-instance
-      (let [{:keys [exit-chan query-state-chan update-state-chan eject-instance-chan trigger-uneject-process-atom uneject-instance-chan]}
+    (deftest test-eject-expired-instance
+      (let [{:as responder-chans :keys [query-state-chan update-state-chan eject-instance-chan trigger-uneject-process-atom uneject-instance-chan]}
             (launch-service-chan-responder 0 {})]
         ; update state and verify whether state changes are reflected correctly
         (let [update-state {:healthy-instances [instance-h1 instance-h2 instance-h3]
@@ -757,10 +765,10 @@
                            :instance-id->request-id->use-reason-map {}
                            :instance-id->consecutive-failures {}
                            :instance-id->state (update-slot-state-fn {} "s1.h2" 1 0)})
-          (async/>!! exit-chan :exit))))
+          (exit-service-chan-responder responder-chans))))
 
-    (deftest test-start-service-chan-responder-simple-state-updates-with-reserved-kill
-      (let [{:keys [exit-chan kill-instance-chan query-state-chan release-instance-chan update-state-chan]}
+    (deftest test-simple-state-updates-with-reserved-kill
+      (let [{:as responder-chans :keys [kill-instance-chan query-state-chan release-instance-chan update-state-chan]}
             (launch-service-chan-responder 0 {})]
         ; update state and verify whether state changes are reflected correctly
         (let [update-state {:healthy-instances [instance-h1 instance-h2 instance-h3]
@@ -823,10 +831,10 @@
                                                                 (update-slot-state-fn "s1.h3" 2 0))
                                           :request-id->work-stealer {}
                                           :work-stealing-queue (make-queue [])})
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-reserve-instances
-      (let [{:keys [exit-chan query-state-chan reserve-instance-chan]}
+    (deftest test-reserve-instances
+      (let [{:as responder-chans :keys [query-state-chan reserve-instance-chan]}
             (launch-service-chan-responder 0 {:id->instance id->instance-data
                                               :instance-id->eject-expiry-time {}
                                               :instance-id->request-id->use-reason-map {}
@@ -858,10 +866,10 @@
                                           :load-balancing :oldest
                                           :request-id->work-stealer {}
                                           :work-stealing-queue (make-queue [])})
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-reserve-expired-instance
-      (let [{:keys [exit-chan query-state-chan reserve-instance-chan update-state-chan]}
+    (deftest test-reserve-expired-instance
+      (let [{:as responder-chans :keys [query-state-chan reserve-instance-chan update-state-chan]}
             (launch-service-chan-responder 0 {:id->instance id->instance-data
                                               :instance-id->eject-expiry-time {}
                                               :instance-id->request-id->use-reason-map {}
@@ -888,10 +896,10 @@
                                           :load-balancing :oldest
                                           :request-id->work-stealer {}
                                           :work-stealing-queue (make-queue [])})
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-slot-state-consistency
-      (let [{:keys [exit-chan kill-instance-chan query-state-chan release-instance-chan reserve-instance-chan update-state-chan]}
+    (deftest test-slot-state-consistency
+      (let [{:as responder-chans :keys [kill-instance-chan query-state-chan release-instance-chan reserve-instance-chan update-state-chan]}
             (launch-service-chan-responder 6 {:id->instance id->instance-data
                                               :instance-id->eject-expiry-time {}
                                               :instance-id->request-id->use-reason-map {"s1.h1" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request}
@@ -947,10 +955,10 @@
                          :load-balancing :oldest
                          :request-id->work-stealer {}
                          :work-stealing-queue (make-queue [])})
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-release-killed-reservation
-      (let [{:keys [exit-chan kill-instance-chan query-state-chan release-instance-chan trigger-uneject-process-atom uneject-instance-chan]}
+    (deftest test-release-killed-reservation
+      (let [{:as responder-chans :keys [kill-instance-chan query-state-chan release-instance-chan trigger-uneject-process-atom uneject-instance-chan]}
             (launch-service-chan-responder 11 {:id->instance id->instance-data
                                                :instance-id->eject-expiry-time {}
                                                :instance-id->request-id->use-reason-map {"s1.h1" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request}
@@ -1055,10 +1063,10 @@
                              :load-balancing :oldest
                              :request-id->work-stealer {}
                              :work-stealing-queue (make-queue [])}))
-          (async/>!! exit-chan :exit))))
+          (exit-service-chan-responder responder-chans))))
 
-    (deftest test-start-service-chan-responder-failed-eject
-      (let [{:keys [eject-instance-chan exit-chan]}
+    (deftest test-failed-eject
+      (let [{:as responder-chans :keys [eject-instance-chan]}
             (launch-service-chan-responder 12 {:id->instance id->instance-data
                                                :instance-id->eject-expiry-time {}
                                                :instance-id->request-id->use-reason-map {"s1.h1" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request}
@@ -1080,10 +1088,10 @@
                                                :sorted-instance-ids ["s1.h1" "s1.h2" "s1.h3" "s1.h4" "s1.u1" "s1.u2"]})]
         ; try ejecting an instance in-use
         (check-eject-instance-fn eject-instance-chan "s1.h1" :in-use)
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-release-success-instances
-      (let [{:keys [exit-chan query-state-chan release-instance-chan update-state-chan]}
+    (deftest test-release-success-instances
+      (let [{:as responder-chans :keys [query-state-chan release-instance-chan update-state-chan]}
             (launch-service-chan-responder 12 {:id->instance id->instance-data
                                                :instance-id->eject-expiry-time {}
                                                :instance-id->request-id->use-reason-map {"s1.h1" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request}
@@ -1132,10 +1140,10 @@
                                                (update-slot-state-fn "s1.u3" 0 0 #{:unhealthy}))
                          :load-balancing :oldest
                          :work-stealing-queue (make-queue [])})
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-make-in-use-instance-unhealthy
-      (let [{:keys [exit-chan kill-instance-chan query-state-chan release-instance-chan update-state-chan]}
+    (deftest test-make-in-use-instance-unhealthy
+      (let [{:as responder-chans :keys [kill-instance-chan query-state-chan release-instance-chan update-state-chan]}
             (launch-service-chan-responder 12 {:id->instance id->instance-data
                                                :instance-id->eject-expiry-time {}
                                                :instance-id->request-id->use-reason-map {"s1.h1" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request}}
@@ -1208,10 +1216,10 @@
                          :load-balancing :oldest
                          :request-id->work-stealer {}
                          :work-stealing-queue (make-queue [])})
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-release-failed-instances
-      (let [{:keys [exit-chan kill-instance-chan query-state-chan release-instance-chan trigger-uneject-process-atom uneject-instance-chan]}
+    (deftest test-release-failed-instances
+      (let [{:as responder-chans :keys [kill-instance-chan query-state-chan release-instance-chan trigger-uneject-process-atom uneject-instance-chan]}
             (launch-service-chan-responder 12 {:id->instance id->instance-data
                                                :instance-id->eject-expiry-time {}
                                                :instance-id->request-id->use-reason-map {"s1.h1" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request}}
@@ -1268,10 +1276,10 @@
                                :request-id->work-stealer {}
                                :work-stealing-queue (make-queue [])})
               (release-instance-fn release-instance-chan "s1.u3" 13 :killed)))
-          (async/>!! exit-chan :exit))))
+          (exit-service-chan-responder responder-chans))))
 
-    (deftest test-start-service-chan-responder-kill-known-healthy-instance:even-with-no-slots
-      (let [{:keys [exit-chan kill-instance-chan query-state-chan]}
+    (deftest test-kill-known-healthy-instance:even-with-no-slots
+      (let [{:as responder-chans :keys [kill-instance-chan query-state-chan]}
             (launch-service-chan-responder 13 {:id->instance id->instance-data
                                                :instance-id->eject-expiry-time {}
                                                :instance-id->request-id->use-reason-map {"s1.h3" {"req-5" {:cid "cid-5" :request-id "req-5" :reason :serve-request}}
@@ -1307,10 +1315,10 @@
                          :load-balancing :oldest
                          :request-id->work-stealer {}
                          :work-stealing-queue (make-queue [])})
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-kill-healthy-instance
-      (let [{:keys [exit-chan kill-instance-chan query-state-chan]}
+    (deftest test-kill-healthy-instance
+      (let [{:as responder-chans :keys [kill-instance-chan query-state-chan]}
             (launch-service-chan-responder 13 {:id->instance id->instance-data
                                                :instance-id->eject-expiry-time {}
                                                :instance-id->request-id->use-reason-map {"s1.h3" {"req-5" {:cid "cid-5" :request-id "req-5" :reason :serve-request}}
@@ -1344,10 +1352,10 @@
                          :load-balancing :oldest
                          :request-id->work-stealer {}
                          :work-stealing-queue (make-queue [])})
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-kill-expired-instance-from-other-router
-      (let [{:keys [exit-chan kill-instance-chan query-state-chan update-state-chan]}
+    (deftest test-kill-expired-instance-from-other-router
+      (let [{:as responder-chans :keys [kill-instance-chan query-state-chan update-state-chan]}
             (->> {:id->instance id->instance-data
                   :instance-id->eject-expiry-time {}
                   :instance-id->request-id->use-reason-map {"s1.h1" {"req-5" {:cid "cid-5" :request-id "req-5" :reason :serve-request}}}
@@ -1412,10 +1420,10 @@
                                                (update-slot-state-fn "s1.h3" 0 0 #{:expired :locked})
                                                (update-slot-state-fn "s1.u2" 0 0 #{:locked})
                                                (update-slot-state-fn "s1.u3" 0 0))})
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-clear-failures
-      (let [{:keys [exit-chan query-state-chan release-instance-chan]}
+    (deftest test-clear-failures
+      (let [{:as responder-chans :keys [query-state-chan release-instance-chan]}
             (launch-service-chan-responder 14 {:id->instance id->instance-data
                                                :instance-id->eject-expiry-time {}
                                                :instance-id->request-id->use-reason-map {"s1.h3" {"req-5" {:cid "cid-5" :request-id "req-5" :reason :serve-request}}
@@ -1446,10 +1454,10 @@
                          :load-balancing :oldest
                          :request-id->work-stealer {}
                          :work-stealing-queue (make-queue [])})
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-release-without-killing
-      (let [{:keys [exit-chan query-state-chan release-instance-chan]}
+    (deftest test-release-without-killing
+      (let [{:as responder-chans :keys [query-state-chan release-instance-chan]}
             (launch-service-chan-responder 14 {:id->instance id->instance-data
                                                :instance-id->eject-expiry-time {}
                                                :instance-id->request-id->use-reason-map {"s1.h2" {"req-14" {:cid "cid-14" :request-id "req-14" :reason :kill-instance}}
@@ -1472,10 +1480,10 @@
                                                (update-slot-state-fn "s1.h2" 1 0)
                                                (update-slot-state-fn "s1.h3" 8 0)
                                                (update-slot-state-fn "s1.u3" 0 0 #{:locked :unhealthy}))})
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-eject-owned-instance
-      (let [{:keys [eject-instance-chan exit-chan query-state-chan release-instance-chan trigger-uneject-process-atom uneject-instance-chan]}
+    (deftest test-eject-owned-instance
+      (let [{:as responder-chans :keys [eject-instance-chan query-state-chan release-instance-chan trigger-uneject-process-atom uneject-instance-chan]}
             (launch-service-chan-responder 14 {:id->instance id->instance-data
                                                :instance-id->eject-expiry-time {}
                                                :instance-id->request-id->use-reason-map {"s1.u3" {"req-13" {:cid "cid-13" :request-id "req-13" :reason :kill-instance}}}
@@ -1520,10 +1528,10 @@
                                                    (update-slot-state-fn "s1.h2" 1 0)
                                                    (update-slot-state-fn "s1.h3" 8 0)
                                                    (update-slot-state-fn "s1.u3" 0 0 #{:locked :unhealthy}))}))
-          (async/>!! exit-chan :exit))))
+          (exit-service-chan-responder responder-chans))))
 
-    (deftest test-start-service-chan-responder-eject-external-instance
-      (let [{:keys [eject-instance-chan exit-chan query-state-chan release-instance-chan trigger-uneject-process-atom uneject-instance-chan]}
+    (deftest test-eject-external-instance
+      (let [{:as responder-chans :keys [eject-instance-chan query-state-chan release-instance-chan trigger-uneject-process-atom uneject-instance-chan]}
             (launch-service-chan-responder 14 {:id->instance id->instance-data
                                                :instance-id->eject-expiry-time {}
                                                :instance-id->request-id->use-reason-map {"s1.u3" {"req-13" {:cid "cid-13" :request-id "req-13" :reason :kill-instance}}}
@@ -1577,10 +1585,10 @@
                                                    (update-slot-state-fn "s1.u3" 0 0 #{:locked :unhealthy}))
                              :load-balancing :oldest
                              :work-stealing-queue (make-queue [])}))
-          (async/>!! exit-chan :exit))))
+          (exit-service-chan-responder responder-chans))))
 
-    (deftest test-start-service-chan-responder-cause-unowned-instance-eject
-      (let [{:keys [exit-chan query-state-chan reserve-instance-chan update-state-chan]}
+    (deftest test-cause-unowned-instance-eject
+      (let [{:as responder-chans :keys [query-state-chan reserve-instance-chan update-state-chan]}
             (launch-service-chan-responder 14 {:id->instance id->instance-data
                                                :instance-id->eject-expiry-time {}
                                                :instance-id->request-id->use-reason-map {"s1.u3" {"req-13" {:cid "cid-13" :request-id "req-13" :reason :kill-instance}}}
@@ -1627,10 +1635,10 @@
                          :load-balancing :oldest
                          :request-id->work-stealer {}
                          :work-stealing-queue (make-queue [])})
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-cause-instance-eject
-      (let [{:keys [exit-chan query-state-chan release-instance-chan trigger-uneject-process-atom uneject-instance-chan]}
+    (deftest test-cause-instance-eject
+      (let [{:as responder-chans :keys [query-state-chan release-instance-chan trigger-uneject-process-atom uneject-instance-chan]}
             (launch-service-chan-responder 16 {:instance-id->eject-expiry-time {}
                                                :instance-id->request-id->use-reason-map {"s1.h1" {"req-15" {:cid "cid-15" :request-id "req-15" :reason :serve-request}}
                                                                                          "s1.h2" {"req-16" {:cid "cid-16" :request-id "req-16" :reason :serve-request}}
@@ -1675,10 +1683,10 @@
                                :load-balancing :oldest
                                :request-id->work-stealer {}
                                :work-stealing-queue (make-queue [])}))
-            (async/>!! exit-chan :exit)))))
+            (exit-service-chan-responder responder-chans)))))
 
-    (deftest test-start-service-chan-responder-locked-healthy-instance-not-used-to-service-request
-      (let [{:keys [exit-chan query-state-chan reserve-instance-chan]}
+    (deftest test-locked-healthy-instance-not-used-to-service-request
+      (let [{:as responder-chans :keys [query-state-chan reserve-instance-chan]}
             (launch-service-chan-responder 14 {:id->instance id->instance-data
                                                :instance-id->eject-expiry-time {}
                                                :instance-id->request-id->use-reason-map {"s1.h1" {"req-12" {:cid "cid-12" :request-id "req-12" :reason :kill-instance}}
@@ -1710,10 +1718,10 @@
                          :load-balancing :oldest
                          :request-id->work-stealer {}
                          :work-stealing-queue (make-queue [])})
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-instance-cleanup-during-state-update
-      (let [{:keys [exit-chan query-state-chan update-state-chan]}
+    (deftest test-instance-cleanup-during-state-update
+      (let [{:as responder-chans :keys [query-state-chan update-state-chan]}
             (launch-service-chan-responder 14 {:instance-id->eject-expiry-time {}
                                                :instance-id->request-id->use-reason-map {"s1.h1" {"req-12" {:cid "cid-12" :request-id "req-12" :reason :kill-instance}}
                                                                                          "s1.h2" {"req-15" {:cid "cid-15" :request-id "req-15" :reason :serve-request}}
@@ -1768,10 +1776,10 @@
                          :load-balancing :oldest
                          :request-id->work-stealer {}
                          :work-stealing-queue (make-queue [])})
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-offer-workstealing-instance-promptly-rejected
-      (let [{:keys [exit-chan query-state-chan work-stealing-chan]}
+    (deftest test-offer-work-stealing-instance-promptly-rejected
+      (let [{:as responder-chans :keys [query-state-chan work-stealing-chan]}
             (launch-service-chan-responder 14 {:id->instance id->instance-data
                                                :instance-id->eject-expiry-time {}
                                                :instance-id->request-id->use-reason-map {"s1.h1" {"req-12" {:cid "cid-12" :request-id "req-12" :reason :kill-instance}}
@@ -1787,8 +1795,7 @@
         (let [response-chan-1 (make-work-stealing-offer work-stealing-chan "test-router" "s1.h1") ;; offer a known instance
               _ (counters/inc! (metrics/service-counter service-id "request-counts" "outstanding") 2) ;; fewer outstanding requests than available slots
               response-chan-2 (make-work-stealing-offer work-stealing-chan "test-router" "s1.h2") ;; offer a known instance
-              response-chan-3 (make-work-stealing-offer work-stealing-chan "test-router" "s1.h4") ;; offer an unknown instance]
-              ]
+              response-chan-3 (make-work-stealing-offer work-stealing-chan "test-router" "s1.h4")] ;; offer an unknown instance]
           (check-state-fn query-state-chan
                           {:id->instance id->instance-data
                            :instance-id->eject-expiry-time {}
@@ -1807,9 +1814,9 @@
           (is (= :promptly-rejected (async/<!! response-chan-1)))
           (is (= :promptly-rejected (async/<!! response-chan-2)))
           (is (= :promptly-rejected (async/<!! response-chan-3))))
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-offer-workstealing-instance-accepted
+    (deftest test-offer-work-stealing-instance-accepted
       (let [initial-state {:id->instance id->instance-data
                            :instance-id->eject-expiry-time {}
                            :instance-id->request-id->use-reason-map {"s1.h1" {"req-11" {:cid "cid-11" :request-id "req-11" :reason :kill-instance}}
@@ -1822,14 +1829,13 @@
                                                  (update-slot-state-fn "s1.h3" 0 0)
                                                  (update-slot-state-fn "s1.u3" 0 0 #{:locked :unhealthy}))
                            :sorted-instance-ids ["s1.h1" "s1.h2" "s1.h3" "s1.u3"]}
-            {:keys [exit-chan query-state-chan work-stealing-chan]}
+            {:as responder-chans :keys [query-state-chan work-stealing-chan]}
             (launch-service-chan-responder 14 initial-state)]
         (counters/clear! (metrics/service-counter service-id "request-counts" "outstanding")) ;; clear the counter to zero
         (counters/inc! (metrics/service-counter service-id "request-counts" "outstanding") 20) ;; more outstanding requests than available slots
         (let [response-chan-1 (make-work-stealing-offer work-stealing-chan "test-router-1" "s1.h1") ;; offer a known instance
               response-chan-2 (make-work-stealing-offer work-stealing-chan "test-router-2" "s1.h2") ;; offer a known instance
-              response-chan-3 (make-work-stealing-offer work-stealing-chan "test-router-1" "s1.h4") ;; offer an unknown instance
-              ]
+              response-chan-3 (make-work-stealing-offer work-stealing-chan "test-router-1" "s1.h4")] ;; offer an unknown instance
           (check-state-fn query-state-chan
                           (-> initial-state
                             (assoc :request-id->work-stealer {}
@@ -1837,9 +1843,9 @@
                                    (make-queue [(make-work-stealing-data "cid-15" "s1.h1" response-chan-1 "test-router-1")
                                                 (make-work-stealing-data "cid-16" "s1.h2" response-chan-2 "test-router-2")
                                                 (make-work-stealing-data "cid-17" "s1.h4" response-chan-3 "test-router-1")])))))
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-offer-workstealing-instance-rejected
+    (deftest test-offer-work-stealing-instance-rejected
       (let [initial-state {:id->instance id->instance-data
                            :instance-id->eject-expiry-time {}
                            :instance-id->request-id->use-reason-map {"s1.h1" {"req-12" {:cid "cid-12" :request-id "req-12" :reason :kill-instance}}
@@ -1851,7 +1857,7 @@
                                                  (update-slot-state-fn "s1.h3" 8 0)
                                                  (update-slot-state-fn "s1.u3" 0 0 #{:locked :unhealthy}))
                            :sorted-instance-ids ["s1.h1" "s1.h2" "s1.h3" "s1.u3"]}
-            {:keys [exit-chan query-state-chan work-stealing-chan]}
+            {:as responder-chans :keys [query-state-chan work-stealing-chan]}
             (launch-service-chan-responder 14 initial-state)]
         (counters/clear! (metrics/service-counter service-id "request-counts" "outstanding")) ;; clear the counter to zero
         (counters/inc! (metrics/service-counter service-id "request-counts" "outstanding") 20) ;; more outstanding requests than available slots
@@ -1860,9 +1866,9 @@
           (make-work-stealing-offer work-stealing-chan "test-router-2" "s1.h2") ;; offer a known instance
           (make-work-stealing-offer work-stealing-chan "test-router-1" "s1.h4") ;; offer an unknown instance
           (check-state-fn query-state-chan initial-state))
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-workstealing-ensure-rejects-during-exit
+    (deftest test-work-stealing-ensure-rejects-during-exit
       (let [response-chan-1 (async/chan 1)
             response-chan-2 (async/chan 1)
             response-chan-3 (async/chan 1)
@@ -1871,7 +1877,7 @@
                                       (update-slot-state-fn "s1.h2" 1 0)
                                       (update-slot-state-fn "s1.h3" 8 0)
                                       (update-slot-state-fn "s1.u3" 0 0 #{:locked :unhealthy}))
-            {:keys [exit-chan]}
+            {:as responder-chans}
             (launch-service-chan-responder 17 {:id->instance id->instance-data
                                                :instance-id->eject-expiry-time {}
                                                :instance-id->request-id->use-reason-map {"s1.h1" {"req-12" {:cid "cid-12" :request-id "req-12" :reason :kill-instance}}
@@ -1883,18 +1889,18 @@
                                                :work-stealing-queue (make-queue [(make-work-stealing-data "cid-15" "s1.h1" response-chan-1 "test-router-1")
                                                                                  (make-work-stealing-data "cid-16" "s1.h2" response-chan-2 "test-router-2")
                                                                                  (make-work-stealing-data "cid-17" "s1.h4" response-chan-3 "test-router-1")])})]
-        (async/>!! exit-chan :exit)
+        (exit-service-chan-responder responder-chans)
         (is (= :rejected (async/<!! response-chan-1)))
         (is (= :rejected (async/<!! response-chan-2)))
         (is (= :rejected (async/<!! response-chan-3)))))
 
-    (deftest test-start-service-chan-responder-workstealing-instances-rejected
+    (deftest test-work-stealing-instances-rejected
       ;; more outstanding requests than available slots
       (metrics/reset-counter (metrics/service-counter service-id "request-counts" "outstanding") 20)
       (let [response-chan-1 (async/chan 1)
             response-chan-2 (async/chan 1)
             response-chan-3 (async/chan 1)
-            {:keys [exit-chan query-state-chan release-instance-chan]}
+            {:as responder-chans :keys [query-state-chan release-instance-chan]}
             (launch-service-chan-responder 17 {:id->instance id->instance-data
                                                :instance-id->eject-expiry-time {}
                                                :instance-id->request-id->use-reason-map {"s1.h1" {"req-12" {:cid "cid-12" :request-id "req-12" :reason :kill-instance}}
@@ -1967,9 +1973,9 @@
                          :work-stealing-queue (make-queue [])})
         (is (zero? (counters/value (metrics/service-counter service-id "work-stealing" "received-from" "in-flight"))))
         (is (= :rejected (async/<!! response-chan-3)))
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-workstealing-instances-used
+    (deftest test-work-stealing-instances-used
       ;; more outstanding requests than available slots
       (metrics/reset-counter (metrics/service-counter service-id "request-counts" "outstanding") 20)
       (let [response-chan-1 (async/chan 1)
@@ -1980,7 +1986,7 @@
                                       (update-slot-state-fn "s1.h2" 1 0)
                                       (update-slot-state-fn "s1.h3" 8 0)
                                       (update-slot-state-fn "s1.u3" 0 0 #{:locked :unhealthy}))
-            {:keys [exit-chan query-state-chan release-instance-chan reserve-instance-chan]}
+            {:as responder-chans :keys [query-state-chan release-instance-chan reserve-instance-chan]}
             (launch-service-chan-responder 17 {:id->instance id->instance-data
                                                :instance-id->eject-expiry-time {}
                                                :instance-id->request-id->use-reason-map {"s1.h1" {"req-12" {:cid "cid-12" :request-id "req-12" :reason :kill-instance}}
@@ -2042,9 +2048,9 @@
                          :work-stealing-queue (make-queue [])})
         (is (= 2 (counters/value (metrics/service-counter service-id "work-stealing" "received-from" "in-flight"))))
         (is (= :rejected (async/<!! response-chan-3)))
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-workstealing-instances-used-when-slots-are-unavailable
+    (deftest test-work-stealing-instances-used-when-slots-are-unavailable
       ;; more outstanding requests than available slots
       (metrics/reset-counter (metrics/service-counter service-id "request-counts" "outstanding") 20)
       (let [response-chan-1 (async/chan 1)
@@ -2055,7 +2061,7 @@
                                       (update-slot-state-fn "s1.h2" 1 1)
                                       (update-slot-state-fn "s1.h3" 1 2)
                                       (update-slot-state-fn "s1.u3" 0 0 #{:locked :unhealthy}))
-            {:keys [exit-chan query-state-chan release-instance-chan reserve-instance-chan]}
+            {:as responder-chans :keys [query-state-chan release-instance-chan reserve-instance-chan]}
             (launch-service-chan-responder 17 {:id->instance id->instance-data
                                                :instance-id->eject-expiry-time {}
                                                :instance-id->request-id->use-reason-map {"s1.h1" {"req-12" {:cid "cid-12" :request-id "req-12" :reason :kill-instance}}
@@ -2130,9 +2136,9 @@
                          :work-stealing-queue (make-queue [])})
         (is (= 2 (counters/value (metrics/service-counter service-id "work-stealing" "received-from" "in-flight"))))
         (is (= :rejected (async/<!! response-chan-3)))
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-workstealing-instances-released
+    (deftest test-work-stealing-instances-released
       ;; more outstanding requests than available slots
       (metrics/reset-counter (metrics/service-counter service-id "request-counts" "outstanding") 20)
       (let [response-chan-1 (async/chan 1)
@@ -2142,7 +2148,7 @@
                                       (update-slot-state-fn "s1.h2" 1 0)
                                       (update-slot-state-fn "s1.h3" 8 0)
                                       (update-slot-state-fn "s1.u3" 0 0 #{:locked :unhealthy}))
-            {:keys [exit-chan query-state-chan release-instance-chan]}
+            {:as responder-chans :keys [query-state-chan release-instance-chan]}
             (launch-service-chan-responder 19 {:id->instance id->instance-data
                                                :instance-id->eject-expiry-time {}
                                                :instance-id->request-id->use-reason-map {"s1.h1" {"req-12" {:cid "cid-12" :request-id "req-12" :reason :kill-instance}
@@ -2184,9 +2190,9 @@
                          :work-stealing-queue (make-queue [])})
         (is (zero? (counters/value (metrics/service-counter service-id "work-stealing" "received-from" "in-flight"))))
         (is (= :success (async/<!! response-chan-1)))
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-workstealing-instances-release-with-instance-error
+    (deftest test-work-stealing-instances-release-with-instance-error
       (counters/clear! (metrics/service-counter service-id "request-counts" "outstanding")) ;; clear the counter to zero
       (counters/inc! (metrics/service-counter service-id "request-counts" "outstanding") 20) ;; more outstanding requests than available slots
       (let [response-chan-1 (async/chan 1)
@@ -2196,7 +2202,7 @@
                                       (update-slot-state-fn "s1.h2" 1 0)
                                       (update-slot-state-fn "s1.h3" 8 0)
                                       (update-slot-state-fn "s1.u3" 0 0 #{:locked :unhealthy}))
-            {:keys [exit-chan query-state-chan release-instance-chan]}
+            {:as responder-chans :keys [query-state-chan release-instance-chan]}
             (launch-service-chan-responder 19 {:id->instance id->instance-data
                                                :instance-id->eject-expiry-time {}
                                                :instance-id->request-id->use-reason-map {"s1.h1" {"req-12" {:cid "cid-12" :request-id "req-12" :reason :kill-instance}
@@ -2228,9 +2234,9 @@
             (is (= :instance-error (async/<!! response-chan-2))))
           (with-redefs [t/now (fn [] (t/plus current-time (t/millis (* 8 max-eject-time-ms))))]
             (check-state-fn query-state-chan nil)))
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-release-async-request-assigned-instance
+    (deftest test-release-async-request-assigned-instance
       (let [initial-state {:id->instance id->instance-data
                            :instance-id->eject-expiry-time {}
                            :instance-id->request-id->use-reason-map {"s1.h1" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request}}
@@ -2246,7 +2252,7 @@
                                                  (update-slot-state-fn "s1.u2" 0 0 #{:killed :unhealthy}))
                            :load-balancing :oldest
                            :sorted-instance-ids ["s1.h1" "s1.h2" "s1.h3" "s1.h4" "s1.u1" "s1.u2"]}
-            {:keys [exit-chan query-state-chan release-instance-chan]}
+            {:as responder-chans :keys [query-state-chan release-instance-chan]}
             (launch-service-chan-responder 10 initial-state)]
         ; release a success async
         (release-instance-fn release-instance-chan "s1.h3" 4 :success-async)
@@ -2261,9 +2267,9 @@
                           (utils/dissoc-in [:instance-id->request-id->use-reason-map "s1.h3" "req-4"])
                           (utils/dissoc-in [:instance-id->consecutive-failures "s1.h3"])
                           (update-in [:instance-id->state] update-slot-state-fn "s1.h3" 8 1)))
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-release-async-request-work-stealing-instance
+    (deftest test-release-async-request-work-stealing-instance
       (let [response-chan-1 (async/chan 4)
             response-chan-2 (async/chan 1)
             initial-state {:id->instance id->instance-data
@@ -2282,7 +2288,7 @@
                            :sorted-instance-ids ["s1.h1" "s1.h2" "s1.h3" "s1.h4" "s1.u1" "s1.u2"]
                            :request-id->work-stealer {"req-4" (make-work-stealing-data "cid-4" "s1.h2" response-chan-1 "test-router-1")}
                            :work-stealing-queue (make-queue [(make-work-stealing-data "cid-7" "s1.h4" response-chan-2 "test-router-1")])}
-            {:keys [exit-chan query-state-chan release-instance-chan]}
+            {:as responder-chans :keys [query-state-chan release-instance-chan]}
             (launch-service-chan-responder 10 initial-state)]
         ; release a success async it also triggers release of the work-stealing head
         (release-instance-fn release-instance-chan "s1.h3" 4 :success-async)
@@ -2303,9 +2309,9 @@
                           (utils/dissoc-in [:request-id->work-stealer "req-4"])
                           (assoc :work-stealing-queue (make-queue []))))
         (is (= :success (async/<!! response-chan-1))) ; work-stealing instance released successfully
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-successfully-release-ejected-instance
+    (deftest test-successfully-release-ejected-instance
       (let [initial-state {:instance-id->eject-expiry-time {"s1.h1" (t/plus (t/now) (t/millis 100000))}
                            :instance-id->request-id->use-reason-map {"s1.h1" {"req-16" {:cid "cid-16" :request-id "req-16" :reason :serve-request}}
                                                                      "s1.h2" {"req-15" {:cid "cid-15" :request-id "req-15" :reason :serve-request}}
@@ -2316,7 +2322,7 @@
                                                  (update-slot-state-fn "s1.h2" 2 1 #{:healthy})
                                                  (update-slot-state-fn "s1.h3" 8 0)
                                                  (update-slot-state-fn "s1.u3" 0 0 #{:locked}))}
-            {:keys [exit-chan query-state-chan release-instance-chan]}
+            {:as responder-chans :keys [query-state-chan release-instance-chan]}
             (launch-service-chan-responder 16 initial-state)]
 
         (testing "check that releasing instance still works as expected"
@@ -2327,9 +2333,9 @@
                             (utils/dissoc-in [:instance-id->request-id->use-reason-map "s1.h1" "req-16"])
                             (utils/dissoc-in [:instance-id->consecutive-failures "s1.h1"])
                             (update-in [:instance-id->state] #(update-slot-state-fn %1 "s1.h1" 2 0)))))
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-successfully-release-borrowed-ejected-instance
+    (deftest test-successfully-release-borrowed-ejected-instance
       (let [initial-state {:instance-id->eject-expiry-time {"s1.h1" (t/plus (t/now) (t/millis 100000))}
                            :instance-id->request-id->use-reason-map {"s1.h1" {"req-16" {:cid "cid-16" :request-id "req-16" :reason :serve-request}}
                                                                      "s1.h2" {"req-15" {:cid "cid-15" :request-id "req-15" :reason :serve-request}}
@@ -2340,7 +2346,7 @@
                                                  (update-slot-state-fn "s1.h2" 2 1 #{:healthy})
                                                  (update-slot-state-fn "s1.h3" 8 0)
                                                  (update-slot-state-fn "s1.u3" 0 0 #{:locked}))}
-            {:keys [exit-chan query-state-chan release-instance-chan]}
+            {:as responder-chans :keys [query-state-chan release-instance-chan]}
             (launch-service-chan-responder 16 initial-state)]
 
         (testing "check that releasing instance still works as expected"
@@ -2351,9 +2357,9 @@
                             (utils/dissoc-in [:instance-id->request-id->use-reason-map "s1.h1" "req-16"])
                             (utils/dissoc-in [:instance-id->consecutive-failures "s1.h1"])
                             (update-in [:instance-id->state] #(update-slot-state-fn %1 "s1.h1" 0 0)))))
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-slot-counts-for-locked-and-ejected-instance
+    (deftest test-slot-counts-for-locked-and-ejected-instance
       (let [initial-state {:instance-id->eject-expiry-time {"s1.h1" (t/plus (t/now) (t/millis 100000))}
                            :instance-id->request-id->use-reason-map {"s1.h1" {"req-16" {:cid "cid-16" :request-id "req-16" :reason :serve-request}}
                                                                      "s1.h2" {"req-15" {:cid "cid-15" :request-id "req-15" :reason :serve-request}}
@@ -2367,14 +2373,14 @@
                                                  (update-slot-state-fn "s1.h3" 7 0)
                                                  (update-slot-state-fn "s1.h4" 11 0 #{:locked})
                                                  (update-slot-state-fn "s1.h5" 0 2))}
-            {:keys [exit-chan query-state-chan]}
+            {:as responder-chans :keys [query-state-chan]}
             (launch-service-chan-responder 16 initial-state)]
 
         (check-state-fn query-state-chan initial-state)
         (assert-instance-counters {"slots-assigned" 23 "slots-available" 9 "slots-in-use" 4})
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-successfully-release-work-stealing-instance-success-async
+    (deftest test-successfully-release-work-stealing-instance-success-async
       (let [response-chan-1 (async/chan 4)
             initial-state {:instance-id->eject-expiry-time {}
                            :instance-id->request-id->use-reason-map {"s1.h1" {"req-16" {:cid "cid-16" :request-id "req-16" :reason :serve-request}}
@@ -2386,7 +2392,7 @@
                                                  (update-slot-state-fn "s1.h2" 2 1 #{:healthy})
                                                  (update-slot-state-fn "s1.u3" 0 0 #{:locked}))
                            :request-id->work-stealer {"req-4" (make-work-stealing-data "cid-4" "s1.h3" response-chan-1 "test-router-1")}}
-            {:keys [exit-chan query-state-chan release-instance-chan]}
+            {:as responder-chans :keys [query-state-chan release-instance-chan]}
             (launch-service-chan-responder 16 initial-state)]
 
         (testing "check releasing instance with :success-async"
@@ -2408,24 +2414,24 @@
           (async/>!! response-chan-1 :not-response)
           (is (= :success (async/<!! response-chan-1))))
 
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-no-instances-assigned-hence-none-available-for-kill
+    (deftest test-no-instances-assigned-hence-none-available-for-kill
       (let [initial-state {:instance-id->eject-expiry-time {}
                            :instance-id->request-id->use-reason-map {}
                            :instance-id->consecutive-failures {}
                            :instance-id->state {}
                            :request-id->work-stealer {}}
-            {:keys [exit-chan kill-instance-chan query-state-chan]}
+            {:as responder-chans :keys [kill-instance-chan query-state-chan]}
             (launch-service-chan-responder 16 initial-state)]
 
         (testing "check kill when no instances assigned"
           (check-kill-request-instance-fn kill-instance-chan :no-matching-instance-found)
           (check-state-fn query-state-chan initial-state))
 
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-no-slots-assigned-hence-none-available-for-kill
+    (deftest test-no-slots-assigned-hence-none-available-for-kill
       (let [initial-state {:instance-id->eject-expiry-time {}
                            :instance-id->request-id->use-reason-map {}
                            :instance-id->consecutive-failures {}
@@ -2436,16 +2442,16 @@
                                                  (update-slot-state-fn "s1.u3" 0 0 #{:locked}))
                            :load-balancing :oldest
                            :request-id->work-stealer {}}
-            {:keys [exit-chan kill-instance-chan query-state-chan]}
+            {:as responder-chans :keys [kill-instance-chan query-state-chan]}
             (launch-service-chan-responder 16 initial-state)]
 
         (testing "check kill when no slots assigned"
           (check-kill-request-instance-fn kill-instance-chan :no-matching-instance-found)
           (check-state-fn query-state-chan initial-state))
 
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-no-idle-instance-available-for-kill
+    (deftest test-no-idle-instance-available-for-kill
       (let [response-chan-1 (async/chan 4)
             initial-state {:instance-id->eject-expiry-time {}
                            :instance-id->request-id->use-reason-map {"s1.h1" {"req-16" {:cid "cid-16" :request-id "req-16" :reason :serve-request}}
@@ -2459,16 +2465,16 @@
                                                  (update-slot-state-fn "s1.h5" 0 0 #{:healthy})
                                                  (update-slot-state-fn "s1.u3" 0 0 #{:locked}))
                            :request-id->work-stealer {"req-4" (make-work-stealing-data "cid-4" "s1.h3" response-chan-1 "test-router-1")}}
-            {:keys [exit-chan kill-instance-chan query-state-chan]}
+            {:as responder-chans :keys [kill-instance-chan query-state-chan]}
             (launch-service-chan-responder 20 initial-state)]
 
         (testing "check kill when no idle assigned instances"
           (check-kill-request-instance-fn kill-instance-chan :no-matching-instance-found)
           (check-state-fn query-state-chan initial-state))
 
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-ejected-instance-cleanup
+    (deftest test-ejected-instance-cleanup
       (let [current-time (t/now)
             initial-state {:instance-id->eject-expiry-time {"s1.h1" (t/minus current-time (t/millis 1000))
                                                                 "s1.h2" (t/minus current-time (t/millis 2000))
@@ -2486,7 +2492,7 @@
                                                  (update-slot-state-fn "s1.h3" 7 0 #{:ejected})
                                                  (update-slot-state-fn "s1.h4" 11 0 #{:ejected :locked})
                                                  (update-slot-state-fn "s1.h5" 0 2))}
-            {:keys [exit-chan query-state-chan update-state-chan]}
+            {:as responder-chans :keys [query-state-chan update-state-chan]}
             (launch-service-chan-responder 16 initial-state)]
 
         (check-state-fn query-state-chan initial-state)
@@ -2512,9 +2518,9 @@
                                                          (update-slot-state-fn "s1.u2" 0 0 #{:unhealthy}))))))
 
 
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-work-stealing-reject
+    (deftest test-work-stealing-reject
       (let [response-chan-1 (async/promise-chan)
             response-chan-2 (async/promise-chan)
             initial-state {:instance-id->eject-expiry-time {}
@@ -2523,7 +2529,7 @@
                            :instance-id->state (update-slot-state-fn {} "s1.h1" 1 1 #{:healthy})
                            :work-stealing-queue (make-queue [(make-work-stealing-data "cid-17" "s1.h4" response-chan-1 "test-router-1")
                                                              (make-work-stealing-data "cid-18" "s1.h5" response-chan-2 "test-router-2")])}
-            {:keys [exit-chan kill-instance-chan query-state-chan release-instance-chan]}
+            {:as responder-chans :keys [kill-instance-chan query-state-chan release-instance-chan]}
             (launch-service-chan-responder 20 initial-state)]
 
         (testing "trigger cleanup of work-stealing queue when releasing instance"
@@ -2548,9 +2554,9 @@
           (async/>!! response-chan-2 :from-test)
           (is (= :rejected (async/<!! response-chan-2))))
 
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-kill-expired-instance-busy-with-all-outdated-requests
+    (deftest test-kill-expired-instance-busy-with-all-outdated-requests
       (let [current-time (t/now)
             time-0 (->> (- lingering-request-threshold-ms 1000) (t/millis) (t/minus current-time))
             time-1 (->> (+ lingering-request-threshold-ms 1000) (t/millis) (t/minus current-time))
@@ -2572,7 +2578,7 @@
                                                  (update-slot-state-fn "s1.u3" 0 0 #{:locked :unhealthy}))
                            :load-balancing :oldest
                            :sorted-instance-ids ["s1.h1" "s1.h2" "s1.h3" "s1.u3"]}
-            {:keys [exit-chan kill-instance-chan query-state-chan]} (launch-service-chan-responder 13 initial-state)]
+            {:as responder-chans :keys [kill-instance-chan query-state-chan]} (launch-service-chan-responder 13 initial-state)]
         ; kill a healthy instance and clear the eject buffer
         (with-redefs [t/now (fn [] current-time)]
           (check-kill-request-instance-fn kill-instance-chan "s1.h1"))
@@ -2587,9 +2593,9 @@
                          (-> instance-id->state
                            (update-slot-state-fn "s1.h1" 1 1 #{:expired :healthy :locked})))))
           (check-state-fn query-state-chan))
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-kill-expired-instance-busy-with-some-outdated-requests
+    (deftest test-kill-expired-instance-busy-with-some-outdated-requests
       (let [current-time (t/now)
             time-0 (->> (- lingering-request-threshold-ms 1000) (t/millis) (t/minus current-time))
             time-1 (->> (- lingering-request-threshold-ms 1000) (t/millis) (t/minus current-time))
@@ -2613,7 +2619,7 @@
                                                  (update-slot-state-fn "s1.u3" 0 0 #{:locked :unhealthy}))
                            :load-balancing :oldest
                            :sorted-instance-ids ["s1.h0" "s1.h1" "s1.h2" "s1.h3" "s1.u3"]}
-            {:keys [exit-chan kill-instance-chan query-state-chan]} (launch-service-chan-responder 13 initial-state)]
+            {:as responder-chans :keys [kill-instance-chan query-state-chan]} (launch-service-chan-responder 13 initial-state)]
         ; kill a healthy instance and clear the eject buffer
         (with-redefs [t/now (fn [] current-time)]
           (check-kill-request-instance-fn kill-instance-chan "s1.h3"))
@@ -2628,9 +2634,9 @@
                          (-> instance-id->state
                            (update-slot-state-fn "s1.h3" 8 1 #{:expired :healthy :locked})))))
           (check-state-fn query-state-chan))
-        (async/>!! exit-chan :exit)))
+        (exit-service-chan-responder responder-chans)))
 
-    (deftest test-start-service-chan-responder-eject-expired-instance
+    (deftest test-eject-expired-instance
       (let [current-time (t/now)
             time-0 (->> (+ lingering-request-threshold-ms 20000) (t/millis) (t/minus current-time))
             time-1 (->> (+ lingering-request-threshold-ms 10000) (t/millis) (t/minus current-time))
@@ -2651,7 +2657,7 @@
                                                  (update-slot-state-fn "s1.h3" 8 1 #{:expired :healthy}))
                            :load-balancing :oldest
                            :sorted-instance-ids ["s1.h1" "s1.h2" "s1.h3"]}
-            {:keys [eject-instance-chan exit-chan query-state-chan]} (launch-service-chan-responder 13 initial-state)]
+            {:as responder-chans :keys [eject-instance-chan query-state-chan]} (launch-service-chan-responder 13 initial-state)]
         ; try ejecting an instance
         (with-redefs [t/now (fn [] current-time)]
           (testing "eject with lingering and active requests"
@@ -2668,9 +2674,9 @@
                    (update :instance-id->state update-slot-state-fn "s1.h1" 4 2 #{:ejected :expired :healthy}))
               (check-state-fn query-state-chan)))
 
-          (async/>!! exit-chan :exit))))
+          (exit-service-chan-responder responder-chans))))
 
-    (deftest test-start-service-chan-responder-kill-healthy-instance-in-presence-of-ejected
+    (deftest test-kill-healthy-instance-in-presence-of-ejected
       (let [current-time (t/now)
             initial-state {:id->instance id->instance-data
                            :instance-id->eject-expiry-time {}
@@ -2682,7 +2688,7 @@
                                                  (update-slot-state-fn "s1.h3" 0 0 #{:ejected}))
                            :load-balancing :oldest
                            :sorted-instance-ids ["s1.h1" "s1.h2" "s1.h3"]}
-            {:keys [kill-instance-chan exit-chan query-state-chan]} (launch-service-chan-responder 13 initial-state)]
+            {:as responder-chans :keys [kill-instance-chan query-state-chan]} (launch-service-chan-responder 13 initial-state)]
 
         (with-redefs [t/now (fn [] current-time)]
           (check-kill-request-instance-fn kill-instance-chan "s1.h3")
@@ -2693,9 +2699,9 @@
                  (update-in [:instance-id->state] #(update-slot-state-fn %1 "s1.h3" 0 0 #{:ejected :locked})))
             (check-state-fn query-state-chan))
 
-          (async/>!! exit-chan :exit))))
+          (exit-service-chan-responder responder-chans))))
 
-    (deftest test-start-service-chan-responder-kill-healthy-instance-in-presence-of-unknown-ejected
+    (deftest test-kill-healthy-instance-in-presence-of-unknown-ejected
       (let [current-time (t/now)
             initial-state {:id->instance (dissoc id->instance-data "s1.h3")
                            :instance-id->eject-expiry-time {}
@@ -2707,7 +2713,7 @@
                                                  (update-slot-state-fn "s1.h3" 0 0 #{:ejected}))
                            :load-balancing :oldest
                            :sorted-instance-ids ["s1.h1" "s1.h2" "s1.h3"]}
-            {:keys [kill-instance-chan exit-chan query-state-chan]} (launch-service-chan-responder 13 initial-state)]
+            {:as responder-chans :keys [kill-instance-chan query-state-chan]} (launch-service-chan-responder 13 initial-state)]
 
         (with-redefs [t/now (fn [] current-time)]
           (check-kill-request-instance-fn kill-instance-chan "s1.h2")
@@ -2718,9 +2724,9 @@
                  (update-in [:instance-id->state] #(update-slot-state-fn %1 "s1.h2" 3 0 #{:healthy :locked})))
             (check-state-fn query-state-chan))
 
-          (async/>!! exit-chan :exit))))
+          (exit-service-chan-responder responder-chans))))
 
-    (deftest test-start-service-chan-responder-scaling-state-updates-oldest-load-balancing
+    (deftest test-scaling-state-updates-oldest-load-balancing
       (let [current-time (t/now)
             initial-state {:id->instance id->instance-data
                            :instance-id->eject-expiry-time {}
@@ -2732,7 +2738,7 @@
                                                  (update-slot-state-fn "s1.h3" 0 0 #{:ejected}))
                            :load-balancing :oldest
                            :sorted-instance-ids ["s1.h1" "s1.h2" "s1.h3" "s1.h4" "s1.h5" "s1.h6" "s1.u1" "s1.u2" "s1.u3"]}
-            {:keys [exit-chan query-state-chan scaling-state-chan]} (launch-service-chan-responder 13 initial-state)]
+            {:as responder-chans :keys [query-state-chan scaling-state-chan]} (launch-service-chan-responder 13 initial-state)]
 
         (with-redefs [t/now (fn [] current-time)]
           (async/>!! scaling-state-chan {:scaling-state :scale-up})
@@ -2744,9 +2750,9 @@
           (async/>!! scaling-state-chan {:scaling-state :stable})
           (check-state-fn query-state-chan initial-state)
 
-          (async/>!! exit-chan :exit))))
+          (exit-service-chan-responder responder-chans))))
 
-    (deftest test-start-service-chan-responder-scaling-state-updates-random-load-balancing
+    (deftest test-scaling-state-updates-random-load-balancing
       (let [current-time (t/now)
             initial-state {:id->instance id->instance-data
                            :instance-id->eject-expiry-time {}
@@ -2758,7 +2764,7 @@
                                                  (update-slot-state-fn "s1.h3" 0 0 #{:ejected}))
                            :load-balancing :random
                            :sorted-instance-ids ["s1.h1" "s1.h2" "s1.h3" "s1.h4" "s1.h5" "s1.h6" "s1.u1" "s1.u2" "s1.u3"]}
-            {:keys [exit-chan query-state-chan scaling-state-chan]} (launch-service-chan-responder 13 initial-state)]
+            {:as responder-chans :keys [query-state-chan scaling-state-chan]} (launch-service-chan-responder 13 initial-state)]
 
         (with-redefs [t/now (fn [] current-time)]
           (async/>!! scaling-state-chan {:scaling-state :scale-up})
@@ -2770,9 +2776,9 @@
           (async/>!! scaling-state-chan {:scaling-state :stable})
           (check-state-fn query-state-chan initial-state)
 
-          (async/>!! exit-chan :exit))))
+          (exit-service-chan-responder responder-chans))))
 
-    (deftest test-start-service-chan-responder-scaling-state-updates-youngest-load-balancing
+    (deftest test-scaling-state-updates-youngest-load-balancing
       (let [current-time (t/now)
             initial-state {:id->instance id->instance-data
                            :instance-id->eject-expiry-time {}
@@ -2784,7 +2790,7 @@
                                                  (update-slot-state-fn "s1.h3" 0 0 #{:ejected}))
                            :load-balancing :youngest
                            :sorted-instance-ids ["s1.h1" "s1.h2" "s1.h3" "s1.h4" "s1.h5" "s1.h6" "s1.u1" "s1.u2" "s1.u3"]}
-            {:keys [exit-chan query-state-chan scaling-state-chan]} (launch-service-chan-responder 13 initial-state)]
+            {:as responder-chans :keys [query-state-chan scaling-state-chan]} (launch-service-chan-responder 13 initial-state)]
 
         (with-redefs [t/now (fn [] current-time)]
           (async/>!! scaling-state-chan {:scaling-state :scale-up})
@@ -2796,9 +2802,9 @@
           (async/>!! scaling-state-chan {:scaling-state :stable})
           (check-state-fn query-state-chan initial-state)
 
-          (async/>!! exit-chan :exit))))
+          (exit-service-chan-responder responder-chans))))
 
-    (deftest test-start-service-chan-responder-load-balancing-random
+    (deftest test-load-balancing-random
       (let [current-time (t/now)
             initial-state {:id->instance id->instance-data
                            :instance-id->eject-expiry-time {}
@@ -2811,7 +2817,7 @@
                                                  (update-slot-state-fn "s1.h4" 1 0))
                            :load-balancing :random
                            :sorted-instance-ids ["s1.h1" "s1.h2" "s1.h3" "s1.h4" "s1.h5" "s1.h6" "s1.u1" "s1.u2" "s1.u3"]}
-            {:keys [exit-chan query-state-chan reserve-instance-chan scaling-state-chan]}
+            {:as responder-chans :keys [query-state-chan reserve-instance-chan scaling-state-chan]}
             (launch-service-chan-responder 14 initial-state)]
 
         (with-redefs [t/now (fn [] current-time)
@@ -2848,9 +2854,9 @@
                             (update-in [:instance-id->state] #(update-slot-state-fn %1 "s1.h2" 2 1))
                             (update-in [:instance-id->state] #(update-slot-state-fn %1 "s1.h3" 1 1))))
 
-          (async/>!! exit-chan :exit))))
+          (exit-service-chan-responder responder-chans))))
 
-    (deftest test-start-service-chan-responder-load-balancing-youngest
+    (deftest test-load-balancing-youngest
       (let [current-time (t/now)
             initial-state {:id->instance id->instance-data
                            :instance-id->eject-expiry-time {}
@@ -2863,7 +2869,7 @@
                                                  (update-slot-state-fn "s1.h4" 1 0))
                            :load-balancing :youngest
                            :sorted-instance-ids ["s1.h1" "s1.h2" "s1.h3" "s1.h4" "s1.h5" "s1.h6" "s1.u1" "s1.u2" "s1.u3"]}
-            {:keys [exit-chan query-state-chan reserve-instance-chan scaling-state-chan]}
+            {:as responder-chans :keys [query-state-chan reserve-instance-chan scaling-state-chan]}
             (launch-service-chan-responder 14 initial-state)]
 
         (with-redefs [t/now (fn [] current-time)]
@@ -2899,9 +2905,9 @@
                             (update-in [:instance-id->state] #(update-slot-state-fn %1 "s1.h3" 2 1))
                             (update-in [:instance-id->state] #(update-slot-state-fn %1 "s1.h4" 1 1))))
 
-          (async/>!! exit-chan :exit))))
+          (exit-service-chan-responder responder-chans))))
 
-    (deftest test-start-service-chan-responder-ejection-expiry-tracking
+    (deftest test-ejection-expiry-tracking
       (counters/clear! (metrics/service-counter service-id "request-counts" "outstanding")) ;; clear the counter to zero
       (counters/inc! (metrics/service-counter service-id "request-counts" "outstanding") 20) ;; more outstanding requests than available slots
       (let [test-instance-id->state (-> {}
@@ -2926,7 +2932,7 @@
                            :work-stealing-queue (make-queue [])}
             service-id->instance-ids-atom (atom {})
             ejection-expiry-tracker (ejection-expiry/->EjectionExpiryTracker 3 service-id->instance-ids-atom)
-            {:keys [exit-chan query-state-chan release-instance-chan]}
+            {:as responder-chans :keys [query-state-chan release-instance-chan]}
             (launch-service-chan-responder 19 initial-state :ejection-expiry-tracker ejection-expiry-tracker)]
         (let [current-time (t/now)]
           (with-redefs [t/now (fn [] current-time)]
@@ -2984,7 +2990,7 @@
                               (update :instance-id->eject-expiry-time dissoc "s1.h1")))
             (is (= {} @service-id->instance-ids-atom))))
 
-        (async/>!! exit-chan :exit)))))
+        (exit-service-chan-responder responder-chans)))))
 
 (deftest test-trigger-uneject-process
   (let [correlation-id "test-correlation-id"


### PR DESCRIPTION
## Changes proposed in this PR

- ensures termination of responder go block in unit tests

## Why are we making these changes?

Reduces flakiness in unit tests.

### Sample logs from flaky unit tests:
```
         START:  waiter.state.responder-test/test-start-service-chan-responder-release-failed-instances                                                                                                                            
         FINISH: waiter.state.responder-test/test-start-service-chan-responder-release-failed-instances 7ms {:test 48, :pass 1148, :fail 0, :error 0, :running 0}                                                                  
         START:  waiter.state.responder-test/test-start-service-chan-responder-workstealing-instances-used                                                                                                                         
#'waiter.state.responder-test/test-start-service-chan-responder-workstealing-instances-used : ejected expected: 0 actual: 1                                                                                                        
                                                                                                                                                                                                                                   
lein test :only waiter.state.responder-test/test-start-service-chan-responder-workstealing-instances-used                                                                                                                          
                                                                                                                                                                                                                                   
FAIL in (test-start-service-chan-responder-workstealing-instances-used) (responder_test.clj:379)                                                                                                                                   
Mismatch in ejected counter value. Expected: 0 Actual: 1                                                                                                                                                                           
expected: 0                                                                                                                                                                                                                        
  actual: 1                                                                                                                                                                                                                        
#'waiter.state.responder-test/test-start-service-chan-responder-workstealing-instances-used : ejected expected: 0 actual: 1                                                                                                        
                                                                                                                                                                                                                                   
lein test :only waiter.state.responder-test/test-start-service-chan-responder-workstealing-instances-used                                                                                                                          
                                                                                                                                                                                                                                   
FAIL in (test-start-service-chan-responder-workstealing-instances-used) (responder_test.clj:379)                                                                                                                                   
Mismatch in ejected counter value. Expected: 0 Actual: 1                                                                                                                                                                           
expected: 0                                                                                                                                                                                                                        
  actual: 1                                                                                                                                                                                                                        
#'waiter.state.responder-test/test-start-service-chan-responder-workstealing-instances-used : ejected expected: 0 actual: 1                                                                                                        
                                                                                                                                                                                                                                   
lein test :only waiter.state.responder-test/test-start-service-chan-responder-workstealing-instances-used

FAIL in (test-start-service-chan-responder-workstealing-instances-used) (responder_test.clj:379)
Mismatch in ejected counter value. Expected: 0 Actual: 1 
expected: 0
  actual: 1
         FINISH: waiter.state.responder-test/test-start-service-chan-responder-workstealing-instances-used 26ms {:test 49, :pass 1190, :fail 3, :error 0, :running 0}
```
