### PR TITLE
makes the cluster metadata token parameter user-editable

### DIFF
--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -151,6 +151,11 @@ def post_token(waiter_url, token_name, token_definition, assert_response=True,
             expected_status_code == response.status_code, \
             f'Expected {expected_status_code}, got {response.status_code} with body {response.text}'
         fetched_token = load_token(waiter_url, token_name, params={})
+        cluster_name = retrieve_waiter_cluster_name(waiter_url)
+        assert \
+            cluster_name == fetched_token['cluster'], \
+            f'Expected cluster {cluster_name}, got {fetched_token["cluster"]}'
+        del fetched_token['cluster']
         del fetched_token['owner']
         if 'cluster' in token_definition:
             del token_definition['cluster']

--- a/token-syncer/src/token_syncer/main.clj
+++ b/token-syncer/src/token_syncer/main.clj
@@ -63,6 +63,7 @@
                             {:status "dry-run"})
                           (partial waiter/hard-delete-token api-http-client))
      :health-check-token (partial waiter/health-check-token health-check-http-client)
+     :load-settings (partial waiter/load-settings api-http-client)
      :load-token (partial waiter/load-token api-http-client)
      :load-token-list (partial waiter/load-token-list api-http-client)
      :store-token (if dry-run

--- a/token-syncer/src/token_syncer/waiter.clj
+++ b/token-syncer/src/token_syncer/waiter.clj
@@ -220,3 +220,12 @@
                  :deleted deleted
                  :health-check-url health-check-url
                  :token token}))))
+
+(defn load-settings
+  "Loads the waiter settings for provided keys on a specific cluster."
+  [^HttpClient http-client waiter-url settings-keys]
+  (-> (make-http-request http-client (str waiter-url "/settings") :headers {"accept" "application/json"})
+    (:body)
+    (async/<!!)
+    (json/read-str)
+    (get-in settings-keys)))

--- a/waiter/config-shell.edn
+++ b/waiter/config-shell.edn
@@ -34,4 +34,9 @@
  :cors-config {:kind :allow-all}
 
  ;; Require fewer failed health checks
- :health-check-config {:failed-check-threshold 2}}
+ :health-check-config {:failed-check-threshold 2}
+
+ ; ---------- Miscellaneous ----------
+ :token-config {:cluster-calculator {:kind :configured
+                                     :configured {:factory-fn waiter.token/new-configured-cluster-calculator
+                                                  :host->cluster {"127.0.0.1" "localhost"}}}}}

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -114,7 +114,8 @@
    s/Str s/Any})
 
 (def user-metadata-schema
-  {(s/optional-key "cors-rules") [{(s/required-key "origin-regex") schema/regex-pattern
+  {(s/optional-key "cluster") schema/non-empty-string
+   (s/optional-key "cors-rules") [{(s/required-key "origin-regex") schema/regex-pattern
                                    (s/optional-key "target-path-regex") schema/regex-pattern
                                    (s/optional-key "methods") (s/both (s/pred not-empty) [schema/http-method])}]
    (s/optional-key "editor") schema/non-empty-string
@@ -160,10 +161,10 @@
 (def ^:const on-the-fly-service-description-keys (set/union service-parameter-keys #{"token"}))
 
 ; keys allowed in system metadata for tokens, these need to be distinct from service description keys
-(def ^:const system-metadata-keys #{"cluster" "deleted" "last-update-time" "last-update-user" "previous" "root"})
+(def ^:const system-metadata-keys #{"deleted" "last-update-time" "last-update-user" "previous" "root"})
 
 ; keys allowed in user metadata for tokens, these need to be distinct from service description keys
-(def ^:const user-metadata-keys #{"cors-rules" "editor" "fallback-period-secs" "https-redirect" "maintenance" "owner" "service-mapping" "stale-timeout-mins"})
+(def ^:const user-metadata-keys #{"cluster" "cors-rules" "editor" "fallback-period-secs" "https-redirect" "maintenance" "owner" "service-mapping" "stale-timeout-mins"})
 
 ; keys allowed in metadata for tokens, these need to be distinct from service description keys
 (def ^:const token-metadata-keys (set/union system-metadata-keys user-metadata-keys))

--- a/waiter/src/waiter/token_validator.clj
+++ b/waiter/src/waiter/token_validator.clj
@@ -24,7 +24,7 @@
 
   (validate [_ {:keys [authenticated-user existing-token-metadata headers new-service-parameter-template new-token-data
                        new-token-metadata new-user-metadata owner service-parameter-with-service-defaults token update-mode
-                       validate-service-description-fn version-hash waiter-hostnames]}]
+                       validate-cluster-fn validate-service-description-fn version-hash waiter-hostnames]}]
     (let [{:strs [authentication interstitial-secs permitted-user run-as-user]} new-service-parameter-template]
       (when (str/blank? token)
         (throw (ex-info "Must provide the token" {:status http-400-bad-request :log-level :warn})))
@@ -35,6 +35,8 @@
       (sd/validate-token token)
       (validate-service-description-fn new-service-parameter-template)
       (sd/validate-user-metadata-schema new-user-metadata new-service-parameter-template)
+      (when-let [cluster (get new-token-metadata "cluster")]
+        (validate-cluster-fn cluster))
       (let [unknown-keys (-> new-token-data
                              keys
                              set


### PR DESCRIPTION
## Changes proposed in this PR

- makes the cluster metadata token parameter user-editable

## Why are we making these changes?

Allows service owners to explicitly configure their token cluster rather than relying on the Waiter API to choose the cluster for them.

