### PR TITLE
fix grpc server cancel handling

### DIFF
--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -556,7 +556,7 @@
            (classify-error exception))))
   (is (= [:instance-error nil http-502-bad-gateway "java.io.IOException"]
          (classify-error (IOException. "internal_error"))))
-  (is (= [:generic-error "Server closed connection as stream no longer needed" http-400-bad-request "java.io.IOException"]
+  (is (= [:server-eagerly-closed "Connection eagerly closed by server" http-400-bad-request "java.io.IOException"]
          (classify-error (IOException. "no_error"))))
   (is (= [:client-error "Connection unexpectedly closed while streaming request" http-400-bad-request "org.eclipse.jetty.io.EofException"]
          (classify-error (ex-info "Test Exception" {:source :test :status http-400-bad-request} (EofException. "Test")))))


### PR DESCRIPTION
## Changes proposed in this PR

Gracefully handle eager-close by server via `RST_STREAM` frame

## Why are we making these changes?

Fixes `test-grpc-bidi-streaming-server-cancellation` test response status being changed by Waiter when an Envoy proxy sits between the Waiter proxy and the backend grpc server.