### PR TITLE
adds same site attribute to oidc challenge cookies

### DIFF
--- a/waiter/integration/waiter/authentication_test.clj
+++ b/waiter/integration/waiter/authentication_test.clj
@@ -333,7 +333,9 @@
          (is (str/starts-with? set-cookie# "x-waiter-oidc-challenge-") assertion-message#)
          (is (str/includes? set-cookie# ";Max-Age=") assertion-message#)
          (is (str/includes? set-cookie# ";Path=/") assertion-message#)
-         (is (str/includes? set-cookie# ";HttpOnly=true") assertion-message#)))))
+         (is (str/includes? set-cookie# ";HttpOnly=true") assertion-message#)
+         (is (str/includes? set-cookie# ";SameSite=None") assertion-message#)
+         (is (str/includes? set-cookie# ";Secure") assertion-message#)))))
 
 (defn- follow-authorize-redirects
   "Asserts for query parameters on the redirect url.
@@ -429,10 +431,10 @@
                     (assert-response-status callback-response http-302-moved-temporarily)
                     (is (= 3 (count cookies)) (str cookies))
                     (if-let [oidc-challenge-cookie (first (filter #(str/starts-with? (:name %) "x-waiter-oidc-challenge-") cookies))]
-                      (is (= {:http-only? true :max-age 0 :path "/" :secure? false}
+                      (is (= {:http-only? true :max-age 0 :path "/" :secure? true}
                              (select-keys oidc-challenge-cookie [:http-only? :max-age :path :secure?])))
                       (is false "OIDC challenge cookie is missing"))
-                    (assert-waiter-authentication-cookies cookies)
+                    (assert-waiter-authentication-cookies cookies true)
                     (if-let [waiter-auth-cookie (first (filter #(= (:name %) "x-waiter-auth") cookies))]
                       (let [x-waiter-auth-max-age (:max-age waiter-auth-cookie)
                             one-day-in-secs (-> 1 t/days t/in-seconds)]

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -846,7 +846,7 @@
       (is (str/includes? set-cookie "Path=/"))
       (is (str/includes? set-cookie "HttpOnly=true"))
       (is (= (System/getProperty "user.name") (str body)))
-      (assert-waiter-authentication-cookies cookies)
+      (assert-waiter-authentication-cookies cookies false)
 
       (let [{:keys [body headers] :as response} (make-request waiter-url "/waiter-auth" :cookies cookies)
             set-cookie (get headers "set-cookie")]
@@ -921,7 +921,7 @@
                   response-waiter-auth-cookie (extract-cookie cookies "x-waiter-auth")]
               (assert-response-status response http-204-no-content)
               (assert-waiter-response response)
-              (assert-waiter-authentication-cookies cookies)
+              (assert-waiter-authentication-cookies cookies false)
               (is (contains? headers "x-waiter-auth-method") (str headers))
               (is (contains? headers "x-waiter-auth-principal") (str headers))
               (is (= (get headers "x-waiter-auth-user") current-user) (str headers))
@@ -938,7 +938,7 @@
                   response-waiter-auth-cookie (extract-cookie cookies "x-waiter-auth")]
               (assert-response-status response http-204-no-content)
               (assert-waiter-response response)
-              (assert-waiter-authentication-cookies cookies)
+              (assert-waiter-authentication-cookies cookies false)
               (is (contains? headers "x-waiter-auth-method") (str headers))
               (is (contains? headers "x-waiter-auth-principal") (str headers))
               (is (= (get headers "x-waiter-auth-user") current-user) (str headers))

--- a/waiter/src/waiter/auth/spnego.clj
+++ b/waiter/src/waiter/auth/spnego.clj
@@ -175,7 +175,7 @@
                 (try
                   (if principal
                     (let [auth-params-map (auth/build-auth-params-map :spnego principal)
-                          response (auth/handle-request-auth request-handler request auth-params-map password)]
+                          response (auth/handle-request-auth request-handler request auth-params-map password nil true)]
                       (log/debug "added cookies to response")
                       (if token
                         (if (map? response)

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1884,7 +1884,7 @@
                                             (let [password (first passwords)]
                                               (letfn [(add-encoded-cookie [response cookie-name value expiry-days]
                                                         (let [age-in-seconds (-> expiry-days t/days t/in-seconds)]
-                                                          (cookie-support/add-encoded-cookie response password cookie-name value age-in-seconds)))
+                                                          (cookie-support/add-encoded-cookie response password cookie-name value age-in-seconds nil)))
                                                       (consent-cookie-value [mode service-id token token-metadata]
                                                         (sd/consent-cookie-value clock mode service-id token token-metadata))]
                                                 (wrap-secure-request-fn

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -354,17 +354,18 @@
 
 (defmacro assert-waiter-authentication-cookies
   "Validates the waiter authentication cookies."
-  [cookies]
-  `(let [cookies# ~cookies]
+  [cookies secure?]
+  `(let [cookies# ~cookies
+         secure?# ~secure?]
      (if-let [waiter-auth-cookie# (extract-cookie cookies# "x-waiter-auth")]
        (do
-         (is (= {:http-only? true :path "/" :secure? false}
+         (is (= {:http-only? true :path "/" :secure? secure?#}
                 (select-keys waiter-auth-cookie# [:http-only? :path :secure?])))
          (is (pos? (:max-age waiter-auth-cookie#))))
        (is false "x-waiter-auth cookie is missing"))
      (if-let [auth-expires-at-cookie# (extract-cookie cookies# "x-auth-expires-at")]
        (do
-         (is (= {:http-only? false :path "/" :secure? false}
+         (is (= {:http-only? false :path "/" :secure? secure?#}
                 (select-keys auth-expires-at-cookie# [:http-only? :path :secure?])))
          (is (pos? (:max-age auth-expires-at-cookie#)))
          (when-let [waiter-auth-cookie# (extract-cookie cookies# "x-waiter-auth")]


### PR DESCRIPTION
## Changes proposed in this PR

- adds same site attribute to oidc challenge cookies

## Why are we making these changes?

Chrome 91 defaults `SameSite=Lax`, previous versions has the default of `SameSite=None`. In addition, cookies with SameSite=None must now also specify the Secure attribute (they require a secure context/HTTPS).
