### PR TITLE
validates the backend-proto and health-check-proto combination on same port

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -328,7 +328,7 @@
                    :concurrency-level 10
                    :cpus 1
                    :distribution-scheme "simple"
-                   :health-check-proto "h2"
+                   :health-check-proto "h2c"
                    :health-check-url "/status"
                    :mem 512
                    :metric-group "waiter_test"

--- a/waiter/integration/waiter/health_check_test.clj
+++ b/waiter/integration/waiter/health_check_test.clj
@@ -90,8 +90,8 @@
   (testing-using-waiter-url
     (let [supported-protocols #{"http" "https" "h2c" "h2"}]
       (doseq [backend-proto supported-protocols
-            health-check-proto (disj supported-protocols backend-proto)
-            health-check-port-index [nil 0]]
+              health-check-proto (disj supported-protocols backend-proto)
+              health-check-port-index [nil 0]]
         (let [request-headers (cond-> {:x-waiter-backend-proto backend-proto
                                        :x-waiter-health-check-proto health-check-proto}
                                 health-check-port-index (assoc :x-waiter-health-check-port-index health-check-port-index))

--- a/waiter/integration/waiter/health_check_test.clj
+++ b/waiter/integration/waiter/health_check_test.clj
@@ -89,7 +89,7 @@
 (deftest ^:parallel ^:integration-fast test-invalid-backend-proto-health-check-proto-combo
   (testing-using-waiter-url
     (let [supported-protocols #{"http" "https" "h2c" "h2"}]
-      (for [backend-proto supported-protocols
+      (doseq [backend-proto supported-protocols
             health-check-proto (disj supported-protocols backend-proto)
             health-check-port-index [nil 0]]
         (let [request-headers (cond-> {:x-waiter-backend-proto backend-proto

--- a/waiter/integration/waiter/health_check_test.clj
+++ b/waiter/integration/waiter/health_check_test.clj
@@ -89,17 +89,17 @@
 (deftest ^:parallel ^:integration-fast test-invalid-backend-proto-health-check-proto-combo
   (testing-using-waiter-url
     (let [supported-protocols #{"http" "https" "h2c" "h2"}]
-      (doseq [backend-proto supported-protocols]
-        (doseq [health-check-proto (disj supported-protocols backend-proto)]
-          (doseq [health-check-port-index [nil 0]]
-            (let [request-headers (cond-> {:x-waiter-backend-proto backend-proto
-                                           :x-waiter-health-check-proto health-check-proto}
-                                    health-check-port-index (assoc :x-waiter-health-check-port-index health-check-port-index))
-                  {:keys [body] :as response} (make-kitchen-request waiter-url request-headers)
-                  error-msg (str "The backend-proto (" backend-proto ") and health check proto (" health-check-proto
-                                 ") must match when health-check-port-index is zero")]
-              (assert-response-status response http-400-bad-request)
-              (is (str/includes? (str body) error-msg)))))))))
+      (for [backend-proto supported-protocols
+            health-check-proto (disj supported-protocols backend-proto)
+            health-check-port-index [nil 0]]
+        (let [request-headers (cond-> {:x-waiter-backend-proto backend-proto
+                                       :x-waiter-health-check-proto health-check-proto}
+                                health-check-port-index (assoc :x-waiter-health-check-port-index health-check-port-index))
+              {:keys [body] :as response} (make-kitchen-request waiter-url request-headers)
+              error-msg (str "The backend-proto (" backend-proto ") and health check proto (" health-check-proto
+                             ") must match when health-check-port-index is zero")]
+          (assert-response-status response http-400-bad-request)
+          (is (str/includes? (str body) error-msg)))))))
 
 (deftest ^:parallel ^:integration-fast test-ping-http-http-port0-timeout
   (testing-using-waiter-url

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -679,7 +679,8 @@
       (when (and (not (str/blank? cmd-type)) (not ((:valid-cmd-types args-map) cmd-type)))
         (sling/throw+ {:type :service-description-error
                        :friendly-error-message (str "Command type " cmd-type " is not supported")
-                       :status http-400-bad-request})))
+                       :status http-400-bad-request
+                       :log-level :info})))
 
     ; validate authentication and health-check-authentication combination
     (let [{:strs [authentication health-check-authentication]} service-description-to-use]
@@ -691,7 +692,7 @@
                        :friendly-error-message (str "The health check authentication (" health-check-authentication ") "
                                                     "cannot be enabled when authentication (" authentication ") is disabled")
                        :status http-400-bad-request
-                       :log-level :warn})))
+                       :log-level :info})))
 
     ; validate the health-check-port-index
     (let [{:strs [health-check-port-index ports]} service-description-to-use]
@@ -700,7 +701,7 @@
                        :friendly-error-message (str "The health check port index (" health-check-port-index ") "
                                                     "must be smaller than ports (" ports ")")
                        :status http-400-bad-request
-                       :log-level :warn})))
+                       :log-level :info})))
 
     ; validate the backend-proto and health-check-proto combination on same port
     (let [{:strs [backend-proto health-check-port-index health-check-proto]} service-description-to-use]
@@ -710,7 +711,7 @@
                        :friendly-error-message (str "The backend-proto (" backend-proto ") and health check proto (" health-check-proto ") "
                                                     "must match when health-check-port-index is zero")
                        :status http-400-bad-request
-                       :log-level :warn})))
+                       :log-level :info})))
 
     ;; currently, if manually specified, the namespace *must* match the run-as-user
     ;; (but we expect the common case to be falling back to the default)
