### PR TITLE
adds support for opting out of token syncing when metadata is configured

### DIFF
--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -98,7 +98,7 @@
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
           limit 10
-          metadata-name nil
+          opt-out-metadata-name nil
           token-name (str "test-token-hard-delete-" (UUID/randomUUID))]
       (try
         ;; ARRANGE
@@ -114,7 +114,7 @@
           (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
 
             ;; ACT
-            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit metadata-name)]
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit opt-out-metadata-name)]
 
               ;; ASSERT
               (let [waiter-sync-result (constantly
@@ -145,7 +145,7 @@
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
           limit 10
-          metadata-name nil
+          opt-out-metadata-name nil
           token-name (str "test-token-soft-delete-" (UUID/randomUUID))]
       (try
         ;; ARRANGE
@@ -162,7 +162,7 @@
           (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
 
             ;; ACT
-            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit metadata-name)]
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit opt-out-metadata-name)]
 
               ;; ASSERT
               (let [waiter-sync-result (constantly
@@ -195,7 +195,7 @@
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
           limit 10
-          metadata-name nil
+          opt-out-metadata-name nil
           token-name (str "test-token-update-previously-soft-deleted-" (UUID/randomUUID))]
       (try
         ;; ARRANGE
@@ -214,7 +214,7 @@
           (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
 
             ;; ACT
-            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit metadata-name)]
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit opt-out-metadata-name)]
 
               ;; ASSERT
               (let [waiter-sync-result (constantly
@@ -247,7 +247,7 @@
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
           limit 10
-          metadata-name nil
+          opt-out-metadata-name nil
           token-name (str "test-token-token-on-single-cluster-" (UUID/randomUUID))]
       (try
         ;; ARRANGE
@@ -260,7 +260,7 @@
           (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
 
             ;; ACT
-            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit metadata-name)]
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit opt-out-metadata-name)]
 
               ;; ASSERT
               (let [waiter-sync-result (constantly
@@ -295,7 +295,7 @@
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
           limit 10
-          metadata-name nil
+          opt-out-metadata-name nil
           token-name (str "test-token-already-synced-" (UUID/randomUUID))]
       (try
         ;; ARRANGE
@@ -309,7 +309,7 @@
           (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
 
             ;; ACT
-            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit metadata-name)]
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit opt-out-metadata-name)]
 
               ;; ASSERT
               (let [expected-result {:details {}
@@ -337,7 +337,7 @@
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
           limit 10
-          metadata-name nil
+          opt-out-metadata-name nil
           token-name (str "test-token-update-" (UUID/randomUUID))]
       (try
         ;; ARRANGE
@@ -357,7 +357,7 @@
           (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
 
             ;; ACT
-            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit metadata-name)]
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit opt-out-metadata-name)]
 
               ;; ASSERT
               (let [waiter-sync-result (constantly
@@ -392,7 +392,7 @@
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
           limit 10
-          metadata-name "sync-opt-out"
+          opt-out-metadata-name "sync-opt-out"
           token-name (str "test-token-update-" (UUID/randomUUID))]
       (try
         ;; ARRANGE
@@ -414,7 +414,7 @@
                 token-etag-2 (token->etag waiter-api (last waiter-urls) token-name)]
 
             ;; ACT
-            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit metadata-name)]
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit opt-out-metadata-name)]
 
               ;; ASSERT
               (let [waiter-sync-result (constantly {:code :success/sync-update
@@ -448,7 +448,7 @@
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
           limit 10
-          metadata-name "sync-opt-out"
+          opt-out-metadata-name "sync-opt-out"
           token-name (str "test-token-update-" (UUID/randomUUID))]
       (try
         ;; ARRANGE
@@ -471,7 +471,7 @@
                 token-etag-2 (token->etag waiter-api (last waiter-urls) token-name)]
 
             ;; ACT
-            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit metadata-name)]
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit opt-out-metadata-name)]
 
               ;; ASSERT
               (let [waiter-sync-result (constantly {:code :success/skip-opt-out})
@@ -510,7 +510,7 @@
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
           limit 10
-          metadata-name "sync-opt-out"
+          opt-out-metadata-name "sync-opt-out"
           token-name (str "test-token-update-" (UUID/randomUUID))]
       (try
         ;; ARRANGE
@@ -531,7 +531,7 @@
           (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
 
             ;; ACT
-            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit metadata-name)]
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit opt-out-metadata-name)]
 
               ;; ASSERT
               (let [waiter-sync-result (constantly
@@ -566,7 +566,7 @@
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
           limit 10
-          metadata-name nil
+          opt-out-metadata-name nil
           token-name (str "test-token-maintenance-mode-" (UUID/randomUUID))]
       (try
         ;; ARRANGE
@@ -584,7 +584,7 @@
           (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
 
             ;; ACT
-            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit metadata-name)]
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit opt-out-metadata-name)]
 
               ;; ASSERT
               (let [waiter-sync-result (constantly
@@ -620,7 +620,7 @@
       (let [waiter-urls (waiter-urls)
             {:keys [load-token store-token] :as waiter-api} (waiter-api)
             limit 10
-            metadata-name nil
+            opt-out-metadata-name nil
             token-name (str "test-token-maintenance-mode-" (UUID/randomUUID))]
         (try
           ;; ARRANGE
@@ -640,7 +640,7 @@
             (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
 
               ;; ACT
-              (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit metadata-name)]
+              (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit opt-out-metadata-name)]
 
                 ;; ASSERT
                 (let [waiter-sync-result (constantly
@@ -675,7 +675,7 @@
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
           limit 10
-          metadata-name nil
+          opt-out-metadata-name nil
           token-name (str "test-token-different-owners-but-same-root-" (UUID/randomUUID))]
       (try
         ;; ARRANGE
@@ -700,7 +700,7 @@
           (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
 
             ;; ACT
-            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit metadata-name)]
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit opt-out-metadata-name)]
 
               ;; ASSERT
               (let [latest-description (assoc basic-description
@@ -744,7 +744,7 @@
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
           limit 10
-          metadata-name nil
+          opt-out-metadata-name nil
           token-name (str "test-token-diff-root-diff-user" (UUID/randomUUID))]
       (try
         ;; ARRANGE
@@ -769,7 +769,7 @@
           (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
 
             ;; ACT
-            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit metadata-name)]
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit opt-out-metadata-name)]
 
               ;; ASSERT
               (let [latest-description (assoc basic-description
@@ -838,7 +838,7 @@
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
           limit 10
-          metadata-name nil
+          opt-out-metadata-name nil
           token-name (str "diff-root-same-user" (UUID/randomUUID))]
       (try
         ;; ARRANGE
@@ -863,7 +863,7 @@
           (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
 
             ;; ACT
-            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit metadata-name)]
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit opt-out-metadata-name)]
 
               ;; ASSERT
               (let [latest-description (assoc basic-description
@@ -915,7 +915,7 @@
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
           limit 10
-          metadata-name nil
+          opt-out-metadata-name nil
           token-name (str "test-token-different-roots-and-deleted-" (UUID/randomUUID))]
       (try
         ;; ARRANGE
@@ -941,7 +941,7 @@
           (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
 
             ;; ACT
-            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit metadata-name)]
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit opt-out-metadata-name)]
 
               ;; ASSERT
               (let [latest-description (assoc basic-description
@@ -989,7 +989,7 @@
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
           limit 10
-          metadata-name nil
+          opt-out-metadata-name nil
           token-name (str "test-token-same-user-params-but-different-root-and-last-update-user-" (UUID/randomUUID))]
       (try
         ;; ARRANGE
@@ -1013,7 +1013,7 @@
           (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
 
             ;; ACT
-            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit metadata-name)]
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit opt-out-metadata-name)]
 
               ;; ASSERT
               (let [latest-description (assoc basic-description
@@ -1067,7 +1067,7 @@
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
           limit 10
-          metadata-name nil
+          opt-out-metadata-name nil
           token-name (str "test-token-same-user-params-and-last-update-user-but-different-root-" (UUID/randomUUID))]
       (try
         ;; ARRANGE
@@ -1091,7 +1091,7 @@
           (let [token-etag (token->etag waiter-api (first waiter-urls) token-name)]
 
             ;; ACT
-            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit metadata-name)]
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit opt-out-metadata-name)]
 
               ;; ASSERT
               (let [latest-description (assoc basic-description

--- a/token-syncer/src/token_syncer/commands/syncer.clj
+++ b/token-syncer/src/token_syncer/commands/syncer.clj
@@ -75,7 +75,7 @@
   "Syncs a given token description on all clusters.
    If the cluster-url->token-data says that a given token was not successfully loaded, it is skipped.
    Token sync-ing is also skipped if the tokens are active and the roots are different."
-  [{:keys [store-token]} cluster-urls token latest-token-description metadata-name cluster-url->token-data]
+  [{:keys [store-token]} cluster-urls token latest-token-description opt-out-metadata-name cluster-url->token-data]
   (pc/map-from-keys
     (fn [cluster-url]
       (let [ignored-root-mismatch-equality-comparison-keys ["cluster" "last-update-time" "last-update-user" "previous" "root"]
@@ -108,8 +108,8 @@
                   {:code :error/tokens-deleted
                    :details {:message "soft-deleted tokens should have already been hard-deleted"}}
 
-                  (and (some? metadata-name)
-                       (= "true" (get-in latest-token-description ["metadata" metadata-name])))
+                  (and (some? opt-out-metadata-name)
+                       (= "true" (get-in latest-token-description ["metadata" opt-out-metadata-name])))
                   {:code :success/skip-opt-out}
 
                   ;; active token, content the same irrespective of system metadata keys but roots different
@@ -155,7 +155,7 @@
 
 (defn- perform-token-syncs
   "Perform token syncs for all the specified tokens."
-  [waiter-api cluster-urls all-tokens metadata-name]
+  [waiter-api cluster-urls all-tokens opt-out-metadata-name]
   (let [token->url->token-data (retrieve-token->url->token-data waiter-api cluster-urls all-tokens)
         token->latest-description (retrieve-token->latest-description token->url->token-data)]
     (pc/map-from-keys
@@ -170,7 +170,7 @@
           (log/info "syncing" token "with token description from" cluster-url {:all-soft-deleted all-soft-deleted})
           (let [sync-result (if all-soft-deleted
                               (hard-delete-token-on-all-clusters waiter-api cluster-urls token token-etag)
-                              (sync-token-on-clusters waiter-api remaining-cluster-urls token description metadata-name
+                              (sync-token-on-clusters waiter-api remaining-cluster-urls token description opt-out-metadata-name
                                                       (token->url->token-data token)))]
             {:latest (token->latest-description token)
              :sync-result sync-result})))
@@ -256,14 +256,14 @@
 (defn sync-tokens
   "Syncs tokens across provided clusters based on cluster-urls and returns the result of token syncing.
    Throws an exception if there was an error during token syncing."
-  [{:keys [load-token-list] :as waiter-api} cluster-urls limit metadata-name]
+  [{:keys [load-token-list] :as waiter-api} cluster-urls limit opt-out-metadata-name]
   (try
     (log/info "syncing tokens on clusters:" cluster-urls)
     (let [cluster-urls-set (set cluster-urls)
           {:keys [all-tokens pending-tokens synced-tokens]} (load-and-classify-tokens load-token-list cluster-urls-set)
           selected-tokens (->> (sort pending-tokens)
                                (take limit))
-          token-sync-result (perform-token-syncs waiter-api cluster-urls-set selected-tokens metadata-name)]
+          token-sync-result (perform-token-syncs waiter-api cluster-urls-set selected-tokens opt-out-metadata-name)]
       (log/info "completed syncing tokens (limited to " (min limit (count pending-tokens)) "tokens)")
       {:details token-sync-result
        :summary (-> {:all-tokens all-tokens
@@ -287,7 +287,7 @@
 (def sync-clusters-config
   {:execute-command (fn execute-sync-clusters-command
                       [{:keys [waiter-api]} {:keys [options]} arguments]
-                      (let [{:keys [limit metadata-name]} options
+                      (let [{:keys [limit opt-out-metadata-name]} options
                             cluster-urls-set (set arguments)]
                         (cond
                           (<= (-> cluster-urls-set set count) 1)
@@ -295,7 +295,7 @@
                            :message (str "at least two different cluster urls required, provided: " (vec arguments))}
 
                           :else
-                          (let [{:keys [details summary] :as sync-result} (sync-tokens waiter-api cluster-urls-set limit metadata-name)
+                          (let [{:keys [details summary] :as sync-result} (sync-tokens waiter-api cluster-urls-set limit opt-out-metadata-name)
                                 exit-code (-> (get-in sync-result [:summary :sync :failed])
                                               empty?
                                               (if 0 1))]
@@ -307,7 +307,7 @@
                    :default 1000
                    :parse-fn #(Integer/parseInt %)
                    :validate [#(< 0 % 10001) "Must be between 1 and 10000"]]
-                  ["-m" "--metadata-name NAME"
+                  ["-m" "--opt-out-metadata-name NAME"
                    (str "The metadata field that must be configured to 'true' on the latest description to "
                         "trigger opting out of syncing, default is all tokens opt in to syncing")
                    :default nil

--- a/token-syncer/test/token_syncer/commands/syncer_test.clj
+++ b/token-syncer/test/token_syncer/commands/syncer_test.clj
@@ -160,6 +160,7 @@
 
 (deftest test-sync-token-on-clusters
   (let [test-token-etag (System/currentTimeMillis)
+        metadata-name nil
         waiter-api {:store-token (fn [cluster-url token token-etag token-description]
                                    (cond
                                      (str/includes? cluster-url "cluster-1")
@@ -189,7 +190,7 @@
                                      :details {:message "token root missing from latest token description"}}
                 "www.cluster-2.com" {:code :error/token-read
                                      :details {:message "cluster-2 data cannot be loaded"}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster error while missing status"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -205,7 +206,7 @@
                                      :details {:message "token root missing from latest token description"}}
                 "www.cluster-2.com" {:code :error/token-read
                                      :details {:message "status missing from response"}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster different owners but same root"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -224,7 +225,7 @@
                 "www.cluster-2.com" {:code :success/sync-update
                                      :details {:etag (str test-token-etag ".2.new")
                                                :status 200}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster different owners and different root"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -244,7 +245,7 @@
                 "www.cluster-2.com" {:code :error/root-mismatch
                                      :details {:cluster {"owner" "test-user-2", "root" "cluster-2"}
                                                :latest token-description}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster similar parameters and owner but different root"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com" "www.cluster-3.com"]
@@ -270,7 +271,7 @@
                 "www.cluster-2.com" {:code :success/skip-token-sync}
                 "www.cluster-3.com" {:code :error/token-sync
                                      :details {:message "token contents match, but were edited by different users"}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster same owner; soft-deleted on one; and different last-update-user and root"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -292,7 +293,7 @@
                 "www.cluster-2.com" {:code :error/root-mismatch
                                      :details {:cluster token-description-2
                                                :latest token-description-1}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster same last-update-user and owner; soft-deleted on one; and different root"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -314,7 +315,7 @@
                 "www.cluster-2.com" {:code :success/soft-delete
                                      :details {:etag (str test-token-etag ".2.new")
                                                :status 200}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster different root and parameters; deleted on both"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -334,7 +335,7 @@
         (is (= {"www.cluster-1.com" {:code :success/token-match}
                 "www.cluster-2.com" {:code :error/tokens-deleted
                                      :details {:message "soft-deleted tokens should have already been hard-deleted"}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster same owner; different last-update-user, parameters and root"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -355,7 +356,7 @@
                 "www.cluster-2.com" {:code :error/root-mismatch
                                      :details {:cluster token-description-2
                                                :latest token-description-1}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster same last-update-user and owner; different parameters and root"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -376,7 +377,7 @@
                 "www.cluster-2.com" {:code :success/sync-update
                                      :details {:etag (str test-token-etag ".2.new")
                                                :status 200}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster with missing owners"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -398,7 +399,7 @@
                 "www.cluster-2.com" {:code :success/sync-update
                                      :details {:etag (str test-token-etag ".2.new")
                                                :status 200}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster with outdated missing last-update-user and root"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -420,7 +421,7 @@
                                                :latest {"last-update-user" "john.doe"
                                                         "name" "test-name-1"
                                                         "root" "test-user-1"}}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster with outdated missing root; different last-update-user"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -444,7 +445,7 @@
                                                :latest {"last-update-user" "john.doe"
                                                         "name" "test-name-1"
                                                         "root" "test-user-1"}}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster with latest missing root"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -461,7 +462,7 @@
                                      :details {:message "token root missing from latest token description"}}
                 "www.cluster-2.com" {:code :error/token-read
                                      :details {:message "token root missing from latest token description"}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster successfully"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -484,7 +485,7 @@
                 "www.cluster-2.com" {:code :success/sync-update
                                      :details {:etag (str test-token-etag ".2.new")
                                                :status 200}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster error"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2-error.com"]
@@ -506,7 +507,109 @@
         (is (= {"www.cluster-1.com" {:code :success/token-match}
                 "www.cluster-2-error.com" {:code :error/token-sync
                                            :details {:message "Error in storing token thrown from test"}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description cluster-url->token-data)))))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
+
+    (testing "sync cluster skip on metadata field mismatch"
+      (let [metadata-name "sync-opt-out"
+            cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
+            test-token "test-token-1"
+            token-description {"last-update-user" "john.doe"
+                               "metadata" {"sync-opt-in" "false"}
+                               "name" "test-name"
+                               "owner" "test-user-1"
+                               "root" "test-cluster-1"}
+            cluster-url->token-data {"www.cluster-1.com" {:description {"last-update-user" "john.doe"
+                                                                        "metadata" {"sync-opt-in" "false"}
+                                                                        "name" "test-name"
+                                                                        "owner" "test-user-1"
+                                                                        "root" "test-cluster-1"}
+                                                          :token-etag (str test-token-etag ".1")
+                                                          :status 200}
+                                     "www.cluster-2.com" {:description {"owner" "test-user-1"
+                                                                        "root" "test-cluster-1"}
+                                                          :token-etag (str test-token-etag ".2")
+                                                          :status 200}}]
+        (is (= {"www.cluster-1.com" {:code :success/token-match}
+                "www.cluster-2.com" {:code :success/sync-update
+                                     :details {:etag (str test-token-etag ".2.new")
+                                               :status 200}}}
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
+
+    (testing "sync cluster skip on metadata field opt-out"
+      (let [metadata-name "sync-opt-out"
+            cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
+            test-token "test-token-1"
+            token-description {"last-update-user" "john.doe"
+                               "metadata" {"sync-opt-out" "true"}
+                               "name" "test-name"
+                               "owner" "test-user-1"
+                               "root" "test-cluster-1"}
+            cluster-url->token-data {"www.cluster-1.com" {:description {"last-update-user" "john.doe"
+                                                                        "metadata" {"sync-opt-out" "true"}
+                                                                        "name" "test-name"
+                                                                        "owner" "test-user-1"
+                                                                        "root" "test-cluster-1"}
+                                                          :token-etag (str test-token-etag ".1")
+                                                          :status 200}
+                                     "www.cluster-2.com" {:description {"owner" "test-user-1"
+                                                                        "root" "test-cluster-1"}
+                                                          :token-etag (str test-token-etag ".2")
+                                                          :status 200}}]
+        (is (= {"www.cluster-1.com" {:code :success/token-match}
+                "www.cluster-2.com" {:code :success/skip-opt-out}}
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
+
+    (testing "sync cluster success on metadata field opt-out non-true value"
+      (let [metadata-name "sync-opt-out"
+            cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
+            test-token "test-token-1"
+            token-description {"last-update-user" "john.doe"
+                               "metadata" {"sync-opt-out" "yes"}
+                               "name" "test-name"
+                               "owner" "test-user-1"
+                               "root" "test-cluster-1"}
+            cluster-url->token-data {"www.cluster-1.com" {:description {"last-update-user" "john.doe"
+                                                                        "metadata" {"sync-opt-out" "yes"}
+                                                                        "name" "test-name"
+                                                                        "owner" "test-user-1"
+                                                                        "root" "test-cluster-1"}
+                                                          :token-etag (str test-token-etag ".1")
+                                                          :status 200}
+                                     "www.cluster-2.com" {:description {"owner" "test-user-1"
+                                                                        "root" "test-cluster-1"}
+                                                          :token-etag (str test-token-etag ".2")
+                                                          :status 200}}]
+        (is (= {"www.cluster-1.com" {:code :success/token-match}
+                "www.cluster-2.com" {:code :success/sync-update
+                                     :details {:etag (str test-token-etag ".2.new")
+                                               :status 200}}}
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
+
+    (testing "sync cluster success on metadata field opt-in"
+      (let [metadata-name "sync-opt-out"
+            cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
+            test-token "test-token-1"
+            token-description {"last-update-user" "john.doe"
+                               "metadata" {"sync-opt-out" "false"}
+                               "name" "test-name"
+                               "owner" "test-user-1"
+                               "root" "test-cluster-1"}
+            cluster-url->token-data {"www.cluster-1.com" {:description {"last-update-user" "john.doe"
+                                                                        "metadata" {"sync-opt-out" "false"}
+                                                                        "name" "test-name"
+                                                                        "owner" "test-user-1"
+                                                                        "root" "test-cluster-1"}
+                                                          :token-etag (str test-token-etag ".1")
+                                                          :status 200}
+                                     "www.cluster-2.com" {:description {"owner" "test-user-1"
+                                                                        "root" "test-cluster-1"}
+                                                          :token-etag (str test-token-etag ".2")
+                                                          :status 200}}]
+        (is (= {"www.cluster-1.com" {:code :success/token-match}
+                "www.cluster-2.com" {:code :success/sync-update
+                                     :details {:etag (str test-token-etag ".2.new")
+                                               :status 200}}}
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))))
 
 (deftest test-load-and-classify-tokens
   (let [current-time-ms (System/currentTimeMillis)
@@ -707,7 +810,8 @@
                                                "token" token}
                                               last-update-time (assoc "etag" (str "E" last-update-time))
                                               owner (assoc "owner" owner)))))
-                             vec)))}]
+                             vec)))}
+        metadata-name "foo-bar"]
     (with-redefs [retrieve-token->url->token-data (fn [_ in-cluster-urls all-tokens]
                                                     (is (= (set cluster-urls) in-cluster-urls))
                                                     (is (= #{"token-2" "token-3" "token-4" "token-5"}
@@ -718,7 +822,8 @@
                                                        token->latest-description)
                   hard-delete-token-on-all-clusters (fn [_ cluster-urls token _]
                                                       (compute-sync-result cluster-urls token :success/hard-delete))
-                  sync-token-on-clusters (fn [_ cluster-urls token description _]
+                  sync-token-on-clusters (fn [_ cluster-urls token description in-metadata-name _]
+                                           (is (= metadata-name in-metadata-name))
                                            (let [token-name (str (get description "name"))
                                                  code (cond
                                                         (str/includes? token-name "all-synced") :success/token-match
@@ -726,7 +831,7 @@
                                                         (str/includes? token-name "soft-delete") :success/soft-delete
                                                         :else :error/token-sync)]
                                              (compute-sync-result cluster-urls token code)))]
-      (let [{:keys [details summary]} (sync-tokens waiter-api cluster-urls (inc (count token->latest-description)))]
+      (let [{:keys [details summary]} (sync-tokens waiter-api cluster-urls (inc (count token->latest-description)) metadata-name)]
         (is (= {"token-2" {:latest (token->latest-description "token-2")
                            :sync-result (-> [cluster-2 cluster-3]
                                             (compute-sync-result "token-2" :success/sync-update))}
@@ -759,10 +864,21 @@
            (:errors (parse-cli-options ["-c" "abcd,abcd"]))))
     (is (= ["Missing required argument for \"-l LIMIT\""]
            (:errors (parse-cli-options ["-l"]))))
-    (is (= {:limit 200}
+    (is (= {:limit 200
+            :metadata-name nil}
            (:options (parse-cli-options ["-l" "200"]))))
-    (is (= {:limit 200}
-           (:options (parse-cli-options ["--limit" "200"]))))))
+    (is (= {:limit 200
+            :metadata-name nil}
+           (:options (parse-cli-options ["--limit" "200"]))))
+    (is (= {:limit 1000
+            :metadata-name "waiter-key"}
+           (:options (parse-cli-options ["-m" "waiter-key"]))))
+    (is (= {:limit 1000
+            :metadata-name "waiter-key"}
+           (:options (parse-cli-options ["--metadata-name" "waiter-key"]))))
+    (is (= {:limit 200
+            :metadata-name "waiter-key"}
+           (:options (parse-cli-options ["--limit" "200" "--metadata-name" "waiter-key"]))))))
 
 (deftest test-sync-clusters-config
   (let [test-command-config (assoc sync-clusters-config :command-name "test-command")
@@ -786,27 +902,40 @@
               :message "test-command: at least two different cluster urls required, provided: [\"http://cluster-1.com\" \"http://cluster-1.com\"]"}
              (cli/process-command test-command-config context args))))
     (let [args ["http://cluster-1.com" "http://cluster-2.com"]]
-      (with-redefs [sync-tokens (fn [in-waiter-api cluster-urls-set limit]
+      (with-redefs [sync-tokens (fn [in-waiter-api cluster-urls-set limit metadata-name]
                                   (is (= waiter-api in-waiter-api))
                                   (is (= #{"http://cluster-1.com" "http://cluster-2.com"} cluster-urls-set))
-                                  (is (= 1000 limit)))]
+                                  (is (= 1000 limit))
+                                  (is (nil? metadata-name)))]
         (is (= {:exit-code 0
                 :message "test-command: exiting with code 0"}
                (cli/process-command test-command-config context args)))))
     (let [args ["-l" "20" "http://cluster-1.com" "http://cluster-2.com"]]
-      (with-redefs [sync-tokens (fn [in-waiter-api cluster-urls-set limit]
+      (with-redefs [sync-tokens (fn [in-waiter-api cluster-urls-set limit metadata-name]
                                   (is (= waiter-api in-waiter-api))
                                   (is (= #{"http://cluster-1.com" "http://cluster-2.com"} cluster-urls-set))
-                                  (is (= 20 limit)))]
+                                  (is (= 20 limit))
+                                  (is (nil? metadata-name)))]
         (is (= {:exit-code 0
                 :message "test-command: exiting with code 0"}
                (cli/process-command test-command-config context args)))))
     (let [args ["http://cluster-1.com" "http://cluster-2.com"]]
-      (with-redefs [sync-tokens (fn [in-waiter-api cluster-urls-set limit]
+      (with-redefs [sync-tokens (fn [in-waiter-api cluster-urls-set limit metadata-name]
                                   (is (= waiter-api in-waiter-api))
                                   (is (= #{"http://cluster-1.com" "http://cluster-2.com"} cluster-urls-set))
                                   (is (= 1000 limit))
+                                  (is (nil? metadata-name))
                                   {:summary {:sync {:failed #{"foo"}}}})]
         (is (= {:exit-code 1
                 :message "test-command: exiting with code 1"}
                (cli/process-command test-command-config context args)))))))
+
+(deftest test-valid-metadata-name?
+  (is (true? (valid-metadata-name? nil)))
+  (is (true? (valid-metadata-name? "waiter-name")))
+  (is (true? (valid-metadata-name? "waiter-name-1234")))
+  (is (true? (valid-metadata-name? "waiter-name")))
+  (is (false? (valid-metadata-name? "1234-waiter-name")))
+  (is (true? (valid-metadata-name? (apply str (repeat 99 "m")))))
+  (is (false? (valid-metadata-name? (apply str (repeat 100 "m")))))
+  (is (false? (valid-metadata-name? (apply str (repeat 101 "m"))))))

--- a/token-syncer/test/token_syncer/commands/syncer_test.clj
+++ b/token-syncer/test/token_syncer/commands/syncer_test.clj
@@ -160,7 +160,7 @@
 
 (deftest test-sync-token-on-clusters
   (let [test-token-etag (System/currentTimeMillis)
-        metadata-name nil
+        opt-out-metadata-name nil
         waiter-api {:store-token (fn [cluster-url token token-etag token-description]
                                    (cond
                                      (str/includes? cluster-url "cluster-1")
@@ -190,7 +190,7 @@
                                      :details {:message "token root missing from latest token description"}}
                 "www.cluster-2.com" {:code :error/token-read
                                      :details {:message "cluster-2 data cannot be loaded"}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description opt-out-metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster error while missing status"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -206,7 +206,7 @@
                                      :details {:message "token root missing from latest token description"}}
                 "www.cluster-2.com" {:code :error/token-read
                                      :details {:message "status missing from response"}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description opt-out-metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster different owners but same root"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -225,7 +225,7 @@
                 "www.cluster-2.com" {:code :success/sync-update
                                      :details {:etag (str test-token-etag ".2.new")
                                                :status 200}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description opt-out-metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster different owners and different root"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -245,7 +245,7 @@
                 "www.cluster-2.com" {:code :error/root-mismatch
                                      :details {:cluster {"owner" "test-user-2", "root" "cluster-2"}
                                                :latest token-description}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description opt-out-metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster similar parameters and owner but different root"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com" "www.cluster-3.com"]
@@ -271,7 +271,7 @@
                 "www.cluster-2.com" {:code :success/skip-token-sync}
                 "www.cluster-3.com" {:code :error/token-sync
                                      :details {:message "token contents match, but were edited by different users"}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 metadata-name cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 opt-out-metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster same owner; soft-deleted on one; and different last-update-user and root"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -293,7 +293,7 @@
                 "www.cluster-2.com" {:code :error/root-mismatch
                                      :details {:cluster token-description-2
                                                :latest token-description-1}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 metadata-name cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 opt-out-metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster same last-update-user and owner; soft-deleted on one; and different root"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -315,7 +315,7 @@
                 "www.cluster-2.com" {:code :success/soft-delete
                                      :details {:etag (str test-token-etag ".2.new")
                                                :status 200}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 metadata-name cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 opt-out-metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster different root and parameters; deleted on both"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -335,7 +335,7 @@
         (is (= {"www.cluster-1.com" {:code :success/token-match}
                 "www.cluster-2.com" {:code :error/tokens-deleted
                                      :details {:message "soft-deleted tokens should have already been hard-deleted"}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 metadata-name cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 opt-out-metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster same owner; different last-update-user, parameters and root"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -356,7 +356,7 @@
                 "www.cluster-2.com" {:code :error/root-mismatch
                                      :details {:cluster token-description-2
                                                :latest token-description-1}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 metadata-name cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 opt-out-metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster same last-update-user and owner; different parameters and root"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -377,7 +377,7 @@
                 "www.cluster-2.com" {:code :success/sync-update
                                      :details {:etag (str test-token-etag ".2.new")
                                                :status 200}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 metadata-name cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description-1 opt-out-metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster with missing owners"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -399,7 +399,7 @@
                 "www.cluster-2.com" {:code :success/sync-update
                                      :details {:etag (str test-token-etag ".2.new")
                                                :status 200}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description opt-out-metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster with outdated missing last-update-user and root"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -421,7 +421,7 @@
                                                :latest {"last-update-user" "john.doe"
                                                         "name" "test-name-1"
                                                         "root" "test-user-1"}}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description opt-out-metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster with outdated missing root; different last-update-user"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -445,7 +445,7 @@
                                                :latest {"last-update-user" "john.doe"
                                                         "name" "test-name-1"
                                                         "root" "test-user-1"}}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description opt-out-metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster with latest missing root"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -462,7 +462,7 @@
                                      :details {:message "token root missing from latest token description"}}
                 "www.cluster-2.com" {:code :error/token-read
                                      :details {:message "token root missing from latest token description"}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description opt-out-metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster successfully"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
@@ -485,7 +485,7 @@
                 "www.cluster-2.com" {:code :success/sync-update
                                      :details {:etag (str test-token-etag ".2.new")
                                                :status 200}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description opt-out-metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster error"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2-error.com"]
@@ -507,10 +507,10 @@
         (is (= {"www.cluster-1.com" {:code :success/token-match}
                 "www.cluster-2-error.com" {:code :error/token-sync
                                            :details {:message "Error in storing token thrown from test"}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description opt-out-metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster skip on metadata field mismatch"
-      (let [metadata-name "sync-opt-out"
+      (let [opt-out-metadata-name "sync-opt-out"
             cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
             test-token "test-token-1"
             token-description {"last-update-user" "john.doe"
@@ -533,10 +533,10 @@
                 "www.cluster-2.com" {:code :success/sync-update
                                      :details {:etag (str test-token-etag ".2.new")
                                                :status 200}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description opt-out-metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster skip on metadata field opt-out"
-      (let [metadata-name "sync-opt-out"
+      (let [opt-out-metadata-name "sync-opt-out"
             cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
             test-token "test-token-1"
             token-description {"last-update-user" "john.doe"
@@ -557,10 +557,10 @@
                                                           :status 200}}]
         (is (= {"www.cluster-1.com" {:code :success/token-match}
                 "www.cluster-2.com" {:code :success/skip-opt-out}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description opt-out-metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster success on metadata field opt-out non-true value"
-      (let [metadata-name "sync-opt-out"
+      (let [opt-out-metadata-name "sync-opt-out"
             cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
             test-token "test-token-1"
             token-description {"last-update-user" "john.doe"
@@ -583,10 +583,10 @@
                 "www.cluster-2.com" {:code :success/sync-update
                                      :details {:etag (str test-token-etag ".2.new")
                                                :status 200}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description opt-out-metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster success on metadata field opt-in"
-      (let [metadata-name "sync-opt-out"
+      (let [opt-out-metadata-name "sync-opt-out"
             cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
             test-token "test-token-1"
             token-description {"last-update-user" "john.doe"
@@ -609,7 +609,7 @@
                 "www.cluster-2.com" {:code :success/sync-update
                                      :details {:etag (str test-token-etag ".2.new")
                                                :status 200}}}
-               (sync-token-on-clusters waiter-api cluster-urls test-token token-description metadata-name cluster-url->token-data)))))))
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description opt-out-metadata-name cluster-url->token-data)))))))
 
 (deftest test-load-and-classify-tokens
   (let [current-time-ms (System/currentTimeMillis)
@@ -811,7 +811,7 @@
                                               last-update-time (assoc "etag" (str "E" last-update-time))
                                               owner (assoc "owner" owner)))))
                              vec)))}
-        metadata-name "foo-bar"]
+        opt-out-metadata-name "foo-bar"]
     (with-redefs [retrieve-token->url->token-data (fn [_ in-cluster-urls all-tokens]
                                                     (is (= (set cluster-urls) in-cluster-urls))
                                                     (is (= #{"token-2" "token-3" "token-4" "token-5"}
@@ -823,7 +823,7 @@
                   hard-delete-token-on-all-clusters (fn [_ cluster-urls token _]
                                                       (compute-sync-result cluster-urls token :success/hard-delete))
                   sync-token-on-clusters (fn [_ cluster-urls token description in-metadata-name _]
-                                           (is (= metadata-name in-metadata-name))
+                                           (is (= opt-out-metadata-name in-metadata-name))
                                            (let [token-name (str (get description "name"))
                                                  code (cond
                                                         (str/includes? token-name "all-synced") :success/token-match
@@ -831,7 +831,7 @@
                                                         (str/includes? token-name "soft-delete") :success/soft-delete
                                                         :else :error/token-sync)]
                                              (compute-sync-result cluster-urls token code)))]
-      (let [{:keys [details summary]} (sync-tokens waiter-api cluster-urls (inc (count token->latest-description)) metadata-name)]
+      (let [{:keys [details summary]} (sync-tokens waiter-api cluster-urls (inc (count token->latest-description)) opt-out-metadata-name)]
         (is (= {"token-2" {:latest (token->latest-description "token-2")
                            :sync-result (-> [cluster-2 cluster-3]
                                             (compute-sync-result "token-2" :success/sync-update))}
@@ -865,20 +865,20 @@
     (is (= ["Missing required argument for \"-l LIMIT\""]
            (:errors (parse-cli-options ["-l"]))))
     (is (= {:limit 200
-            :metadata-name nil}
+            :opt-out-metadata-name nil}
            (:options (parse-cli-options ["-l" "200"]))))
     (is (= {:limit 200
-            :metadata-name nil}
+            :opt-out-metadata-name nil}
            (:options (parse-cli-options ["--limit" "200"]))))
     (is (= {:limit 1000
-            :metadata-name "waiter-key"}
+            :opt-out-metadata-name "waiter-key"}
            (:options (parse-cli-options ["-m" "waiter-key"]))))
     (is (= {:limit 1000
-            :metadata-name "waiter-key"}
-           (:options (parse-cli-options ["--metadata-name" "waiter-key"]))))
+            :opt-out-metadata-name "waiter-key"}
+           (:options (parse-cli-options ["--opt-out-metadata-name" "waiter-key"]))))
     (is (= {:limit 200
-            :metadata-name "waiter-key"}
-           (:options (parse-cli-options ["--limit" "200" "--metadata-name" "waiter-key"]))))))
+            :opt-out-metadata-name "waiter-key"}
+           (:options (parse-cli-options ["--limit" "200" "--opt-out-metadata-name" "waiter-key"]))))))
 
 (deftest test-sync-clusters-config
   (let [test-command-config (assoc sync-clusters-config :command-name "test-command")
@@ -902,29 +902,29 @@
               :message "test-command: at least two different cluster urls required, provided: [\"http://cluster-1.com\" \"http://cluster-1.com\"]"}
              (cli/process-command test-command-config context args))))
     (let [args ["http://cluster-1.com" "http://cluster-2.com"]]
-      (with-redefs [sync-tokens (fn [in-waiter-api cluster-urls-set limit metadata-name]
+      (with-redefs [sync-tokens (fn [in-waiter-api cluster-urls-set limit opt-out-metadata-name]
                                   (is (= waiter-api in-waiter-api))
                                   (is (= #{"http://cluster-1.com" "http://cluster-2.com"} cluster-urls-set))
                                   (is (= 1000 limit))
-                                  (is (nil? metadata-name)))]
+                                  (is (nil? opt-out-metadata-name)))]
         (is (= {:exit-code 0
                 :message "test-command: exiting with code 0"}
                (cli/process-command test-command-config context args)))))
     (let [args ["-l" "20" "http://cluster-1.com" "http://cluster-2.com"]]
-      (with-redefs [sync-tokens (fn [in-waiter-api cluster-urls-set limit metadata-name]
+      (with-redefs [sync-tokens (fn [in-waiter-api cluster-urls-set limit opt-out-metadata-name]
                                   (is (= waiter-api in-waiter-api))
                                   (is (= #{"http://cluster-1.com" "http://cluster-2.com"} cluster-urls-set))
                                   (is (= 20 limit))
-                                  (is (nil? metadata-name)))]
+                                  (is (nil? opt-out-metadata-name)))]
         (is (= {:exit-code 0
                 :message "test-command: exiting with code 0"}
                (cli/process-command test-command-config context args)))))
     (let [args ["http://cluster-1.com" "http://cluster-2.com"]]
-      (with-redefs [sync-tokens (fn [in-waiter-api cluster-urls-set limit metadata-name]
+      (with-redefs [sync-tokens (fn [in-waiter-api cluster-urls-set limit opt-out-metadata-name]
                                   (is (= waiter-api in-waiter-api))
                                   (is (= #{"http://cluster-1.com" "http://cluster-2.com"} cluster-urls-set))
                                   (is (= 1000 limit))
-                                  (is (nil? metadata-name))
+                                  (is (nil? opt-out-metadata-name))
                                   {:summary {:sync {:failed #{"foo"}}}})]
         (is (= {:exit-code 1
                 :message "test-command: exiting with code 1"}


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for opting out of token syncing when metadata is configured

## Why are we making these changes?

We wish to allow service owners to explicitly opt-out of token syncing across clusters.

