### PR TITLE
adds support for context in replicaset-spec-builder-fn

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -658,7 +658,7 @@
                       {:cmd-type cmd-type
                        :service-description service-description
                        :service-id service-id}))))
-  (let [rs-spec (replicaset-spec-builder-fn scheduler service-id service-description)
+  (let [rs-spec (replicaset-spec-builder-fn scheduler service-id service-description {})
         request-namespace (k8s-object->namespace rs-spec)
         request-url (str api-server-url "/apis/" replicaset-api-version "/namespaces/" request-namespace "/replicasets")
         response-json
@@ -1570,8 +1570,9 @@
                                                utils/resolve-symbol
                                                deref)]
                                      (assert (fn? f) "ReplicaSet spec function must be a Clojure fn")
-                                     (fn [scheduler service-id service-description]
-                                       (f scheduler service-id service-description replicaset-spec-builder-ctx)))
+                                     (fn [scheduler service-id service-description in-context]
+                                       (let [context (merge replicaset-spec-builder-ctx in-context)]
+                                         (f scheduler service-id service-description context))))
         response->deployment-error-msg-fn (-> response->deployment-error-msg-fn utils/resolve-symbol!)
         restart-kill-threshold (or restart-kill-threshold (+ 2 restart-expiry-threshold))
         watch-trigger-chan (au/latest-chan)

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -1033,20 +1033,21 @@
 
 (defn determine-namespace
   "Determines the k8s namespace to use while creating k8s objects for the service."
-  [scheduler-namespace default-namespace {:strs [namespace run-as-user]}]
-  (when-not (or namespace default-namespace scheduler-namespace)
+  [scheduler-namespace default-namespace override-namespace {:strs [namespace run-as-user]}]
+  (when-not (or namespace default-namespace override-namespace scheduler-namespace)
     (throw (ex-info "Waiter configuration is missing a default namespace for Kubernetes pods" {})))
   (when (and scheduler-namespace namespace (not= scheduler-namespace namespace))
     (throw (ex-info "service namespace does not match scheduler namespace"
                     {:scheduler-ns scheduler-namespace :service-ns namespace})))
-  (or namespace
+  (or override-namespace
+      namespace
       (if (= "*" default-namespace) run-as-user default-namespace)
       scheduler-namespace))
 
 (defn determine-replicaset-namespace
   "Default implementation that determines the namespace to use for a replicaset"
-  [{scheduler-namespace :namespace} _ service-description {:keys [default-namespace]}]
-  (determine-namespace scheduler-namespace default-namespace service-description))
+  [{scheduler-namespace :namespace} _ service-description {:keys [default-namespace override-namespace]}]
+  (determine-namespace scheduler-namespace default-namespace override-namespace service-description))
 
 (defn default-replicaset-builder
   "Factory function which creates a Kubernetes ReplicaSet spec for the given Waiter Service."

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -84,11 +84,12 @@
       :replicaset-api-version "apps/v1"
       :replicaset-spec-builder-fn #(waiter.scheduler.kubernetes/default-replicaset-builder
                                      %1 %2 %3
-                                     {:container-init-commands ["waiter-k8s-init"]
-                                      :default-namespace default-namespace
-                                      :default-container-image "twosigma/waiter-test-apps:latest"
-                                      :log-bucket-sync-secs log-bucket-sync-secs
-                                      :log-bucket-url log-bucket-url})
+                                     (merge {:container-init-commands ["waiter-k8s-init"]
+                                             :default-namespace default-namespace
+                                             :default-container-image "twosigma/waiter-test-apps:latest"
+                                             :log-bucket-sync-secs log-bucket-sync-secs
+                                             :log-bucket-url log-bucket-url}
+                                            %4))
       :retrieve-auth-token-state-fn (constantly nil)
       :retrieve-syncer-state-fn (constantly nil)
       :response->deployment-error-msg-fn waiter.scheduler.kubernetes/default-k8s-message-transform
@@ -158,7 +159,7 @@
                                         :predicate-fn (constantly fileserver-enabled)
                                         :scheme "http"}
                            :service-id->service-description-fn (constantly service-description)})
