### PR TITLE
Event-maintainer for sending external events

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -1043,13 +1043,13 @@
  ;; Configure event maintainer that handles internal events to be sent externally
  :instance-tracker-config {
                            ;; component that handles new instance failures
-                           {:instance-failure-handler {:kind :default
-                                                       :default {:factory-fn 'waiter.instance-tracker/create-instance-failure-event-handler
-                                                                 :config {
-                                                                          ;; configuration for recent-failed-instance-cache
-                                                                          ;; the cache is used for integration and debugging purposes
-                                                                          :recent-failed-instance-cache {:threshold 5000
-                                                                                                         :ttl 900000}}}}}}
+                           :instance-failure-handler {:kind :default
+                                                      :default {:factory-fn 'waiter.instance-tracker/create-instance-failure-event-handler
+                                                                :config {
+                                                                         ;; configuration for recent-failed-instance-cache
+                                                                         ;; the cache is used for integration and debugging purposes
+                                                                         :recent-failed-instance-cache {:threshold 5000
+                                                                                                        :ttl 900000}}}}}
 
  :token-config {
                 ;; Define the calculator that compute the root assigned to a token when they are created.

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -1040,6 +1040,17 @@
                        ;; flagged as never-passed-health-checks upon failure
                        :failed-check-threshold 5}
 
