### PR TITLE
Rename Waiter's Envoy reverse proxy sidecar to Raven

### DIFF
--- a/containers/bin/build-docker-images.sh
+++ b/containers/bin/build-docker-images.sh
@@ -25,8 +25,6 @@ cd "$DIR"
 ./test-apps/bin/build-docker-image.sh
 ./custom-env/bin/build-docker-image.sh
 
-# the fileserver container is independent
+# the fileserver and raven containers have no dependencies on our other images or codebases
 ./fileserver/bin/build-docker-image.sh
-
-# the envoy reverse-proxy container is independent
-./reverse-proxy/bin/build-docker-image.sh
+./raven/bin/build-docker-image.sh

--- a/containers/raven/Dockerfile
+++ b/containers/raven/Dockerfile
@@ -2,7 +2,7 @@ FROM envoyproxy/envoy-alpine:v1.18.3
 
 RUN apk add --no-cache openssl
 
-COPY envoy-start /opt/waiter/envoy/bin/
+COPY raven-start /opt/waiter/raven/bin/
 COPY envoy.template.yaml /etc/envoy/
 
-ENTRYPOINT /opt/waiter/envoy/bin/envoy-start
+ENTRYPOINT /opt/waiter/raven/bin/raven-start

--- a/containers/raven/README.md
+++ b/containers/raven/README.md
@@ -1,4 +1,6 @@
-# Waiter-Kubernetes Reverse-Proxy Sidecar Container
+# Waiter-Kubernetes Raven Reverse-Proxy Sidecar Container
+
+Waiter's default Envoy reverse-proxy sidecar offering is called Raven.
 
 The sidecar container starts an envoy reverse-proxy that
 is serving on `SERVICE_PORT` and forwards all traffic to `PORT0` on localhost.
@@ -16,7 +18,7 @@ and no additional health check port is proxied if absent.
 
 ## Building the Docker image
 
-    docker build -t twosigma/waiter-envoy .
+    docker build -t twosigma/waiter-raven .
 
 There is also a helper script included in `./bin`
 for building the image in both the host docker

--- a/containers/raven/bin/build-docker-image.sh
+++ b/containers/raven/bin/build-docker-image.sh
@@ -3,5 +3,5 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 cd "$DIR"
 
-echo "Building docker image for envoy sidecar"
-docker build -t twosigma/waiter-envoy .
+echo "Building docker image for raven sidecar"
+docker build -t twosigma/waiter-raven .

--- a/containers/raven/envoy.template.yaml
+++ b/containers/raven/envoy.template.yaml
@@ -22,7 +22,7 @@ static_resources:
                   name: app-proxy
                   response_headers_to_add:
                     - header:
-                        key: x-envoy-response-flags
+                        key: x-raven-response-flags
                         value: "%RESPONSE_FLAGS%"
                   virtual_hosts:
                     - name: app-backend

--- a/containers/raven/raven-start
+++ b/containers/raven/raven-start
@@ -41,14 +41,14 @@ is_tls() {
 if [ "${SERVICE_PORT}" ]; then
   log "SERVICE_PORT=${SERVICE_PORT}"
 else
-  die 'SERVICE_PORT is not set. Exiting envoy-start'
+  die 'SERVICE_PORT is not set. Exiting raven-start'
 fi
 
 # check if PORT0 is present
 if [ "${PORT0}" ]; then
   log "PORT0=${PORT0}"
 else
-  die 'PORT0 is not set. Exiting envoy-start'
+  die 'PORT0 is not set. Exiting raven-start'
 fi
 
 CONFIG_YAML=/etc/envoy/envoy.yaml

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -510,11 +510,16 @@
                                  ;; Unless you've custom-patched your Kubernetes code, then this is probably hard-coded to 5 in the controller code.
                                  ;; https://github.com/kubernetes/kubernetes/blob/207e9d1/staging/src/k8s.io/apiserver/pkg/storage/names/generate.go#L45
                                  :pod-suffix-length 5
-                                 :reverse-proxy {:cmd ["/opt/waiter/envoy/bin/envoy-start"]
-                                                 :image "twosigma/waiter-envoy"
-                                                 :predicate-fn waiter.scheduler.kubernetes/envoy-sidecar-enabled?
-                                                 :resources {:cpu 0.1 :mem 256}
-                                                 :scheme "http"}
+                                 :raven-sidecar {:cmd ["/opt/waiter/raven/bin/raven-start"]
+                                                 ;; environment variables use by provided predicate functions
+                                                 :env-vars {;; flag env vars set to a "true"-like value enable raven,
+                                                            ;; "false"-like values disable raven
+                                                            :flags ["RAVEN_ENABLED"]
+                                                            ;; configuring a raven feature implicitly enables raven
+                                                            :features ["RAVEN_OVERRIDE_IMAGE"]}
+                                                 :image "twosigma/waiter-raven"
+                                                 :predicate-fn waiter.scheduler.kubernetes/raven-sidecar-opt-in?
+                                                 :resources {:cpu 0.1 :mem 256}}
                                  ;; Version string used for creating and operating on ReplicaSet objects:
                                  :replicaset-api-version "apps/v1"
 

--- a/waiter/config-k8s.edn
+++ b/waiter/config-k8s.edn
@@ -60,11 +60,12 @@
                                                            :image-aliases {"alias/integration" "twosigma/integration"}}
                                  :restart-expiry-threshold 2
                                  :restart-kill-threshold 8
