### PR TITLE
Fix CLI parsing non string values for "env" and "metadata" fields

### DIFF
--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1213,6 +1213,21 @@ class WaiterCliTest(util.WaiterTest):
         finally:
             util.delete_token(self.waiter_url, token_name)
 
+    def test_create_env_metadata_are_parsed_as_strings(self):
+        token_name = self.token_name()
+        try:
+            create_flags = f'{token_name} --metadata.foo true --env.KEY_2 true --env.KEY_3 false'
+            cp = cli.create(self.waiter_url, flags='--verbose', create_flags=create_flags)
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            token_data = util.load_token(self.waiter_url, token_name)
+            self.assertEqual({'KEY_2': 'true',
+                              'KEY_3': 'false'},
+                             token_data['env'])
+            self.assertEqual({'foo': 'true'},
+                             token_data['metadata'])
+        finally:
+            util.delete_token(self.waiter_url, token_name)
+
     def __test_create_nested_args_parameter_override_success(self, file_format, create_existing_token=False):
         token_name = self.token_name()
         create_doc = {'token': token_name,

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1216,14 +1216,14 @@ class WaiterCliTest(util.WaiterTest):
     def test_create_env_metadata_are_parsed_as_strings(self):
         token_name = self.token_name()
         try:
-            create_flags = f'{token_name} --metadata.foo true --env.KEY_2 true --env.KEY_3 false'
+            create_flags = f'{token_name} --metadata.instances 5 --env.KEY_2 true --env.KEY_3 false'
             cp = cli.create(self.waiter_url, flags='--verbose', create_flags=create_flags)
             self.assertEqual(0, cp.returncode, cp.stderr)
             token_data = util.load_token(self.waiter_url, token_name)
             self.assertEqual({'KEY_2': 'true',
                               'KEY_3': 'false'},
                              token_data['env'])
-            self.assertEqual({'foo': 'true'},
+            self.assertEqual({'instances': '5'},
                              token_data['metadata'])
         finally:
             util.delete_token(self.waiter_url, token_name)

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -14,6 +14,7 @@ from waiter.util import deep_merge, FALSE_STRINGS, is_admin_enabled, print_info,
 BOOL_STRINGS = TRUE_STRINGS + FALSE_STRINGS
 INT_PARAM_SUFFIXES = ['-failures', '-index', '-instances', '-length', '-level', '-mins', '-secs']
 FLOAT_PARAM_SUFFIXES = ['-factor', '-rate', '-threshold']
+STRING_PARAM_PREFIXES = ['env', 'metadata']
 
 
 class Action(Enum):
@@ -142,6 +143,7 @@ def create_or_update_token(clusters, args, _, enforce_cluster, action):
                             '--input, --json, or --yaml.')
         token_fields_from_json = {}
         fields_from_args_only = True
+    print(args)
 
     token_fields_from_args = args
     overrides = get_overrides(token_fields_from_json, token_fields_from_args)
@@ -152,7 +154,7 @@ def create_or_update_token(clusters, args, _, enforce_cluster, action):
                             f'without specifying the --override flag.')
         else:
             logging.debug(f'Following parameters have specified values in both file and flags: {overrides}')
-
+    print(token_fields_from_args)
     token_fields = merge_token_fields_from_args(token_fields_from_json, token_fields_from_args)
     token_name_from_json = token_fields.pop('token', None)
     if token_name_from_args and token_name_from_json:
@@ -272,12 +274,15 @@ def add_implicit_arguments(unknown_args, parser):
     for i in range(num_unknown_args):
         arg = unknown_args[i]
         if arg.startswith(("-", "--")):
+            arg_dest = arg.lstrip('-')
             if any(arg.endswith(suffix) for suffix in INT_PARAM_SUFFIXES):
                 arg_type = possible_int
             elif any(arg.endswith(suffix) for suffix in FLOAT_PARAM_SUFFIXES):
                 arg_type = possible_float
+            elif any(arg_dest.startswith(prefix) for prefix in STRING_PARAM_PREFIXES):
+                arg_type = None
             elif (i + 1) < num_unknown_args and unknown_args[i + 1].lower() in BOOL_STRINGS:
                 arg_type = str2bool
             else:
                 arg_type = None
-            parser.add_argument(arg, dest=arg.lstrip('-'), type=arg_type)
+            parser.add_argument(arg, dest=arg_dest, type=arg_type)

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -273,12 +273,12 @@ def add_implicit_arguments(unknown_args, parser):
         arg = unknown_args[i]
         if arg.startswith(("-", "--")):
             arg_dest = arg.lstrip('-')
-            if any(arg.endswith(suffix) for suffix in INT_PARAM_SUFFIXES):
+            if any(arg_dest.startswith(prefix) for prefix in STRING_PARAM_PREFIXES):
+                arg_type = None
+            elif any(arg.endswith(suffix) for suffix in INT_PARAM_SUFFIXES):
                 arg_type = possible_int
             elif any(arg.endswith(suffix) for suffix in FLOAT_PARAM_SUFFIXES):
                 arg_type = possible_float
-            elif any(arg_dest.startswith(prefix) for prefix in STRING_PARAM_PREFIXES):
-                arg_type = None
             elif (i + 1) < num_unknown_args and unknown_args[i + 1].lower() in BOOL_STRINGS:
                 arg_type = str2bool
             else:

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -143,7 +143,6 @@ def create_or_update_token(clusters, args, _, enforce_cluster, action):
                             '--input, --json, or --yaml.')
         token_fields_from_json = {}
         fields_from_args_only = True
-    print(args)
 
     token_fields_from_args = args
     overrides = get_overrides(token_fields_from_json, token_fields_from_args)
@@ -154,7 +153,6 @@ def create_or_update_token(clusters, args, _, enforce_cluster, action):
                             f'without specifying the --override flag.')
         else:
             logging.debug(f'Following parameters have specified values in both file and flags: {overrides}')
-    print(token_fields_from_args)
     token_fields = merge_token_fields_from_args(token_fields_from_json, token_fields_from_args)
     token_name_from_json = token_fields.pop('token', None)
     if token_name_from_args and token_name_from_json:


### PR DESCRIPTION
## Changes proposed in this PR

- fixes improper parsing of env and metadata fields as non strings

## Why are we making these changes?

- by setting these fields to a boolean value like "true", the CLI command would fail:
```
$ waiter create --cpus 0.1 --mem 1024 --name testing --env.example "true" --metadata.example "true" kitchen.localtest.me
Attempting to create token on WAITER1...
Service description using waiter headers/token improperly configured
The following metadata keys did not have string values: example: true. Metadata values must be strings.
```
