### PR TITLE
adds --no-wait flag to maintenance stop

### DIFF
--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1974,7 +1974,6 @@ class WaiterCliTest(util.WaiterTest):
         try:
             cp = cli.maintenance('stop', token_name, self.waiter_url, maintenance_flags='--no-wait')
             stdout = cli.stdout(cp)
-            print(stdout)
             self.assertEqual(0, cp.returncode, cp.stderr)
             self.assertIn(f'Pinging token {token_name}', stdout)
             self.assertIn('Service is currently Starting', stdout)

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1964,6 +1964,28 @@ class WaiterCliTest(util.WaiterTest):
         finally:
             util.delete_token(self.waiter_url, token_name, kill_services=True)
 
+    def test_maintenance_stop_with_ping_no_wait(self):
+        token_name = self.token_name()
+        token_fields = util.minimal_service_description()
+        token_fields['cmd'] = f"sleep 30 && {token_fields['cmd']}"
+        custom_maintenance_message = "custom maintenance message"
+        util.post_token(self.waiter_url, token_name,
+                        {**token_fields, 'maintenance': {'message': custom_maintenance_message}})
+        try:
+            cp = cli.maintenance('stop', token_name, self.waiter_url, maintenance_flags='--no-wait')
+            stdout = cli.stdout(cp)
+            print(stdout)
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            self.assertIn(f'Pinging token {token_name}', stdout)
+            self.assertIn('Service is currently Starting', stdout)
+            token_data = util.load_token(self.waiter_url, token_name)
+            self.assertEqual(None, token_data.get('maintenance', None))
+            for key, value in token_fields.items():
+                self.assertEqual(value, token_data[key])
+            self.assertEqual(1, len(util.wait_until_services_for_token(self.waiter_url, token_name, 1)))
+        finally:
+            util.delete_token(self.waiter_url, token_name, kill_services=True)
+
     def test_maintenance_stop_no_cluster(self):
         self.__test_no_cluster(partial(cli.maintenance, 'stop'))
 

--- a/cli/waiter/subcommands/maintenance.py
+++ b/cli/waiter/subcommands/maintenance.py
@@ -96,7 +96,7 @@ def stop_maintenance(clusters, args, enforce_cluster):
     token_name = args['token']
     ping_token = args.pop('ping_token', True)
     timeout = args.pop('timeout', 300)
-    wait_for_ping = True
+    wait_for_ping = args.pop('wait', True)
     cluster, existing_token_data, existing_token_etag = _get_existing_token_data(clusters, token_name, enforce_cluster)
     maintenance_mode_active = _is_token_in_maintenance_mode(existing_token_data)
     if not maintenance_mode_active:
@@ -151,6 +151,8 @@ def register_stop(add_parser):
                             help='Ping the token after stopping maintenance.')
     parser.add_argument('--timeout', '-t', default=300, help='read timeout (in seconds) for ping request.',
                         type=check_positive)
+    parser.add_argument('--no-wait', '-n', help='do not wait for ping request to return',
+                        dest='wait', action='store_false')
     parser.add_argument('token')
     parser.set_defaults(sub_func=stop_maintenance)
 


### PR DESCRIPTION
## Changes proposed in this PR

- adds --no-wait flag to maintenance stop

## Why are we making these changes?

Allows the `maintenace stop` command to return without waiting for the ping request to complete.


