### PR TITLE
Add request-protocol to ServiceScheduler interface

### DIFF
--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -93,13 +93,13 @@
 (defn async-make-request-helper
   "Helper function that returns a function that can invoke make-request-fn."
   [http-clients instance-request-properties make-basic-auth-fn service-id->password-fn prepare-request-properties-fn make-request-fn]
-  (fn async-make-request-fn [instance {:keys [headers] :as request} end-route metric-group backend-proto]
+  (fn async-make-request-fn [instance {:keys [headers] :as request} end-route metric-group request-proto]
     (let [{:keys [passthrough-headers waiter-headers]} (headers/split-headers headers)
           instance-request-properties (prepare-request-properties-fn instance-request-properties waiter-headers)
-          proto-version (hu/backend-protocol->http-version backend-proto)]
+          proto-version (hu/backend-protocol->http-version request-proto)]
       (make-request-fn http-clients make-basic-auth-fn service-id->password-fn instance request
                        instance-request-properties passthrough-headers end-route metric-group
-                       backend-proto proto-version))))
+                       request-proto proto-version))))
 
 (defn- async-make-http-request
   "Helper function for async status/result handlers."

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -252,7 +252,7 @@
     (->> port-index dec (nth extra-ports))
     port))
 
-(defn port-index-protocol
+(defn retrieve-protocol
   "Get the protocol for the given port index based off the service description.
    Used as the default implementation for the request-protocol function
    on most ServiceScheduler protocol implementations."
@@ -326,15 +326,14 @@
 (defn available?
   "Async go block which returns the status code and success of a health check.
    Returns {:healthy? false} if such a connection cannot be established."
-  [service-id->password-fn ^HttpClient http-client scheduler-promise-chan scheduler-name
+  [service-id->password-fn ^HttpClient http-client scheduler scheduler-name
    {:keys [host port service-id] :as service-instance}
    {:strs [health-check-authentication health-check-port-index health-check-url]
     :or {health-check-port-index 0} :as service-description}]
   (async/go
     (try
       (if (and port (pos? port) host (not= UNKNOWN-IP host))
-        (let [scheduler (async/<! scheduler-promise-chan)
-              protocol (request-protocol scheduler service-instance health-check-port-index service-description)
+        (let [protocol (request-protocol scheduler service-instance health-check-port-index service-description)
               instance-health-check-url (build-health-check-url scheduler service-instance service-description)
               request-timeout-ms (max (+ (.getConnectTimeout http-client) (.getIdleTimeout http-client)) http-200-ok )
               request-abort-chan (async/chan 1)

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -30,6 +30,7 @@
             [waiter.headers :as headers]
             [waiter.metrics :as metrics]
             [waiter.request-log :as rlog]
+            [waiter.service-description :as sd]
             [waiter.statsd :as statsd]
             [waiter.status-codes :refer :all]
             [waiter.util.async-utils :as au]
@@ -149,6 +150,10 @@
      These options should be merged (to override) the global :deployment-error-config options
      in the waiter.state module when computing the deployment errors for the given service-id.")
 
+  (request-protocol [this instance port-index service-description]
+     "Returns the protocol to use for a request to the given instance on the given port.
+      Will return one of the following values: http, https, h2, h2c")
+
   (scale-service [this ^String service-id target-instances force]
     "Instructs the scheduler to scale up/down instances of the specified service to the specified number
      of instances. The force flag can be used enforce the scaling by ignoring previous pending operations.")
@@ -247,7 +252,19 @@
     (->> port-index dec (nth extra-ports))
     port))
 
-(defn base-url
+(defn port-index-protocol
+  "Get the protocol for the given port index based off the service description.
+   Used as the default implementation for the request-protocol function
+   on most ServiceScheduler protocol implementations."
+  [port-index {:strs [backend-proto health-check-port-index health-check-proto] :as service-description}]
+  (cond
+    (zero? port-index) backend-proto
+    (= port-index health-check-port-index) health-check-proto
+    :else (throw (ex-info "Unrecognized port index"
+                          {:port-index port-index
+                           :service-description service-description}))))
+
+(defn- base-url
   "Returns the url at which the service definition resides."
   [^String protocol ^String host port]
   (let [scheme (hu/backend-proto->scheme protocol)]
@@ -261,9 +278,11 @@
 
 (defn build-health-check-url
   "Returns the health check url which can be queried on the service instance."
-  [{:keys [host] :as instance} health-check-proto health-check-port-index health-check-path]
-  (let [url-port (instance->port instance health-check-port-index)]
-    (end-point-url health-check-proto host url-port health-check-path)))
+  [scheduler {:keys [host] :as instance} {:strs [health-check-port-index] :as service-description}]
+  (let [health-check-path (sd/service-description->health-check-url service-description)
+        proto (request-protocol scheduler instance health-check-port-index service-description)
+        url-port (instance->port instance health-check-port-index)]
+    (end-point-url proto host url-port health-check-path)))
 
 (defn log-health-check-issues
   "Logs messages based on the type of error (if any) encountered by a health check"
@@ -307,13 +326,16 @@
 (defn available?
   "Async go block which returns the status code and success of a health check.
    Returns {:healthy? false} if such a connection cannot be established."
-  [service-id->password-fn ^HttpClient http-client scheduler-name {:keys [host port service-id] :as service-instance}
-   {:strs [health-check-authentication health-check-port-index health-check-url] :as service-description}]
+  [service-id->password-fn ^HttpClient http-client scheduler-promise-chan scheduler-name
+   {:keys [host port service-id] :as service-instance}
+   {:strs [health-check-authentication health-check-port-index health-check-url]
+    :or {health-check-port-index 0} :as service-description}]
   (async/go
     (try
       (if (and port (pos? port) host (not= UNKNOWN-IP host))
-        (let [protocol (service-description->health-check-protocol service-description)
-              instance-health-check-url (build-health-check-url service-instance protocol health-check-port-index health-check-url)
+        (let [scheduler (async/<! scheduler-promise-chan)
+              protocol (request-protocol scheduler service-instance health-check-port-index service-description)
+              instance-health-check-url (build-health-check-url scheduler service-instance service-description)
               request-timeout-ms (max (+ (.getConnectTimeout http-client) (.getIdleTimeout http-client)) http-200-ok )
               request-abort-chan (async/chan 1)
               request-time (t/now)
@@ -340,15 +362,15 @@
                                     (instance? SocketTimeoutException error) :timeout-exception
                                     (instance? TimeoutException error) :timeout-exception)]
                    (log-health-check-issues service-instance instance-health-check-url response)
-                   (let [backend-protocol (hu/backend-protocol->http-version protocol)
-                         backend-scheme (hu/backend-proto->scheme protocol)
-                         request {:client-protocol backend-protocol
+                   (let [proto-version (hu/backend-protocol->http-version protocol)
+                         proto-scheme (hu/backend-proto->scheme protocol)
+                         request {:client-protocol proto-version
                                   :headers request-headers
-                                  :internal-protocol backend-protocol
+                                  :internal-protocol proto-version
                                   :request-id correlation-id
                                   :request-method :get
                                   :request-time request-time
-                                  :scheme backend-scheme
+                                  :scheme proto-scheme
                                   :uri health-check-url}
                          backend-response-latency-ns (- response-time-ns request-time-ns)
                          response (assoc response
@@ -359,7 +381,7 @@
                                     :instance service-instance
                                     :instance-proto protocol
                                     :latest-service-id service-id
-                                    :protocol protocol
+                                    :protocol proto-version
                                     :request-type "health-check"
                                     :waiter-api-call? false)]
                      (rlog/log-request! request response))

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -259,7 +259,7 @@
   [port-index {:strs [backend-proto health-check-port-index health-check-proto] :as service-description}]
   (cond
     (zero? port-index) backend-proto
-    (= port-index health-check-port-index) health-check-proto
+    (= port-index health-check-port-index) (or health-check-proto backend-proto)
     :else (throw (ex-info "Unrecognized port index"
                           {:port-index port-index
                            :service-description service-description}))))

--- a/waiter/src/waiter/scheduler/composite.clj
+++ b/waiter/src/waiter/scheduler/composite.clj
@@ -84,6 +84,12 @@
         service-id->scheduler
         (scheduler/deployment-error-config service-id)))
 
+  (request-protocol [_ instance port-index service-description]
+    (-> instance
+        :service-id
+        service-id->scheduler
+        (scheduler/request-protocol instance port-index service-description)))
+
   (scale-service [_ service-id target-instances force]
     (-> service-id
         service-id->scheduler

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -804,6 +804,9 @@
     ;; container restarts repeadly within a single Pod, normally not switching hosts.
     {:min-hosts 1})
 
+  (request-protocol [_ _ port-index service-description]
+    (scheduler/port-index-protocol port-index service-description))
+
   (scale-service [this service-id scale-to-instances _]
     (ss/try+
       (if-let [service (service-id->service this service-id)]

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -805,7 +805,7 @@
     {:min-hosts 1})
 
   (request-protocol [_ _ port-index service-description]
-    (scheduler/port-index-protocol port-index service-description))
+    (scheduler/retrieve-protocol port-index service-description))
 
   (scale-service [this service-id scale-to-instances _]
     (ss/try+

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -415,6 +415,9 @@
   (deployment-error-config [_ _]
     (comment ":deployment-error-config overrides currently not supported."))
 
+  (request-protocol [_ _ port-index service-description]
+    (scheduler/port-index-protocol port-index service-description))
+
   (scale-service [_ service-id scale-to-instances force]
     (ss/try+
       (scheduler/suppress-transient-server-exceptions

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -416,7 +416,7 @@
     (comment ":deployment-error-config overrides currently not supported."))
 
   (request-protocol [_ _ port-index service-description]
-    (scheduler/port-index-protocol port-index service-description))
+    (scheduler/retrieve-protocol port-index service-description))
 
   (scale-service [_ service-id scale-to-instances force]
     (ss/try+

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -662,7 +662,7 @@
     (comment ":deployment-error-config overrides currently not supported."))
 
   (request-protocol [_ _ port-index service-description]
-    (scheduler/port-index-protocol port-index service-description))
+    (scheduler/retrieve-protocol port-index service-description))
 
   (scale-service [this service-id scale-to-instances _]
     (if (scheduler/service-exists? this service-id)

--- a/waiter/src/waiter/websocket.clj
+++ b/waiter/src/waiter/websocket.clj
@@ -255,7 +255,7 @@
 (defn make-request
   "Makes an asynchronous websocket request to the instance endpoint and returns a channel."
   [websocket-client service-id->password-fn {:keys [host port] :as instance} {:keys [query-string] :as ws-request}
-   request-properties passthrough-headers end-route _ backend-proto proto-version]
+   request-properties passthrough-headers end-route _ request-proto proto-version]
   (let [ws-middleware (fn ws-middleware [_ ^UpgradeRequest request]
                         (let [service-password (-> instance scheduler/instance->service-id service-id->password-fn)
                               {:keys [authorization/metadata authorization/principal]} ws-request
@@ -278,7 +278,7 @@
                                        :middleware ws-middleware}
                                 (not (str/blank? sec-websocket-protocol))
                                 (assoc :subprotocols (str/split sec-websocket-protocol #",")))
-        ws-protocol (if (= "https" (hu/backend-proto->scheme backend-proto)) "wss" "ws")
+        ws-protocol (if (= "https" (hu/backend-proto->scheme request-proto)) "wss" "ws")
         instance-url (cond-> (scheduler/end-point-url ws-protocol host port end-route)
                        (not (str/blank? query-string))
                        (str "?" query-string))

--- a/waiter/test/waiter/async_request_test.clj
+++ b/waiter/test/waiter/async_request_test.clj
@@ -20,6 +20,7 @@
             [plumbing.core :as pc]
             [waiter.async-request :refer :all]
             [waiter.auth.authentication :as auth]
+            [waiter.scheduler :as scheduler]
             [waiter.service :as service]
             [waiter.status-codes :refer :all]
             [waiter.test-helpers :refer :all]
@@ -329,10 +330,8 @@
             populate-maintainer-chan! (make-populate-maintainer-chan! instance-rpc-chan)
             complete-async-request-atom (atom nil)
             response {}
-            b64-url-json-encode* utils/b64-url-json-encode
-            get-async-request-protocol* get-async-request-protocol]
-        (with-redefs [get-async-request-protocol (if v2? (constantly "https") get-async-request-protocol*)
-                      service/release-instance-go (constantly nil)
+            b64-url-json-encode* utils/b64-url-json-encode]
+        (with-redefs [service/release-instance-go (constantly nil)
                       utils/b64-url-json-encode #(->> % (into (sorted-map)) b64-url-json-encode*)
                       monitor-async-request
                       (fn [make-get-request-fn complete-async-request-fn request-still-active? _
@@ -347,8 +346,11 @@
           (let [descriptor {:service-description {"backend-proto" backend-proto
                                                   "metric-group" metric-group}
                             :service-id service-id}
+                scheduler (reify scheduler/ServiceScheduler
+                            (request-protocol [_ _ i sd]
+                              (if v2? "https" (scheduler/port-index-protocol i sd))))
                 {:keys [headers]} (post-process-async-request-response
-                                    router-id async-request-store-atom make-http-request-fn auth-params-map
+                                    scheduler router-id async-request-store-atom make-http-request-fn auth-params-map
                                     populate-maintainer-chan! user-agent response descriptor instance reason-map
                                     request-properties location query-string)]
             (is (get @async-request-store-atom request-id))
@@ -424,8 +426,11 @@
             descriptor {:service-description {"backend-proto" backend-proto
                                               "metric-group" metric-group}
                         :service-id service-id}
+            scheduler (reify scheduler/ServiceScheduler
+                        (request-protocol [_ _ i sd]
+                          (scheduler/port-index-protocol i sd)))
             {:keys [headers]} (post-process-async-request-response
-                                router-id async-request-store-atom make-http-request-fn auth-params-map
+                                scheduler router-id async-request-store-atom make-http-request-fn auth-params-map
                                 populate-maintainer-chan! user-agent response descriptor instance
                                 reason-map request-properties location query-string)]
         (is (get @async-request-store-atom request-id))

--- a/waiter/test/waiter/async_request_test.clj
+++ b/waiter/test/waiter/async_request_test.clj
@@ -348,7 +348,7 @@
                             :service-id service-id}
                 scheduler (reify scheduler/ServiceScheduler
                             (request-protocol [_ _ i sd]
-                              (if v2? "https" (scheduler/port-index-protocol i sd))))
+                              (if v2? "https" (scheduler/retrieve-protocol i sd))))
                 {:keys [headers]} (post-process-async-request-response
                                     scheduler router-id async-request-store-atom make-http-request-fn auth-params-map
                                     populate-maintainer-chan! user-agent response descriptor instance reason-map
@@ -428,7 +428,7 @@
                         :service-id service-id}
             scheduler (reify scheduler/ServiceScheduler
                         (request-protocol [_ _ i sd]
-                          (scheduler/port-index-protocol i sd)))
+                          (scheduler/retrieve-protocol i sd)))
             {:keys [headers]} (post-process-async-request-response
                                 scheduler router-id async-request-store-atom make-http-request-fn auth-params-map
                                 populate-maintainer-chan! user-agent response descriptor instance

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -66,15 +66,17 @@
       first
       :task-stats))
 
+(def ^:const max-agent-wait-ms (-> 1 t/minutes t/in-millis))
+
 (defn- ensure-agent-finished
   "Awaits the scheduler's agent"
   [{:keys [id->service-agent]}]
-  (await id->service-agent))
+  (is (await-for max-agent-wait-ms id->service-agent)))
 
 (defn- force-update-service-health
   "Forces a call to update-service-health"
   [{:keys [id->service-agent port->reservation-atom scheduler-name] :as scheduler} {:keys [port-grace-period-ms]}]
-  (send id->service-agent update-service-health scheduler-name port->reservation-atom port-grace-period-ms nil)
+  (send id->service-agent update-service-health scheduler scheduler-name port->reservation-atom port-grace-period-ms nil)
   (ensure-agent-finished scheduler))
 
 (defn- force-maintain-instance-scale

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -550,14 +550,19 @@
   (let [http-client (HttpClient.)
         service-password "test-password"
         service-id->password-fn (constantly service-password)
+        scheduler (reify ServiceScheduler
+                    (request-protocol [_ _ i sd]
+                      (port-index-protocol i sd)))
+        scheduler-promise-chan (au/singleton-chan scheduler)
         scheduler-name "test-scheduler"
         waiter-principal "waiter@test.com"
         health-check-proto "http"
         available-fn? (fn available-fn? [service-instance service-description]
-                        (available? service-id->password-fn http-client scheduler-name
-                                    service-instance service-description))
+                        (available? service-id->password-fn http-client scheduler-promise-chan
+                                    scheduler-name service-instance service-description))
         service-instance {:extra-ports [81] :host "www.example.com" :port 80}
-        service-description {"health-check-proto" health-check-proto
+        service-description {"backend-proto" health-check-proto
+                             "health-check-proto" health-check-proto
                              "health-check-port-index" 0
                              "health-check-url" "/health-check"}]
 

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -552,13 +552,12 @@
         service-id->password-fn (constantly service-password)
         scheduler (reify ServiceScheduler
                     (request-protocol [_ _ i sd]
-                      (port-index-protocol i sd)))
-        scheduler-promise-chan (au/singleton-chan scheduler)
+                      (retrieve-protocol i sd)))
         scheduler-name "test-scheduler"
         waiter-principal "waiter@test.com"
         health-check-proto "http"
         available-fn? (fn available-fn? [service-instance service-description]
-                        (available? service-id->password-fn http-client scheduler-promise-chan
+                        (available? service-id->password-fn http-client scheduler
                                     scheduler-name service-instance service-description))
         service-instance {:extra-ports [81] :host "www.example.com" :port 80}
         service-description {"backend-proto" health-check-proto


### PR DESCRIPTION
## Changes proposed in this PR

Delegate protocol selection to the Scheduler implementation rather than assuming the backend-protocol on the service-description is correct. The assumption is that, although we can't just infer the correct protocol from the service-description, the Scheduler has enough data at request time to make that determination for a specific back-end instance.

## Why are we making these changes?

Allows us to connect to backends via an intermediate proxy with a different protocol (e.g., enabling TLS via a proxy for a cleartext backend service).