@@ -719,7 +720,7 @@
         (sling/throw+ {:type :service-description-error
                        :friendly-error-message "Service namespace must either be omitted or match the run-as-user."
                        :status http-400-bad-request
-                       :log-level :warn})))
+                       :log-level :info})))
 
     ;; when using the default namespace, there are stricter restrictions on min-instances
     (let [{:strs [min-instances namespace]} service-description-to-use]
@@ -730,7 +731,7 @@
                        :friendly-error-message (str "min-instances (" min-instances ") in the default namespace "
                                                     "must be less than or equal to " maximum-default-namespace-min-instances)
                        :status http-400-bad-request
-                       :log-level :warn})))
+                       :log-level :info})))
 
     ; validate the profile when it is configured
     (let [{:strs [profile]} service-description-to-use]

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -702,6 +702,16 @@
                        :status http-400-bad-request
                        :log-level :warn})))
 
+    ; validate the backend-proto and health-check-proto combination on same port
+    (let [{:strs [backend-proto health-check-port-index health-check-proto]} service-description-to-use]
+      (when (and backend-proto health-check-port-index health-check-proto
+                 (zero? health-check-port-index) (not= backend-proto health-check-proto))
+        (sling/throw+ {:type :service-description-error
+                       :friendly-error-message (str "The backend-proto (" backend-proto ") and health check proto (" health-check-proto ") "
+                                                    "must match when health-check-port-index is zero")
+                       :status http-400-bad-request
+                       :log-level :warn})))
+
     ;; currently, if manually specified, the namespace *must* match the run-as-user
     ;; (but we expect the common case to be falling back to the default)
     (let [{:strs [namespace run-as-user]} service-description-to-use]

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -2201,7 +2201,7 @@
 
     (testing "testing invalid backend proto and health check proto combination"
       (let [supported-protocols #{"http" "https" "h2c" "h2"}]
-        (for [backend-proto supported-protocols
+        (doseq [backend-proto supported-protocols
               health-check-proto (disj supported-protocols backend-proto)]
           (do
             (run-validate-schema-test

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -2199,6 +2199,25 @@
         constraints-schema profile->defaults config
         "The health check port index (5) must be smaller than ports (3)"))
 
+    (testing "testing invalid backend proto and health check proto combination"
+      (let [supported-protocols #{"http" "https" "h2c" "h2"}]
+        (doseq [backend-proto supported-protocols]
+          (doseq [health-check-proto (disj supported-protocols backend-proto)]
+            (run-validate-schema-test
+              (assoc valid-description
+                "backend-proto" backend-proto
+                "health-check-port-index" 0
+                "health-check-proto" health-check-proto)
+              constraints-schema profile->defaults config
+              (str "The backend-proto (" backend-proto ") and health check proto (" health-check-proto
+                   ") must match when health-check-port-index is zero"))
+            (is (nil? (validate-schema (assoc valid-description
+                                         "backend-proto" backend-proto
+                                         "health-check-port-index" 1
+                                         "health-check-proto" health-check-proto
+                                         "ports" 2)
+                                       constraints-schema profile->defaults config)))))))
+
     (testing "testing invalid metric-group"
       (run-validate-schema-test
         (assoc valid-description "metric-group" (str/join "" (repeat 100 "m")))

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -2202,7 +2202,7 @@
     (testing "testing invalid backend proto and health check proto combination"
       (let [supported-protocols #{"http" "https" "h2c" "h2"}]
         (doseq [backend-proto supported-protocols
-              health-check-proto (disj supported-protocols backend-proto)]
+                health-check-proto (disj supported-protocols backend-proto)]
           (do
             (run-validate-schema-test
               (assoc valid-description

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -2201,8 +2201,9 @@
 
     (testing "testing invalid backend proto and health check proto combination"
       (let [supported-protocols #{"http" "https" "h2c" "h2"}]
-        (doseq [backend-proto supported-protocols]
-          (doseq [health-check-proto (disj supported-protocols backend-proto)]
+        (for [backend-proto supported-protocols
+              health-check-proto (disj supported-protocols backend-proto)]
+          (do
             (run-validate-schema-test
               (assoc valid-description
                 "backend-proto" backend-proto


### PR DESCRIPTION

## Changes proposed in this PR

- validates the backend-proto and health-check-proto combination on same port

## Why are we making these changes?

We do not support forwarding requests using different protocols on the same port while introducing an Envoy proxy to front requests to backends.

