### PR TITLE
Integration test sanitization

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -410,14 +410,14 @@
           (is (= (:x-waiter-cmd headers) (get-in service-settings [:service-description :cmd])))
           (is (not-empty (get service-settings :effective-parameters)))
           (is (= (:x-waiter-cmd headers) (get-in service-settings [:effective-parameters :cmd])))
-          (is (= "other" (get-in service-settings [:effective-parameters :metric-group])) service-id))
+          (is (= "waiter_test" (get-in service-settings [:effective-parameters :metric-group])) service-id))
 
         (let [service-settings (service-settings waiter-url service-id
                                                  :query-params {"include" "references"})]
           (is (= [{}] (get service-settings :references)) (str service-settings)))
 
-        (testing "metric group should be other"
-          (is (= "other" (service-id->metric-group waiter-url service-id))
+        (testing "metric group should be waiter_test"
+          (is (= "waiter_test" (service-id->metric-group waiter-url service-id))
               (str "Invalid metric group for " service-id)))))))
 
 (deftest ^:parallel ^:integration-fast test-basic-health-check-port-index

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -459,9 +459,15 @@
 
         (finally
           (doseq [token all-tokens]
-            (delete-token-and-assert waiter-url token))
+            (try
+              (delete-token-and-assert waiter-url token)
+              (catch Exception ex
+                (log/error ex (str "error in deleting token " token)))))
           (doseq [service-id @service-ids-atom]
-            (delete-service waiter-url service-id)))))))
+            (try
+              (delete-service waiter-url service-id)
+              (catch Exception ex
+                (log/error ex (str "error in deleting service " service-id))))))))))
 
 (defn- service-id->metadata-id [waiter-url service-id]
   (get-in (service-settings waiter-url service-id) [:service-description :metadata :id]))

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1174,6 +1174,7 @@
                                      "FEE" "FIE"
                                      "FOO" "BAR"}
                                :name (rand-name)
+                               :metric-group "waiter_test"
                                :version "does-not-matter"}
           kitchen-request #(make-kitchen-request waiter-url % :path "/environment")]
       (try

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -850,7 +850,7 @@
 (defn create-token-name
   "Creates a random token name using the waiter url."
   ([waiter-url separator]
-   (let [prefix (str "test-" java-pid "-" (System/nanoTime))]
+   (let [prefix (str "c" (System/nanoTime) "-w8r-")]
      (create-token-name waiter-url separator prefix)))
   ([waiter-url separator prefix]
    (str prefix "." (subs waiter-url 0 (str/index-of waiter-url separator)))))

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -535,10 +535,11 @@
     :or {body nil cookies {} debug true method :post path "/endpoint" query-params {}}}]
   (let [headers (cond->
                   (-> {:x-waiter-cpus 0.1
-                       :x-waiter-mem 256
                        :x-waiter-grace-period-secs 120
                        :x-waiter-health-check-url "/status"
-                       :x-waiter-idle-timeout-mins 10}
+                       :x-waiter-idle-timeout-mins 10
+                       :x-waiter-mem 256
+                       :x-waiter-metric-group "waiter_test"}
                       (merge custom-headers)
                       (ensure-cid-in-headers)
                       (walk/stringify-keys))


### PR DESCRIPTION
## Changes proposed in this PR

- changes test token names to c _timestamp_-w8r-_suffix_ pattern
- ensures deletion of all tokens created in test-service-list-filtering
- adds metric group to integration tests

## Why are we making these changes?

Cleanup integration tests.

