### PR TITLE
Cli add update and create nested fields support

### DIFF
--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1327,7 +1327,7 @@ class WaiterCliTest(util.WaiterTest):
         self.assertIn('foo-level', cli.stderr(cp))
         self.assertIn('bar-rate', cli.stderr(cp))
 
-    def test_nested_args_no_override(self):
+    def test_update_nested_args_no_override(self):
         token_name = self.token_name()
         initial_token_config = {'cmd': 'foo',
                                 'cpus': 0.1,
@@ -1352,7 +1352,7 @@ class WaiterCliTest(util.WaiterTest):
         finally:
             util.delete_token(self.waiter_url, token_name)
 
-    def __test_nested_args_with_overrides_success(self, file_format):
+    def __test_update_nested_args_with_overrides_success(self, file_format):
         token_name = self.token_name()
         initial_token_config = {'cmd': 'foo',
                                 'cpus': 0.1,
@@ -1383,16 +1383,16 @@ class WaiterCliTest(util.WaiterTest):
         finally:
             util.delete_token(self.waiter_url, token_name)
 
-    def test_nested_args_json_with_overrides_success(self):
-        self.__test_nested_args_with_overrides_success('json')
+    def test_update_nested_args_json_with_overrides_success(self):
+        self.__test_update_nested_args_with_overrides_success('json')
 
-    def test_nested_args_yaml_with_overrides_success(self):
-        self.__test_nested_args_with_overrides_success('yaml')
+    def test_update_nested_args_yaml_with_overrides_success(self):
+        self.__test_update_nested_args_with_overrides_success('yaml')
 
-    def test_nested_args_json_with_overrides_failure(self):
+    def test_update_nested_args_json_with_overrides_failure(self):
         self.__test_update_token_override_failure('json', False, update_flags="--env.FOO testing")
 
-    def test_nested_args_json_with_overrides_failure(self):
+    def test_update_nested_args_json_with_overrides_failure(self):
         self.__test_update_token_override_failure('yaml', False, update_flags="--env.FOO testing")
 
     def test_show_service_current(self):

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -8,8 +8,8 @@ import requests
 from waiter import terminal, http_util
 from waiter.data_format import load_data
 from waiter.querying import get_token, query_token, get_target_cluster_from_token
-from waiter.util import assoc_in, deep_merge, FALSE_STRINGS, is_admin_enabled, print_info, response_message, \
-    TRUE_STRINGS, guard_no_cluster, str2bool
+from waiter.util import deep_merge, FALSE_STRINGS, is_admin_enabled, print_info, response_message, TRUE_STRINGS, \
+    guard_no_cluster, str2bool, update_in
 
 BOOL_STRINGS = TRUE_STRINGS + FALSE_STRINGS
 INT_PARAM_SUFFIXES = ['-failures', '-index', '-instances', '-length', '-level', '-mins', '-secs']
@@ -65,7 +65,7 @@ def merge_token_fields_from_args(token_fields_base, token_fields_from_args):
     token_fields = {**token_fields_base}
     for key_raw, value in token_fields_from_args.items():
         keys = key_raw.split('.')
-        token_fields = assoc_in(token_fields, keys, value)
+        update_in(token_fields, keys, value)
     return token_fields
 
 

--- a/cli/waiter/util.py
+++ b/cli/waiter/util.py
@@ -12,14 +12,12 @@ TRUE_STRINGS = ('yes', 'true', 'y')
 FALSE_STRINGS = ('no', 'false', 'n')
 
 
-def assoc_in(obj, keys, value):
+def update_in(obj, keys, value):
     """Given a list of keys and a value, return a new object with that value set"""
-    obj = obj.copy()
     cur_node = obj
     for key in keys[:-1]:
         cur_node = cur_node.setdefault(key, {})
     cur_node[keys[-1]] = value
-    return obj
 
 
 def deep_merge(a, b):

--- a/cli/waiter/util.py
+++ b/cli/waiter/util.py
@@ -12,6 +12,16 @@ TRUE_STRINGS = ('yes', 'true', 'y')
 FALSE_STRINGS = ('no', 'false', 'n')
 
 
+def assoc_in(obj, keys, value):
+    """Given a list of keys and a value, return a new object with that value set"""
+    obj = obj.copy()
+    cur_node = obj
+    for key in keys[:-1]:
+        cur_node = cur_node.setdefault(key, {})
+    cur_node[keys[-1]] = value
+    return obj
+
+
 def deep_merge(a, b):
     """Merges a and b, letting b win if there is a conflict"""
     merged = a.copy()


### PR DESCRIPTION
## Changes proposed in this PR

- allows for nested fields: ex. `waiter create [token] --field1.field2.field3 50`
- for update command, these fields will be applied to existing token configuration (deep-merge) if there is no override/json/yaml input. Overrides will result in a shallow merge behavio
![Screenshot from 2021-05-28 11-24-27](https://user-images.githubusercontent.com/8290559/120014128-4ac80c00-bfa7-11eb-9995-106fd23bc1c7.png)


## Why are we making these changes?

- makes modifying nested fields much easier for users

