### PR TITLE
adds support for periodically refreshing the graphite reporter host IP

### DIFF
--- a/waiter/test/waiter/reporters_test.clj
+++ b/waiter/test/waiter/reporters_test.clj
@@ -114,7 +114,8 @@ services.service-id.counters.fee.fie
                      (getFailures [_] 0)
                      (isConnected [_] true)
                      (send [_ name value timestamp] (swap! actual-values assoc name value "timestamp" timestamp)))
-          codahale-reporter (make-graphite-reporter 0 #".*" "prefix" graphite)]
+          retrieve-graphite-instance (constantly graphite)
+          codahale-reporter (make-graphite-reporter 0 #".*" "prefix" retrieve-graphite-instance)]
       (is (satisfies? CodahaleReporter codahale-reporter))
       (with-redefs [t/now (constantly time)]
         (report codahale-reporter))
@@ -164,7 +165,8 @@ services.service-id.counters.fee.fie
                      (getFailures [_] 0)
                      (isConnected [_] true)
                      (send [_ name value timestamp] (swap! actual-values assoc name value "timestamp" timestamp)))
-          codahale-reporter (make-graphite-reporter 0 #"^.*fee.*" "prefix" graphite)]
+          retrieve-graphite-instance (constantly graphite)
+          codahale-reporter (make-graphite-reporter 0 #"^.*fee.*" "prefix" retrieve-graphite-instance)]
       (is (satisfies? CodahaleReporter codahale-reporter))
       (with-redefs [t/now (constantly time)]
         (report codahale-reporter))
@@ -191,7 +193,8 @@ services.service-id.counters.fee.fie
                      (getFailures [_] 0)
                      (isConnected [_] true)
                      (send [_ _ _ _] (throw (ex-info "test" {}))))
-          codahale-reporter (make-graphite-reporter 0 #".*" "prefix" graphite)]
+          retrieve-graphite-instance (constantly graphite)
+          codahale-reporter (make-graphite-reporter 0 #".*" "prefix" retrieve-graphite-instance)]
       (is (satisfies? CodahaleReporter codahale-reporter))
       (with-redefs [t/now (constantly time)]
         (is (thrown-with-msg? ExceptionInfo #"^test$"


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for periodically refreshing the graphite reporter host IP

## Why are we making these changes?

We would like to refresh the IP address of the Graphite server host periodically instead of using a static IP for the lifetime of the Waiter router process. This allows picking up updates to the IP address of the Graphite server host at runtime and avoids the need to restart Waiter routers.

