### PR TITLE
avoids tracking known killed instances as failed instances

### DIFF
--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -42,6 +42,16 @@
            (org.eclipse.jetty.client HttpClient)
            (org.joda.time DateTime)))
 
+(def ^:const max-failed-instances-to-keep
+  "The maximum number of failed instances tracked per service."
+  10)
+
+(def ^:const max-killed-instances-to-keep
+  "The maximum number of kill instances tracked per service."
+  ;; track more killed instances than failed instances
+  (+ max-failed-instances-to-keep 2))
+
+
 (defmacro log
   "Log Scheduler-specific messages."
   [& args]

--- a/waiter/src/waiter/scheduler/cook.clj
+++ b/waiter/src/waiter/scheduler/cook.clj
@@ -319,7 +319,7 @@
   "Launches a timer task that tracks failed instances."
   [service-id->failed-instances-transient-store scheduler failed-tracker-interval-ms]
   (let [last-start-time-atom (atom nil)
-        max-instances-to-keep 10]
+        max-instances-to-keep scheduler/max-failed-instances-to-keep]
     (du/start-timer-task
       (t/millis failed-tracker-interval-ms)
       (fn track-failed-instances-fn []

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -64,10 +64,6 @@
   "Kubernetes reports dates in ISO8061 format, sans the milliseconds component."
   (DateTimeFormat/forPattern "yyyy-MM-dd'T'HH:mm:ss'Z'"))
 
-(def max-failed-instances-to-keep
-  "The maximum number of failed instances tracked per service."
-  10)
-
 (defn timestamp-str->datetime
   "Parse a Kubernetes API timestamp string."
   [k8s-timestamp-str]
@@ -240,7 +236,7 @@
                                               (not (killed-by-k8s? newest-failure))
                                               (assoc :exit-code (:exitCode newest-failure)))]
                 (scheduler/add-to-store-and-track-failed-instance!
-                  service-id->failed-instances-transient-store max-failed-instances-to-keep service-id newest-failure-instance)))))))
+                  service-id->failed-instances-transient-store scheduler/max-failed-instances-to-keep service-id newest-failure-instance)))))))
     (catch Throwable e
       (log/error e "error converting failed pod to waiter service instance" pod)
       (comment "Returning nil on failure."))))
@@ -493,7 +489,7 @@
     (doseq [{:keys [service-id] :as failed-instance} failed-instances]
       (->> (assoc failed-instance :healthy? false)
         (scheduler/add-to-store-and-track-failed-instance!
-          service-id->failed-instances-transient-store max-failed-instances-to-keep service-id)))
+          service-id->failed-instances-transient-store scheduler/max-failed-instances-to-keep service-id)))
     ;; returns only pods with non-Failed phase
     (vec active-instances)))
 

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -78,7 +78,7 @@
                                     :healthy? false
                                     :port 0
                                     :started-at (some-> failed-marathon-task :timestamp (du/str-to-date formatter-marathon))))
-                max-instances-to-keep 10]
+                max-instances-to-keep scheduler/max-failed-instances-to-keep]
             (scheduler/add-to-store-and-track-failed-instance!
               service-id->failed-instances-transient-store max-instances-to-keep service-id failed-instance)))))
     (when (some failed-instance-ids (map :id active-instances))


### PR DESCRIPTION
## Changes proposed in this PR

- avoids tracking known killed instances as failed instances

## Why are we making these changes?

Avoid the bug where known killed instances are treated as failed instances and can trigger false positive workflows for failed instances.


