### PR TITLE
Add raven-response-flags to request logs

### DIFF
--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -62,7 +62,7 @@
                   ;; allow non-proxy requests to provide tokens for use in the request log
                   (:waiter/token response))
         {:strs [image metric-group profile run-as-user version]} service-description
-        {:strs [content-length content-type grpc-status location server]} headers
+        {:strs [content-length content-type grpc-status location server x-raven-response-flags]} headers
         {:keys [k8s/node-name k8s/pod-name]} instance]
     (cond-> {}
       status (assoc :status status)
@@ -98,6 +98,7 @@
       location (assoc :response-location location)
       token (assoc :token token)
       (some? waiter-api-call?) (assoc :waiter-api waiter-api-call?)
+      x-raven-response-flags (assoc :raven-response-flags x-raven-response-flags)
       error-class (assoc :waiter-error-class error-class))))
 
 (defn log-request!

--- a/waiter/test/waiter/request_log_test.clj
+++ b/waiter/test/waiter/request_log_test.clj
@@ -76,7 +76,8 @@
                             "content-type" "application/xml"
                             "grpc-status" "13"
                             "location" "/foo/bar"
-                            "server" "foo-bar"}
+                            "server" "foo-bar"
+                            "x-raven-response-flags" "-"}
                   :instance {:host "instance-host"
                              :id "instance-id"
                              :k8s/node-name "test-node-name"
@@ -111,6 +112,7 @@
             :oidc-mode "oidc-mode"
             :oidc-redirect-uri "oidc-redirect-uri"
             :principal "principal@DOMAIN.COM"
+            :raven-response-flags "-"
             :request-type "test-request"
             :response-content-length "40"
             :response-content-type "application/xml"


### PR DESCRIPTION
## Changes proposed in this PR

Add x-raven-response-flags header value to request logs.

## Why are we making these changes?

Makes it easier to debug when we get error responses from the Raven layer.