### PR TITLE
adds dry-run flag to token create/update

### DIFF
--- a/cli/waiter/data_format.py
+++ b/cli/waiter/data_format.py
@@ -110,8 +110,8 @@ def determine_format(options):
     """
     validate_options(options)
     as_yaml = options.get(YAML.name())
-    input_format = YAML if as_yaml else JSON
-    return input_format
+    data_format = YAML if as_yaml else JSON
+    return data_format
 
 
 def read_from_standard_input(input_format):

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -213,7 +213,7 @@ def add_arguments(parser):
     format_group.add_argument('--yaml', help='provide the data in a YAML file', dest='yaml')
     format_group.add_argument('--input', help='provide the data in a JSON/YAML file', dest='input')
     parser.add_argument('--output', help='outputs the computed token configuration in a JSON/YAML file without '
-                                         'performing any write operations')
+                                         'performing any token edit operations')
     parser.add_argument('--context', dest='context',
                         help='can be used only when a data file has been provided via --input, --json, or --yaml; '
                              'this JSON/YAML file provides the context variables used '

--- a/cli/waiter/token_post.py
+++ b/cli/waiter/token_post.py
@@ -212,8 +212,8 @@ def add_arguments(parser):
     format_group.add_argument('--json', help='provide the data in a JSON file', dest='json')
     format_group.add_argument('--yaml', help='provide the data in a YAML file', dest='yaml')
     format_group.add_argument('--input', help='provide the data in a JSON/YAML file', dest='input')
-    parser.add_argument('--output', help='outputs the computed token configuration in a JSON/YAML file without '
-                                         'performing any token edit operations')
+    parser.add_argument('--output', help='outputs the computed token configuration in a JSON/YAML file (or to stdout using -)'
+                                         'without performing any token edit operations')
     parser.add_argument('--context', dest='context',
                         help='can be used only when a data file has been provided via --input, --json, or --yaml; '
                              'this JSON/YAML file provides the context variables used '


### PR DESCRIPTION
## Changes proposed in this PR

- adds dry-run flag to token create/update

## Why are we making these changes?

We would like to confirm the token configuration being submitted before actually performing the operation.


### Example output
```
$ waiter create -h
usage: waiter create [-h] [--name NAME] [--owner OWNER] [--version VERSION] [--cmd CMD] [--cmd-type CMD-TYPE] [--cpus CPUS] [--mem MEM] [--ports PORTS]
                     [--json JSON | --yaml YAML | --input INPUT] [--context CONTEXT] [--dry-run] [--override]
                     [token]
...
    --output OUTPUT       outputs the computed token configuration in a JSON/YAML file without performing any token edit operations
...
```

```
$ waiter create --output - foo-bar --ports 3 --cpus 1 --mem 2 --env.foo bar
Attempting to create token with dry-run enabled on WAITER1...
Token configuration (as json) is:
{
  "cpus": 1.0,
  "env": {
    "foo": "bar"
  },
  "mem": 2,
  "ports": 3
}

$ waiter create --output out.json foo-bar --ports 3 --cpus 1 --mem 2 --env.foo bar
Attempting to create token with dry-run enabled on WAITER1...
Writing token configuration (as json) to out.json

$ cat out.json 
{
  "cpus": 1.0,
  "env": {
    "foo": "bar"
  },
  "mem": 2,
  "ports": 3
}

$ waiter create --output out.yaml foo-bar --ports 3 --cpus 1 --mem 2 --env.foo bar
Attempting to create token with dry-run enabled on WAITER1...
Writing token configuration (as yaml) to out.yaml

$ cat out.yaml 
cpus: 1.0
env:
  foo: bar
mem: 2
ports: 3
```