-              replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler test-service-id service-description)]
+              replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler test-service-id service-description {})]
           (is (= {:waiter/revision-timestamp (du/date-to-str current-time)
                   :waiter/revision-version "0"
                   :waiter/service-id test-service-id}
@@ -184,7 +185,7 @@
       (let [service-description (assoc dummy-service-description "health-check-port-index" 2 "ports" 3)
             scheduler (make-dummy-scheduler ["test-service-id"]
                                             {:service-id->service-description-fn (constantly service-description)})
-            replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler "test-service-id" service-description)]
+            replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler "test-service-id" service-description {})]
         (is (= {:waiter/port-count "3"
                 :waiter/revision-timestamp (du/date-to-str current-time)
                 :waiter/revision-version "0"
@@ -206,7 +207,7 @@
               {:keys [log-bucket-sync-secs replicaset-spec-builder-fn] :as scheduler}
               (make-dummy-scheduler ["test-service-id"]
                                     {:service-id->service-description-fn (constantly service-description)})
-              replicaset-spec (replicaset-spec-builder-fn scheduler "test-service-id" service-description)]
+              replicaset-spec (replicaset-spec-builder-fn scheduler "test-service-id" service-description {})]
           (is (= (+ log-bucket-sync-secs spec-termination-grace-period-secs)
                  (get-in replicaset-spec [:spec :template :spec :terminationGracePeriodSeconds])))))
 
@@ -217,7 +218,7 @@
                                   {:log-bucket-sync-secs 10
                                    :log-bucket-url nil
                                    :pod-sigkill-delay-secs pod-sigkill-delay-secs})
-            replicaset-spec (replicaset-spec-builder-fn scheduler "test-service-id" service-description)]
+            replicaset-spec (replicaset-spec-builder-fn scheduler "test-service-id" service-description {})]
         (is (= pod-sigkill-delay-secs (get-in replicaset-spec [:spec :template :spec :terminationGracePeriodSeconds]))))
 
       (let [log-bucket-url "http://service.example.com:1234/service-logs"
@@ -229,7 +230,7 @@
                                   {:log-bucket-sync-secs log-bucket-sync-secs
                                    :log-bucket-url nil
                                    :pod-sigkill-delay-secs pod-sigkill-delay-secs})
-            replicaset-spec (replicaset-spec-builder-fn scheduler "test-service-id" service-description)]
+            replicaset-spec (replicaset-spec-builder-fn scheduler "test-service-id" service-description {})]
         (is (= (+ pod-sigkill-delay-secs log-bucket-sync-secs)
                (get-in replicaset-spec [:spec :template :spec :terminationGracePeriodSeconds])))))))
 
@@ -267,8 +268,7 @@
           service-description (assoc dummy-service-description "env" {ct/reverse-proxy-flag "yes"
                                                                       "PORT0" "to-be-overwritten"
                                                                       "SERVICE_PORT" "to-be-overwritten"})
-          replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler service-id
-                           service-description)
+          replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler service-id service-description {})
           app-container (get-in replicaset-spec [:spec :template :spec :containers 0])
           sidecar-container (some
                               #(if (= "waiter-envoy-sidecar" (:name %)) %)
@@ -343,8 +343,7 @@
                                             "SERVICE_PORT" "to-be-overwritten"}
                                      "health-check-port-index" 5
                                      "ports" 9)
-          replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler service-id
-                           service-description)
+          replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler service-id service-description {})
           app-container (get-in replicaset-spec [:spec :template :spec :containers 0])
           sidecar-container (some
                               #(if (= "waiter-envoy-sidecar" (:name %)) %)
@@ -423,7 +422,7 @@
         (let [service-description dummy-service-description
               scheduler (make-dummy-scheduler ["test-service-id"]
                                               {:service-id->service-description-fn (constantly service-description)})
-              replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler "test-service-id" service-description)
+              replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler "test-service-id" service-description {})
               waiter-app-container (get-in replicaset-spec [:spec :template :spec :containers 0])]
           (is (= (assoc basic-probe :failureThreshold 3 :initialDelaySeconds 7)
                  (:livenessProbe waiter-app-container)))
@@ -433,7 +432,7 @@
         (let [service-description (assoc dummy-service-description "grace-period-secs" 0)
               scheduler (make-dummy-scheduler ["test-service-id"]
                                               {:service-id->service-description-fn (constantly service-description)})
-              replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler "test-service-id" service-description)
+              replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler "test-service-id" service-description {})
               waiter-app-container (get-in replicaset-spec [:spec :template :spec :containers 0])]
           (is (not (contains? waiter-app-container :livenessProbe)))
           (is (= basic-probe (:readinessProbe waiter-app-container))))))))