-                                 :reverse-proxy {:cmd ["/opt/waiter/envoy/bin/envoy-start"]
-                                                 :image "twosigma/waiter-envoy"
-                                                 :predicate-fn waiter.scheduler.kubernetes/envoy-sidecar-enabled?
-                                                 :resources {:cpu 0.1 :mem 256}
-                                                 :scheme "http"}
+                                 :raven-sidecar {:cmd ["/opt/waiter/raven/bin/raven-start"]
+                                                 :image "twosigma/waiter-raven"
+                                                 ;; defaulting to Raven opt-in
+                                                 ;; for opt-out, use waiter.scheduler.kubernetes/raven-sidecar-opt-out?
+                                                 :predicate-fn waiter.scheduler.kubernetes/raven-sidecar-opt-in?
+                                                 :resources {:cpu 0.1 :mem 256}}
                                  :url "http://localhost:8001"}}
 
  ; ---------- Error Handling ----------

--- a/waiter/integration/waiter/grpc_test.clj
+++ b/waiter/integration/waiter/grpc_test.clj
@@ -23,7 +23,8 @@
             [plumbing.core :as pc]
             [waiter.correlation-id :as cid]
             [waiter.status-codes :refer :all]
-            [waiter.util.client-tools :refer :all])
+            [waiter.util.client-tools :refer :all]
+            [waiter.util.utils :as utils])
   (:import (com.twosigma.waiter.courier CourierReply CourierSummary GrpcClient GrpcClient$CancellationPolicy GrpcClient$RpcResult StateReply)
            (io.grpc Status)
            (java.util ArrayList)
@@ -1151,32 +1152,32 @@
                     (is (nil? message-summary) assertion-message)
                     (assert-request-state grpc-client request-headers service-id correlation-id ::server-cancel)))))))))))
 
