### PR TITLE
fixes check for number of OIDC auth cookies

### DIFF
--- a/waiter/integration/waiter/authentication_test.clj
+++ b/waiter/integration/waiter/authentication_test.clj
@@ -547,7 +547,7 @@
                              "accept-redirect" "yes"
                              "cookie" (->> (range oidc-num-challenge-cookies-allowed-in-request)
                                         (map #(str "x-waiter-oidc-challenge-" % "=v" %))
-                                        (str/join ";"))
+                                        (str/join "; "))
                              "host" waiter-token
                              "x-forwarded-proto" "https"}
             port (waiter-settings-port waiter-url)

--- a/waiter/src/waiter/auth/oidc.clj
+++ b/waiter/src/waiter/auth/oidc.clj
@@ -311,7 +311,7 @@
         request-cookies (cond->> cookie-header
                           (not (string? cookie-header)) (str/join ";"))
         num-challenge-cookies (count
-                                (filter #(str/starts-with? % oidc-challenge-cookie-prefix)
+                                (filter #(str/starts-with? (str/trim %) oidc-challenge-cookie-prefix)
                                         (str/split (str request-cookies) #";")))]
     (log/info "request has" num-challenge-cookies "oidc challenge cookies")
     (> num-challenge-cookies num-allowed)))


### PR DESCRIPTION
## Changes proposed in this PR

- fixes check for number of OIDC auth cookies

## Why are we making these changes?

The existing cookie count check was faulty!


