### PR TITLE
supports forcing authenticated health checks in k8s scheduled services

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -405,6 +405,10 @@
                                  ;; that returns an instance of waiter.scheduler.ServiceScheduler:
                                  :factory-fn waiter.scheduler.kubernetes/kubernetes-scheduler
 
+                                 ;; Whether to always use authenticated health checks on pods readiness and liveness checks
+                                 ;; regardless of the health-check-authentication parameter in the service description.
+                                 :authenticate-health-checks? false
+
                                  ;; Configuration for obtaining the credentials to authenticate with the Kubernetes API server.
                                  ;; If authentication isn't required (e.g., using kubectl proxy), then this can be omitted.
                                  :authentication {;; Unary function which can be called periodically (or just once if :refresh-delay-mins is omitted)

--- a/waiter/config-k8s.edn
+++ b/waiter/config-k8s.edn
@@ -47,7 +47,8 @@
  ; ---------- Scheduling ----------
 
  :scheduler-config {:kind :kubernetes
-                    :kubernetes {:authorizer {:kind :sanity-check
+                    :kubernetes {:authenticate-health-checks? true
+                                 :authorizer {:kind :sanity-check
                                               :sanity-check {:factory-fn waiter.authorization/sanity-check-authorizer}}
                                  :container-running-grace-secs 90
                                  :fileserver {:port 591}

--- a/waiter/src/waiter/scheduler/composite.clj
+++ b/waiter/src/waiter/scheduler/composite.clj
@@ -90,6 +90,11 @@
         service-id->scheduler
         (scheduler/request-protocol instance port-index service-description)))
 
+  (use-authenticated-health-checks? [_ service-id]
+    (-> service-id
+      service-id->scheduler
+      (scheduler/use-authenticated-health-checks? service-id)))
+
   (scale-service [_ service-id target-instances force]
     (-> service-id
         service-id->scheduler

--- a/waiter/src/waiter/scheduler/marathon.clj
+++ b/waiter/src/waiter/scheduler/marathon.clj
@@ -418,6 +418,10 @@
   (request-protocol [_ _ port-index service-description]
     (scheduler/retrieve-protocol port-index service-description))
 
+  (use-authenticated-health-checks? [this service-id]
+    (let [service-description (service-id->service-description-fn service-id)]
+      (scheduler/authenticated-health-check-configured? service-description)))
+
   (scale-service [_ service-id scale-to-instances force]
     (ss/try+
       (scheduler/suppress-transient-server-exceptions

--- a/waiter/src/waiter/scheduler/shell.clj
+++ b/waiter/src/waiter/scheduler/shell.clj
@@ -664,6 +664,10 @@
   (request-protocol [_ _ port-index service-description]
     (scheduler/retrieve-protocol port-index service-description))
 
+  (use-authenticated-health-checks? [this service-id]
+    (let [service-description (service-id->service-description-fn service-id)]
+      (scheduler/authenticated-health-check-configured? service-description)))
+
   (scale-service [this service-id scale-to-instances _]
     (if (scheduler/service-exists? this service-id)
       (let [completion-promise (promise)]

--- a/waiter/test/waiter/scheduler/marathon_test.clj
+++ b/waiter/test/waiter/scheduler/marathon_test.clj
@@ -1432,3 +1432,13 @@
                                                    :version newish-version}])]
           (is (nil? (start-new-service-wrapper marathon-api service-id marathon-descriptor)))
           (is (= 1 @create-call-counter)))))))
+
+(deftest test-use-authenticated-health-checks?
+  (doseq [{:keys [expected-result health-check-authentication]}
+          [{:expected-result true
+            :health-check-authentication "standard"}
+           {:expected-result false
+            :health-check-authentication "disabled"}]]
+    (let [service-id->service-description (constantly {"health-check-authentication" health-check-authentication})
+          marathon-scheduler (create-marathon-scheduler :service-id->service-description-fn service-id->service-description)]
+      (is (= expected-result (scheduler/use-authenticated-health-checks? marathon-scheduler "s1"))))))

--- a/waiter/test/waiter/scheduler/shell_test.clj
+++ b/waiter/test/waiter/scheduler/shell_test.clj
@@ -765,3 +765,15 @@
                             :task-stats {:healthy 1 :running 1 :staged 0 :unhealthy 0}))
              @id->service-agent))
       (is (= port->reservation @port->reservation-atom)))))
+
+(deftest test-use-authenticated-health-checks?
+  (doseq [{:keys [expected-result health-check-authentication]}
+          [{:expected-result true
+            :health-check-authentication "standard"}
+           {:expected-result false
+            :health-check-authentication "disabled"}]]
+    (let [service-id->service-description (constantly {"health-check-authentication" health-check-authentication})
+          valid-config (-> (common-scheduler-config)
+                         (assoc :service-id->service-description-fn service-id->service-description))
+          marathon-scheduler (create-shell-scheduler valid-config)]
+      (is (= expected-result (scheduler/use-authenticated-health-checks? marathon-scheduler "s1"))))))


### PR DESCRIPTION
## Changes proposed in this PR

- supports forcing authenticated health checks in k8s scheduled services

## Why are we making these changes?

Allows supporting reverse proxies that do cannot handle unauthenticated health checks when authentication is enabled for regular proxied requests.

