### PR TITLE
adds validation for authentication and health-check-authentication combination

### DIFF
--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -681,6 +681,18 @@
                        :friendly-error-message (str "Command type " cmd-type " is not supported")
                        :status http-400-bad-request})))
 
+    ; validate authentication and health-check-authentication combination
+    (let [{:strs [authentication health-check-authentication]} service-description-to-use]
+      (when (and authentication
+                 health-check-authentication
+                 (= authentication "disabled")
+                 (= health-check-authentication "standard"))
+        (sling/throw+ {:type :service-description-error
+                       :friendly-error-message (str "The health check authentication (" health-check-authentication ") "
+                                                    "cannot be enabled when authentication (" authentication ") is disabled")
+                       :status http-400-bad-request
+                       :log-level :warn})))
+
     ; validate the health-check-port-index
     (let [{:strs [health-check-port-index ports]} service-description-to-use]
       (when (and health-check-port-index ports (>= health-check-port-index ports))

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -873,7 +873,7 @@
 
 (defn delete-token-and-assert
   "Deletes and token and asserts that the delete was successful."
-  [waiter-url token & {:keys [hard-delete headers] :or {hard-delete true}}]
+  [waiter-url token & {:keys [hard-delete headers response-status] :or {hard-delete true response-status http-200-ok}}]
   (log/info "deleting token" token {:hard-delete hard-delete})
   (let [headers (cond->> headers
                   (and hard-delete (nil? headers)) (attach-token-etag waiter-url token))
@@ -881,7 +881,7 @@
                                :headers (assoc headers "host" token)
                                :method :delete
                                :query-params (if hard-delete {"hard-delete" true} {}))]
-    (assert-response-status response http-200-ok)))
+    (assert-response-status response response-status)))
 
 (defn wait-for
   "Invoke predicate every interval (default 10) seconds until it returns true,

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -2183,6 +2183,12 @@
         constraints-schema profile->defaults config
         "min-instances (3) must be less than or equal to max-instances (2)"))
 
+    (testing "testing invalid health check authentication"
+      (run-validate-schema-test
+        (assoc valid-description "authentication" "disabled" "health-check-authentication" "standard")
+        constraints-schema profile->defaults config
+        "The health check authentication (standard) cannot be enabled when authentication (disabled) is disabled"))
+
     (testing "testing invalid health check port index"
       (run-validate-schema-test
         (assoc valid-description "health-check-port-index" 1 "ports" 1)


### PR DESCRIPTION
## Changes proposed in this PR

- adds validation for authentication and health-check-authentication combination

## Why are we making these changes?

It does not make sense to support authentication health checks when authentication is disabled overall for the service.
