### PR TITLE
enables server reflection in courier

### DIFF
--- a/containers/test-apps/courier/pom.xml
+++ b/containers/test-apps/courier/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>twosigma</groupId>
     <artifactId>courier</artifactId>
-    <version>1.5.19</version>
+    <version>1.5.20</version>
 
     <name>courier</name>
     <url>https://github.com/twosigma/waiter/tree/master/test-apps/courier</url>
@@ -30,6 +30,11 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-protobuf</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-services</artifactId>
             <version>${grpc.version}</version>
         </dependency>
         <dependency>

--- a/containers/test-apps/courier/src/main/java/com/twosigma/waiter/courier/GrpcServer.java
+++ b/containers/test-apps/courier/src/main/java/com/twosigma/waiter/courier/GrpcServer.java
@@ -26,6 +26,7 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.services.ProtoReflectionService;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 
@@ -128,6 +129,7 @@ public class GrpcServer {
         server = ServerBuilder
             .forPort(port)
             .addService(new CourierImpl())
+            .addService(ProtoReflectionService.newInstance())
             .intercept(new GrpcServerInterceptor())
             .intercept(new CorrelationIdInterceptor())
             .build()


### PR DESCRIPTION
## Changes proposed in this PR

- enables server reflection in courier

## Why are we making these changes?

We would like to use tools like `grpcurl` to interact with Courier services.

### Example logs:
```
$ grpcurl -plaintext localhost:8080 list
courier.Courier
grpc.reflection.v1alpha.ServerReflection

$ grpcurl -plaintext localhost:8080 describe courier.Courier
courier.Courier is a service:
service Courier {
  rpc AggregatePackages ( stream .courier.CourierRequest ) returns ( .courier.CourierSummary );
  rpc CollectPackages ( stream .courier.CourierRequest ) returns ( stream .courier.CourierSummary );
  rpc RetrieveState ( .courier.StateRequest ) returns ( .courier.StateReply );
  rpc SendPackage ( .courier.CourierRequest ) returns ( .courier.CourierReply );
}
```

