### PR TITLE
adds support for periodically refreshing the statsd host IP

### DIFF
--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -173,6 +173,7 @@
                                        (s/required-key :host) schema/non-empty-string
                                        (s/required-key :port) schema/positive-int
                                        (s/required-key :publish-interval-ms) schema/positive-int
+                                       (s/optional-key :refresh-interval-ms) schema/non-negative-int
                                        (s/required-key :server) schema/non-empty-string
                                        (s/required-key :sync-instances-interval-ms) schema/positive-int})
    (s/required-key :support-info) [{(s/required-key :label) schema/non-empty-string


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for periodically refreshing the statsd host IP

## Why are we making these changes?

Waiter routers should be resilient to the statsd host IPs changing, the client should regularly re-compute the IP.

