### PR TITLE
upgrades to jetty version 9.4.43.v20210629

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -45,8 +45,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20210714_175127-g9b2f58a"
-                  :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
+                 [twosigma/jet "0.7.10-20210727_051136-g07f2beb"]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]
                  [clj-time "0.15.2"


### PR DESCRIPTION
## Changes proposed in this PR

- upgrades to jetty version 9.4.43.v20210629

## Why are we making these changes?


