### PR TITLE
twosigma/jet 2021-07-14

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -45,7 +45,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20210126_171807-gea4b804"
+                 [twosigma/jet "0.7.10-20210714_175127-g9b2f58a"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]


### PR DESCRIPTION
## Changes proposed in this PR

Upgraded to twosigma/jet build 2021-07-14.

## Why are we making these changes?

Pull in Jetty SslContextFactory Client/Server changes from twosigma/jet#53.