### PR TITLE
adds include params to cache state

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1922,13 +1922,13 @@
                                  ; If adding new middleware for websocket upgrade requests, consider adding the same middleware to
                                  ; process-request-wrapper-fn
                                  (let [handler (-> #(ws/request-subprotocol-acceptor (:upgrade-request %) (:upgrade-response %))
-                                                 websocket-secure-request-acceptor-fn
-                                                 auth/wrap-auth-bypass-acceptor
-                                                 pr/wrap-maintenance-mode-acceptor
-                                                 handler/wrap-wss-redirect
-                                                 ws/wrap-service-discovery-data
-                                                 wrap-service-discovery-fn
-                                                 ws/wrap-ws-acceptor-error-handling)]
+                                                   websocket-secure-request-acceptor-fn
+                                                   auth/wrap-auth-bypass-acceptor
+                                                   pr/wrap-maintenance-mode-acceptor
+                                                   handler/wrap-wss-redirect
+                                                   ws/wrap-service-discovery-data
+                                                   wrap-service-discovery-fn
+                                                   ws/wrap-ws-acceptor-error-handling)]
                                    (ws/make-websocket-request-acceptor server-name handler)))
    :websocket-secure-request-acceptor-fn (pc/fnk [[:state passwords]]
                                            (fn websocket-secure-request-acceptor-fn

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1788,12 +1788,11 @@
                                  (wrap-secure-request-fn
                                    (fn scheduler-state-handler-fn [request]
                                      (handler/get-scheduler-state router-id scheduler request))))
-   :state-service-description-builder-handler-fn (pc/fnk [[:state router-id service-description-builder]]
-                                                   (fn service-description-builder-state-handler-fn [request]
-                                                     (handler/get-query-fn-state
-                                                       router-id
-                                                       #(sd/state service-description-builder)
-                                                       request)))
+   :state-service-description-builder-handler-fn (pc/fnk [[:state router-id service-description-builder]
+                                                          wrap-secure-request-fn]
+                                                   (wrap-secure-request-fn
+                                                     (fn service-description-builder-state-handler-fn [request]
+                                                       (handler/get-service-description-builder-store-state router-id service-description-builder request))))
    :state-service-maintainer-handler-fn (pc/fnk [[:daemons service-chan-maintainer]
                                                  [:state router-id]
                                                  wrap-secure-request-fn]
@@ -1923,13 +1922,13 @@
                                  ; If adding new middleware for websocket upgrade requests, consider adding the same middleware to
                                  ; process-request-wrapper-fn
                                  (let [handler (-> #(ws/request-subprotocol-acceptor (:upgrade-request %) (:upgrade-response %))
-                                                   websocket-secure-request-acceptor-fn
-                                                   auth/wrap-auth-bypass-acceptor
-                                                   pr/wrap-maintenance-mode-acceptor
-                                                   handler/wrap-wss-redirect
-                                                   ws/wrap-service-discovery-data
-                                                   wrap-service-discovery-fn
-                                                   ws/wrap-ws-acceptor-error-handling)]
+                                                 websocket-secure-request-acceptor-fn
+                                                 auth/wrap-auth-bypass-acceptor
+                                                 pr/wrap-maintenance-mode-acceptor
+                                                 handler/wrap-wss-redirect
+                                                 ws/wrap-service-discovery-data
+                                                 wrap-service-discovery-fn
+                                                 ws/wrap-ws-acceptor-error-handling)]
                                    (ws/make-websocket-request-acceptor server-name handler)))
    :websocket-secure-request-acceptor-fn (pc/fnk [[:state passwords]]
                                            (fn websocket-secure-request-acceptor-fn

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -853,7 +853,9 @@
 (defn get-kv-store-state
   "Outputs the kv-store state."
   [router-id kv-store request]
-  (get-function-state #(kv/state kv-store) router-id request))
+  (let [{:strs [include]} (-> request ru/query-params-request :query-params)
+        include-flags (if (string? include) #{include} (set include))]
+    (get-function-state #(kv/state kv-store include-flags) router-id request)))
 
 (defn get-local-usage-state
   "Outputs the local metrics agent state."

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -886,6 +886,11 @@
   [router-id scheduler request]
   (get-function-state-with-include-flags #(scheduler/state scheduler %) router-id request))
 
+(defn get-service-description-builder-store-state
+  "Outputs the kv-store state."
+  [router-id service-description-builder request]
+  (get-function-state-with-include-flags #(sd/state service-description-builder %) router-id request))
+
 (defn get-statsd-state
   "Outputs the statsd state."
   [router-id request]

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -729,7 +729,7 @@
     "Returns a map of reference type to stale function for references of the specified type.
      The values are functions that have the following signature (fn reference-entry)")
 
-  (state [this]
+  (state [this include-flags]
     "Returns the global (i.e. non-service-specific) state the service description builder is maintaining")
 
   (validate [this service-description args-map]
@@ -839,7 +839,7 @@
   (retrieve-reference-type->stale-info-fn [_ {:keys [token->token-hash token->token-parameters]}]
     {:token (fn [{:keys [sources]}] (retrieve-token-stale-info token->token-hash token->token-parameters sources))})
 
-  (state [_]
+  (state [_ _]
     {})
 
   (validate [_ service-description args-map]

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -1362,10 +1362,11 @@
 
 (deftest test-get-kv-store-state
   (let [router-id "test-router-id"
+        include-flags #{}
         test-fn (wrap-handler-json-response get-kv-store-state)]
     (testing "successful response"
       (let [kv-store (kv/new-local-kv-store {})
-            state (walk/stringify-keys (kv/state kv-store))
+            state (walk/stringify-keys (kv/state kv-store include-flags))
             {:keys [body status]} (test-fn router-id kv-store {})]
         (is (= http-200-ok status))
         (is (= (json/read-str body) {"router-id" router-id, "state" state}))))

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -3136,7 +3136,7 @@
     (is (contains? (service-id->references kv-store service-id) references-4))))
 
 (deftest test-service-description-builder-state
-  (is {} (state (create-default-service-description-builder {}))))
+  (is {} (state (create-default-service-description-builder {}) #{})))
 
 (deftest test-retrieve-most-recently-modified-token-update-time
   (let [descriptor {:sources {:token->token-data {}}}]


### PR DESCRIPTION
## Changes proposed in this PR

- adds include params to cache state

## Why are we making these changes?

Including the KV data unnecessarily increases the payload when the client is not interested in the KV data.

