### PR TITLE
Adds support for determining the creation time of a service

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -869,6 +869,7 @@
    :scheduler (pc/fnk [[:settings scheduler-config scheduler-syncer-interval-secs]
                        [:state custom-components leader?-fn scheduler-state-chan service-id-prefix]
                        scheduler-promise-chan
+                       service-id->creation-time*
                        service-id->password-fn*
                        service-id->service-description-fn*
                        start-scheduler-syncer-fn]
@@ -881,12 +882,19 @@
                                          :scheduler-state-chan scheduler-state-chan
                                          ;; TODO scheduler-syncer-interval-secs should be inside the scheduler's config
                                          :scheduler-syncer-interval-secs scheduler-syncer-interval-secs
+                                         :service-id->creation-time-fn service-id->creation-time*
                                          :service-id->password-fn service-id->password-fn*
                                          :service-id->service-description-fn service-id->service-description-fn*
                                          :start-scheduler-syncer-fn start-scheduler-syncer-fn}
                       scheduler (utils/create-component scheduler-config :context scheduler-context)]
                   (async/>!! scheduler-promise-chan scheduler)
                   scheduler))
+   ; This function is only included here for initializing the scheduler above.
+   ; Prefer accessing the non-starred version of this function through the routines map.
+   :service-id->creation-time* (pc/fnk [[:state kv-store]]
+                                 (fn service-id->creation-time
+                                   [service-id]
+                                   (sd/service-id->creation-time kv-store service-id)))
    ; This function is only included here for initializing the scheduler above.
    ; Prefer accessing the non-starred version of this function through the routines map.
    :service-id->password-fn* (pc/fnk [[:state passwords]]

--- a/waiter/test/waiter/kv_test.clj
+++ b/waiter/test/waiter/kv_test.clj
@@ -14,7 +14,8 @@
 ;; limitations under the License.
 ;;
 (ns waiter.kv-test
-  (:require [clj-time.core :as t]
+  (:require [clj-time.coerce :as tc]
+            [clj-time.core :as t]
             [clojure.java.io :as io]
             [clojure.test :refer :all]
             [waiter.curator :as curator]
@@ -27,15 +28,30 @@
 (deftest test-local-kv-store
   (let [test-store (kv/new-local-kv-store {})
         bytes (byte-array 10)
-        include-flags #{"data"}]
+        include-flags #{"data"}
+        time-0 (t/now)
+        time-1 (t/plus time-0 (t/seconds 1))
+        time-2 (t/plus time-0 (t/seconds 2))]
     (Arrays/fill bytes (byte 1))
     (is (nil? (kv/fetch test-store :a)))
-    (kv/store test-store :a bytes)
+    (with-redefs [t/now (constantly time-1)]
+      (kv/store test-store :a bytes))
     (is (Arrays/equals bytes ^bytes (kv/fetch test-store :a)))
-    (kv/store test-store :a 3)
+    (is (= {:store {:count 1
+                    :data {:a {:stats {:creation-time (tc/to-long time-1)
+                                       :modified-time (tc/to-long time-1)}
+                               :value bytes}}}
+            :supported-include-params ["data"]
+            :variant "in-memory"}
+           (kv/state test-store include-flags)))
+    (with-redefs [t/now (constantly time-2)]
+      (kv/store test-store :a 3))
     (is (= 3 (kv/fetch test-store :a)))
     (is (nil? (kv/fetch test-store :b)))
-    (is (= {:store {:count 1, :data {:a 3}}
+    (is (= {:store {:count 1
+                    :data {:a {:stats {:creation-time (tc/to-long time-1)
+                                       :modified-time (tc/to-long time-2)}
+                               :value 3}}}
             :supported-include-params ["data"]
             :variant "in-memory"}
            (kv/state test-store include-flags)))
@@ -126,32 +142,49 @@
   (let [cache-config {:threshold 1000 :ttl (-> 60 t/seconds t/in-millis)}
         local-kv-store (kv/new-local-kv-store {})
         include-flags #{"data"}
-        {:keys [cache] :as cached-kv-store} (kv/new-cached-kv-store cache-config local-kv-store)]
+        {:keys [cache] :as cached-kv-store} (kv/new-cached-kv-store cache-config local-kv-store)
+        time-0 (t/now)
+        time-1 (t/plus time-0 (t/seconds 1))
+        time-2 (t/plus time-0 (t/seconds 2))
+        time-3 (t/plus time-0 (t/seconds 3))
+        time-4 (t/plus time-0 (t/seconds 4))
+        time-5 (t/plus time-0 (t/seconds 5))]
     (is (nil? (kv/fetch local-kv-store :a)))
     (is (nil? (kv/fetch cached-kv-store :a)))
-    (kv/store local-kv-store :a 1)
+    (with-redefs [t/now (constantly time-1)]
+      (kv/store local-kv-store :a 1))
     ; cache looks up underlying store during miss
     (is (kv/fetch local-kv-store :a))
     (is (= 1 (kv/fetch local-kv-store :a)))
     (is (nil? (kv/fetch cached-kv-store :a)))
     ; store to cache propagates to underlying store 
-    (kv/store cached-kv-store :b 2)
+    (with-redefs [t/now (constantly time-2)]
+      (kv/store cached-kv-store :b 2))
     (is (true? (cu/cache-contains? cache :b)))
     (is (= 2 (kv/fetch cached-kv-store :b)))
     (is (= 2 (kv/fetch local-kv-store :b)))
-    (kv/store cached-kv-store :b 11)
+    (with-redefs [t/now (constantly time-3)]
+      (kv/store cached-kv-store :b 11))
     (is (= 11 (kv/fetch cached-kv-store :b)))
     (is (= 11 (kv/fetch local-kv-store :b)))
     ; cache works with refresh call
-    (kv/store cached-kv-store :b 13)
+    (with-redefs [t/now (constantly time-4)]
+      (kv/store cached-kv-store :b 13))
     (is (true? (cu/cache-contains? cache :b)))
     (is (= 13 (kv/fetch cached-kv-store :b)))
-    (kv/store local-kv-store :b 17)
+    (with-redefs [t/now (constantly time-5)]
+      (kv/store local-kv-store :b 17))
     (is (= 13 (kv/fetch cached-kv-store :b)))
     (is (= 17 (kv/fetch local-kv-store :b)))
     (is (= 17 (kv/fetch cached-kv-store :b :refresh true)))
     (is (= "cache" (get (kv/state cached-kv-store include-flags) :variant)))
-    (is (= {:count 2, :data {:a 1, :b 17}}
+    (is (= {:count 2
+            :data {:a {:stats {:creation-time (tc/to-long time-1)
+                               :modified-time (tc/to-long time-1)}
+                       :value 1}
+                   :b {:stats {:creation-time (tc/to-long time-2)
+                               :modified-time (tc/to-long time-5)}
+                       :value 17}}}
            (get-in (kv/state cached-kv-store include-flags) [:inner-state :store])))
     ; delete removes entry from cache
     (kv/delete cached-kv-store :b)
@@ -160,7 +193,10 @@
     (is (nil? (kv/fetch cached-kv-store :b)))
     (is (nil? (kv/fetch cached-kv-store :b :refresh true)))
     (is (= "cache" (get (kv/state cached-kv-store include-flags) :variant)))
-    (is (= {:count 1, :data {:a 1}}
+    (is (= {:count 1
+            :data {:a {:stats {:creation-time (tc/to-long time-1)
+                               :modified-time (tc/to-long time-1)}
+                       :value 1}}}
            (get-in (kv/state cached-kv-store include-flags) [:inner-state :store])))))
 
 (deftest test-validate-zk-key


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for stats in local key-value store
- adds support for stats in file-based key-value store
- adds stats support to key-value store protocol
- adds `service-id->creation-time` function
- provides the `service-id->creation-time` function to the scheduler factory

## Why are we making these changes?

Provides the scheduler the opportunity to make any validation and/or scheduler object creation decisions based on the service creation time.