+ ;; Configure event maintainer that handles internal events to be sent externally
+ :instance-tracker-config {
+                           ;; component that handles new instance failures
+                           {:instance-failure-handler {:kind :default
+                                                       :default {:factory-fn 'waiter.instance-tracker/create-instance-failure-event-handler
+                                                                 :config {
+                                                                          ;; configuration for recent-failed-instance-cache
+                                                                          ;; the cache is used for integration and debugging purposes
+                                                                          :recent-failed-instance-cache {:threshold 5000
+                                                                                                         :ttl 900000}}}}}}
+
  :token-config {
                 ;; Define the calculator that compute the root assigned to a token when they are created.
                 :cluster-calculator {;; :kind :configured create a calculator that looks up the cluster name using a configured map.

--- a/waiter/integration/waiter/instance_tracker_integration_test.clj
+++ b/waiter/integration/waiter/instance_tracker_integration_test.clj
@@ -66,13 +66,13 @@
               (let [{:keys [failed-instances]} (:instances (service-settings router-url service-id :cookies cookies))]
                 (log/info "The failed instances should be tracked by the instance-tracker" {:failed-instances failed-instances})
                 (is (pos? (count failed-instances)))
-                (let [query-params "include=instance-failure-handler&include=recent-id->failed-instance-date"
+                (let [query-params "include=instance-failure-handler&include=id->failed-date"
                       {{:keys [last-update-time]
-                        {:keys [last-error-time recent-id->failed-instance-date type]} :instance-failure-handler} :state}
+                        {:keys [last-error-time id->failed-date type]} :instance-failure-handler} :state}
                       (get-instance-tracker-state router-url
                                                   :cookies cookies
                                                   :query-params query-params)
-                      default-event-handler-ids (set (keys recent-id->failed-instance-date))]
+                      default-event-handler-ids (set (keys id->failed-date))]
                   (is (t/before? start-time (du/str-to-date last-update-time)))
                   (when (= type "DefaultInstanceFailureHandler")
                     ; assert failed instances are tracked by DefaultInstanceFailureHandler cache of new failed instances

--- a/waiter/integration/waiter/instance_tracker_integration_test.clj
+++ b/waiter/integration/waiter/instance_tracker_integration_test.clj
@@ -60,10 +60,10 @@
             (is (wait-for
                   (fn []
                     (let [{:keys [failed-instances]} (:instances (service-settings router-url service-id :cookies cookies))]
-                      (< 0 (count failed-instances))))))
+                      (pos? (count failed-instances))))))
             (let [{:keys [failed-instances]} (:instances (service-settings router-url service-id :cookies cookies))]
               (log/info "The failed instances should be tracked by the instance-tracker" {:failed-instances failed-instances})
-              (is (< 0 (count failed-instances)))
+              (is (pos? (count failed-instances)))
               (let [query-params "include=instance-failure-handler&include=recent-id->failed-instance-date&include=id->failed-instance"
                     {{:keys [id->failed-instance]
                       {:keys [last-error-time recent-id->failed-instance-date type]} :instance-failure-handler} :state}

--- a/waiter/integration/waiter/instance_tracker_integration_test.clj
+++ b/waiter/integration/waiter/instance_tracker_integration_test.clj
@@ -45,7 +45,7 @@
     (let [{:keys [cookies]} (make-request waiter-url "/waiter-auth")
           routers (routers waiter-url)
           router-urls (vals routers)]
-      (testing "new failing instances appear in instance-tracker state on same router"
+      (testing "new failing instances appear in instance-tracker state on all routers"
         (let [start-time (t/now)
               {:keys [service-id] :as response}
               (make-request-with-debug-info

--- a/waiter/integration/waiter/instance_tracker_integration_test.clj
+++ b/waiter/integration/waiter/instance_tracker_integration_test.clj
@@ -49,12 +49,12 @@
         (let [start-time (t/now)
               {:keys [service-id] :as response}
               (make-request-with-debug-info
-                {:x-waiter-cmd "invalidcmd34sdfadsve"
+                {:x-kitchen-delay-ms 5000
                  :x-waiter-name (rand-name)}
-                #(make-kitchen-request waiter-url % :cookies cookies))]
+                #(make-kitchen-request waiter-url % :cookies cookies :path "/die"))]
           (with-service-cleanup
             service-id
-            (assert-response-status response http-503-service-unavailable)
+            (assert-response-status response #{http-502-bad-gateway http-503-service-unavailable})
             ; wait for all routers to have positive number of failed instances
             (is (wait-for
                   (fn every-router-has-failed-instances? []

--- a/waiter/integration/waiter/instance_tracker_integration_test.clj
+++ b/waiter/integration/waiter/instance_tracker_integration_test.clj
@@ -1,5 +1,6 @@
 (ns waiter.instance-tracker-integration-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.set :as set]
+            [clojure.test :refer :all]
             [waiter.util.client-tools :refer :all]))
 
 (defn- get-instance-tracker-state
@@ -24,4 +25,14 @@
           (is (= (set (keys state))
                  default-state-fields))
           (is (= (set supported-include-params)
-                 #{"id->failed-instance" "instance-failure-handler"})))))))
+                 #{"id->failed-instance" "instance-failure-handler"})))))
+
+    (testing "InstanceEventHandler provides default state fields"
+      (let [query-params "include=instance-failure-handler"
+            {:keys [body] :as response} (get-instance-tracker-state waiter-url :query-params query-params)
+            default-inst-event-handler-state-fields #{"last-error-time" "supported-include-params" "type"}]
+        (assert-response-status response 200)
+        (let [body-json (try-parse-json body)
+              state (get-in body-json ["state" "instance-failure-handler"] #{"!@#$#^!#$13"})]
+          (is (set/superset? (set (keys state))
+                             default-inst-event-handler-state-fields)))))))

--- a/waiter/integration/waiter/instance_tracker_integration_test.clj
+++ b/waiter/integration/waiter/instance_tracker_integration_test.clj
@@ -1,38 +1,80 @@
 (ns waiter.instance-tracker-integration-test
   (:require [clojure.set :as set]
             [clojure.test :refer :all]
+            [clojure.tools.logging :as log]
+            [clojure.walk :as walk]
+            [waiter.status-codes :refer :all]
             [waiter.util.client-tools :refer :all]))
 
 (defn- get-instance-tracker-state
-  [waiter-url & {:keys [cookies query-params]}]
-  (make-request waiter-url "/state/instance-tracker"
-                :cookies cookies
-                :query-params query-params
-                :method :get))
+  [waiter-url & {:keys [cookies keywordize-keys query-params]
+                 :or {keywordize-keys true}}]
+  (let [response (make-request waiter-url "/state/instance-tracker"
+                               :cookies cookies
+                               :query-params query-params
+                               :method :get)]
+    (assert-response-status response http-200-ok)
+    (cond-> (some-> response :body try-parse-json)
+            keywordize-keys walk/keywordize-keys)))
 
-(deftest ^:parallel ^:integration-fast test-instance-tracker-daemon
+(deftest ^:parallel ^:integration-fast test-instance-tracker-daemon-state
   (testing-using-waiter-url
-    (let [{:keys [cookies]} (make-request waiter-url "/waiter-auth")
-          routers (routers waiter-url)
-          router-urls (vals routers)])
+    (let [{:keys [cookies]} (make-request waiter-url "/waiter-auth")]
 
-    (testing "no query parameters provides the default state fields"
-      (let [{:keys [body] :as response} (get-instance-tracker-state waiter-url)
-            default-state-fields #{"last-update-time" "supported-include-params"}]
-        (assert-response-status response 200)
-        (let [{:strs [state]} (try-parse-json body)
-              {:strs [supported-include-params]} state]
+      (testing "no query parameters provides the default state fields"
+        (let [{{:keys [supported-include-params] :as state} :state} (get-instance-tracker-state waiter-url :cookies cookies)
+              default-state-fields #{:last-update-time :supported-include-params}]
           (is (= (set (keys state))
                  default-state-fields))
           (is (= (set supported-include-params)
-                 #{"id->failed-instance" "instance-failure-handler"})))))
+                 #{"id->failed-instance" "instance-failure-handler"}))))
 
-    (testing "InstanceEventHandler provides default state fields"
-      (let [query-params "include=instance-failure-handler"
-            {:keys [body] :as response} (get-instance-tracker-state waiter-url :query-params query-params)
-            default-inst-event-handler-state-fields #{"last-error-time" "supported-include-params" "type"}]
-        (assert-response-status response 200)
-        (let [body-json (try-parse-json body)
-              state (get-in body-json ["state" "instance-failure-handler"] #{"!@#$#^!#$13"})]
-          (is (set/superset? (set (keys state))
+      (testing "InstanceEventHandler provides default state fields"
+        (let [query-params "include=instance-failure-handler"
+              body (get-instance-tracker-state waiter-url
+                                               :cookies cookies
+                                               :query-params query-params)
+              default-inst-event-handler-state-fields #{:last-error-time :supported-include-params :type}]
+          (is (set/superset? (set (keys (get-in body [:state :instance-failure-handler] #{"!@#!@#14132"})))
                              default-inst-event-handler-state-fields)))))))
+
+(deftest ^:parallel ^:integration-fast ^:resource-heavy test-instance-tracker-failing-instance
+  (testing-using-waiter-url
+    (let [{:keys [cookies]} (make-request waiter-url "/waiter-auth")]
+
+      ; TODO: When instance tracking becomes more reliable in multi router scenarios this test should not be
+      ; on the same router
+      (testing "new failing instances appear in instance-tracker state on same router"
+        (let [router-url (rand-router-url waiter-url)
+              {:keys [service-id] :as response}
+              (make-request-with-debug-info
+                {:x-waiter-cmd "invalidcmd34sdfadsve"
+                 :x-waiter-name (rand-name)}
+                #(make-kitchen-request router-url % :cookies cookies))]
+          (with-service-cleanup
+            service-id
+            (assert-response-status response http-503-service-unavailable)
+            (is (wait-for
+                  (fn []
+                    (let [{:keys [failed-instances]} (:instances (service-settings router-url service-id :cookies cookies))]
+                      (< 0 (count failed-instances))))))
+            (let [{:keys [failed-instances]} (:instances (service-settings router-url service-id :cookies cookies))]
+              (log/info "The failed instances should be tracked by the instance-tracker" {:failed-instances failed-instances})
+              (is (< 0 (count failed-instances)))
+              (let [query-params "include=instance-failure-handler&include=recent-id->failed-instance-date&include=id->failed-instance"
+                    {{:keys [id->failed-instance]
+                      {:keys [type recent-id->failed-instance-date]} :instance-failure-handler} :state}
+                    (get-instance-tracker-state router-url
+                                                :cookies cookies
+                                                :query-params query-params)
+                    daemon-failed-ids (set (keys id->failed-instance))
+                    default-event-handler-ids (set (keys recent-id->failed-instance-date))]
+                ; assert failed instances are tracked by daemon
+                (doseq [{:keys [id]} failed-instances]
+                  (is (contains? daemon-failed-ids
+                                 (keyword id)))
+                  ; assert failed instances are tracked by DefaultInstanceFailureHandler cache of new failed instances
+                  (when (= type "DefaultInstanceFailureHandler")
+                    (is (contains? default-event-handler-ids
+                                   (keyword id)))))))))))))
+

--- a/waiter/integration/waiter/instance_tracker_integration_test.clj
+++ b/waiter/integration/waiter/instance_tracker_integration_test.clj
@@ -1,0 +1,27 @@
+(ns waiter.instance-tracker-integration-test
+  (:require [clojure.test :refer :all]
+            [waiter.util.client-tools :refer :all]))
+
+(defn- get-instance-tracker-state
+  [waiter-url & {:keys [cookies query-params]}]
+  (make-request waiter-url "/state/instance-tracker"
+                :cookies cookies
+                :query-params query-params
+                :method :get))
+
+(deftest ^:parallel ^:integration-fast test-instance-tracker-daemon
+  (testing-using-waiter-url
+    (let [{:keys [cookies]} (make-request waiter-url "/waiter-auth")
+          routers (routers waiter-url)
+          router-urls (vals routers)])
+
+    (testing "no query parameters provides the default state fields"
+      (let [{:keys [body] :as response} (get-instance-tracker-state waiter-url)
+            default-state-fields #{"last-update-time" "supported-include-params"}]
+        (assert-response-status response 200)
+        (let [{:strs [state]} (try-parse-json body)
+              {:strs [supported-include-params]} state]
+          (is (= (set (keys state))
+                 default-state-fields))
+          (is (= (set supported-include-params)
+                 #{"id->failed-instance" "instance-failure-handler"})))))))

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -814,7 +814,7 @@
                      (str (when scheme (str scheme "://")) host "/state/" path))]
       (utils/clj->streaming-json-response {:details (->> ["autoscaler" "autoscaling-multiplexer" "codahale-reporters"
                                                           "ejection-expiry" "entitlement-manager" "fallback"
-                                                          "gc-broken-services" "gc-services" "gc-transient-metrics" "interstitial"
+                                                          "gc-broken-services" "gc-services" "gc-transient-metrics" "instance-tracker" "interstitial"
                                                           "jwt-auth-server" "kv-store" "launch-metrics" "leader" "local-usage"
                                                           "maintainer" "router-metrics" "scheduler" "service-description-builder"
                                                           "service-maintainer" "statsd" "token-watch-maintainer" "work-stealing"]
@@ -906,17 +906,13 @@
        :leader-id (leader-id-fn)})
     router-id request))
 
-(defn get-token-watch-maintainer-state
-  "Using the query-state-fn, pass include-flags to get the token-watch-maintainer-state and return
+(defn get-daemon-state
+  "Using the query-state-fn, pass include-flags to get the daemon state and return
   streaming response"
   [router-id query-state-fn request]
-  (try
-    (let [{:strs [include]} (-> request ru/query-params-request :query-params)
-          include-flags (if (string? include) #{include} (set include))]
-      (utils/clj->streaming-json-response {:router-id router-id
-                                           :state (query-state-fn include-flags)}))
-    (catch Exception ex
-      (utils/exception->response ex request))))
+  (let [{:strs [include]} (-> request ru/query-params-request :query-params)
+        include-flags (if (string? include) #{include} (set include))]
+    (get-function-state #(query-state-fn include-flags) router-id request)))
 
 (defn get-router-metrics-state
   "Outputs the router metrics state."

--- a/waiter/src/waiter/instance_tracker.clj
+++ b/waiter/src/waiter/instance_tracker.clj
@@ -10,7 +10,7 @@
 ; Events are being handled by all routers in a cluster for resiliency
 (defprotocol InstanceEventHandler
 
-  (handle-instances-event! [this instances]
+  (handle-instances-event! [this instances-event]
     "handles the instances event")
 
   (state [this include-flags]
@@ -110,8 +110,8 @@
                             (assoc current-state :id->failed-instance id->failed-instance')))
 
                         query-chan
-                        (let [{:keys [response-chan]} msg]
-                          (async/put! response-chan (query-state-fn))
+                        (let [{:keys [include-flags response-chan]} msg]
+                          (async/put! response-chan (query-state-fn include-flags))
                           current-state))]
                   (if next-state
                     (recur (assoc next-state :last-update-time (clock)))

--- a/waiter/src/waiter/instance_tracker.clj
+++ b/waiter/src/waiter/instance_tracker.clj
@@ -1,0 +1,125 @@
+(ns waiter.instance-tracker
+  (:require [clojure.core.async :as async]
+            [clojure.set :as set]
+            [clojure.tools.logging :as log]
+            [metrics.timers :as timers]
+            [waiter.correlation-id :as cid]
+            [waiter.metrics :as metrics]
+            [waiter.util.cache-utils :as cu]))
+
+; Events are being handled by all routers in a cluster for resiliency
+(defprotocol InstanceEventHandler
+
+  (handle-instances-event! [this instances]
+    "handles the instances event")
+
+  (state [this include-flags]
+    "returns the state of the handler:
+    {:last-error-time :supported-include-params :type}"))
+
+(defrecord DefaultInstanceFailureHandler [clock
+                                          handler-state]
+
+  InstanceEventHandler
+
+  (handle-instances-event! [this {:keys [new-failed-instances]}]
+    (let [{:keys [clock handler-state]} this
+          {:keys [recent-id->failed-instance-date-cache]} @handler-state]
+      (log/info "default failed-instance handler received new new-failed-instances" {:new-failed-instances new-failed-instances})
+      (swap! handler-state assoc :last-error-time (clock))
+      (doseq [inst new-failed-instances]
+        (cu/cache-put! recent-id->failed-instance-date-cache (:id inst) (clock)))))
+
+  (state [this include-flags]
+    (let [{:keys [handler-state]} this
+          {:keys [last-error-time recent-id->failed-instance-date-cache]} @handler-state]
+      (cond-> {:last-error-time last-error-time
+               :supported-include-params ["recent-id->failed-instance-date"]
+               :type "DefaultInstanceFailureHandler"}
+              (contains? include-flags "recent-id->failed-instance-date")
+              (assoc :recent-id->failed-instance-date (reduce
+                                                        (fn [transformed-map [id value]]
+                                                          (assoc transformed-map id (:data value)))
+                                                        {}
+                                                        (cu/cache->map recent-id->failed-instance-date-cache)))))))
+
+(defn create-instance-failure-event-handler
+  [{:keys [clock config]}]
+  {:pre [(-> config :recent-failed-instance-cache :threshold pos-int?)
+         (-> config :recent-failed-instance-cache :ttl pos-int?)]}
+  (let [{:keys [recent-failed-instance-cache]} config
+        recent-id->failed-instance-date-cache (cu/cache-factory recent-failed-instance-cache)
+        handler-state (atom {:last-error-time nil
+                             :recent-id->failed-instance-date-cache recent-id->failed-instance-date-cache})]
+    (DefaultInstanceFailureHandler. clock handler-state)))
+
+(defn start-instance-tracker
+  "Starts daemon thread that tracks instances and produces events based on state changes. It routes these events to the
+  proper instance handler component"
+  [clock router-state-chan instance-failure-handler-component]
+  (cid/with-correlation-id
+    "instance-tracker"
+    (let [exit-chan (async/promise-chan)
+          query-chan (async/chan)
+          state-atom (atom {:id->failed-instance {}
+                            :last-update-time nil})
+          query-state-fn
+          (fn instance-tracker-query-state-fn
+            [include-flags]
+            (let [{:keys [id->failed-instance last-update-time]} @state-atom]
+              (cond-> {:last-update-time last-update-time
+                       :supported-include-params ["id->failed-instance" "instance-failure-handler"]}
+                      (contains? include-flags "id->failed-instance")
+                      (assoc :id->failed-instance id->failed-instance)
+                      (contains? include-flags "instance-failure-handler")
+                      (assoc :instance-failure-handler (state instance-failure-handler-component include-flags)))))
+          go-chan
+          (async/go
+            (try
+              (loop [{:keys [id->failed-instance] :as current-state} @state-atom]
+                (reset! state-atom current-state)
+                (let [[msg current-chan] (async/alts! [exit-chan router-state-chan query-chan] :priority true)
+                      next-state
+                      (condp = current-chan
+                        exit-chan
+                        (do
+                          (log/warn "stopping instance-tracker")
+                          (when (not= :exit msg)
+                            (throw (ex-info "Stopping instance-tracker" {:time (clock) :reason msg}))))
+
+                        router-state-chan
+                        (timers/start-stop-time!
+                          (metrics/waiter-timer "core" "instance-tracker" "router-state-chan")
+                          (let [{:keys [service-id->failed-instances]} msg
+                                id->failed-instance' (reduce
+                                                       (fn [cur-id->failed-instance cur-failed-instances]
+                                                         (reduce
+                                                           (fn [inner-cur-id->failed-instance failed-instance]
+                                                             (assoc inner-cur-id->failed-instance (:id failed-instance) failed-instance))
+                                                           cur-id->failed-instance
+                                                           cur-failed-instances))
+                                                       {}
+                                                       (vals service-id->failed-instances))
+                                all-failed-instances-ids' (set (keys id->failed-instance'))
+                                all-failed-instances-ids (set (keys id->failed-instance))
+                                new-failed-instances-ids (filter (complement all-failed-instances-ids) all-failed-instances-ids')
+                                new-failed-instances (map id->failed-instance' new-failed-instances-ids)]
+                            (when (not (empty? new-failed-instances))
+                              (log/info "new failed instances" {:new-failed-instances (map :id new-failed-instances)})
+                              (handle-instances-event! instance-failure-handler-component {:new-failed-instances new-failed-instances}))
+                            (assoc current-state :id->failed-instance id->failed-instance')))
+
+                        query-chan
+                        (let [{:keys [response-chan]} msg]
+                          (async/put! response-chan (query-state-fn))
+                          current-state))]
+                  (if next-state
+                    (recur (assoc next-state :last-update-time (clock)))
+                    (log/info "stopping instance-tracker as next loop state is nil"))))
+              (catch Exception e
+                (log/error e "fatal error in instance-tracker")
+                (System/exit 1))))]
+      {:exit-chan exit-chan
+       :go-chan go-chan
+       :query-chan query-chan
+       :query-state-fn query-state-fn})))

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -73,6 +73,8 @@
                                                   (s/required-key :output-buffer-size) schema/positive-int
                                                   (s/required-key :queue-timeout-ms) schema/positive-int
                                                   (s/required-key :streaming-timeout-ms) schema/positive-int}
+   (s/required-key :instance-tracker-config) {(s/required-key :instance-failure-handler) {:kind s/Keyword
+                                                                                          s/Keyword schema/require-symbol-factory-fn}}
    (s/required-key :kv-config) schema/kv-store-config
    (s/optional-key :messages) {s/Keyword s/Str}
    (s/required-key :metric-group-mappings) schema/valid-metric-group-mappings
@@ -306,6 +308,10 @@
                                  :output-buffer-size 4096 ;; 4 KiB
                                  :queue-timeout-ms 300000
                                  :streaming-timeout-ms 20000}
+   :instance-tracker-config {:instance-failure-handler {:kind :default
+                                                        :default {:factory-fn 'waiter.instance-tracker/create-instance-failure-event-handler
+                                                                  :config {:recent-failed-instance-cache {:threshold 5000
+                                                                                                          :ttl 900000}}}}}
    :kv-config {:kind :zk
                :zk {:factory-fn 'waiter.kv/new-zk-kv-store
                     :sync-timeout-ms 2000}

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -73,8 +73,10 @@
                                                   (s/required-key :output-buffer-size) schema/positive-int
                                                   (s/required-key :queue-timeout-ms) schema/positive-int
                                                   (s/required-key :streaming-timeout-ms) schema/positive-int}
-   (s/required-key :instance-tracker-config) {(s/required-key :instance-failure-handler) {:kind s/Keyword
-                                                                                          s/Keyword schema/require-symbol-factory-fn}}
+   (s/required-key :instance-tracker-config) {(s/required-key :instance-failure-handler) (s/constrained
+                                                                                           {:kind s/Keyword
+                                                                                            s/Keyword schema/require-symbol-factory-fn}
+                                                                                           schema/contains-kind-sub-map?)}
    (s/required-key :kv-config) schema/kv-store-config
    (s/optional-key :messages) {s/Keyword s/Str}
    (s/required-key :metric-group-mappings) schema/valid-metric-group-mappings

--- a/waiter/test/waiter/instance_tracker_test.clj
+++ b/waiter/test/waiter/instance_tracker_test.clj
@@ -1,0 +1,146 @@
+(ns waiter.instance-tracker-test
+  (:require [clj-time.core :as t]
+            [clojure.core.async :as async]
+            [clojure.test :refer :all]
+            [waiter.instance-tracker :refer :all]
+            [waiter.util.async-utils :as au])
+  (:import (org.joda.time DateTime)))
+
+(let [current-time (t/now)]
+  (defn- clock [] current-time)
+
+  (defn- clock-millis [] (.getMillis ^DateTime (clock))))
+
+(defrecord TestInstanceFailureHandler [handler-state]
+
+  InstanceEventHandler
+
+  (handle-instances-event! [this instances-event]
+    (swap! (:handler-state this)
+           (fn [{:keys [handle-instances-event!] :as handler-state}]
+             (assoc handler-state
+               :handle-instances-event! (concat handle-instances-event! [[instances-event]])))))
+
+  (state [this include-flags]
+    (swap! (:handler-state this)
+           (fn [{:keys [state] :as handler-state}]
+             (assoc handler-state :state (concat state [include-flags]))))))
+
+(defn stop-instance-tracker!!
+  [go-chan exit-chan]
+  (async/>!! exit-chan :exit)
+  (async/<!! go-chan))
+
+(defn get-latest-instance-tracker-state!!
+  [query-chan]
+  (let [temp-chan (async/promise-chan)]
+    (async/>!! query-chan {:include-flags #{"id->failed-date" "id->failed-instance" "instance-failure-handler"}
+                           :response-chan temp-chan})
+    (async/<!! temp-chan)))
+
+(deftest test-instance-tracker
+  (let [router-state-1 {:service-id->failed-instances {"service-id-1" [{:id "s1.instance-id-1"}]}}
+        router-state-2 {:service-id->failed-instances {}}
+        router-state-3 {:service-id->failed-instances {"service-id-1" [{:id "s1.instance-id-1" :field "value changed"}]}}
+        router-state-4 {:service-id->failed-instances {"service-id-2" [{:id "s2.instance-id-1"}
+                                                                       {:id "s2.instance-id-2"}
+                                                                       {:id "s2.instance-id-3"}]}}]
+
+    (testing "instance-tracker daemon determines new failed instances from initial router-state"
+      (let [ev-handler-call-history-atom (atom {:handle-instances-event! [] :state []})
+            ev-handler (TestInstanceFailureHandler. ev-handler-call-history-atom)
+            router-state-chan (au/latest-chan)
+            {:keys [exit-chan go-chan query-chan]} (start-instance-tracker clock router-state-chan ev-handler)]
+
+        ; instance-tracker considers initial failed instances as new failed instances because they are not persisted
+        (async/>!! router-state-chan router-state-1)
+        (let [{:keys [id->failed-instance]} (get-latest-instance-tracker-state!! query-chan)
+              {:keys [handle-instances-event!]} @ev-handler-call-history-atom]
+          (is (= {"s1.instance-id-1" {:id "s1.instance-id-1"}}
+                 id->failed-instance))
+          (is (= [[{:new-failed-instances [{:id "s1.instance-id-1"}]}]]
+                 handle-instances-event!)))
+
+        (stop-instance-tracker!! go-chan exit-chan)))
+
+    (testing "instance-tracker daemon determines new failed instances from router-state changes"
+      (let [ev-handler-call-history-atom (atom {:handle-instances-event! [] :state []})
+            ev-handler (TestInstanceFailureHandler. ev-handler-call-history-atom)
+            router-state-chan (au/latest-chan)
+            {:keys [exit-chan go-chan query-chan]} (start-instance-tracker clock router-state-chan ev-handler)]
+
+        ; assert no new failed instances
+        (async/>!! router-state-chan router-state-2)
+        (let [{:keys [id->failed-instance]} (get-latest-instance-tracker-state!! query-chan)
+              {:keys [handle-instances-event!]} @ev-handler-call-history-atom]
+          (is (= {} id->failed-instance))
+          (is (= [] handle-instances-event!)))
+
+        ; assert new failed instances
+        (async/>!! router-state-chan router-state-1)
+        (let [{:keys [id->failed-instance]} (get-latest-instance-tracker-state!! query-chan)
+              {:keys [handle-instances-event!]} @ev-handler-call-history-atom]
+          (is (= {"s1.instance-id-1" {:id "s1.instance-id-1"}}
+                 id->failed-instance))
+          (is (= [[{:new-failed-instances [{:id "s1.instance-id-1"}]}]]
+                 handle-instances-event!)))
+
+        (stop-instance-tracker!! go-chan exit-chan)))
+
+    (testing "instance-tracker daemon determines new failed instances based on instance id changes"
+      (let [ev-handler-call-history-atom (atom {:handle-instances-event! [] :state []})
+            ev-handler (TestInstanceFailureHandler. ev-handler-call-history-atom)
+            router-state-chan (au/latest-chan)
+            {:keys [exit-chan go-chan query-chan]} (start-instance-tracker clock router-state-chan ev-handler)]
+
+        ; initial new failed instances
+        (async/>!! router-state-chan router-state-1)
+        (let [{:keys [id->failed-instance]} (get-latest-instance-tracker-state!! query-chan)
+              {:keys [handle-instances-event!]} @ev-handler-call-history-atom]
+          (is (= {"s1.instance-id-1" {:id "s1.instance-id-1"}}
+                 id->failed-instance))
+          (is (= [[{:new-failed-instances [{:id "s1.instance-id-1"}]}]]
+                 handle-instances-event!)))
+
+        ; no new failed instances, just field changed
+        (async/>!! router-state-chan router-state-3)
+        (let [{:keys [id->failed-instance]} (get-latest-instance-tracker-state!! query-chan)
+              {:keys [handle-instances-event!]} @ev-handler-call-history-atom]
+          (is (= {"s1.instance-id-1" {:id "s1.instance-id-1" :field "value changed"}}
+                 id->failed-instance))
+          ; assert history did not change
+          (is (= [[{:new-failed-instances [{:id "s1.instance-id-1"}]}]]
+                 handle-instances-event!)))
+
+        (stop-instance-tracker!! go-chan exit-chan)))
+
+    (testing "instance-tracker daemon determines multiple new failed instances based changes"
+      (let [ev-handler-call-history-atom (atom {:handle-instances-event! [] :state []})
+            ev-handler (TestInstanceFailureHandler. ev-handler-call-history-atom)
+            router-state-chan (au/latest-chan)
+            {:keys [exit-chan go-chan query-chan]} (start-instance-tracker clock router-state-chan ev-handler)]
+
+        ; initial new failed instances
+        (async/>!! router-state-chan router-state-1)
+        (let [{:keys [id->failed-instance]} (get-latest-instance-tracker-state!! query-chan)
+              {:keys [handle-instances-event!]} @ev-handler-call-history-atom]
+          (is (= {"s1.instance-id-1" {:id "s1.instance-id-1"}}
+                 id->failed-instance))
+          (is (= [[{:new-failed-instances [{:id "s1.instance-id-1"}]}]]
+                 handle-instances-event!)))
+
+        ; multiple new failed instances
+        (async/>!! router-state-chan router-state-4)
+        (let [{:keys [id->failed-instance]} (get-latest-instance-tracker-state!! query-chan)
+              {:keys [handle-instances-event!]} @ev-handler-call-history-atom]
+          (is (= {"s2.instance-id-1" {:id "s2.instance-id-1"}
+                  "s2.instance-id-2" {:id "s2.instance-id-2"}
+                  "s2.instance-id-3" {:id "s2.instance-id-3"}}
+                 id->failed-instance))
+          (is (= 2 (count handle-instances-event!)))
+          (is (= #{{:id "s2.instance-id-1"}
+                   {:id "s2.instance-id-2"}
+                   {:id "s2.instance-id-3"}}
+                 (some-> handle-instances-event! second first :new-failed-instances set))))
+
+        (stop-instance-tracker!! go-chan exit-chan)))))

--- a/waiter/test/waiter/settings_test.clj
+++ b/waiter/test/waiter/settings_test.clj
@@ -120,13 +120,14 @@
 (defn- settings-with-bogus-factory-fn
   "Returns a settings map with the given key's :kind
   sub-map containing a bogus (non-symbol) :factory-fn"
-  [k]
+  [& k]
   (let [$ (load-full-settings)]
-    (assoc-in $ [k (get-in $ [k :kind]) :factory-fn] "not-a-symbol")))
+    (assoc-in $ (concat k [(get-in $ (concat k [:kind])) :factory-fn]) "not-a-symbol")))
 
 (deftest test-factory-fn-should-be-symbol
   (is (some? (s/check settings-schema (settings-with-bogus-factory-fn :cors-config))))
   (is (some? (s/check settings-schema (settings-with-bogus-factory-fn :entitlement-config))))
+  (is (some? (s/check settings-schema (settings-with-bogus-factory-fn :instance-tracker-config :instance-failure-handler))))
   (is (some? (s/check settings-schema (settings-with-bogus-factory-fn :kv-config))))
   (is (some? (s/check settings-schema (settings-with-bogus-factory-fn :password-store-config))))
   (is (some? (s/check settings-schema (settings-with-bogus-factory-fn :scheduler-config))))
@@ -134,13 +135,14 @@
 
 (defn- settings-with-missing-kind-sub-map
   "Returns a settings map with the given key's :kind sub-map removed"
-  [k]
+  [& k]
   (let [$ (load-full-settings)]
-    (update-in $ [k] #(dissoc % (get-in $ [k :kind])))))
+    (update-in $ k #(dissoc % (get-in $ (concat k [:kind]))))))
 
 (deftest test-kind-sub-map-should-be-present
   (is (some? (s/check settings-schema (settings-with-missing-kind-sub-map :cors-config))))
   (is (some? (s/check settings-schema (settings-with-missing-kind-sub-map :entitlement-config))))
+  (is (some? (s/check settings-schema (settings-with-missing-kind-sub-map :instance-tracker-config :instance-failure-handler))))
   (is (some? (s/check settings-schema (settings-with-missing-kind-sub-map :kv-config))))
   (is (some? (s/check settings-schema (settings-with-missing-kind-sub-map :password-store-config))))
   (is (some? (s/check settings-schema (settings-with-missing-kind-sub-map :scheduler-config))))


### PR DESCRIPTION
## Changes proposed in this PR

- adds a components that allows tracking failed instances across all services

## Why are we making these changes?

We would like to configure custom logic around discovery of new failed instances, e.g. notification to interested parties.


