### PR TITLE
Improve deployment error messages for TLS mismatch

### DIFF
--- a/containers/raven/envoy.template.yaml
+++ b/containers/raven/envoy.template.yaml
@@ -24,6 +24,9 @@ static_resources:
                     - header:
                         key: x-raven-response-flags
                         value: "%RESPONSE_FLAGS%"
+                    - header:
+                        key: x-raven-status-code-details
+                        value: "%RESPONSE_CODE_DETAILS%"
                   virtual_hosts:
                     - name: app-backend
                       domains:

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -975,6 +975,7 @@
  ;; Certain messages that Waiter returns can be customized:
  :messages {:backend-request-failed "Request to service backend failed"
             :backend-request-timed-out "Request to service backend timed out"
+            :bad-socket "Backend is closing socket without responding (ensure backend-proto is correctly configured)"
             :bad-startup-command "Invalid startup command"
             :cannot-connect "Unable to connect to run health checks"
             :cannot-identify-service "Unable to identify service using waiter headers/token"
@@ -986,7 +987,8 @@
             :metadata-error-info "Error in metadata"
             :not-enough-memory "Not enough memory allocated"
             :not-found "Not found"
-            :prestashed-tickets-not-available "Prestashed jobsystem tickets not available"}
+            :prestashed-tickets-not-available "Prestashed jobsystem tickets not available"
+            :tls-error "Unable to complete TLS handshake with backend (ensure backend-proto is correctly configured)"}
 
  ;; Support information used to provide user guidance in error messages
  :support-info [{:label "Email Support Team" :link {:type :email :value "support@example.com"}}

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -333,6 +333,7 @@
                :relative-path "tokens"}
    :messages {:backend-request-failed "Request to service backend failed"
               :backend-request-timed-out "Request to service backend timed out"
+              :bad-socket "Backend is closing socket without responding (ensure backend-proto is correctly configured)"
               :bad-startup-command "Invalid startup command"
               :cannot-connect "Unable to connect to run health checks"
               :cannot-identify-service "Unable to identify service using waiter headers/token"
@@ -346,7 +347,8 @@
               :service-state-failing "Failing"
               :service-state-inactive "Inactive"
               :service-state-running "Running"
-              :service-state-starting "Starting"}
+              :service-state-starting "Starting"
+              :tls-error "Unable to complete TLS handshake with backend (ensure backend-proto is correctly configured)"}
    :metric-group-mappings []
    :metrics-config {:inter-router-metrics-idle-timeout-ms 2000
                     :metrics-gc-interval-ms 60000

--- a/waiter/src/waiter/state/maintainer.clj
+++ b/waiter/src/waiter/state/maintainer.clj
@@ -490,8 +490,11 @@
           deployment-error (cond
                              (and has-failed-instances? all-instances-exited-similarly?) :bad-startup-command
                              (and has-failed-instances? (all-instances-flagged-with? :memory-limit-exceeded)) :not-enough-memory
+                             (and has-failed-instances? (all-instances-flagged-with? :ssl-exception)) :tls-error
                              (and has-failed-instances? (no-instances-flagged-with? :has-connected)) :cannot-connect
-                             (and has-failed-instances? (no-instances-flagged-with? :has-responded)) :health-check-timed-out
+                             (and has-failed-instances? (no-instances-flagged-with? :has-responded)) (if (all-instances-flagged-with? :hangup-exception)
+                                                                                                       :bad-socket
+                                                                                                       :health-check-timed-out)
                              (and has-failed-instances? (all-instances-flagged-with? :never-passed-health-checks)) :invalid-health-check-response
                              (and has-unhealthy-instances? (= first-unhealthy-status http-401-unauthorized)) :health-check-requires-authentication)]
       (when deployment-error

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -892,6 +892,14 @@
     (when (not= result envoy-empty-response-flags)
       result)))
 
+(defn raven-status-details
+  "Returns the response status details from a backend sidecar proxy,
+   and nil when no flags were set or no backend proxy is present.
+   See the Envoy Proxy documentation for details on the response flags format:
+   https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/response_code_details"
+  [response]
+  (get-in response [:headers "x-raven-status-code-details"]))
+
 (defn raven-proxy-response?
   "Returns true if the response is from a backend sidecar proxy."
   [response]


### PR DESCRIPTION
## Changes proposed in this PR

Improve deployment error messages for TLS mismatch.

## Why are we making these changes?

Help users debug more easily when they've configured the wrong backend protocol for their service.