### PR TITLE
adds support for filtering token based on repeated query param keys

### DIFF
--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -319,12 +319,12 @@
                                           (or (seq run-as-user)
                                               (authz/manage-service? entitlement-manager auth-user service-id service-description))
                                           (or (str/blank? token)
-                                              (let [filter-fn (utils/str->filter-fn token)]
+                                              (let [filter-fn (utils/str->filter-fn token true)]
                                                 (->> source-tokens
                                                   (map #(get % "token"))
                                                   (some filter-fn))))
                                           (or (str/blank? token-version)
-                                              (let [filter-fn (utils/str->filter-fn token-version)]
+                                              (let [filter-fn (utils/str->filter-fn token-version true)]
                                                 (->> source-tokens
                                                   (map #(get % "version"))
                                                   (some filter-fn)))))))

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -1637,28 +1637,30 @@
 (defn param-value->filter-fn
   "Accepts a single string or a sequence of strings as input.
    Creates the filter function that does substring match for the input string or any string in the sequence."
-  [param-value]
+  [param-value regex-support?]
   (if (string? param-value)
-    (utils/str->filter-fn param-value)
-    (utils/strs->filter-fn param-value)))
+    (utils/str->filter-fn param-value regex-support?)
+    (utils/strs->filter-fn param-value regex-support?)))
 
 (defn query-params->service-description-filter-predicate
   "Creates the filter function for service descriptions that matches every parameter provided in the request-params map."
-  [request-params]
-  (let [service-description-params (utils/filterm
-                                     (fn [[param-name _]]
-                                       (->> (str/split param-name #"\.")
-                                            (first)
-                                            (contains? service-parameter-keys)))
-                                     request-params)
-        param-predicates (map (fn [[param-name param-value]]
-                                (let [param-predicate (param-value->filter-fn param-value)]
-                                  (fn [service-description]
-                                    (->> (str/split param-name #"\.")
-                                         (get-in service-description)
-                                         (str)
-                                         (param-predicate)))))
-                              (seq service-description-params))]
-    (fn [service-description]
-      (or (empty? param-predicates)
-          (every? #(%1 service-description) param-predicates)))))
+  ([request-params]
+   (query-params->service-description-filter-predicate request-params service-parameter-keys true))
+  ([request-params parameter-keys regex-support?]
+   (let [service-description-params (utils/filterm
+                                      (fn [[param-name _]]
+                                        (->> (str/split param-name #"\.")
+                                          (first)
+                                          (contains? parameter-keys)))
+                                      request-params)
+         param-predicates (map (fn [[param-name param-value]]
+                                 (let [param-predicate (param-value->filter-fn param-value regex-support?)]
+                                   (fn [service-description]
+                                     (->> (str/split param-name #"\.")
+                                       (get-in service-description)
+                                       (str)
+                                       (param-predicate)))))
+                               (seq service-description-params))]
+     (fn [service-description]
+       (or (empty? param-predicates)
+           (every? #(%1 service-description) param-predicates))))))

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -661,18 +661,8 @@
                           (string? owner-param) #{owner-param}
                           (coll? owner-param) (set owner-param)
                           :else (list-token-owners kv-store))
-                 filterable-parameter? (disj sd/token-data-keys "owner" "maintenance")
-                 parameter-filter-predicates (for [[parameter-name raw-param] request-params
-                                                   :let [param-name-components (str/split parameter-name #"\.")
-                                                         param-name-head (first param-name-components)]
-                                                   :when (filterable-parameter? param-name-head)]
-                                               (let [search-parameter-values (cond
-                                                                               (string? raw-param) #{raw-param}
-                                                                               :else (set raw-param))]
-                                                 (fn [token-parameters]
-                                                   (and (contains? token-parameters param-name-head)
-                                                        (contains? search-parameter-values
-                                                                   (str (get-in token-parameters param-name-components)))))))
+                 service-description-filter-predicate (-> (dissoc request-params "deleted" "maintenance" "owner" "previous")
+                                                        (sd/query-params->service-description-filter-predicate sd/token-data-keys false))
                  index-filter-fn
                  (every-pred
                    (fn list-tokens-delete-predicate [entry]
@@ -688,7 +678,7 @@
                                               kv-store token
                                               :error-on-missing false
                                               :include-deleted include-deleted)]
-                       (and (every? #(% token-parameters) parameter-filter-predicates)
+                       (and (service-description-filter-predicate token-parameters)
                             (or (nil? include-run-as-requester)
                                 (= include-run-as-requester (sd/run-as-requester? token-parameters)))
                             (or (nil? include-requires-parameters)

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -852,18 +852,20 @@
     watch-chans))
 
 (defn str->filter-fn
-  "Returns a name-filtering function given a user-provided name filter string"
-  [name]
-  (let [pattern (-> (str name)
+  "Returns a value-filtering function given a user-provided value as filter string"
+  [value regex-support?]
+  (if regex-support?
+    (let [pattern (-> (str value)
                     (str/replace #"\." "\\\\.")
                     (str/replace #"\*+" ".*")
                     re-pattern)]
-    #(re-matches pattern %)))
+      #(re-matches pattern %))
+    #(= value %)))
 
 (defn strs->filter-fn
-  "Returns a name-filtering function that matches on any of the given sequence of user-provided names as filter string."
-  [names]
-  (let [filter-fns (map str->filter-fn names)]
+  "Returns a value-filtering function that matches on any of the given sequence of user-provided values as filter string."
+  [values regex-support?]
+  (let [filter-fns (map #(str->filter-fn % regex-support?) values)]
     (fn [value] (some #(%1 value) filter-fns))))
 
 (defn match-yes-like


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for filtering token based on repeated query param keys

## Why are we making these changes?

We would like to include tokens where the parameter support one of the multiple search values.
This can now be supported using a query parameter such as:
`permitted-user=&permitted-user=*`


