### PR TITLE
improves logic to determine when exclusive mode is enabled

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1128,7 +1128,7 @@
         service-id
         (let [{:keys [env] :as service-description} (response->service-description waiter-url response)
               expected-env (cond-> {:BINARY binary}
-                             (exclusive-mode? waiter-url) (assoc :WAITER_CONFIG_TOKEN token))]
+                             (exclusive-mode-by-default? waiter-url) (assoc :WAITER_CONFIG_TOKEN token))]
           (is (= expected-env env) (str service-description))
           (delete-token-and-assert waiter-url token))))))
 
@@ -1227,7 +1227,7 @@
                 {:keys [body] :as response} (make-request-with-debug-info request-headers kitchen-request)]
             (assert-response-status response http-400-bad-request)
             (is (str/includes? body "Some params cannot be configured"))))
-        (let [extra-env (when (exclusive-mode? waiter-url) {:WAITER_CONFIG_TOKEN token})
+        (let [extra-env (when (exclusive-mode-by-default? waiter-url) {:WAITER_CONFIG_TOKEN token})
               service-ids (set [(run-token-param-support
                                   waiter-url kitchen-request
                                   {:x-waiter-token token}
@@ -1901,7 +1901,7 @@
                             :permitted-user "*"
                             :run-as-user (retrieve-username)
                             :version "1"}
-          exclusive? (exclusive-mode? waiter-url)]
+          exclusive? (exclusive-mode-by-default? waiter-url)]
       (doseq [[profile {:keys [defaults]}] (seq profile-config)]
         (let [token (rand-name)
               token-description (-> (utils/remove-keys base-description (keys defaults))

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1126,8 +1126,10 @@
       (assert-response-status response http-200-ok)
       (with-service-cleanup
         service-id
-        (let [{:keys [env] :as service-description} (response->service-description waiter-url response)]
-          (is (= {:BINARY binary} env) (str service-description))
+        (let [{:keys [env] :as service-description} (response->service-description waiter-url response)
+              expected-env (cond-> {:BINARY binary}
+                             (exclusive-mode? waiter-url) (assoc :WAITER_CONFIG_TOKEN token))]
+          (is (= expected-env env) (str service-description))
           (delete-token-and-assert waiter-url token))))))
 
 (deftest ^:parallel ^:integration-fast test-token-https-redirects
@@ -1225,26 +1227,27 @@
                 {:keys [body] :as response} (make-request-with-debug-info request-headers kitchen-request)]
             (assert-response-status response http-400-bad-request)
             (is (str/includes? body "Some params cannot be configured"))))
-        (let [service-ids (set [(run-token-param-support
+        (let [extra-env (when (exclusive-mode? waiter-url) {:WAITER_CONFIG_TOKEN token})
+              service-ids (set [(run-token-param-support
                                   waiter-url kitchen-request
                                   {:x-waiter-token token}
-                                  {:BINARY binary :FEE "FIE" :FOO "BAR"})
+                                  (merge extra-env {:BINARY binary :FEE "FIE" :FOO "BAR"}))
                                 (run-token-param-support
                                   waiter-url kitchen-request
                                   {:x-waiter-param-fee "value-1p" :x-waiter-token token}
-                                  {:BINARY binary :FEE "value-1p" :FOO "BAR"})
+                                  (merge extra-env {:BINARY binary :FEE "value-1p" :FOO "BAR"}))
                                 (run-token-param-support
                                   waiter-url kitchen-request
                                   {:x-waiter-allowed-params ["FEE" "FII" "FOO"] :x-waiter-param-fee "value-1p" :x-waiter-token token}
-                                  {:BINARY binary :FEE "value-1p" :FOO "BAR"})
+                                  (merge extra-env {:BINARY binary :FEE "value-1p" :FOO "BAR"}))
                                 (run-token-param-support
                                   waiter-url kitchen-request
                                   {:x-waiter-allowed-params "FEE,FOO" :x-waiter-param-fee "value-1p" :x-waiter-token token}
-                                  {:BINARY binary :FEE "value-1p" :FOO "BAR"})
+                                  (merge extra-env {:BINARY binary :FEE "value-1p" :FOO "BAR"}))
                                 (run-token-param-support
                                   waiter-url kitchen-request
                                   {:x-waiter-param-fee "value-1p" :x-waiter-param-foo "value-2p" :x-waiter-token token}
-                                  {:BINARY binary :FEE "value-1p" :FOO "value-2p"})])]
+                                  (merge extra-env {:BINARY binary :FEE "value-1p" :FOO "value-2p"}))])]
           (is (= 5 (count service-ids)) "Unique service-ids were not created!"))
         (finally
           (delete-token-and-assert waiter-url token)
@@ -1897,11 +1900,13 @@
                             :name "test-profile-inside-token"
                             :permitted-user "*"
                             :run-as-user (retrieve-username)
-                            :version "1"}]
+                            :version "1"}
+          exclusive? (exclusive-mode? waiter-url)]
       (doseq [[profile {:keys [defaults]}] (seq profile-config)]
         (let [token (rand-name)
               token-description (-> (utils/remove-keys base-description (keys defaults))
-                                  (assoc :profile (name profile) :token token))]
+                                  (assoc :profile (name profile) :token token))
+              extra-env (when exclusive? {:WAITER_CONFIG_TOKEN token})]
           (try
             (testing (str "token creation with profile " profile)
               (let [register-response (post-token waiter-url token-description)]
@@ -1911,7 +1916,9 @@
                   (let [service-id (retrieve-service-id waiter-url {"x-waiter-token" token})
                         _ (is service-id "No service created by using token!")
                         service-description (service-id->service-description waiter-url service-id)]
-                    (is (= service-description (dissoc token-description :token)))))))
+                    (is (= service-description
+                           (cond-> (dissoc token-description :token)
+                             extra-env (update :env merge extra-env))))))))
 
             (testing (str "token creation with interstitial and profile " profile)
               (let [token-description (assoc token-description :interstitial-secs 10)
@@ -1922,7 +1929,9 @@
                   (let [service-id (retrieve-service-id waiter-url {"x-waiter-token" token})
                         _ (is service-id "No service created by using token!")
                         service-description (service-id->service-description waiter-url service-id)]
-                    (is (= service-description (dissoc token-description :token)))))))
+                    (is (= service-description
+                           (cond-> (dissoc token-description :token)
+                             extra-env (update :env merge extra-env))))))))
 
             (finally
               (delete-token-and-assert waiter-url token))))))))

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -1319,8 +1319,8 @@
          (-> jwt-config :oidc-authorize-uri str/blank? not)
          (-> jwt-config :oidc-token-uri str/blank? not))))
 
