### PR TITLE
Fix type confusion when SPNEGO completes with no response

### DIFF
--- a/waiter/src/waiter/auth/spnego.clj
+++ b/waiter/src/waiter/auth/spnego.clj
@@ -177,12 +177,10 @@
                     (let [auth-params-map (auth/build-auth-params-map :spnego principal)
                           response (auth/handle-request-auth request-handler request auth-params-map password nil true)]
                       (log/debug "added cookies to response")
-                      (if token
-                        (if (map? response)
-                          (rr/header response "www-authenticate" token)
-                          (let [actual-response (async/<! response)]
-                            (rr/header actual-response "www-authenticate" token)))
-                        response))
+                      (let [actual-response (if (map? response) response (async/<! response))]
+                        (if token
+                          (rr/header actual-response "www-authenticate" token)
+                          actual-response)))
                     (response-http-401-unauthorized-negotiate request))
                   (catch Throwable th
                     (log/error th "error while processing response")


### PR DESCRIPTION
Previously this code was only taking a response from the chan if it had
a non-nil token from .acceptSecContext. If .acceptSecContext returns nil
without throwing (which means that negotiation is complete and no
WWW-Authenticate reply needs to be sent), we also need to ensure we
return an actual response, not a chan, or we'll confuse later code
that's accepting a map.

## Changes proposed in this PR

- above

## Why are we making these changes?

- It's easy to trigger a case where there is no reply from .acceptSecContext. In particular, using the GSSAPI libraries instead of the Kerberos API directly seems to trigger it. This blocks us from migrating from https://github.com/requests/requests-kerberos to the newer and better-maintained https://github.com/pythongssapi/requests-gssapi.