### PR TITLE
adds support for date parsing in settings files

### DIFF
--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -21,6 +21,7 @@
             [clojure.walk :as walk]
             [schema.core :as s]
             [waiter.schema :as schema]
+            [waiter.util.date-utils :as du]
             [waiter.util.utils :as utils]))
 
 (def settings-schema
@@ -229,11 +230,12 @@
     (if (.exists config-file)
       (do
         (log/info "reading settings from file:" config-file-path)
-        (let [edn-readers {:readers {'config/regex (fn [expr] (re-pattern expr))
+        (let [edn-readers {:readers {'config/date #(du/str-to-date-safe %)
                                      'config/env #(env % config-file-path)
                                      'config/env-default (fn [[var-name default]]
                                                            (or (System/getenv var-name) default))
-                                     'config/env-int #(Integer/parseInt (env % config-file-path))}}
+                                     'config/env-int #(Integer/parseInt (env % config-file-path))
+                                     'config/regex (fn [expr] (re-pattern expr))}}
               settings (edn/read-string edn-readers (slurp config-file-path))]
           (log/info "configured settings:\n" (with-out-str (clojure.pprint/pprint settings)))
           settings))

--- a/waiter/test-files/test-bar.edn
+++ b/waiter/test-files/test-bar.edn
@@ -17,4 +17,6 @@
  :bar2 2
  :bar3 [3]
  :bar4 {:key 4}
- :common "from-bar"}
+ :common "from-bar"
+ :start-time #config/date "2021-09-15T01:02:03.456Z"
+ :start-time-nil #config/date nil}

--- a/waiter/test/waiter/settings_test.clj
+++ b/waiter/test/waiter/settings_test.clj
@@ -17,7 +17,8 @@
   (:require [clojure.test :refer :all]
             [schema.core :as s]
             [waiter.settings :refer :all]
-            [waiter.util.utils :as utils]))
+            [waiter.util.utils :as utils]
+            [waiter.util.date-utils :as du]))
 
 (deftest test-load-missing-edn-file
   (let [exit-called-atom (atom false)]
@@ -44,7 +45,9 @@
                                  :bar2 2
                                  :bar3 [3]
                                  :bar4 {:key 4}
-                                 :common "from-bar"}})]
+                                 :common "from-bar"
+                                 :start-time (du/str-to-date "2021-09-15T01:02:03.456Z")
+                                 :start-time-nil nil}})]
     (doseq [{:keys [name input expected]} test-cases]
       (testing (str "Test " name)
         (is (= expected (load-settings-file input)))))))


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for date parsing in settings files

## Why are we making these changes?

We would like the ability to configure date object in settings files.

