### PR TITLE
supports regexes in token list queries

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -2120,3 +2120,89 @@
                         (is false (str "Unexpected service " service-id " was started!")))))
                   (finally
                     (delete-token-and-assert waiter-url token)))))))))))
+
+(deftest ^:parallel ^:integration-fast test-token-list-filtering
+  (testing-using-waiter-url
+    (let [retrieve-tokens (fn [query-params]
+                            (let [tokens-response (make-request waiter-url "/tokens" :query-params query-params)]
+                              (assert-response-status tokens-response http-200-ok)
+                              (->> tokens-response
+                                :body
+                                (try-parse-json)
+                                (walk/keywordize-keys)
+                                (map :token)
+                                (set))))
+          token-1 (rand-name)
+          description-1 {:env {"FLAG" "true"} :load-balancing "oldest" :metadata {"flag" "false"} :name "test-token-1" :token token-1}
+          token-2 (rand-name)
+          description-2 {:env {"FLAG" "false"} :load-balancing "youngest" :metadata {"flag" "true"} :name "test-token-2" :token token-2}]
+      (testing "invalid authentication and health-check-authentication"
+        (try
+          (let [response-1 (post-token waiter-url description-1)]
+            (assert-response-status response-1 http-200-ok))
+          (try
+            (let [response-2 (post-token waiter-url description-2)]
+              (assert-response-status response-2 http-200-ok))
+
+            (testing "tokens show up without filtering"
+              (let [token-set (retrieve-tokens {})]
+                (is (contains? token-set token-1) (str token-set))
+                (is (contains? token-set token-2) (str token-set))))
+
+            (testing "cluster filtering"
+              (let [cluster-name (retrieve-token-cluster waiter-url)
+                    token-set (retrieve-tokens {"cluster" cluster-name})]
+                (is (contains? token-set token-1) (str token-set))
+                (is (contains? token-set token-2) (str token-set)))
+              (let [token-set (retrieve-tokens {"cluster" "k-means"})]
+                (is (not (contains? token-set token-1)) (str token-set))
+                (is (not (contains? token-set token-2)) (str token-set))))
+
+            (testing "metadata filtering"
+              (let [token-set (retrieve-tokens {"last-update-user" (retrieve-username)})]
+                (is (contains? token-set token-1) (str token-set))
+                (is (contains? token-set token-2) (str token-set)))
+              (let [token-set (retrieve-tokens {"last-update-user" "john.doe"})]
+                (is (not (contains? token-set token-1)) (str token-set))
+                (is (not (contains? token-set token-2)) (str token-set))))
+
+            (testing "field filtering"
+              (let [token-set (retrieve-tokens {"load-balancing" "oldest"})]
+                (is (contains? token-set token-1) (str token-set))
+                (is (not (contains? token-set token-2)) (str token-set)))
+              (let [token-set (retrieve-tokens {"load-balancing" "youngest"})]
+                (is (not (contains? token-set token-1)) (str token-set))
+                (is (contains? token-set token-2) (str token-set)))
+              (let [token-set (retrieve-tokens {"load-balancing" ["oldest" "youngest"]})]
+                (is (contains? token-set token-1) (str token-set))
+                (is (contains? token-set token-2) (str token-set))))
+
+            (testing "nested field filtering"
+              (let [token-set (retrieve-tokens {"env.FLAG" "true"})]
+                (is (contains? token-set token-1) (str token-set))
+                (is (not (contains? token-set token-2)) (str token-set)))
+              (let [token-set (retrieve-tokens {"env.FLAG" "false"})]
+                (is (not (contains? token-set token-1)) (str token-set))
+                (is (contains? token-set token-2) (str token-set)))
+              (let [token-set (retrieve-tokens {"env.FLAG" ["false" "true"]})]
+                (is (contains? token-set token-1) (str token-set))
+                (is (contains? token-set token-2) (str token-set))))
+
+            (testing "regex filtering"
+              (let [token-set (retrieve-tokens {"name" "test-token-1"})]
+                (is (contains? token-set token-1) (str token-set))
+                (is (not (contains? token-set token-2)) (str token-set)))
+              (let [token-set (retrieve-tokens {"name" "test-token-2"})]
+                (is (not (contains? token-set token-1)) (str token-set))
+                (is (contains? token-set token-2) (str token-set)))
+              (let [token-set (retrieve-tokens {"name" "test-token"})]
+                (is (not (contains? token-set token-1)) (str token-set))
+                (is (not (contains? token-set token-2)) (str token-set)))
+              (let [token-set (retrieve-tokens {"name" "test-token*"})]
+                (is (contains? token-set token-1) (str token-set))
+                (is (contains? token-set token-2) (str token-set))))
+
+            (finally
+              (delete-token-and-assert waiter-url token-2)))
+          (finally
+            (delete-token-and-assert waiter-url token-1)))))))

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -1619,21 +1619,23 @@
 
 (defn query-params->service-description-filter-predicate
   "Creates the filter function for service descriptions that matches every parameter provided in the request-params map."
-  [request-params]
-  (let [service-description-params (utils/filterm
-                                     (fn [[param-name _]]
-                                       (->> (str/split param-name #"\.")
-                                            (first)
-                                            (contains? service-parameter-keys)))
-                                     request-params)
-        param-predicates (map (fn [[param-name param-value]]
-                                (let [param-predicate (param-value->filter-fn param-value)]
-                                  (fn [service-description]
-                                    (->> (str/split param-name #"\.")
-                                         (get-in service-description)
-                                         (str)
-                                         (param-predicate)))))
-                              (seq service-description-params))]
-    (fn [service-description]
-      (or (empty? param-predicates)
-          (every? #(%1 service-description) param-predicates)))))
+  ([request-params]
+   (query-params->service-description-filter-predicate request-params service-parameter-keys))
+  ([request-params parameter-keys]
+   (let [service-description-params (utils/filterm
+                                      (fn [[param-name _]]
+                                        (->> (str/split param-name #"\.")
+                                          (first)
+                                          (contains? parameter-keys)))
+                                      request-params)
+         param-predicates (map (fn [[param-name param-value]]
+                                 (let [param-predicate (param-value->filter-fn param-value)]
+                                   (fn [service-description]
+                                     (->> (str/split param-name #"\.")
+                                       (get-in service-description)
+                                       (str)
+                                       (param-predicate)))))
+                               (seq service-description-params))]
+     (fn [service-description]
+       (or (empty? param-predicates)
+           (every? #(%1 service-description) param-predicates))))))

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -661,18 +661,8 @@
                           (string? owner-param) #{owner-param}
                           (coll? owner-param) (set owner-param)
                           :else (list-token-owners kv-store))
-                 filterable-parameter? (disj sd/token-data-keys "owner" "maintenance")
-                 parameter-filter-predicates (for [[parameter-name raw-param] request-params
-                                                   :let [param-name-components (str/split parameter-name #"\.")
-                                                         param-name-head (first param-name-components)]
-                                                   :when (filterable-parameter? param-name-head)]
-                                               (let [search-parameter-values (cond
-                                                                               (string? raw-param) #{raw-param}
-                                                                               :else (set raw-param))]
-                                                 (fn [token-parameters]
-                                                   (and (contains? token-parameters param-name-head)
-                                                        (contains? search-parameter-values
-                                                                   (str (get-in token-parameters param-name-components)))))))
+                 service-description-filter-predicate (-> (dissoc request-params "deleted" "maintenance" "owner" "previous")
+                                                        (sd/query-params->service-description-filter-predicate sd/token-data-keys))
                  index-filter-fn
                  (every-pred
                    (fn list-tokens-delete-predicate [entry]
@@ -688,7 +678,7 @@
                                               kv-store token
                                               :error-on-missing false
                                               :include-deleted include-deleted)]
-                       (and (every? #(% token-parameters) parameter-filter-predicates)
+                       (and (service-description-filter-predicate token-parameters)
                             (or (nil? include-run-as-requester)
                                 (= include-run-as-requester (sd/run-as-requester? token-parameters)))
                             (or (nil? include-requires-parameters)


### PR DESCRIPTION
## Changes proposed in this PR

- supports regexes in token list queries

## Why are we making these changes?

We would like the tokens list search query params to work similarly to services list search query params. They are more dynamic (supporting regexes) rather than exact string matches.

