### PR TITLE
ensures services accessed directly be service-ID get stale GC-ed

### DIFF
--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -819,10 +819,11 @@
   [token->token-hash token->token-parameters source-tokens]
   ;; safe assumption mark a service stale when every token used to access it is stale
   (let [sanitized-tokens (remove-service-entry-tokens source-tokens)
-        stale? (and (not (empty? sanitized-tokens)) ;; ensures boolean value
-                    (every? (fn [{:keys [token version]}]
-                              (not= (token->token-hash token) version))
-                            sanitized-tokens))]
+        stale? (and (not (empty? source-tokens)) ;; ensures boolean value
+                    (or (empty? sanitized-tokens)
+                        (every? (fn [{:keys [token version]}]
+                                  (not= (token->token-hash token) version))
+                                sanitized-tokens)))]
     (cond-> {:stale? stale?}
       stale? (assoc :update-epoch-time
                     (->> sanitized-tokens

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -2629,10 +2629,10 @@
           token->token-hash #(str "v" (get-in token->token-parameters [% "last-update-time"]))
           run-retrieve-token-stale-info (partial retrieve-token-stale-info token->token-hash token->token-parameters)]
 
-      (testing "no source tokens"
+      (testing "direct service-id access token"
         (is (= {:stale? false} (run-retrieve-token-stale-info [])))
         (let [source-tokens [{:token "^SERVICE-ID#s4" :version "v100"}]]
-          (is (= {:stale? false} (run-retrieve-token-stale-info source-tokens)))))
+          (is (= {:stale? true :update-epoch-time nil} (run-retrieve-token-stale-info source-tokens)))))
 
       (testing "source tokens active"
         (let [source-tokens [{:token "t1" :version "v90"}]]


### PR DESCRIPTION
## Changes proposed in this PR

- ensures services accessed directly be service-ID get stale GC-ed

## Why are we making these changes?

We would like to ensure services get GC-ed even if they were accessed using special service-ID knowledge. A reference entry with direct service ID access would report as not stale and that prevented the service from getting eagerly GC-ed even if other references (e.g. tokens) used to access the token have been modified. 

