### PR TITLE
Enable TLS termination by Raven sidecar

### DIFF
--- a/containers/raven/raven-start
+++ b/containers/raven/raven-start
@@ -2,11 +2,13 @@
 # This script takes no argument and uses SERVICE_PORT and PORT0 environment variables
 # to setup /etc/envoy/envoy.yaml file.
 # SERVICE_PORT and PORT0 must be set
+# FORCE_TLS_TERMINATION is optional (true|false, default false)
 # HEALTH_CHECK_POROTOCOL is optional (https|http|h2|h2c, default to SERVICE_PROTOCOL)
 # HEALTH_CHECK_PORT_INDEX is optional ([0-9], default 0)
 # SERVICE_POROTOCOL is optional (https|http|h2|h2c, default http)
 
 : ${CONFIG_DEBUG:=0}
+: ${FORCE_TLS_TERMINATION:=false}
 : ${SERVICE_PROTOCOL:=http}
 : ${HEALTH_CHECK_PORT_INDEX:=0}
 : ${HEALTH_CHECK_PROTOCOL:=${SERVICE_PROTOCOL}}
@@ -34,7 +36,7 @@ is_http2() {
 }
 
 is_tls() {
-    echo $1 | grep -iqE '^(https|h2)$'
+    [ $1 == true ] || ( echo $2 | grep -iqE '^(https|h2)$' )
 }
 
 # check if SERVICE_PORT is present
@@ -89,22 +91,22 @@ else
     sed -i -E '/# WHEN (up|down)stream-http2/d' ${CONFIG_YAML}
 fi
 
-if ! is_tls ${SERVICE_PROTOCOL}; then
+if ! is_tls false ${SERVICE_PROTOCOL}; then
     log 'Removing app upstream TLS options'
     drop_config_section 'app upstream-tls'
 fi
 
-if ! is_tls ${HEALTH_CHECK_PROTOCOL}; then
+if ! is_tls false ${HEALTH_CHECK_PROTOCOL}; then
     log 'Removing health-check upstream TLS options'
     drop_config_section 'health-check upstream-tls'
 fi
 
-if ! is_tls ${SERVICE_PROTOCOL}; then
+if ! is_tls ${FORCE_TLS_TERMINATION} ${SERVICE_PROTOCOL}; then
     log 'Removing app downstream TLS options'
     drop_config_section 'app downstream-tls'
 fi
 
-if ! is_tls ${HEALTH_CHECK_PROTOCOL}; then
+if ! is_tls ${FORCE_TLS_TERMINATION} ${HEALTH_CHECK_PROTOCOL}; then
     log 'Removing health-check downstream TLS options'
     drop_config_section 'health-check downstream-tls'
 fi

--- a/containers/test-apps/kitchen/bin/kitchen
+++ b/containers/test-apps/kitchen/bin/kitchen
@@ -588,6 +588,8 @@ class Kitchen(HTTPWebSocketsHandler):
             for k, v in self.__headers.items():
                 if k.lower() not in self.__excluded_headers:
                     self.send_header(k, v)
+            for trailer_key, _ in self.__response_trailers.items():
+                self.send_header('Trailer', trailer_key)
             self.end_headers()
 
             if response_bytes is not None:

--- a/containers/test-apps/nginx/data/nginx-template.conf
+++ b/containers/test-apps/nginx/data/nginx-template.conf
@@ -14,7 +14,7 @@ http {
 
   server {
     listen ${PORT0} ${NGINX_SSL} ${NGINX_HTTP2};
-    listen ${PORT1};
+    listen ${PORT1} ${PORT1_SSL} ${PORT1_HTTP2};
 
     server_name localhost;
 

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -516,7 +516,10 @@
                                                             ;; "false"-like values disable raven
                                                             :flags ["RAVEN_ENABLED"]
                                                             ;; configuring a raven feature implicitly enables raven
-                                                            :features ["RAVEN_OVERRIDE_IMAGE"]}
+                                                            :features ["RAVEN_OVERRIDE_IMAGE"]
+                                                            ;; flag env vars for specifically toggling tls downstream on/off
+                                                            ;; (these do not enable the raven sidecar on their own)
+                                                            :tls-flags ["RAVEN_FORCE_INGRESS_TLS"]}
                                                  :image "twosigma/waiter-raven"
                                                  :predicate-fn waiter.scheduler.kubernetes/raven-sidecar-opt-in?
                                                  :resources {:cpu 0.1 :mem 256}}

