### PR TITLE
requires strict oidc mode when using scoped tokens

### DIFF
--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -713,7 +713,18 @@
     ; validate the profile when it is configured
     (let [{:strs [profile]} service-description-to-use]
       (when-not (str/blank? profile)
-        (validate-profile-parameter profile->defaults profile)))))
+        (validate-profile-parameter profile->defaults profile)))
+
+    ; validate scoped tokens must use strict mode
+    (let [{:strs [env metadata]} service-description-to-use
+          accept-scope? (= "true" (get metadata "accept-scoped-token"))
+          strict-mode? (= "strict" (get env "USE_OIDC_AUTH"))]
+      (when (and accept-scope? (not strict-mode?))
+        (sling/throw+ {:type :service-description-error
+                       :friendly-error-message (str "scoped tokens must be used with strict OIDC auth mode, "
+                                                    "please configure env.USE_OIDC_AUTH=strict")
+                       :status http-400-bad-request
+                       :log-level :warn})))))
 
 (defprotocol ServiceDescriptionBuilder
   "A protocol for constructing a service description from the various sources. Implementations

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -2241,7 +2241,15 @@
       (doseq [termination-grace-period-secs [900 "5" -1]]
         (run-validate-schema-test
           (assoc valid-description "termination-grace-period-secs" termination-grace-period-secs)
-          constraints-schema profile->defaults config "termination-grace-period-secs must be an integer in the range [0, 300].")))))
+          constraints-schema profile->defaults config "termination-grace-period-secs must be an integer in the range [0, 300].")))
+
+    (testing "testing OIDC auth strict mode with accepting scoped tokens"
+      (doseq [oidc-auth-mode ["relaxed" "true"]]
+        (run-validate-schema-test
+          (-> valid-description
+            (assoc-in ["env" "USE_OIDC_AUTH"] oidc-auth-mode)
+            (assoc-in ["metadata" "accept-scoped-token"] "true"))
+          constraints-schema profile->defaults config "scoped tokens must be used with strict OIDC auth mode, please configure env.USE_OIDC_AUTH=strict")))))
 
 (deftest test-service-description-schema
   (testing "Service description schema"


### PR DESCRIPTION
## Changes proposed in this PR

- requires strict oidc mode when using scoped tokens

## Why are we making these changes?

When using the relaxed mode, scoped tokens may be invalid when used past their expiry time. Instead, with strict mode, such a scenario cannot occur and hence scoped token are passed along to the backend only when they are valid.