-(defn exclusive-mode?
-  "Get the authenticator that Waiter is configured to use"
+(defn exclusive-mode-by-default?
+  "Returns true if service-mapping is exclusive by default."
   [waiter-url]
   (-> (waiter-settings waiter-url)
     (get-in [:token-config :token-defaults :service-mapping])

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -1318,3 +1318,10 @@
          (map? jwt-config)
          (-> jwt-config :oidc-authorize-uri str/blank? not)
          (-> jwt-config :oidc-token-uri str/blank? not))))
+
+(defn exclusive-mode?
+  "Get the authenticator that Waiter is configured to use"
+  [waiter-url]
+  (-> (waiter-settings waiter-url)
+    (get-in [:token-config :token-defaults :service-mapping])
+    (= "exclusive")))


### PR DESCRIPTION
## Changes proposed in this PR

- improves logic to determine when exclusive mode is enabled in incoming requests and avoiding unintentional updates to the service description
- enabling exclusive mode also changing the integration tests to include the token in the service description environment

## Why are we making these changes?

`WAITER_CONFIG_TOKEN` should only be configured when explicit tokens are in use (and not for service-ID tokens) and not be dependent on what the token defaults are (even if no tokens are being used). This resolves a bug that occurs when service-ID tokens (of the form `^SERVICE-ID#<target-service-id>`) get included in the `WAITER_CONFIG_TOKEN` environment, effectively changing the computed service ID and configuration (by removing the old token from the environment) and making the target service unreachable. 