@@ -446,7 +445,7 @@
         (let [scheduler (make-dummy-scheduler [service-id]
                                               {:default-namespace "*"
                                                :service-id->service-description-fn (constantly dummy-service-description)})
-              replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler service-id dummy-service-description)
+              replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler service-id dummy-service-description {})
               {:strs [run-as-user]} dummy-service-description]
           (is (nil? (scheduler/validate-service scheduler service-id)))
           (is (= run-as-user (get-in replicaset-spec [:metadata :namespace])))
@@ -454,7 +453,7 @@
       (testing "Default namespace"
         (let [scheduler (make-dummy-scheduler [service-id]
                                               {:service-id->service-description-fn (constantly dummy-service-description)})
-              replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler service-id dummy-service-description)]
+              replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler service-id dummy-service-description {})]
           (is (nil? (scheduler/validate-service scheduler service-id)))
           (is (= dummy-scheduler-default-namespace (get-in replicaset-spec [:metadata :namespace])))
           (is (false? (get-in replicaset-spec [:spec :template :spec :automountServiceAccountToken])))))
@@ -463,7 +462,7 @@
               service-description (assoc dummy-service-description "namespace" target-namespace)
               scheduler (make-dummy-scheduler [service-id]
                                               {:service-id->service-description-fn (constantly service-description)})
-              replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler service-id service-description)]
+              replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler service-id service-description {})]
           (is (nil? (scheduler/validate-service scheduler service-id)))
           (is (= target-namespace (get-in replicaset-spec [:metadata :namespace])))
           (is (true? (get-in replicaset-spec [:spec :template :spec :automountServiceAccountToken])))))
@@ -471,7 +470,7 @@
         (let [target-namespace "myself"
               service-description (assoc dummy-service-description "namespace" target-namespace)
               scheduler (make-dummy-scheduler [service-id] {:namespace target-namespace})
-              replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler service-id service-description)]
+              replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler service-id service-description {})]
           (is (nil? (scheduler/validate-service scheduler service-id)))
           (is (= target-namespace (get-in replicaset-spec [:metadata :namespace])))
           (is (true? (get-in replicaset-spec [:spec :template :spec :automountServiceAccountToken])))))
@@ -480,13 +479,13 @@
               service-description (assoc dummy-service-description "namespace" target-namespace)
               scheduler (make-dummy-scheduler [service-id] {:namespace (str "x" target-namespace)})]
           (is (thrown-with-msg? RuntimeException #"service namespace does not match scheduler namespace"
-              ((:replicaset-spec-builder-fn scheduler) scheduler service-id service-description))))))))
+              ((:replicaset-spec-builder-fn scheduler) scheduler service-id service-description {}))))))))
 
 (deftest test-replicaset-spec-no-image
   (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")
                 config/retrieve-waiter-principal (constantly "waiter@test.com")]
     (let [scheduler (make-dummy-scheduler ["test-service-id"])
-          replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler "test-service-id" dummy-service-description)]
+          replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler "test-service-id" dummy-service-description {})]
       (is (= "twosigma/waiter-test-apps:latest" (get-in replicaset-spec [:spec :template :spec :containers 0 :image]))))))
 
 (deftest test-replicaset-spec-custom-image
@@ -494,7 +493,7 @@
                 config/retrieve-waiter-principal (constantly "waiter@test.com")]
     (let [scheduler (make-dummy-scheduler ["test-service-id"])
           replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler "test-service-id"
-                            (assoc dummy-service-description "image" "custom/image"))]
+                            (assoc dummy-service-description "image" "custom/image") {})]
       (is (= "custom/image" (get-in replicaset-spec [:spec :template :spec :containers 0 :image]))))))
 
 (deftest test-default-pdb-spec-builder
@@ -1406,8 +1405,8 @@
             dummy-scheduler (-> (make-dummy-scheduler [service-id])
                                 (update :replicaset-spec-builder-fn
                                         (fn [base-spec-builder-fn]
-                                          (fn [scheduler service-id context]
-                                            (-> (base-spec-builder-fn scheduler service-id context)
+                                          (fn [scheduler service-id service-description context]
+                                            (-> (base-spec-builder-fn scheduler service-id service-description context)
                                                 (assoc-in [:metadata :annotations] {:waiter/x :waiter/y}))))))]
         (let [spec-json (with-redefs [api-request (fn [_ _ & {:keys [body]}] body)
                                       replicaset->Service identity]


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for context in replicaset-spec-builder-fn

## Why are we making these changes?

Using the context allows passing additional information to the replicaset builder which can only be dynamically determined at the call-site. E.g. a forcing function to override the namespace used by the replicaset as demonstrated with the `override-namespace` example in the default function to determine namespaces.
