### PR TITLE
improves token updates error messages

### DIFF
--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1657,7 +1657,7 @@ class WaiterCliTest(util.WaiterTest):
                 util.delete_token(self.waiter_url, token_name)
         else:
             self.assertEqual(1, cp.returncode, cp.stderr)
-            self.assertIn('Cannot run as user.', cli.decode(cp.stderr))
+            self.assertIn('Cannot run as user: FAKE_USERNAME', cli.decode(cp.stderr))
 
     def test_create_token_admin_mode(self):
         self.__test_create_update_token_admin_mode('create', self.token_name(), True)

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -1322,7 +1322,7 @@
                  :headers {"x-waiter-token" token}
                  :request-method :post})]
           (is (= http-403-forbidden status))
-          (is (str/includes? body "Cannot run as user"))))
+          (is (str/includes? body "Cannot run as user: tu0"))))
 
       (testing "post:new-service-description:edit-unauthorized-owner"
         (let [kv-store (kv/->LocalKeyValueStore (atom {}))
@@ -1338,7 +1338,7 @@
                  :headers {"x-waiter-token" token}
                  :request-method :post})]
           (is (= http-403-forbidden status))
-          (is (str/includes? body "Cannot update token"))))
+          (is (str/includes? body "Cannot update token (owner=tu0) as user: tu1"))))
 
       (testing "post:new-service-description:create-unauthorized-owner"
         (let [kv-store (kv/->LocalKeyValueStore (atom {}))
@@ -1353,7 +1353,7 @@
                  :headers {"x-waiter-token" token}
                  :request-method :post})]
           (is (= http-403-forbidden status))
-          (is (str/includes? body "Cannot create token as user"))))
+          (is (str/includes? body "Cannot create token as provided owner"))))
 
       (testing "post:new-service-description:token-sync:invalid-admin-mode"
         (let [kv-store (kv/->LocalKeyValueStore (atom {}))
@@ -2023,7 +2023,7 @@
                  :headers {}
                  :request-method :post})]
           (is (= http-403-forbidden status))
-          (is (str/includes? body "Cannot run as user"))))
+          (is (str/includes? body "Cannot run as user: to2A"))))
 
       (testing "post:edit-service-description:editor-privileges:failure"
         (let [token (str token "-editor-test-edit-fail")
@@ -2033,7 +2033,7 @@
                                       (and (or (= :manage verb) (= :run-as verb))
                                            (or (str/includes? subject user) (str/includes? user subject)))))
               cur-service-description (walk/stringify-keys
-                                        {:cmd "cmd1" :mem 100 :permitted-user "tp1" :run-as-user "to2A" :version "v1"
+                                        {:cmd "cmd1" :mem 100 :permitted-user "tp1" :run-as-user "to1" :version "v1"
                                          :editor "te1" :owner "to1" :token token})
               _ (kv/store kv-store token cur-service-description)
               new-service-description (walk/stringify-keys (assoc cur-service-description :cmd "cmd2"))
@@ -2045,7 +2045,7 @@
                  :headers {}
                  :request-method :post})]
           (is (= http-403-forbidden status))
-          (is (str/includes? body "Cannot run as user"))))
+          (is (str/includes? body "Cannot run as user: to1"))))
 
       (testing "post:edit-service-description:editor-privileges:edit-restricted-field-owner"
         (let [token (str token "-editor-test")


### PR DESCRIPTION
## Changes proposed in this PR

- improves token updates error messages

## Why are we making these changes?

The CLI reports these error messages, so improving the messages improves the error reporting by the CLI.

