### PR TITLE
Fix test-kubernetes-pod-expiry-grace-period timeout

### DIFF
--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -373,7 +373,8 @@
                                :x-waiter-max-instances 1
                                :x-waiter-min-instances 1
                                :x-waiter-name (rand-name)
-                               :x-waiter-timeout 30000)
+                               :x-waiter-timeout 30000
+                               :x-waiter-queue-timeout 30000)
               service-id (retrieve-service-id waiter-url waiter-headers)
               timeout-secs 150]
           (cond


### PR DESCRIPTION
## Changes proposed in this PR

Fix test-kubernetes-pod-expiry-grace-period timeout to account for queue time.

## Why are we making these changes?

This test takes way longer than the 30 seconds intended because `x-waiter-timeout` doesn't apply while the request is still in the queue. (Apparently it only applies to the socket between Waiter and the back-end instance.)