### PR TITLE
adds write-through behavior for cached kv-store

### DIFF
--- a/waiter/src/waiter/kv.clj
+++ b/waiter/src/waiter/kv.clj
@@ -252,7 +252,9 @@
     (cu/cache-get-or-load cache key #(retrieve inner-kv-store key refresh)))
   (store [_ key value]
     (cu/cache-evict cache key)
-    (store inner-kv-store key value))
+    (let [result (store inner-kv-store key value)]
+      (cu/cache-put! cache key value)
+      result))
   (delete [_ key]
     (log/info "evicting deleted entry" key "from cache")
     (cu/cache-evict cache key)


### PR DESCRIPTION
## Changes proposed in this PR

- adds write-through behavior for cached kv-store

## Why are we making these changes?

There can be a race when we perform a read immediately after a write. If the write has not made its way to the underlying write store, the read from the underlying store will come back with empty/stale data. This can be avoided by using write-through behavior in our cache.
