### PR TITLE
adds ability to configure same-site cookie attribute in OIDC cookies

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -277,7 +277,7 @@
                               ;; The default value is #{"chrome" "mozilla"}
                               :oidc-redirect-user-agent-products #{"chrome" "mozilla"}
                               ;; (optional) the same-site attribute configured on cookies emitted as result of OIDC auth
-                              ;; The default value is "None"
+                              ;; Valid values are "Lax", "None", "Strict" or nil. The default value is "None"
                               :oidc-same-site-attribute "None"
                               ;; (optional) url of the authorization server get token endpoint:
                               :oidc-token-uri "http://127.0.0.1:8040/id-token"

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -276,6 +276,9 @@
                               ;; Relies on the heuristic of inspecting common user-agents to determine if it is a browser.
                               ;; The default value is #{"chrome" "mozilla"}
                               :oidc-redirect-user-agent-products #{"chrome" "mozilla"}
+                              ;; (optional) the same-site attribute configured on cookies emitted as result of OIDC auth
+                              ;; The default value is "None"
+                              :oidc-same-site-attribute "None"
                               ;; (optional) url of the authorization server get token endpoint:
                               :oidc-token-uri "http://127.0.0.1:8040/id-token"
                               ;; The keyword used to retrieve the subject from the access token claims

--- a/waiter/src/waiter/schema.clj
+++ b/waiter/src/waiter/schema.clj
@@ -129,6 +129,11 @@
    Valid values are :disabled, :relaxed or :strict."
   (s/pred #(contains? #{:relaxed :strict} %) 'invalid-oidc-mode))
 
+(def valid-same-site-attribute
+  "Validator for the OIDC SameSite cookie attribute.
+   Valid values are Lax, None, Strict or `nil`."
+  (s/pred #(contains? #{"Lax" "None" "Strict" nil} %) 'invalid-oidc-same-site-attribute))
+
 (def valid-jwt-authenticator-config
   "Validator for the Zookeeper connection configuration. We allow either
   a non-empty string (representing a connection string), or the keyword
@@ -147,6 +152,7 @@
      (s/optional-key :oidc-default-mode) valid-oidc-mode
      (s/optional-key :oidc-num-challenge-cookies-allowed-in-request) positive-int
      (s/optional-key :oidc-redirect-user-agent-products) #{non-empty-string}
+     (s/optional-key :oidc-same-site-attribute) valid-same-site-attribute
      (s/optional-key :oidc-token-uri) non-empty-string
      (s/required-key :subject-key) s/Keyword
      (s/optional-key :subject-regex) s/Regex


### PR DESCRIPTION
## Changes proposed in this PR

- adds the ability to configure same-site cookie attribute in OIDC cookies

## Why are we making these changes?

Allows changing behavior via configuration instead of having to revert if backward incompatibility is discovered.


