### PR TITLE
adds support for including healthy instances in /apps endpoint

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -611,6 +611,22 @@
               (is (get service "scaling-state") (str service))
               (is (pos? (get-in service ["service-description" "cpus"])) service)))
 
+          (testing "with include healthy-instances parameter"
+            (let [service (service waiter-url service-id {"include" "healthy-instances"})
+                  healthy-instances (get-in service ["instances" "healthy-instances"])]
+              (is service)
+              (is (contains? #{"Running" "Starting"} (get service "status")))
+              (is (seq healthy-instances) (str service))
+              (doseq [instance healthy-instances]
+                (is (every? #(contains? instance %) ["host" "id" "port" "started-at"])
+                    (str {:healthy-instances healthy-instances :instance instance})))
+              (is (-> (get service "last-request-time") du/str-to-date .getMillis pos?))
+              (is (get-in service ["request-metrics" "outstanding"]) (str service))
+              (is (get-in service ["request-metrics" "total"]) (str service))
+              (is (get service "resource-usage") (str service))
+              (is (get service "scaling-state") (str service))
+              (is (pos? (get-in service ["service-description" "cpus"])) service)))
+
           (testing "with star run-as-user parameter"
             (let [run-as-user-param (->> current-user reverse (drop 2) (cons "*") reverse (str/join ""))
                   service (service waiter-url service-id {"run-as-user" run-as-user-param})] ;; see my app as myself

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -369,6 +369,7 @@
           include-effective-parameters? (or (utils/request-flag request-params "effective-parameters")
                                             (utils/param-contains? request-params "include" "effective-parameters"))
           include-references? (utils/param-contains? request-params "include" "references")
+          include-healthy-instances? (utils/param-contains? request-params "include" "healthy-instances")
           response-data (map
                           (fn service-id->service-info [service-id]
                             (let [scaling-state (retrieve-scaling-state query-autoscaler-state-fn service-id)
@@ -390,6 +391,10 @@
                                  :url (prepend-waiter-url (str "/apps/" service-id))}
                                 include-effective-parameters?
                                 (assoc :effective-parameters effective-service-description)
+                                include-healthy-instances?
+                                (assoc-in [:instances :healthy-instances]
+                                          (->> (get service-id->healthy-instances service-id)
+                                            (map #(select-keys % [:host :id :port :started-at]))))
                                 include-references?
                                 (assoc :references (seq (service-id->references-fn service-id)))
                                 scaling-state


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for including healthy instances in /apps endpoint

## Why are we making these changes?

We would like to know all the healthy instances in an aggregate query instead of making individual queries for services.

<img width="505" alt="Screen Shot 2021-04-29 at 8 55 55 AM" src="https://user-images.githubusercontent.com/6611249/116567126-f6107300-a8cc-11eb-97e5-99d0c7fcd972.png">


