### PR TITLE
adds delay while sending chunked requests in integration test

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -228,7 +228,7 @@
               (is (str/includes? (str (get headers "server")) "Python"))))))
 
       (testing "content headers"
-        (let [request-length 100000
+        (let [request-length 120000
               long-request (apply str (repeat request-length "a"))]
 
           (testing "unchunked request"
@@ -247,7 +247,7 @@
                                  waiter-url
                                  request-headers
                                  :path "/request-info"
-                                 :body (make-chunked-body long-request 4096 20))
+                                 :body (make-chunked-body long-request 16384 200))
                   chunked-body-str (str (:body chunked-resp))
                   chunked-body-json (try-parse-json chunked-body-str)]
               (is (= request-length (get-in chunked-body-json ["request-length"])) chunked-body-str)


### PR DESCRIPTION
## Changes proposed in this PR

- adds delay while sending chunked requests in integration test

## Why are we making these changes?

When the Waiter server is slow to process incoming requests, all data may become available in buffers and result in the chunked payload being converted to full payload without chunks and forwarded to the backend as such. Introducing a larger delay between the sending of chunks helps avoid reduce the chances of this happening.


