### PR TITLE
Support running Waiter in a single Kubernetes namespace

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -535,6 +535,10 @@
                                  ;; Maximum number of characters allowed for a Kubernetes object name:
                                  :max-name-length 63
 
+                                 ;; Target Kubernetes namespace for all Waiter-managed objects.
+                                 ;; When nil, Waiter operates at the global scope with access to all namespaces.
+                                 :namespace nil
+
                                  ;; Port number used to set the $PORT0 (service port) for Waiter service instances.
                                  ;; Waiter generates a random offset in the range [0, 990] each time it creates a service,
                                  ;; adding that offset to the pod-base-port value to get that Waiter service's $PORT0 value.

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -713,6 +713,7 @@
                                 http-client
                                 leader?-fn
                                 log-bucket-url
+                                namespace
                                 max-patch-retries
                                 max-name-length
                                 pdb-api-version
@@ -991,7 +992,8 @@
 (defn default-replicaset-builder
   "Factory function which creates a Kubernetes ReplicaSet spec for the given Waiter Service."
   [{:keys [cluster-name fileserver pod-base-port pod-sigkill-delay-secs
-           replicaset-api-version reverse-proxy service-id->password-fn] :as scheduler}
+           replicaset-api-version reverse-proxy service-id->password-fn]
+    scheduler-namespace :namespace :as scheduler}
    service-id
    {:strs [backend-proto cmd cpus grace-period-secs health-check-authentication health-check-interval-secs
            health-check-max-consecutive-failures health-check-port-index health-check-proto image
@@ -1001,7 +1003,7 @@
     :as context}]
   (when-not (or image default-container-image)
     (throw (ex-info "Waiter configuration is missing a default image for Kubernetes pods" {})))
