### PR TITLE
adds token-based fallback info to /apps and /apps/<service-id> endpoints

### DIFF
--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -421,6 +421,7 @@
                                   :make-inter-router-requests-async-fn (fn [& args]
                                                                         (let [target-fn @make-inter-router-requests-async-fn-atom]
                                                                           (apply target-fn args)))
+                                  :retrieve-token-based-fallback-fn (constantly nil)
                                   :router-metrics-helpers {:service-id->metrics-fn (constantly {})}
                                   :service-id->references-fn (constantly [])
                                   :service-id->service-description-fn (constantly {})
@@ -581,6 +582,7 @@
                        :routines {:allowed-to-manage-service?-fn (constantly true)
                                   :generate-log-url-fn (partial handler/generate-log-url #(str "http://www.example.com" %))
                                   :make-inter-router-requests-async-fn nil
+                                  :retrieve-token-based-fallback-fn (constantly nil)
                                   :router-metrics-helpers {:service-id->metrics-fn (constantly service-id->metrics)}
                                   :service-id->references-fn (constantly [])
                                   :service-id->service-description-fn (fn [service-id _ effective?]


### PR DESCRIPTION
## Changes proposed in this PR

- adds token-based fallback info to /apps and /apps/<service-id> endpoints

## Why are we making these changes?

A request for a new service is routed to a fallback service when there are no healthy instances for the new service, there are healthy instances for a previous version of the service, and the new service is still inside its fallback period. We would like to easily determine the fallback service, however, this is complicated in the general scenario where `x-waiter-*` request headers are involved in service discovery and are not tracked as references. In the more common case where only a single token is used for service discovery, computing the fallback service is easy. This allows us to compute the fallback service for such use-cases and allows an external system to easily detect when traffic for a new service is being routed to the fallback service by querying the `/apps` and `/apps/<service-id>` endpoints.

**Note**: Use of the new `service-mapping=exclusive` service parameter means such services satisfy the case where only a single token is used to resolve to a service during service discovery.

### Sample output

<img width="1048" alt="Screen Shot 2021-05-18 at 10 05 20 PM" src="https://user-images.githubusercontent.com/6611249/118701646-90334f00-b7d9-11eb-8299-df87046851da.png">

