### PR TITLE
ensures deletion of all tokens created in test-service-list-filtering

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -459,9 +459,15 @@
 
         (finally
           (doseq [token all-tokens]
-            (delete-token-and-assert waiter-url token))
+            (try
+              (delete-token-and-assert waiter-url token)
+              (catch Exception ex
+                (log/error ex (str "error in deleting token " token)))))
           (doseq [service-id @service-ids-atom]
-            (delete-service waiter-url service-id)))))))
+            (try
+              (delete-service waiter-url service-id)
+              (catch Exception ex
+                (log/error ex (str "error in deleting service " service-id))))))))))
 
 (defn- service-id->metadata-id [waiter-url service-id]
   (get-in (service-settings waiter-url service-id) [:service-description :metadata :id]))


### PR DESCRIPTION
## Changes proposed in this PR

- ensures deletion of all tokens created in test-service-list-filtering

## Why are we making these changes?

Avoids orphaned tokens from lingering around from integration test runs.