-(deftest ^:parallel ^:integration-fast test-kubernetes-reverse-proxy-sidecar-grpc
+(deftest ^:parallel ^:integration-fast test-kubernetes-raven-sidecar-grpc
   (testing-using-waiter-url
-    (when (using-k8s? waiter-url)
-      (if-not (contains? (get-kubernetes-scheduler-settings waiter-url) :reverse-proxy)
-        (log/warn "skipping the integration test as :reverse-proxy is not defined")
-        (let [request-headers (assoc (basic-grpc-service-parameters)
-                                     "content-type" "application/grpc"
-                                     (str "x-waiter-env-" reverse-proxy-flag) "yes")
-              {:keys [service-id]} (start-courier-instance waiter-url request-headers)]
-          (with-service-cleanup
-            service-id
-            (let [;; grpc post-data = {id: "x", from: "y", message: "z"}
-                  ;; see the Proto3 Language Guide for details on the binary encoding:
-                  ;; https://developers.google.com/protocol-buffers/docs/proto3
-                  post-data (byte-array [0x00 0x00 0x00 0x00 0x09 0x0a 0x01 0x78 0x12 0x01 0x79 0x1a 0x01 0x7a])
-                  request-fn #(make-shell-request waiter-url % :body post-data :path "/courier.Courier/SendPackage")
-                  {:keys [cookies] :as response} (make-request-with-debug-info request-headers request-fn)
-                  _ (assert-response-status response http-200-ok)
-                  response-headers (:headers response)
-                  response-body-bytes (-> response :body .getBytes)
-                  received-msg-bytes (-> "received" .getBytes vec)]
-              (testing "proxied through envoy"
-                (is (some? (get response-headers "x-envoy-upstream-service-time"))))
-              (testing "request payload received by courier"
-                ;; response payload ends with the 8 bytes "received" (ascii/utf8)
-                (is (= received-msg-bytes (take-last 8 response-body-bytes )))))))))))
+    (if-not (using-raven? waiter-url)
+      (log/warn "skipping the integration test as :raven-sidecar is not defined")
+      (let [raven-sidecar-flag (get-raven-sidecar-flag waiter-url)
+            request-headers (assoc (basic-grpc-service-parameters)
+                                   "content-type" "application/grpc"
+                                   (str "x-waiter-env-" raven-sidecar-flag) "true")
+            {:keys [service-id]} (start-courier-instance waiter-url request-headers)]
+        (with-service-cleanup
+          service-id
+          (let [;; grpc post-data = {id: "x", from: "y", message: "z"}
+                ;; see the Proto3 Language Guide for details on the binary encoding:
+                ;; https://developers.google.com/protocol-buffers/docs/proto3
+                post-data (byte-array [0x00 0x00 0x00 0x00 0x09 0x0a 0x01 0x78 0x12 0x01 0x79 0x1a 0x01 0x7a])
+                request-fn #(make-shell-request waiter-url % :body post-data :path "/courier.Courier/SendPackage")
+                {:keys [cookies] :as response} (make-request-with-debug-info request-headers request-fn)
+                _ (assert-response-status response http-200-ok)
+                response-headers (:headers response)
+                response-body-bytes (-> response :body .getBytes)
+                received-msg-bytes (-> "received" .getBytes vec)]
+            (testing "proxied through Raven"
+              (is (utils/raven-proxy-response? response)))
+            (testing "request payload received by courier"
+              ;; response payload ends with the 8 bytes "received" (ascii/utf8)
+              (is (= received-msg-bytes (take-last 8 response-body-bytes))))))))))
 
 (deftest ^:parallel ^:integration-slow test-grpc-health-check-authentication
   (testing-using-waiter-url

--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -5,7 +5,8 @@
             [clojure.tools.logging :as log]
             [clojure.walk :as walk]
             [waiter.status-codes :refer :all]
-            [waiter.util.client-tools :refer :all]))
+            [waiter.util.client-tools :refer :all]
+            [waiter.util.utils :as utils]))
 
 (defn- get-watch-state [state-json]
   (or (get-in state-json ["state" "watch-state"])
@@ -418,43 +419,42 @@
                     :timeout timeout-secs)))))
         (log/warn "skipping test as INTEGRATION_TEST_BAD_IMAGE is not specified")))))
 
