### PR TITLE
improves messaging in the test-identical-version assertion

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -1069,12 +1069,11 @@
 
 (deftest ^:parallel ^:integration-fast test-identical-version
   (testing-using-waiter-url
-    (let [{:keys [cookies]} (make-request waiter-url "/waiter-auth")]
-      (is (= 1 (->> (routers waiter-url)
-                    vals
-                    (map #(:git-version (waiter-settings % :cookies cookies)))
-                    set
-                    count))))))
+    (let [{:keys [cookies]} (make-request waiter-url "/waiter-auth")
+          router->git-version (pc/map-from-keys
+                                (fn [router-url] (:git-version (waiter-settings router-url :cookies cookies)))
+                                (vals (routers waiter-url)))]
+      (is (-> router->git-version (vals) (set) (count) (= 1)) (str router->git-version)))))
 
 (deftest ^:parallel ^:integration-fast test-cors-request-allowed
   (testing-using-waiter-url


### PR DESCRIPTION
## Changes proposed in this PR

- improves messaging in the test-identical-version assertion

## Why are we making these changes?

It should be easy to identify which router disagrees on the deployed version when the test assertion fails.