--- a/waiter/config-k8s.edn
+++ b/waiter/config-k8s.edn
@@ -62,9 +62,12 @@
                                  :restart-kill-threshold 8
                                  :raven-sidecar {:cmd ["/opt/waiter/raven/bin/raven-start"]
                                                  :image "twosigma/waiter-raven"
-                                                 ;; defaulting to Raven opt-in
-                                                 ;; for opt-out, use waiter.scheduler.kubernetes/raven-sidecar-opt-out?
-                                                 :predicate-fn waiter.scheduler.kubernetes/raven-sidecar-opt-in?
+                                                 :env-vars {:flags ["RAVEN_ENABLED"]
+                                                            :tls-flags ["RAVEN_FORCE_INGRESS_TLS"]}
+                                                 ;; default to Raven with strict tls (always on) in raven downstream
+                                                 ;; for opt-out (no strict tls), use waiter.scheduler.kubernetes/raven-sidecar-opt-out?
+                                                 ;; for opt-in, use waiter.scheduler.kubernetes/raven-sidecar-opt-out?
+                                                 :predicate-fn waiter.scheduler.kubernetes/raven-sidecar-strict-tls-opt-out?
                                                  :resources {:cpu 0.1 :mem 256}}
                                  :url "http://localhost:8001"}}
 

--- a/waiter/integration/waiter/deployment_errors_test.clj
+++ b/waiter/integration/waiter/deployment_errors_test.clj
@@ -93,9 +93,10 @@
                    :x-waiter-health-check-interval-secs 5
                    :x-waiter-health-check-max-consecutive-failures 1
                    :x-waiter-queue-timeout 600000}
