### PR TITLE
adds integration test for authenticated health checks

### DIFF
--- a/containers/test-apps/courier/bin/run-courier-server.sh
+++ b/containers/test-apps/courier/bin/run-courier-server.sh
@@ -9,6 +9,7 @@ set -ux
 
 GRPC_SERVER_PORT=${1:-${PORT0:-8080}}
 HEALTH_CHECK_SERVER_PORT=${2:-${PORT1:-8081}}
+HEALTH_CHECK_AUTH=${3:-false}
 
 # Log a message to stdout
 function courier_log() {
@@ -34,6 +35,7 @@ if [[ -z "${JAVA_CMD}" ]]; then
 fi
 
 courier_log "launching courier grpc and health checks servers at ports ${GRPC_SERVER_PORT} and ${HEALTH_CHECK_SERVER_PORT}"
-${JAVA_CMD} -jar ${COURIER_JAR} ${GRPC_SERVER_PORT} ${HEALTH_CHECK_SERVER_PORT}
+courier_log "server health check authentication enabled: ${HEALTH_CHECK_AUTH}"
+${JAVA_CMD} -jar ${COURIER_JAR} ${GRPC_SERVER_PORT} ${HEALTH_CHECK_SERVER_PORT} ${HEALTH_CHECK_AUTH}
 
 courier_log "exiting."

--- a/containers/test-apps/courier/pom.xml
+++ b/containers/test-apps/courier/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>twosigma</groupId>
     <artifactId>courier</artifactId>
-    <version>1.5.17</version>
+    <version>1.5.18</version>
 
     <name>courier</name>
     <url>https://github.com/twosigma/waiter/tree/master/test-apps/courier</url>

--- a/containers/test-apps/courier/src/main/java/com/twosigma/waiter/courier/Authenticator.java
+++ b/containers/test-apps/courier/src/main/java/com/twosigma/waiter/courier/Authenticator.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Two Sigma Open Source, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twosigma.waiter.courier;
+
+import com.sun.net.httpserver.Headers;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.logging.Logger;
+
+public interface Authenticator {
+
+    boolean authenticate(Headers requestHeaders);
+
+    class BasicAuthenticator implements Authenticator {
+
+        private final static Logger LOGGER = Logger.getLogger(BasicAuthenticator.class.getName());
+
+        private final String expectedAuthorization;
+
+        public BasicAuthenticator(String username, String password) {
+            String auth = username + ":" + password;
+            byte[] encodedAuth = Base64.getEncoder().encode(auth.getBytes(StandardCharsets.UTF_8));
+            expectedAuthorization = "Basic " + new String(encodedAuth);
+        }
+
+        @Override
+        public boolean authenticate(Headers requestHeaders) {
+            final String authorization = requestHeaders.getFirst("authorization");
+            if (authorization == null) {
+                LOGGER.info("No authorization header provided");
+                return false;
+            }
+            if (!expectedAuthorization.equals(authorization)) {
+                LOGGER.info("Invalid authorization header: " + authorization);
+                return false;
+            }
+            LOGGER.info("Successfully authenticated request");
+            return true;
+        }
+    }
+
+    class DisabledAuthenticator implements Authenticator {
+
+        @Override
+        public boolean authenticate(Headers requestHeaders) {
+            return true;
+        }
+    }
+}

--- a/containers/test-apps/courier/src/main/java/com/twosigma/waiter/courier/Main.java
+++ b/containers/test-apps/courier/src/main/java/com/twosigma/waiter/courier/Main.java
@@ -15,6 +15,7 @@
  */
 package com.twosigma.waiter.courier;
 
+import java.util.Arrays;
 import java.util.logging.Logger;
 
 public class Main {
@@ -23,19 +24,22 @@ public class Main {
 
     // In order to run this, you need the alpn-boot-XXX.jar in the bootstrap classpath.
     public static void main(final String... args) throws Exception {
+        LOGGER.info("gRPC server command-line arguments: " + Arrays.toString(args));
         final int port0 = args.length > 0 ? Integer.parseInt(args[0]) : 8080;
         final int port1 = args.length > 1 ? Integer.parseInt(args[1]) : 8081;
+        final boolean healthCheckAuthentication = args.length > 2 && Boolean.parseBoolean(args[2]);
 
         LoggingConfig.initializeLogging();
 
         LOGGER.info("gRPC server configured to run on port " + port0);
-        LOGGER.info("health-check (http) server configured to run on port " + port1);
+        LOGGER.info("health-check (http, authentication=" + healthCheckAuthentication + ") " +
+            "server configured to run on port " + port1);
 
         final GrpcServer grpcServer = new GrpcServer();
         grpcServer.start(port0);
 
         final HealthCheckServer healthCheckServer = new HealthCheckServer();
-        healthCheckServer.start(port1);
+        healthCheckServer.start(port1, healthCheckAuthentication);
 
         grpcServer.blockUntilShutdown();
     }


### PR DESCRIPTION
## Changes proposed in this PR

- courier: adds support for authenticated health checks
- adds integration test for authenticated health checks

## Why are we making these changes?

Adds an automated test to verify the use-case where services uses authenticated health checks on a port index greater than zero, e.g. gRPC services using authenticated health checks.
