### PR TITLE
adds templating with variable substitution support to input file

### DIFF
--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -160,6 +160,30 @@ def write_yaml(path, config):
         yaml.safe_dump(config, outfile)
 
 
+class temp_file:
+    """
+    A context manager used to generate and subsequently delete a temporary
+    text file for the CLI. Takes as input context to use.
+    """
+
+    def __init__(self, content):
+        self.content = content
+
+    def write_temp_file(self):
+        path = tempfile.NamedTemporaryFile(delete=False).name
+        with open(path, 'w') as outfile:
+            logging.info('echo \'%s\' > %s' % (self.content, path))
+            outfile.write(self.content)
+        return path
+
+    def __enter__(self):
+        self.path = self.write_temp_file()
+        return self.path
+
+    def __exit__(self, _, __, ___):
+        os.remove(self.path)
+
+
 class temp_config_file:
     """
     A context manager used to generate and subsequently delete a temporary

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1635,7 +1635,7 @@ class WaiterCliTest(util.WaiterTest):
     def __test_create_update_token_context_success(self, action, file_format):
         token_name = self.token_name()
         context_fields = {'fee': 'bar', 'fie': 'baz', 'foe': 'fum'}
-        token_fields = {'cmd': '{{ fee }}-{{ fie }}', 'cpus': 0.2, 'mem': 256, 'metadata': {'foe': '{{ foe }}'}}
+        token_fields = {'cmd': '${fee}-${fie}', 'cpus': 0.2, 'mem': 256, 'metadata': {'foe': '${foe}'}}
         try:
             if action == 'update':
                 util.post_token(self.waiter_url, token_name, {'cpus': 0.1, 'mem': 128})

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1555,6 +1555,122 @@ class WaiterCliTest(util.WaiterTest):
     def test_update_token_no_admin_mode(self):
         self.__test_create_update_token_admin_mode('update', self.token_name(), False)
 
+    def __test_create_update_token_context_missing_data_failure(self, action):
+        token_name = self.token_name()
+        context_fields = {'fee': 'bar', 'fie': 'baz', 'foe': 'fum'}
+        try:
+            with cli.temp_token_file({**context_fields}, 'yaml') as path:
+                flags = f'--context {path}'
+                cp = getattr(cli, action)(self.waiter_url, token_name, flags='-v', **{f'{action}_flags': flags})
+                self.assertEqual(1, cp.returncode, cp.stderr)
+                stderr = cli.stderr(cp)
+                err_msg = '--context file can only be used when a data file is specified via --input, --json, or --yaml'
+                self.assertIn(err_msg, stderr)
+        finally:
+            # the token should not have been created, but cleaning up in case the test failed
+            util.delete_token(self.waiter_url, token_name, assert_response=False)
+
+    def test_create_token_context_missing_data_failure(self):
+        self.__test_create_update_token_context_missing_data_failure('create')
+
+    def test_update_token_context_missing_data_failure(self):
+        self.__test_create_update_token_context_missing_data_failure('update')
+
+    def __test_create_update_token_context_missing_file_failure(self, action, file_format):
+        token_name = self.token_name()
+        token_fields = {'cmd': 'foo-bar', 'cpus': 0.2, 'mem': 256}
+        try:
+            with cli.temp_token_file({**token_fields}, file_format) as token_path:
+                with tempfile.NamedTemporaryFile(delete=True) as file:
+                    flags = f'--context {file.name} --{file_format} {token_path}'
+                    cp = getattr(cli, action)(self.waiter_url, token_name, flags='-v', **{f'{action}_flags': flags})
+                    self.assertEqual(1, cp.returncode, cp.stderr)
+                    stderr = cli.stderr(cp)
+                    err_msg = f'Unable to load yaml from {file.name}'
+                    self.assertIn(err_msg, stderr)
+        finally:
+            # the token should not have been created, but cleaning up in case the test failed
+            util.delete_token(self.waiter_url, token_name, assert_response=False)
+
+    def test_create_token_context_missing_file_failure_json_data(self):
+        self.__test_create_update_token_context_missing_file_failure('create', 'json')
+
+    def test_create_token_context_missing_file_failure_yaml_data(self):
+        self.__test_create_update_token_context_missing_file_failure('create', 'yaml')
+
+    def test_update_token_context_missing_file_failure_json_data(self):
+        self.__test_create_update_token_context_missing_file_failure('update', 'json')
+
+    def test_update_token_context_missing_file_failure_yaml_data(self):
+        self.__test_create_update_token_context_missing_file_failure('update', 'yaml')
+
+    def __test_create_update_token_context_bad_format_failure(self, action, file_format):
+        token_name = self.token_name()
+        token_fields = {'cmd': 'foo-bar', 'cpus': 0.2, 'mem': 256}
+        try:
+            with cli.temp_token_file({**token_fields}, file_format) as token_path:
+                with cli.temp_file('foo-bar') as context_path:
+                    flags = f'--context {context_path} --{file_format} {token_path}'
+                    cp = getattr(cli, action)(self.waiter_url, token_name, flags='-v', **{f'{action}_flags': flags})
+                    self.assertEqual(1, cp.returncode, cp.stderr)
+                    stderr = cli.stderr(cp)
+                    err_msg = 'Provided context file must evaluate to a dictionary, instead it is foo-bar'
+                    self.assertIn(err_msg, stderr)
+        finally:
+            # the token should not have been created, but cleaning up in case the test failed
+            util.delete_token(self.waiter_url, token_name, assert_response=False)
+
+    def test_create_token_context_bad_format_failure_json_data(self):
+        self.__test_create_update_token_context_bad_format_failure('create', 'json')
+
+    def test_create_token_context_bad_format_failure_yaml_data(self):
+        self.__test_create_update_token_context_bad_format_failure('create', 'yaml')
+
+    def test_update_token_context_bad_format_failure_json_data(self):
+        self.__test_create_update_token_context_bad_format_failure('update', 'json')
+
+    def test_update_token_context_bad_format_failure_yaml_data(self):
+        self.__test_create_update_token_context_bad_format_failure('update', 'yaml')
+
+    def __test_create_update_token_context_success(self, action, file_format):
+        token_name = self.token_name()
+        context_fields = {'fee': 'bar', 'fie': 'baz', 'foe': 'fum'}
+        token_fields = {'cmd': '{{ fee }}-{{ fie }}', 'cpus': 0.2, 'mem': 256, 'metadata': {'foe': '{{ foe }}'}}
+        try:
+            if action == 'update':
+                util.post_token(self.waiter_url, token_name, {'cpus': 0.1, 'mem': 128})
+                token_data = util.load_token(self.waiter_url, token_name)
+                self.assertEqual(0.1, token_data['cpus'])
+                self.assertEqual(128, token_data['mem'])
+
+            with cli.temp_token_file({**token_fields}, file_format) as token_path:
+                with cli.temp_token_file({**context_fields}, 'yaml') as context_path:
+                    flags = f'--context {context_path} --{file_format} {token_path}'
+                    cp = getattr(cli, action)(self.waiter_url, token_name, flags='-v', **{f'{action}_flags': flags})
+                    self.assertEqual(0, cp.returncode, cp.stderr)
+                    stdout = cli.stdout(cp)
+                    out_msg = f'Successfully {action}d {token_name}'
+                    self.assertIn(out_msg, stdout)
+                    token_data = util.load_token(self.waiter_url, token_name)
+                    self.assertEqual('bar-baz', token_data['cmd'])
+                    self.assertEqual(0.2, token_data['cpus'])
+                    self.assertEqual(256, token_data['mem'])
+                    self.assertEqual({'foe': 'fum'}, token_data['metadata'])
+        finally:
+            util.delete_token(self.waiter_url, token_name)
+
+    def test_create_token_context_success_json_data(self):
+        self.__test_create_update_token_context_success('create', 'json')
+
+    def test_create_token_context_success_yaml_data(self):
+        self.__test_create_update_token_context_success('create', 'yaml')
+
+    def test_update_token_context_success_json_data(self):
+        self.__test_create_update_token_context_success('update', 'json')
+
+    def test_update_token_context_success_yaml_data(self):
+        self.__test_create_update_token_context_success('update', 'yaml')
+
     def run_maintenance_start_test(self, start_args='', ping_token=False):
         token_name = self.token_name()
         token_fields = util.minimal_service_description()

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1671,6 +1671,79 @@ class WaiterCliTest(util.WaiterTest):
     def test_update_token_context_success_yaml_data(self):
         self.__test_create_update_token_context_success('update', 'yaml')
 
+    def __test_create_update_token_context_missing_variable_failure(self, action, file_format):
+        token_name = self.token_name()
+        context_fields = {'fee': 'bar', 'fie': 'baz'}
+        token_fields = {'cmd': '${fee}-${fie}-${foe}', 'cpus': 0.2, 'mem': 256, 'metadata': {'foe': '${foe}'}}
+        try:
+            if action == 'update':
+                util.post_token(self.waiter_url, token_name, {'cpus': 0.1, 'mem': 128})
+                token_data = util.load_token(self.waiter_url, token_name)
+                self.assertEqual(0.1, token_data['cpus'])
+                self.assertEqual(128, token_data['mem'])
+
+            with cli.temp_token_file({**token_fields}, file_format) as token_path:
+                with cli.temp_token_file({**context_fields}, 'yaml') as context_path:
+                    flags = f'--context {context_path} --{file_format} {token_path}'
+                    cp = getattr(cli, action)(self.waiter_url, token_name, flags='-v', **{f'{action}_flags': flags})
+                    self.assertEqual(1, cp.returncode, cp.stderr)
+                    stderr = cli.stderr(cp)
+                    err_msg = "Error when processing template: missing variable 'foe'"
+                    self.assertIn(err_msg, stderr)
+        finally:
+            util.delete_token(self.waiter_url, token_name, assert_response=False)
+
+    def test_create_token_context_missing_variable_failure_json_data(self):
+        self.__test_create_update_token_context_missing_variable_failure('create', 'json')
+
+    def test_create_token_context_missing_variable_failure_yaml_data(self):
+        self.__test_create_update_token_context_missing_variable_failure('create', 'yaml')
+
+    def test_update_token_context_missing_variable_failure_json_data(self):
+        self.__test_create_update_token_context_missing_variable_failure('update', 'json')
+
+    def test_update_token_context_missing_variable_failure_yaml_data(self):
+        self.__test_create_update_token_context_missing_variable_failure('update', 'yaml')
+
+    def __test_create_update_token_context_override_variable_success(self, action, file_format):
+        token_name = self.token_name()
+        context_fields = {'fee': 'bar', 'fie': 'baz'}
+        token_fields = {'cmd': '${fee}-${fie}-${foe}', 'cpus': 0.2, 'mem': 256, 'metadata': {'foe': '${foe}'}}
+        try:
+            if action == 'update':
+                util.post_token(self.waiter_url, token_name, {'cpus': 0.1, 'mem': 128})
+                token_data = util.load_token(self.waiter_url, token_name)
+                self.assertEqual(0.1, token_data['cpus'])
+                self.assertEqual(128, token_data['mem'])
+
+            with cli.temp_token_file({**token_fields}, file_format) as token_path:
+                with cli.temp_token_file({**context_fields}, 'yaml') as context_path:
+                    flags = f'--context {context_path} --context.fie box --context.foe fum --{file_format} {token_path}'
+                    cp = getattr(cli, action)(self.waiter_url, token_name, flags='-v', **{f'{action}_flags': flags})
+                    self.assertEqual(0, cp.returncode, cp.stderr)
+                    stdout = cli.stdout(cp)
+                    out_msg = f'Successfully {action}d {token_name}'
+                    self.assertIn(out_msg, stdout)
+                    token_data = util.load_token(self.waiter_url, token_name)
+                    self.assertEqual('bar-box-fum', token_data['cmd'])
+                    self.assertEqual(0.2, token_data['cpus'])
+                    self.assertEqual(256, token_data['mem'])
+                    self.assertEqual({'foe': 'fum'}, token_data['metadata'])
+        finally:
+            util.delete_token(self.waiter_url, token_name, assert_response=False)
+
+    def test_create_token_context_override_variable_success_json_data(self):
+        self.__test_create_update_token_context_override_variable_success('create', 'json')
+
+    def test_create_token_context_override_variable_success_yaml_data(self):
+        self.__test_create_update_token_context_override_variable_success('create', 'yaml')
+
+    def test_update_token_context_override_variable_success_json_data(self):
+        self.__test_create_update_token_context_override_variable_success('update', 'json')
+
+    def test_update_token_context_override_variable_success_yaml_data(self):
+        self.__test_create_update_token_context_override_variable_success('update', 'yaml')
+
     def run_maintenance_start_test(self, start_args='', ping_token=False):
         token_name = self.token_name()
         token_fields = util.minimal_service_description()

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1586,7 +1586,7 @@ class WaiterCliTest(util.WaiterTest):
                     cp = getattr(cli, action)(self.waiter_url, token_name, flags='-v', **{f'{action}_flags': flags})
                     self.assertEqual(1, cp.returncode, cp.stderr)
                     stderr = cli.stderr(cp)
-                    err_msg = f'Unable to load yaml from {file.name}'
+                    err_msg = f'Unable to load context from {file.name}'
                     self.assertIn(err_msg, stderr)
         finally:
             # the token should not have been created, but cleaning up in case the test failed

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -6,6 +6,7 @@ from setuptools import setup
 requirements = [
     'arrow>=0.13.1',
     'humanfriendly>=4.18',
+    'Jinja2>=3.0.1',
     'pyyaml>=3.13',
     'requests>=2.20.0',
     'tabulate>=0.8.3'

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -6,7 +6,6 @@ from setuptools import setup
 requirements = [
     'arrow>=0.13.1',
     'humanfriendly>=4.18',
-    'Jinja2>=3.0.1',
     'pyyaml>=3.13',
     'requests>=2.20.0',
     'tabulate>=0.8.3'

--- a/cli/waiter/data_format.py
+++ b/cli/waiter/data_format.py
@@ -1,3 +1,4 @@
+import jinja2
 import json
 import logging
 import os
@@ -157,6 +158,21 @@ def load_data(options):
         content = load_file(input_file)
         if not content:
             raise Exception(f'Unable to load {input_format} from {input_file}.')
+
+        context_file = options.get('context')
+        if context_file:
+            logging.debug(f'reading context as yaml from {context_file}')
+            context_content = load_file(context_file)
+            if not context_content:
+                raise Exception(f'Unable to load yaml from {context_file}.')
+
+            context_obj = YAML.parse(context_content)
+            if not isinstance(context_obj, dict):
+                raise Exception(f'Provided context file must evaluate to a dictionary, instead it is {context_obj}')
+
+            logging.debug(f'applying jinja templating to input using context {context_obj}')
+            jinja_template = jinja2.Template(content)
+            content = jinja_template.render(**context_obj)
 
     content = input_format.parse(content)
     if type(content) is dict:

--- a/cli/waiter/data_format.py
+++ b/cli/waiter/data_format.py
@@ -164,10 +164,10 @@ def load_data(options):
         context_file = options.get('context_file')
         if context_file:
             context_provided = True
-            logging.debug(f'reading context as yaml from {context_file}')
+            logging.debug(f'reading context from {context_file}')
             context_content = load_file(context_file)
             if not context_content:
-                raise Exception(f'Unable to load yaml from {context_file}.')
+                raise Exception(f'Unable to load context from {context_file}.')
 
             context_file_obj = YAML.parse(context_content)
             if not isinstance(context_file_obj, dict):

--- a/cli/waiter/data_format.py
+++ b/cli/waiter/data_format.py
@@ -1,7 +1,7 @@
-import jinja2
 import json
 import logging
 import os
+import string
 import sys
 
 import yaml
@@ -170,9 +170,9 @@ def load_data(options):
             if not isinstance(context_obj, dict):
                 raise Exception(f'Provided context file must evaluate to a dictionary, instead it is {context_obj}')
 
-            logging.debug(f'applying jinja templating to input using context {context_obj}')
-            jinja_template = jinja2.Template(content)
-            content = jinja_template.render(**context_obj)
+            logging.debug(f'applying string templating to input using context {context_obj}')
+            string_template = string.Template(content)
+            content = string_template.substitute(context_obj)
 
     content = input_format.parse(content)
     if type(content) is dict:

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -200,8 +200,8 @@ def add_arguments(parser):
     format_group.add_argument('--yaml', help='provide the data in a YAML file', dest='yaml')
     format_group.add_argument('--input', help='provide the data in a JSON/YAML file', dest='input')
     parser.add_argument('--context', dest='context',
-                        help='can be used only when a JSON or YAML data file has been provided; '
-                             'this YAML file provides the context variables used '
+                        help='can be used only when a data file has been provided via --input, --json, or --yaml; '
+                             'this JSON/YAML file provides the context variables used '
                              'to render the data file as a template')
     add_override_flags(parser)
 

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -109,15 +109,20 @@ def create_or_update_token(clusters, args, _, enforce_cluster, action):
     json_file = args.pop('json', None)
     yaml_file = args.pop('yaml', None)
     input_file = args.pop('input', None)
+    context_file = args.pop('context', None)
     admin_mode = args.pop('admin', None)
     allow_override = args.pop('override', False)
 
     if input_file or json_file or yaml_file:
-        token_fields_from_json = load_data({'data': input_file,
+        token_fields_from_json = load_data({'context': context_file,
+                                            'data': input_file,
                                             'json': json_file,
                                             'yaml': yaml_file})
         fields_from_args_only = False
     else:
+        if context_file:
+            raise Exception('The --context file can only be used when a data file is specified via '
+                            '--input, --json, or --yaml.')
         token_fields_from_json = {}
         fields_from_args_only = True
 
@@ -177,6 +182,10 @@ def add_arguments(parser):
     format_group.add_argument('--json', help='provide the data in a JSON file', dest='json')
     format_group.add_argument('--yaml', help='provide the data in a YAML file', dest='yaml')
     format_group.add_argument('--input', help='provide the data in a JSON/YAML file', dest='input')
+    parser.add_argument('--context', dest='context',
+                        help='can be used only when a JSON or YAML data file has been provided; '
+                             'this YAML file provides the context variables used '
+                             'to render the data file as a Jinja template')
     add_override_flags(parser)
 
 

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -185,7 +185,7 @@ def add_arguments(parser):
     parser.add_argument('--context', dest='context',
                         help='can be used only when a JSON or YAML data file has been provided; '
                              'this YAML file provides the context variables used '
-                             'to render the data file as a Jinja template')
+                             'to render the data file as a template')
     add_override_flags(parser)
 
 


### PR DESCRIPTION
## Changes proposed in this PR

- adds templating with variable substitution support to input file

## Why are we making these changes?

Templating simplifies the management of multiple tokens that differ in certain values but otherwise share a common template. Such tokens want to have different names, which is why they cannot be treated as parameterized services. 

We limit the support to variable substitution and intentionally avoid full-fledged Jinja templating support, e.g. conditional and looping, to provide a simple interface to users. In addition, the simple substitution scheme ensures that all tokens managed by a common template always have the same shape.

### Example output:
```
$ cat template.json 
{"mem": 1024, "cmd":"/opt/bin/run-service ${version} ${name} $${WAITER_CLUSTER}", "token":"my-token"}

$ cat context.json 
{"version": "f1137960-aa23-488f-aff4-66ba6a744882"}

$ waiter create --context context.json --env.FOO bar 
The --context file can only be used when a data file is specified via --input, --json, or --yaml.

$ waiter create --env.FOO bar --context.name john.doe
The --context.xyz overrides can only be used when a data file is specified via --input, --json, or --yaml.

$ waiter create --input template.json --context invalid.json --env.FOO bar --context.name john.doe
Unable to load yaml from invalid.json.

$ waiter create --input template.json --context context.json --env.FOO bar
Error when processing template: missing variable 'name'

$ waiter create --input template.json --context context.json --env.FOO bar --context.name john.doe
Attempting to create token on WAITER1...
Successfully created my-token.

$ curl -s 'http://localhost:9091/token?token=my-token' | jq -rS .
{
  "cmd": "/opt/bin/run-service f1137960-aa23-488f-aff4-66ba6a744882 john.doe ${WAITER_CLUSTER}",
  "env": {
    "FOO": "bar"
  },
  "mem": 1024,
  "owner": "shamsimam"
}
```