-          response (make-request-with-debug-info headers #(make-shell-request waiter-url % :method :post :path "/waiter-ping"))]
-      (with-service-cleanup
-        (response->service-id response)
+          {:keys [cookies service-id] :as response}
+          (make-request-with-debug-info headers #(make-shell-request waiter-url % :method :post :path "/waiter-ping"))]
+      (do ;with-service-cleanup
+        service-id
         (assert-deployment-error response :cannot-connect)))))
 
 (deftest ^:parallel ^:integration-slow test-health-check-timed-out

--- a/waiter/integration/waiter/grpc_test.clj
+++ b/waiter/integration/waiter/grpc_test.clj
@@ -130,12 +130,12 @@
   "Asserts that the status represents a grpc OK status."
   [status message assertion-message]
   `(let [status# ~status
-         message# ~message
+         msg# ~message
          assertion-message# ~assertion-message]
      (is status# assertion-message#)
      (when status#
        (is (= "CANCELLED" (-> status# .getCode str)) assertion-message#)
-       (is (= message# (.getDescription status#)) assertion-message#))))
+       (is (= msg# (.getDescription status#)) assertion-message#))))
 
 (defmacro assert-grpc-deadline-exceeded-status
   "Asserts that the status represents a grpc OK status."

--- a/waiter/integration/waiter/request_timeout_test.clj
+++ b/waiter/integration/waiter/request_timeout_test.clj
@@ -106,7 +106,7 @@
             (if-let [raven-flags (utils/raven-response-flags response)]
               (do
                 (assert-response-status response http-503-service-unavailable)
-                (is (= raven-flags utils/envoy-upstream-connection-termination)))
+                (is (= raven-flags envoy-upstream-connection-termination)))
               (do
                 (is error-message)
                 (assert-response-status response http-502-bad-gateway)

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -339,10 +339,10 @@
     (utils/raven-proxy-response? response)
     (when-let [raven-error (utils/raven-response-flags response)]
       (cond
-        (= raven-error utils/envoy-upstream-connection-failure) :connect-exception
-        (= raven-error utils/envoy-upstream-connection-termination) :hangup-exception
-        (= raven-error utils/envoy-stream-idle-timeout) :timeout-exception
-        (= raven-error utils/envoy-upstream-request-timeout) :timeout-exception))))
+        (= raven-error envoy-upstream-connection-failure) :connect-exception
+        (= raven-error envoy-upstream-connection-termination) :hangup-exception
+        (= raven-error envoy-stream-idle-timeout) :timeout-exception
+        (= raven-error envoy-upstream-request-timeout) :timeout-exception))))
 
 (defn available?
   "Async go block which returns the status code and success of a health check.

--- a/waiter/src/waiter/schema.clj
+++ b/waiter/src/waiter/schema.clj
@@ -108,7 +108,8 @@
 (def valid-raven-sidecar-config
   {:cmd [s/Str]
    (s/optional-key :env-vars) {(s/optional-key :flags) [s/Str]
-                               (s/optional-key :features) [s/Str]}
+                               (s/optional-key :features) [s/Str]
+                               (s/optional-key :tls-flags) [s/Str]}
    :image s/Str
    :predicate-fn s/Symbol
    :resources {:cpu s/Num

--- a/waiter/src/waiter/status_codes.clj
+++ b/waiter/src/waiter/status_codes.clj
@@ -81,3 +81,11 @@
 (def ^:const grpc-14-unavailable 14)
 (def ^:const grpc-15-data-loss 15)
 (def ^:const grpc-16-unauthenticated 16)
+
+;; Envoy "%RESPONSE_FLAGS%" values returned by Raven for error diagnostics
+;; https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-response-flags
+(def ^:const envoy-empty-response-flags "-")
+(def ^:const envoy-stream-idle-timeout "SI")
+(def ^:const envoy-upstream-connection-failure "UF")
+(def ^:const envoy-upstream-connection-termination "UC")
+(def ^:const envoy-upstream-request-timeout "UT")

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -1266,6 +1266,14 @@
      (doseq [[_# router-url#] (routers waiter-url#)]
        (is (wait-for #(= etag# (token->etag router-url# token# :cookies cookies#)))))))
 
+(defn has-raven-proxy-instance?
+  "Returns true if the service has an active instance with a sidecar proxy."
+  [waiter-url service-id & {:keys [cookies] :or {cookies {}}}]
+  (assert-service-on-all-routers waiter-url service-id cookies)
+  (let [instance (active-instances waiter-url service-id :cookies cookies)
+        proxy-mode (:k8s/raven instance)]
+  (not= "disabled" proxy-mode)))
+
 (defn make-chunked-body
   "Returns a channel that receives chunks from the input body string.
    Introducing the delay affects the jetty behavior of converting chunked encoding to non-chunked."

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -45,14 +45,6 @@
            (org.joda.time DateTime)
            (schema.utils ValidationError)))
 
-;; Envoy "%RESPONSE_FLAGS%" values returned by Raven for error diagnostics
-;; https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-response-flags
-(def ^:const envoy-empty-response-flags "-")
-(def ^:const envoy-stream-idle-timeout "SI")
-(def ^:const envoy-upstream-connection-failure "UF")
-(def ^:const envoy-upstream-connection-termination "UC")
-(def ^:const envoy-upstream-request-timeout "UT")
-
 (defn select-keys-pred
   "Returns a map with only the keys, k, for which (pred k) is true."
   [pred m]


### PR DESCRIPTION
## Changes proposed in this PR

Make it possible to configure the envoy sidecar to terminate TLS and then pass traffic to the backend service in cleartext.

## Why are we making these changes?

We want to allow services to offload TLS concerns to the Waiter platform. Currently we assume that the envoy sidecar uses the same protocol as the backend service, but this change allows the sidecar to handle TLS termination for the service.

If the backend service process is only listening on loopback, then we know all traffic entering the pod is encrypted.