### PR TITLE
ensures unique version of services per integration test run

### DIFF
--- a/waiter/integration/waiter/health_check_test.clj
+++ b/waiter/integration/waiter/health_check_test.clj
@@ -93,7 +93,8 @@
               health-check-proto (disj supported-protocols backend-proto)
               health-check-port-index [nil 0]]
         (let [request-headers (cond-> {:x-waiter-backend-proto backend-proto
-                                       :x-waiter-health-check-proto health-check-proto}
+                                       :x-waiter-health-check-proto health-check-proto
+                                       :x-waiter-name (rand-name)}
                                 health-check-port-index (assoc :x-waiter-health-check-port-index health-check-port-index))
               {:keys [body] :as response} (make-kitchen-request waiter-url request-headers)
               error-msg (str "The backend-proto (" backend-proto ") and health check proto (" health-check-proto

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -2082,6 +2082,7 @@
           (let [token-description (assoc base-description
                                     :authentication "disabled"
                                     :health-check-authentication "standard"
+                                    :name (rand-name)
                                     :token token)
                 {:keys [body] :as register-response} (post-token waiter-url token-description)]
             (assert-response-status register-response http-400-bad-request)
@@ -2105,6 +2106,7 @@
                   (let [token-description (assoc base-description
                                             other-parameter-name other-parameter-value
                                             :https-redirect false
+                                            :name (rand-name)
                                             :permitted-user "*"
                                             :profile (name profile)
                                             :run-as-user (retrieve-username)


### PR DESCRIPTION
## Changes proposed in this PR

- ensures unique version of services per integration test run

## Why are we making these changes?

We would like to have independent outcomes on different test runs.

