### PR TITLE
fixes a bug in comparing datetime strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The quickest way to get Mesos, Marathon, and Waiter running locally is with [doc
 
 Waiter can also be run without Mesos and Marathon, using the "shell scheduler". Note that this scheduler should only be used for testing purposes, not in production.
 
+1. Ensure `setsid` is installed on your system and on your path
 1. Clone down this repo
 1. `cd waiter`
 1. Run `bin/run-using-shell-scheduler.sh` to start Waiter

--- a/waiter/integration/waiter/reporters_integration_test.clj
+++ b/waiter/integration/waiter/reporters_integration_test.clj
@@ -30,8 +30,10 @@
   [router-url cookies]
   (let [state (get-graphite-reporter-state router-url cookies)
         {:strs [last-connect-failed-time last-flush-failed-time last-reporting-time last-send-failed-time]} state
-        last-event-time (reduce utils/nil-safe-max [last-connect-failed-time last-flush-failed-time last-reporting-time last-send-failed-time])]
-    (some-> last-event-time du/str-to-date .getMillis)))
+        last-event-time (->> [last-connect-failed-time last-flush-failed-time last-reporting-time last-send-failed-time]
+                             (map #(some-> % du/str-to-date .getMillis))
+                             (reduce utils/nil-safe-max))]
+    last-event-time))
 
 (defn- wait-for-period
   [period-ms fun]


### PR DESCRIPTION
## Changes proposed in this PR

- fixes a bug in the reporters integration tests that attempts to numerically compare date strings
- includes an additional change to the readme Quickstart that highlights the internal use of `setsid` by the shell scheduler

## Why are we making these changes?

- this bug causes integration tests to fail under certain circumstances
