### PR TITLE
removes version for token

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1976,7 +1976,7 @@
           token-2 (create-token-name waiter-url ".")
           token-description (retrieve-service-mapping-parameters service-name "invalid")]
       (try
-        (let [token-parameters (-> token-description (dissoc :cmd :cmd-type) (assoc :service-mapping "legacy" :token token-1))
+        (let [token-parameters (-> token-description (dissoc :cmd :cmd-type :version) (assoc :service-mapping "legacy" :token token-1))
               response (post-token waiter-url token-parameters)]
           (assert-response-status response http-200-ok))
         (try


### PR DESCRIPTION
## Changes proposed in this PR

- removes version for token

## Why are we making these changes?

Increases the diff between tokens and allow validation for version by command type.

