### PR TITLE
propagate k8s watch changes promptly to scheduler state

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -902,11 +902,10 @@
                                                    (scheduler/available? service-id->password-fn* http-client
                                                                          scheduler-name service-instance service-description))]
                                   (fn start-scheduler-syncer-fn
-                                    [scheduler-name get-service->instances-fn scheduler-state-chan scheduler-syncer-interval-secs]
-                                    (let [timer-ch (-> scheduler-syncer-interval-secs t/seconds t/in-millis au/timer-chan)]
-                                      (scheduler/start-scheduler-syncer
-                                        clock timer-ch service-id->service-description-fn* available?
-                                        failed-check-threshold scheduler-name get-service->instances-fn scheduler-state-chan)))))})
+                                    [scheduler-name get-service->instances-fn scheduler-state-chan trigger-chan]
+                                    (scheduler/start-scheduler-syncer
+                                      clock trigger-chan service-id->service-description-fn* available?
+                                      failed-check-threshold scheduler-name get-service->instances-fn scheduler-state-chan))))})
 
 (def routines
   {:allowed-to-manage-service?-fn (pc/fnk [[:state entitlement-manager kv-store]]

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -558,8 +558,9 @@
         service-id->failed-instances-transient-store (atom {})
         get-service->instances-fn
         #(get-service->instances cook-api allowed-users search-interval service-id->failed-instances-transient-store)
+        syncer-trigger-chan (scheduler/scheduler-syncer-timer-chan scheduler-syncer-interval-secs)
         {:keys [retrieve-syncer-state-fn]}
-        (start-scheduler-syncer-fn scheduler-name get-service->instances-fn scheduler-state-chan scheduler-syncer-interval-secs)
+        (start-scheduler-syncer-fn scheduler-name get-service->instances-fn scheduler-state-chan syncer-trigger-chan)
         scheduler (create-cook-scheduler config cook-api service-id->failed-instances-transient-store retrieve-syncer-state-fn)]
     (start-track-failed-instances service-id->failed-instances-transient-store scheduler failed-tracker-interval-ms)
     scheduler))

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -1507,11 +1507,12 @@
                                       (do
                                         (log/warn "scheduler instance has not yet been initialized")
                                         {})))
+        syncer-trigger-chan (scheduler/scheduler-syncer-timer-chan scheduler-syncer-interval-secs)
         {:keys [retrieve-syncer-state-fn]} (start-scheduler-syncer-fn
                                              scheduler-name
                                              get-service->instances-fn
                                              scheduler-state-chan
-                                             scheduler-syncer-interval-secs)
+                                             syncer-trigger-chan)
         fileserver (update fileserver :predicate-fn (fn [predicate-fn]
                                                       (if (nil? predicate-fn)
                                                         fileserver-container-enabled?

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -648,8 +648,9 @@
         get-service->instances-fn
         #(get-service->instances marathon-api mesos-api is-waiter-service?-fn retrieve-framework-id-fn
                                  service-id->failed-instances-transient-store)
+        syncer-trigger-chan (scheduler/scheduler-syncer-timer-chan scheduler-syncer-interval-secs)
         {:keys [retrieve-syncer-state-fn]}
-        (start-scheduler-syncer-fn scheduler-name get-service->instances-fn scheduler-state-chan scheduler-syncer-interval-secs)
+        (start-scheduler-syncer-fn scheduler-name get-service->instances-fn scheduler-state-chan syncer-trigger-chan)
         marathon-descriptor-builder-fn (let [f (-> marathon-descriptor-builder
                                                    :factory-fn
                                                    utils/resolve-symbol

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -853,8 +853,9 @@
          (fn? start-scheduler-syncer-fn)]}
   (let [id->service-agent (agent {})
         get-service->instances-fn #(get-service->instances id->service-agent)
+        syncer-trigger-chan (scheduler/scheduler-syncer-timer-chan scheduler-syncer-interval-secs)
         {:keys [retrieve-syncer-state-fn]}
-        (start-scheduler-syncer-fn scheduler-name get-service->instances-fn scheduler-state-chan scheduler-syncer-interval-secs)
+        (start-scheduler-syncer-fn scheduler-name get-service->instances-fn scheduler-state-chan syncer-trigger-chan)
         {:keys [id->service-agent port->reservation-atom work-directory] :as scheduler}
         (create-shell-scheduler (assoc config
                                   :id->service-agent id->service-agent


### PR DESCRIPTION
## Changes proposed in this PR

- moves responsibility of creating syncer trigger chans to the schedule… …
- adds support to throttle rate of receiving messages on channel channel
- adds triggers from watch state updates in k8s scheduler

## Why are we making these changes?

Changing from polling (every few seconds with the timer chan) to push updates based on the k8s watch triggers reduces the latency in Waiter picking up information about new service instances. This mean state changes are propagated much quicker to other Waiter components including queued requests being services quicker when new instances become available.


### Example logs 

Displaying that the scheduler syncer is being triggered irregularly and more frequently than every 5 seconds:
```
$ grep 'scheduler-syncer: kubernetes sync' log/waiter.log | tail -n 10
2021-07-06 15:55:16,864 INFO  waiter.scheduler [async-dispatch-19] -  scheduler-syncer: kubernetes sync took 24 ms for 7 services.
2021-07-06 15:55:16,964 INFO  waiter.scheduler [async-dispatch-15] -  scheduler-syncer: kubernetes sync took 24 ms for 7 services.
2021-07-06 15:55:20,161 INFO  waiter.scheduler [async-dispatch-1] -  scheduler-syncer: kubernetes sync took 24 ms for 7 services.
2021-07-06 15:55:23,224 INFO  waiter.scheduler [async-dispatch-39] -  scheduler-syncer: kubernetes sync took 24 ms for 8 services.
2021-07-06 15:55:23,550 INFO  waiter.scheduler [async-dispatch-50] -  scheduler-syncer: kubernetes sync took 24 ms for 8 services.
2021-07-06 15:55:23,650 INFO  waiter.scheduler [async-dispatch-35] -  scheduler-syncer: kubernetes sync took 24 ms for 8 services.
2021-07-06 15:55:25,166 INFO  waiter.scheduler [async-dispatch-46] -  scheduler-syncer: kubernetes sync took 29 ms for 8 services.
2021-07-06 15:55:25,296 INFO  waiter.scheduler [async-dispatch-53] -  scheduler-syncer: kubernetes sync took 57 ms for 8 services.
2021-07-06 15:55:26,596 INFO  waiter.scheduler [async-dispatch-53] -  scheduler-syncer: kubernetes sync took 47 ms for 8 services.
2021-07-06 15:55:27,636 INFO  waiter.scheduler [async-dispatch-1] -  scheduler-syncer: kubernetes sync took 48 ms for 8 services.
```
