### PR TITLE
fixes reference to default namespace in k8s scheduler factory function

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -1454,12 +1454,13 @@
 (defn kubernetes-scheduler
   "Returns a new KubernetesScheduler with the provided configuration. Validates the
    configuration against kubernetes-scheduler-schema and throws if it's not valid."
-  [{:keys [authenticate-health-checks? authentication authorizer cluster-name container-running-grace-secs custom-options default-namespace http-options leader?-fn log-bucket-sync-secs
+  [{:keys [authenticate-health-checks? authentication authorizer cluster-name container-running-grace-secs custom-options http-options leader?-fn log-bucket-sync-secs
            log-bucket-url max-patch-retries max-name-length namespace pdb-api-version pdb-spec-builder pod-base-port pod-sigkill-delay-secs
-           pod-suffix-length replicaset-api-version replicaset-spec-builder response->deployment-error-msg-fn restart-expiry-threshold restart-kill-threshold
+           pod-suffix-length replicaset-api-version response->deployment-error-msg-fn restart-expiry-threshold restart-kill-threshold
            reverse-proxy scheduler-name scheduler-state-chan scheduler-syncer-interval-secs service-id->service-description-fn
            service-id->password-fn start-scheduler-syncer-fn url watch-chan-throttle-interval-ms watch-connect-timeout-ms watch-init-timeout-ms watch-retries watch-socket-timeout-ms]
     {fileserver-port :port fileserver-scheme :scheme :as fileserver} :fileserver
+    {:keys [default-namespace] :as replicaset-spec-builder} :replicaset-spec-builder
     {service-id->deployment-error-cache-threshold :threshold service-id->deployment-error-cache-ttl-sec :ttl} :service-id->deployment-error-cache
     :as context}]
   {:pre [(or (nil? authenticate-health-checks?) (boolean? authenticate-health-checks?))

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -1605,7 +1605,10 @@
             (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :response->deployment-error-msg-fn "string")))))
 
           (testing "bad (non-matching) scheduler namespace and default-namespace"
-            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :default-namespace "x" :namespace "y")))))
+            (let [config (-> base-config
+                           (assoc :namespace "y")
+                           (assoc-in [:replicaset-spec-builder :default-namespace] "x"))]
+              (is (thrown? Throwable (kubernetes-scheduler config)))))
 
           (testing "good (non-conflicting) scheduler namespace and default-namespace"
             (is (instance? KubernetesScheduler (kubernetes-scheduler (assoc base-config :namespace "y"))))


### PR DESCRIPTION
## Changes proposed in this PR

- fixes reference to default namespace in k8s scheduler factory function

## Why are we making these changes?

Resolves bug in code which is referencing the default namespace from the wrong location.

