### PR TITLE
Add streaming timeout to test instance watches

### DIFF
--- a/waiter/integration/waiter/instance_tracker_integration_test.clj
+++ b/waiter/integration/waiter/instance_tracker_integration_test.clj
@@ -89,7 +89,8 @@
                     (is (t/before? start-time (du/str-to-date last-error-time)))))))))))))
 
 (defn- start-watch
-  [router-url cookies & {:keys [query-params] :or {query-params {"watch" "true"}}}]
+  [router-url cookies & {:keys [query-params] :or {query-params {"streaming-timeout" "1000000"
+                                                                 "watch" "true"}}}]
   (let [{:keys [body error headers] :as response}
         (make-request router-url "/apps/instances" :async? true :cookies cookies :query-params query-params)
         _ (assert-response-status response 200)

--- a/waiter/integration/waiter/instance_tracker_integration_test.clj
+++ b/waiter/integration/waiter/instance_tracker_integration_test.clj
@@ -89,7 +89,7 @@
                     (is (t/before? start-time (du/str-to-date last-error-time)))))))))))))
 
 (defn- start-watch
-  [router-url cookies & {:keys [query-params] :or {query-params {"streaming-timeout" "1000000"
+  [router-url cookies & {:keys [query-params] :or {query-params {"streaming-timeout" "120000"
                                                                  "watch" "true"}}}]
   (let [{:keys [body error headers] :as response}
         (make-request router-url "/apps/instances" :async? true :cookies cookies :query-params query-params)


### PR DESCRIPTION
## Changes proposed in this PR

- set the streaming-timeout on integration test instance tracking watches to 1000 seconds

## Why are we making these changes?

- the watches would get disconnected during the test due to the default 20-second streaming timeout. This would cause the watch to disconnect prematurely and no longer receive instance updates.