-(deftest ^:parallel ^:integration-fast test-kubernetes-reverse-proxy-sidecar
+(deftest ^:parallel ^:integration-fast test-kubernetes-raven-sidecar
   (testing-using-waiter-url
-    (when (using-k8s? waiter-url)
-      (if (contains? (get-kubernetes-scheduler-settings waiter-url) :reverse-proxy)
-        (let [reverse-proxy-flag reverse-proxy-flag
-              x-waiter-name (rand-name)
-              request-headers {:x-waiter-name x-waiter-name
-                               (keyword (str "x-waiter-env-" reverse-proxy-flag)) "yes"}
-              _ (log/info "making canary request")
-              {:keys [cookies service-id] :as response} (make-request-with-debug-info
-                                                          request-headers
-                                                          #(make-kitchen-request waiter-url % :method :get :path "/status"))]
-          (with-service-cleanup
-            service-id
-            (assert-service-on-all-routers waiter-url service-id cookies)
+    (if-not (using-raven? waiter-url)
+      (log/warn "skipping the integration test as :raven-sidecar is not configured")
+      (let [x-waiter-name (rand-name)
+            raven-sidecar-flag (get-raven-sidecar-flag waiter-url)
+            request-headers {:x-waiter-name x-waiter-name
+                             (keyword (str "x-waiter-env-" raven-sidecar-flag)) "true"}
+            _ (log/info "making canary request")
+            {:keys [cookies service-id] :as response} (make-request-with-debug-info
+                                                        request-headers
+                                                        #(make-kitchen-request waiter-url % :method :get :path "/status"))]
+        (with-service-cleanup
+          service-id
+          (assert-service-on-all-routers waiter-url service-id cookies)
+          (assert-response-status response http-200-ok)
+
+          (let [response (make-kitchen-request waiter-url request-headers :method :get :path "/request-info")]
             (assert-response-status response http-200-ok)
-
-            (let [response (make-kitchen-request waiter-url request-headers :method :get :path "/request-info")]
-              (assert-response-status response http-200-ok)
-              (testing "Expected envoy specific headers are present in both request and response"
-                (let [response-body (try-parse-json (:body response))
-                      response-headers (:headers response)]
-                  ;; x-envoy-expected-rq-timeout-ms is absent when timeouts are disabled
-                  (is (contains? (get response-body "headers") "x-envoy-external-address"))
-                  (is (contains? response-headers "x-envoy-upstream-service-time")))))
-
-            (let [response (make-request-with-debug-info
-                             request-headers
-                             #(make-kitchen-request waiter-url % :method :get :path "/environment"))]
-              (assert-response-status response http-200-ok)
+            (testing "Expected Raven/Envoy specific headers are present in both request and response"
               (let [response-body (try-parse-json (:body response))
                     response-headers (:headers response)]
-                (testing "Port value is correctly offset compared to instance value"
-                  (let [response-header-backend-port (get response-headers "x-waiter-backend-port")
-                        env-response-port0 (get response-body "PORT0")]
-                    (is (not= response-header-backend-port env-response-port0))))
-                (testing "Reverse proxy flag environment variable is present"
-                  (is (contains? response-body reverse-proxy-flag))
-                  (is (= "yes" (get response-body reverse-proxy-flag))))))))
-        (log/warn "skipping the integration test as :reverse-proxy is not defined")))))
+                ;; x-envoy-expected-rq-timeout-ms is absent when timeouts are disabled
+                (is (some (get response-body "headers") ["x-envoy-external-address" "x-envoy-internal"]))
+                (is (utils/raven-proxy-response? response)))))
+
+          (let [response (make-request-with-debug-info
+                           request-headers
+                           #(make-kitchen-request waiter-url % :method :get :path "/environment"))]
+            (assert-response-status response http-200-ok)
+            (let [response-body (try-parse-json (:body response))
+                  response-headers (:headers response)]
+              (testing "Port value is correctly offset compared to instance value"
+                (let [response-header-backend-port (get response-headers "x-waiter-backend-port")
+                      env-response-port0 (get response-body "PORT0")]
+                  (is (not= response-header-backend-port env-response-port0))))
+              (testing "Reverse proxy flag environment variable is present"
+                (is (contains? response-body raven-sidecar-flag))
+                (is (= "true" (get response-body raven-sidecar-flag)))))))))))

--- a/waiter/src/waiter/schema.clj
+++ b/waiter/src/waiter/schema.clj
@@ -105,13 +105,14 @@
   [{:keys [kind] :as config}]
   (nil? (s/check {(s/required-key :factory-fn) s/Symbol, s/Keyword s/Any} (get config kind))))
 
-(def valid-reverse-proxy-config
+(def valid-raven-sidecar-config
   {:cmd [s/Str]
+   (s/optional-key :env-vars) {(s/optional-key :flags) [s/Str]
+                               (s/optional-key :features) [s/Str]}
    :image s/Str
    :predicate-fn s/Symbol
    :resources {:cpu s/Num
-               :mem s/Int}
-   :scheme s/Str})
+               :mem s/Int}})
 
 (def valid-jwt-issuer-config
   "Validator for the JWT issuer field.

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -43,8 +43,6 @@
 (def ^:const WAITER-PORT 9091)
 (def ^:const HTTP-SCHEME "http://")
 
-(def reverse-proxy-flag (or (System/getenv "WAITER_TEST_REVERSE_PROXY_FLAG") "REVERSE_PROXY"))
-
 (def use-spnego (-> (System/getenv "USE_SPNEGO") str Boolean/parseBoolean))
 
 (def ^:const ANSI-YELLOW "\033[1m\033[33m")
@@ -1107,6 +1105,21 @@
   "Returns true if Waiter is configured to use Shell Scheduler for scheduling"
   [waiter-url]
   (= "shell" (retrieve-default-scheduler-name waiter-url)))
+
+(defn using-raven?
+  "Returns true if Waiter is configured to use Kubernetes and the Raven sidecar proxy"
+  [waiter-url]
+  (and (using-k8s? waiter-url)
+       (contains? (get-kubernetes-scheduler-settings waiter-url) :raven-sidecar)))
+
+(defn get-raven-sidecar-flag
+  "Fetches (from the k8s scheduler config) the env var name for enabling the raven sidecar."
+  [waiter-url]
+  {:post [(not (str/blank? %))]}
+  (-> waiter-url
+      (get-kubernetes-scheduler-settings)
+      (get-in [:raven-sidecar :env-vars :flags])
+      (first)))
 
 (defn get-authenticator-kind
   "Get the authenticator that Waiter is configured to use"


### PR DESCRIPTION
## Changes proposed in this PR

Rename Waiter's Envoy reverse proxy sidecar to Raven.

## Why are we making these changes?

Clearer naming for Raven logic, e.g., the `x-raven-response-flags` header.