### PR TITLE
Add protocol to async request parameters

### DIFF
--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -105,15 +105,16 @@
   "Helper function for async status/result handlers."
   [counter-name make-http-request-fn service-id->service-description-fn
    {:keys [route-params uri] :as request}]
-  (let [{:keys [host location port request-id router-id service-id]} route-params]
+  (let [{:keys [host location port proto request-id router-id service-id]} route-params]
     (when-not (and host location port request-id router-id service-id)
       (throw (ex-info "Missing host, location, port, request-id, router-id or service-id in uri"
                       {:log-level :info :route-params route-params :status http-400-bad-request :uri uri})))
     (counters/inc! (metrics/service-counter service-id "request-counts" counter-name))
     (let [{:strs [backend-proto metric-group] :as service-description} (service-id->service-description-fn service-id)
+          request-proto (or proto backend-proto)
           instance (scheduler/make-ServiceInstance {:host host :port port :service-id service-id})
           _ (log/info request-id counter-name "relative location is" location)
-          response-chan (make-http-request-fn instance request location metric-group backend-proto)]
+          response-chan (make-http-request-fn instance request location metric-group request-proto)]
       (async/go
         (-> (async/<! response-chan)
           (assoc :descriptor {:service-description service-description
@@ -161,12 +162,12 @@
    {:keys [request-method route-params] :as request}]
   (async/go
     (try
-      (let [{:keys [host location port request-id router-id service-id]} route-params
+      (let [{:keys [host location port proto request-id router-id service-id]} route-params
             {:keys [error status] :as backend-response}
             (async/<! (async-make-http-request "async-status" make-http-request-fn service-id->service-description-fn request))]
         (when error (throw error))
-        (let [{:strs [backend-proto]} (service-id->service-description-fn service-id)
-              endpoint (scheduler/end-point-url backend-proto host port location)
+        (let [request-proto (or proto (-> service-id service-id->service-description-fn (get "backend-proto")))
+              endpoint (scheduler/end-point-url request-proto host port location)
               location-header (get-in backend-response [:headers "location"])
               location-url (async-req/normalize-location-header endpoint location-header)
               relative-location? (str/starts-with? (str location-url) "/")]
@@ -178,7 +179,8 @@
                              (= http-204-no-content status))))
             (async-trigger-terminate-fn router-id service-id request-id))
           (if (and (= request-method :get) (= http-303-see-other status) relative-location?)
-            (let [result-location (async-req/route-params->uri "/waiter-async/result/" (assoc route-params :location location-url))]
+            (let [result-params (assoc route-params :location location-url :proto proto)
+                  result-location (async-req/route-params->uri :result result-params)]
               (assoc-in backend-response [:headers "location"] result-location))
             backend-response)))
       (catch Exception ex

--- a/waiter/src/waiter/util/async_utils.clj
+++ b/waiter/src/waiter/util/async_utils.clj
@@ -22,6 +22,11 @@
   (:import (clojure.core.async.impl.channels ManyToManyChannel)
            (java.util.concurrent ExecutorService)))
 
+(defn singleton-chan [v]
+  "Creates a channel for returning the single value v."
+  (doto (async/chan 1)
+    (async/>!! v)))
+
 (defn sliding-buffer-chan [n]
   (async/chan (async/sliding-buffer n)))
 

--- a/waiter/src/waiter/util/async_utils.clj
+++ b/waiter/src/waiter/util/async_utils.clj
@@ -24,7 +24,7 @@
 
 (defn singleton-chan [v]
   "Creates a channel for returning the single value v."
-  (doto (async/chan 1)
+  (doto (async/promise-chan)
     (async/>!! v)))
 
 (defn sliding-buffer-chan [n]

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -187,11 +187,12 @@
 
 (defn try-parse-json
   "parses json and throws exception with the input string"
-  [s]
-  (try
-    (json/read-str s)
-    (catch Exception e
-      (throw (ex-info "Couldn't parse JSON" {:string s} e)))))
+  ([s] (try-parse-json s identity))
+  ([s key-fn]
+   (try
+     (json/read-str s :key-fn key-fn)
+     (catch Exception e
+       (throw (ex-info "Couldn't parse JSON" {:string s} e))))))
 
 (defn clj->json
   "Convert the input Clojure data structure into a json string."
@@ -234,6 +235,21 @@
                        (.flush writer)))))}
       (attach-waiter-namespace-keys data-map)
       (attach-waiter-source))))
+
+(let [b64-decoder (java.util.Base64/getUrlDecoder)]
+  (defn b64-url-json-decode [^String json-str]
+    "Decode a URL-safe Base64 JSON string into a Clojure data structure."
+    (-> (.decode b64-decoder json-str)
+        (String. java.nio.charset.StandardCharsets/UTF_8)
+        (try-parse-json keyword))))
+
+(let [b64-encoder (.withoutPadding (java.util.Base64/getUrlEncoder))]
+  (defn b64-url-json-encode [data]
+    "Encode a Clojure data structure as a JSON object in a URL-safe Base64 string."
+    (as-> data $
+      (clj->json $)
+      (.getBytes $ java.nio.charset.StandardCharsets/UTF_8)
+      (.encodeToString b64-encoder $))))
 
 (defn escape-html
   "Change special characters into HTML character entities to prevent XSS."

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -240,7 +240,7 @@
   (defn b64-url-json-decode [^String json-str]
     "Decode a URL-safe Base64 JSON string into a Clojure data structure."
     (-> (.decode b64-decoder json-str)
-        (String. java.nio.charset.StandardCharsets/UTF_8)
+        (String. StandardCharsets/UTF_8)
         (try-parse-json keyword))))
 
 (let [b64-encoder (.withoutPadding (java.util.Base64/getUrlEncoder))]
@@ -248,7 +248,7 @@
     "Encode a Clojure data structure as a JSON object in a URL-safe Base64 string."
     (as-> data $
       (clj->json $)
-      (.getBytes $ java.nio.charset.StandardCharsets/UTF_8)
+      (.getBytes $ StandardCharsets/UTF_8)
       (.encodeToString b64-encoder $))))
 
 (defn escape-html


### PR DESCRIPTION
## Changes proposed in this PR

Add request protocol to async request parameters.

## Why are we making these changes?

There is currently no way to determine the correct backend protocol for async requests when the backend is using a proxy with a different protocol from that in the service description. The async parameters should include *all* of the information to independently make the request on any router, which means we need the protocol.