### PR TITLE
enables support for grpc retries

### DIFF
--- a/containers/test-apps/courier/pom.xml
+++ b/containers/test-apps/courier/pom.xml
@@ -6,13 +6,13 @@
 
     <groupId>twosigma</groupId>
     <artifactId>courier</artifactId>
-    <version>1.5.18</version>
+    <version>1.5.19</version>
 
     <name>courier</name>
     <url>https://github.com/twosigma/waiter/tree/master/test-apps/courier</url>
 
     <properties>
-        <grpc.version>1.30.2</grpc.version>
+        <grpc.version>1.20.0</grpc.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -36,7 +36,7 @@
                   :exclusions [[commons-codec]]]
                  ;; resolve the cheshire dependency used by buddy and jet
                  [cheshire "5.10.0"]
-                 [twosigma/courier "1.5.15"
+                 [twosigma/courier "1.5.19"
                   :exclusions [com.google.guava/guava io.grpc/grpc-core]
                   :scope "test"]
                  ;; avoids the following:
@@ -45,7 +45,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20210714_175127-g9b2f58a"
+                 [twosigma/jet "0.7.10-20210727_221451-g7742bea"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]

--- a/waiter/src/waiter/util/http_utils.clj
+++ b/waiter/src/waiter/util/http_utils.clj
@@ -222,6 +222,18 @@
   [{:strs [content-type]} proto-version]
   (and (= "HTTP/2.0" proto-version) (= content-type "application/grpc")))
 
+(defn grpc-status-error?
+  "Returns true if the grpc-status is not blank and represents an error."
+  [grpc-status]
+  (and (not (str/blank? grpc-status))
+       (not= (str grpc-0-ok) grpc-status)))
+
+(defn grpc-status-success?
+  "Returns true if the grpc-status is not blank and represents a success."
+  [grpc-status]
+  (and (not (str/blank? grpc-status))
+       (= (str grpc-0-ok) grpc-status)))
+
 (defn service-unavailable?
   "Returns true if the response represents the service is unavailable.
    This means either the response status is 503 or the grpc response status is UNAVAILABLE, i.e. 14."


### PR DESCRIPTION
## Changes proposed in this PR

- enables support for grpc retries

## Why are we making these changes?

gRPC retry mechanism relies on [only trailers being present in the response](https://github.com/grpc/proposal/blob/master/A6-client-retries.md#when-retries-are-valid) with the corresponding grpc-status reflecting the error. We rely on Jetty API to emit only header frames when the body is empty to mimic this behavior to trigger gRPC retries.

### Related PRs

- jet: [closes response streams eagerly when content length is known](https://github.com/twosigma/jet/pull/55)

### Logs

Before the change, gRPC errors triggered header and trailer frames in responses:
```
2021-07-27 11:45:37.603 FINE    (io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2FrameLogger logHeaders) [id: 0x1460480d, L:/127.0.0.1:52342 - R:courier.localtest.me/127.0.0.1:9091] INBOUND HEADERS: streamId=3 headers=GrpcHttp2ResponseHeaders[:status: 200, content-type: application/grpc, x-cid: courier-request-691744339116712, grpc-message: Cancelled by server, grpc-status: 1, ...] padding=0 endStream=false 
2021-07-27 11:45:37.610 FINE    (io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2FrameLogger logHeaders) [id: 0x1460480d, L:/127.0.0.1:52342 - R:courier.localtest.me/127.0.0.1:9091] INBOUND HEADERS: streamId=3 headers=GrpcHttp2ResponseHeaders[grpc-message: Cancelled by server, grpc-status: 1] padding=0 endStream=true 
```

After the change, gRPC error responses trigger trailer-only responses:
```
2021-07-27 11:45:37.603 FINE    (io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2FrameLogger logHeaders) [id: 0x1460480d, L:/127.0.0.1:52342 - R:courier.localtest.me/127.0.0.1:9091] INBOUND HEADERS: streamId=3 headers=GrpcHttp2ResponseHeaders[:status: 200, content-type: application/grpc, x-cid: courier-request-691744339116712,grpc-message: Cancelled by server, grpc-status: 1] padding=0 endStream=true 
```