-  (when-not (or namespace default-namespace)
+  (when-not (or namespace default-namespace scheduler-namespace)
     (throw (ex-info "Waiter configuration is missing a default namespace for Kubernetes pods" {})))
   (let [work-path (str "/home/" run-as-user)
         home-path (str work-path "/latest")
@@ -1064,7 +1066,7 @@
                            :waiter/service-hash service-hash
                            :waiter/user run-as-user}
                   :name k8s-name
-                  :namespace (or namespace default-namespace)}
+                  :namespace (or namespace default-namespace scheduler-namespace)}
        :spec {:replicas min-instances
               :selector {:matchLabels {:app k8s-name
                                        :waiter/user run-as-user}}
@@ -1258,6 +1260,7 @@
     (Thread.
       (fn k8s-watch []
         (try
+          (log/info "starting" resource-name "watch at" resource-url)
           ;; retry getting state updates forever
           (while true
             (retry-watch-runner
@@ -1313,14 +1316,16 @@
 
 (defn start-pods-watch!
   "Start a thread to continuously update the watch-state atom based on watched Pod events."
-  [{:keys [api-server-url cluster-name watch-state] :as scheduler} options]
+  [{:keys [api-server-url cluster-name namespace watch-state] :as scheduler} options]
   (start-k8s-watch!
     scheduler
     (->
       {:query-fn global-pods-state-query
        :resource-key :service-id->pod-id->pod
        :resource-name "Pods"
-       :resource-url (str api-server-url "/api/v1/pods?labelSelector=waiter%2Fcluster=" cluster-name)
+       :resource-url (str api-server-url "/api/v1"
+                          (when namespace (str "/namespaces/" namespace))
+                          "/pods?labelSelector=waiter%2Fcluster=" cluster-name)
        :metadata-key :pods-metadata
        :update-fn (fn pods-watch-update [{pod :object update-type :type}]
                     (let [now (t/now)
@@ -1356,7 +1361,7 @@
 
 (defn start-replicasets-watch!
   "Start a thread to continuously update the watch-state atom based on watched ReplicaSet events."
-  [{:keys [api-server-url cluster-name replicaset-api-version watch-state] :as scheduler} options]
+  [{:keys [api-server-url cluster-name namespace replicaset-api-version watch-state] :as scheduler} options]
   (start-k8s-watch!
     scheduler
     (->
@@ -1364,6 +1369,7 @@
        :resource-key :service-id->service
        :resource-name "ReplicaSets"
        :resource-url (str api-server-url "/apis/" replicaset-api-version
+                          (when namespace (str "/namespaces/" namespace))
                           "/replicasets?labelSelector=waiter%2Fcluster="
                           cluster-name)
        :metadata-key :rs-metadata
@@ -1415,7 +1421,7 @@
   "Returns a new KubernetesScheduler with the provided configuration. Validates the
    configuration against kubernetes-scheduler-schema and throws if it's not valid."
   [{:keys [authentication authorizer cluster-name container-running-grace-secs custom-options http-options leader?-fn log-bucket-sync-secs
-           log-bucket-url max-patch-retries max-name-length pdb-api-version pdb-spec-builder pod-base-port pod-sigkill-delay-secs
+           log-bucket-url max-patch-retries max-name-length namespace pdb-api-version pdb-spec-builder pod-base-port pod-sigkill-delay-secs
            pod-suffix-length replicaset-api-version replicaset-spec-builder response->deployment-error-msg-fn restart-expiry-threshold restart-kill-threshold
            reverse-proxy scheduler-name scheduler-state-chan scheduler-syncer-interval-secs service-id->service-description-fn
            service-id->password-fn start-scheduler-syncer-fn url watch-connect-timeout-ms watch-init-timeout-ms watch-retries watch-socket-timeout-ms]
@@ -1440,6 +1446,7 @@
          (utils/non-neg-int? max-patch-retries)
          (pos-int? max-name-length)
          (not (str/blank? cluster-name))
+         (or (nil? namespace) (not (str/blank? namespace)))
          (or (nil? pdb-api-version) (not (str/blank? pdb-api-version)))
          (or (nil? pdb-spec-builder) (symbol? (:factory-fn pdb-spec-builder)))
          (integer? pod-base-port)
@@ -1535,6 +1542,7 @@
                             :log-bucket-url log-bucket-url
                             :max-patch-retries max-patch-retries
                             :max-name-length max-name-length
+                            :namespace namespace
                             :pdb-api-version pdb-api-version
                             :pdb-spec-builder-fn pdb-spec-builder-fn
                             :pod-base-port pod-base-port

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -404,7 +404,20 @@
                                               {:service-id->service-description-fn (constantly service-description)})
               replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler service-id service-description)]
           (is (nil? (scheduler/validate-service scheduler service-id)))
-          (is (= target-namespace (get-in replicaset-spec [:metadata :namespace]))))))))
+          (is (= target-namespace (get-in replicaset-spec [:metadata :namespace])))))
+      (testing "Custom namespace matches scheduler namespace"
+        (let [target-namespace "myself"
+              service-description (assoc dummy-service-description "namespace" target-namespace)
+              scheduler (make-dummy-scheduler [service-id] {:namespace target-namespace})
+              replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler service-id service-description)]
+          (is (nil? (scheduler/validate-service scheduler service-id)))
+          (is (= target-namespace (get-in replicaset-spec [:metadata :namespace])))))
+      (testing "Custom namespace does not match scheduler namespace"
+        (let [target-namespace "myself"
+              service-description (assoc dummy-service-description "namespace" target-namespace)
+              scheduler (make-dummy-scheduler [service-id] {:namespace (str "x" target-namespace)})]
+          (is (thrown-with-msg? RuntimeException #"service namespace does not match scheduler namespace"
+              ((:replicaset-spec-builder-fn scheduler) scheduler service-id service-description))))))))
 
 (deftest test-replicaset-spec-no-image
   (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")
@@ -1532,6 +1545,14 @@
             (is (thrown? Throwable (kubernetes-scheduler (dissoc base-config :response->deployment-error-msg-fn))))
             (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :response->deployment-error-msg-fn 1))))
             (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :response->deployment-error-msg-fn "string")))))
+
+          (testing "bad (non-matching) scheduler namespace and default-namespace"
+            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :default-namespace "x" :namespace "y")))))
+
+          (testing "good (non-conflicting) scheduler namespace and default-namespace"
+            (is (instance? KubernetesScheduler (kubernetes-scheduler (assoc base-config :namespace "y"))))
+            (is (instance? KubernetesScheduler (kubernetes-scheduler (assoc base-config :default-namespace "x"))))
+            (is (instance? KubernetesScheduler (kubernetes-scheduler (assoc base-config :default-namespace "x" :namespace "x")))))
 
           (testing "bad service-id->deployment-error-cache-threshold"
             (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :service-id->deployment-error-cache {:threshold 1}))))


### PR DESCRIPTION
## Changes proposed in this PR

Support running Waiter in a single Kubernetes namespace.

## Why are we making these changes?

Using a single namespace is useful for users who want to start a Waiter cluster for development purposes, but don't have permissions to access the global (all-namespace) k8s api endpoints.