### PR TITLE
Fix Flakey Integration tests for Instance Tracking

### DIFF
--- a/waiter/integration/waiter/instance_tracker_integration_test.clj
+++ b/waiter/integration/waiter/instance_tracker_integration_test.clj
@@ -216,7 +216,8 @@
       (testing "watch stream gets initial list of healthy instances that were created before watch started"
         (let [{:keys [service-id] :as response}
               (make-request-with-debug-info
-                {:x-waiter-name (rand-name)}
+                {:x-waiter-max-instances 1
+                 :x-waiter-name (rand-name)}
                 #(make-kitchen-request waiter-url % :cookies cookies :path "/status"))]
           (with-service-cleanup
             service-id
@@ -236,7 +237,8 @@
         (let [watches (start-watches router-urls cookies)
               {:keys [service-id] :as response}
               (make-request-with-debug-info
-                {:x-waiter-name (rand-name)}
+                {:x-waiter-max-instances 1
+                 :x-waiter-name (rand-name)}
                 #(make-kitchen-request waiter-url % :cookies cookies :path "/status"))]
           (with-service-cleanup
             service-id
@@ -256,6 +258,7 @@
               {:keys [service-id] :as response}
               (make-request-with-debug-info
                 {:x-kitchen-die-after-ms 10000
+                 :x-waiter-max-instances 1
                  :x-waiter-name (rand-name)}
                 #(make-kitchen-request waiter-url % :cookies cookies :path "/status"))]
           (with-service-cleanup
@@ -277,7 +280,8 @@
         (let [watches (start-watches router-urls cookies)
               {:keys [service-id] :as response}
               (make-request-with-debug-info
-                {:x-waiter-name (rand-name)}
+                {:x-waiter-max-instances 1
+                 :x-waiter-name (rand-name)}
                 #(make-kitchen-request waiter-url % :cookies cookies :path "/status"))]
           (with-service-cleanup
             service-id
@@ -297,11 +301,13 @@
       (testing "service-id filter provides initial healthy-instances only for a service"
         (let [{:keys [service-id] :as response}
               (make-request-with-debug-info
-                {:x-waiter-name (rand-name)}
+                {:x-waiter-max-instances 1
+                 :x-waiter-name (rand-name)}
                 #(make-kitchen-request waiter-url % :cookies cookies :path "/status"))
               {service-id-filtered :service-id :as response-filtered}
               (make-request-with-debug-info
-                {:x-waiter-metadata-foo "baz"
+                {:x-waiter-max-instances 1
+                 :x-waiter-metadata-foo "baz"
                  :x-waiter-name (rand-name)}
                 #(make-kitchen-request waiter-url % :cookies cookies :path "/status"))]
           (with-service-cleanup
@@ -332,11 +338,13 @@
       (testing "service-id filter provides [:healthy-instances :update] events only for a service"
         (let [{:keys [service-id] :as response}
               (make-request-with-debug-info
-                {:x-waiter-name (rand-name)}
+                {:x-waiter-max-instances 1
+                 :x-waiter-name (rand-name)}
                 #(make-kitchen-request waiter-url % :cookies cookies :path "/status"))
               {service-id-filtered :service-id :as response-filtered}
               (make-request-with-debug-info
-                {:x-waiter-metadata-foo "baz"
+                {:x-waiter-max-instances 1
+                 :x-waiter-metadata-foo "baz"
                  :x-waiter-name (rand-name)}
                 #(make-kitchen-request waiter-url % :cookies cookies :path "/status"))]
           (with-service-cleanup
@@ -367,7 +375,8 @@
       (testing "streams initial instances for service-ids that match service description filter"
         (let [{:keys [service-id] :as response}
               (make-request-with-debug-info
-                {:x-waiter-metadata-foo "testingfoo1013"
+                {:x-waiter-max-instances 1
+                 :x-waiter-metadata-foo "testingfoo1013"
                  :x-waiter-name (rand-name)}
                 #(make-kitchen-request waiter-url % :cookies cookies :path "/status"))
               {service-id-filtered :service-id :as response-filtered}
@@ -407,7 +416,8 @@
                                                 "watch" "true"})
               {:keys [service-id] :as response}
               (make-request-with-debug-info
-                {:x-waiter-metadata-foo "random-value-required"
+                {:x-waiter-max-instances 1
+                 :x-waiter-metadata-foo "random-value-required"
                  :x-waiter-name (rand-name)}
                 #(make-kitchen-request waiter-url % :cookies cookies :path "/status"))
               {service-id-filtered :service-id :as response-filtered}

--- a/waiter/src/waiter/instance_tracker.clj
+++ b/waiter/src/waiter/instance_tracker.clj
@@ -154,7 +154,7 @@
                                 (log/info "new failed instances" {:new-failed-instances new-failed-instances})
                                 (handle-instances-event! instance-failure-handler-component {:new-failed-instances new-failed-instances}))
                               (when (not-empty updated-healthy-instances)
-                                (log/info "new healthy instances" {:new-healthy-instances (map :id new-healthy-instances)}))
+                                (log/info "new healthy instances" {:new-healthy-instances (map :id updated-healthy-instances)}))
                               (when (not-empty removed-healthy-instances)
                                 (log/info "removed healthy instances" {:removed-healthy-instances (map :id removed-healthy-instances)}))
                               (let [healthy-instances-event


### PR DESCRIPTION
## Changes proposed in this PR

- Limit the number of instances for the service to 1.

## Why are we making these changes?

- The `wait-for` blocks can be triggered by other instances created or becoming failing, which will make the assertions incorrect.
