### PR TITLE
moves maintenance mode handling inside the ping response

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1491,14 +1491,14 @@
                                   [:routines make-inter-router-requests-async-fn]
                                   [:settings health-check-config]
                                   [:state fallback-state-atom router-id user-agent-version]
-                                  process-request-handler-fn process-request-wrapper-fn wrap-secure-request-fn]
+                                  process-request-fn wrap-descriptor-fn wrap-secure-request-fn]
                            (let [{{:keys [query-state-fn]} :maintainer} router-state-maintainer
                                  user-agent (str "waiter-ping/" user-agent-version)
-                                 handler (process-request-wrapper-fn
+                                 handler (wrap-descriptor-fn
                                            (fn inner-ping-service-handler [request]
                                              (let [retrieve-service-status-label-fn #(service/retrieve-service-status-label % (query-state-fn))
                                                    service-state-fn (partial descriptor/extract-service-state router-id retrieve-service-status-label-fn fallback-state-atom make-inter-router-requests-async-fn)]
-                                               (pr/ping-service user-agent process-request-handler-fn service-state-fn health-check-config request))))]
+                                               (pr/ping-service user-agent process-request-fn service-state-fn health-check-config request))))]
                              (wrap-secure-request-fn
                                (fn ping-service-handler [request]
                                  (let [request-params (-> request ru/query-params-request :query-params)

--- a/waiter/src/waiter/util/ring_utils.clj
+++ b/waiter/src/waiter/util/ring_utils.clj
@@ -49,6 +49,16 @@
        (>= status http-400-bad-request)
        (<= status 599)))
 
+(defn redirect-response?
+  "Determines if a response is a redirect response"
+  [{:keys [status]}]
+  (contains? #{http-301-moved-permanently
+               http-302-moved-temporarily
+               http-303-see-other
+               http-307-temporary-redirect
+               http-308-permanent-redirect}
+             status))
+
 (defn attach-header
   "Attaches the specified header into the response."
   [response header-name header-value]


### PR DESCRIPTION
## Changes proposed in this PR
- adds integration tests for waiter-ping and https-redirect and maintenance mode behavior
- moves maintenance mode handling inside the ping response

## Why are we making these changes?

When a token is in maintenance mode, the ping request fails a 503 Maintenance mode error. Instead, we should reflect this error in the `ping-response` field of the `/waiter-ping` response. The ping itself is successful and should return a `2XX` response. 

There is one corner case for `3XX` redirects which we propagate in the ping response as existing clients already rely on the `3XX` behavior for HTTPS redirects.

**Note**: [This commit highlights](https://github.com/twosigma/waiter/pull/1350/commits/4f7f9617b9b9c164fb827a55dca8a0d885001b1e?diff=split&w=1) the behavior changes in `/waiter-ping` via changes in assertions of the integration tests.
Summary:
- eager `4XX` response without the HTTPS redirect
- `3XX` response on `/waiter-ping` includes a body
- Maintenance mode token report the `503` inside the ping body, the going response itself is a `200`.