### PR TITLE
adds support for nested filters in list services and tokens

### DIFF
--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -315,11 +315,19 @@
 (defn query-params->service-description-filter-predicate
   "Creates the filter function for service descriptions that matches every parameter provided in the request-params map."
   [request-params]
-  (let [service-description-params (select-keys request-params sd/service-parameter-keys)
+  (let [service-description-params (utils/filterm
+                                     (fn [[param-name _]]
+                                       (->> (str/split param-name #"\.")
+                                         (first)
+                                         (contains? sd/service-parameter-keys)))
+                                     request-params)
         param-predicates (map (fn [[param-name param-value]]
                                 (let [param-predicate (param-value->filter-fn param-value)]
                                   (fn [service-description]
-                                    (param-predicate (str (get service-description param-name))))))
+                                    (->> (str/split param-name #"\.")
+                                      (get-in service-description)
+                                      (str)
+                                      (param-predicate)))))
                               (seq service-description-params))]
     (fn [service-description]
       (or (empty? param-predicates)

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -765,14 +765,16 @@
                           :else (list-token-owners kv-store))
                  filterable-parameter? (disj sd/token-data-keys "owner" "maintenance")
                  parameter-filter-predicates (for [[parameter-name raw-param] request-params
-                                                   :when (filterable-parameter? parameter-name)]
+                                                   :let [param-name-components (str/split parameter-name #"\.")
+                                                         param-name-head (first param-name-components)]
+                                                   :when (filterable-parameter? param-name-head)]
                                                (let [search-parameter-values (cond
                                                                                (string? raw-param) #{raw-param}
                                                                                :else (set raw-param))]
                                                  (fn [token-parameters]
-                                                   (and (contains? token-parameters parameter-name)
+                                                   (and (contains? token-parameters param-name-head)
                                                         (contains? search-parameter-values
-                                                                   (str (get token-parameters parameter-name)))))))
+                                                                   (str (get-in token-parameters param-name-components)))))))
                  index-filter-fn
                  (every-pred
                    (fn list-tokens-delete-predicate [entry]


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for nested filters in list services and tokens

## Why are we making these changes?

Allows querying for services and tokens by nested parameters, like `env` and `metadata`.

