### PR TITLE
improves assertion in test for * default namespace in replicaset spec builder

### DIFF
--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -290,7 +290,8 @@
   (testing-using-waiter-url
     (when (using-k8s? waiter-url)
       (let [current-user (retrieve-username)
-            default-namespace (-> waiter-url get-kubernetes-scheduler-settings :replicaset-spec-builder :default-namespace)
+            configured-namespace (-> waiter-url get-kubernetes-scheduler-settings :replicaset-spec-builder :default-namespace)
+            default-namespace (if (= "*" configured-namespace) current-user configured-namespace)
             star-user-header {:x-waiter-run-as-user "*"}
             current-user-header {:x-waiter-run-as-user current-user}
             not-current-user "not-current-user"]


### PR DESCRIPTION

## Changes proposed in this PR

- improves assertion in test for * default namespace in replicaset spec builder

## Why are we making these changes?

Improve the integration tests to handle sceanrio where the default namespace is `*`

