### PR TITLE
Less aggressive grace period on ssl deployment error tests

### DIFF
--- a/waiter/integration/waiter/deployment_errors_test.clj
+++ b/waiter/integration/waiter/deployment_errors_test.clj
@@ -104,7 +104,7 @@
     (let [headers {:x-waiter-name (rand-name)
                    ; wrong backend-proto
                    :x-waiter-backend-proto "https"
-                   :x-waiter-grace-period-secs 15
+                   :x-waiter-grace-period-secs 45
                    :x-waiter-health-check-interval-secs 5
                    :x-waiter-health-check-max-consecutive-failures 1
                    :x-waiter-queue-timeout 600000}
@@ -120,7 +120,7 @@
                    ; wrong backend-proto
                    :x-waiter-backend-proto "http"
                    :x-waiter-cmd (kitchen-cmd "--port $PORT0 --ssl-self-signed")
-                   :x-waiter-grace-period-secs 15
+                   :x-waiter-grace-period-secs 45
                    :x-waiter-health-check-interval-secs 5
                    :x-waiter-health-check-max-consecutive-failures 1
                    :x-waiter-queue-timeout 600000}


### PR DESCRIPTION
## Changes proposed in this PR

Use less aggressive grace period on ssl deployment error tests.

## Why are we making these changes?

In some of our testing environments it looks like the backend isn't actually able to start within the current grace period, resulting in the wrong deployment error here.

The new value (45s) is copied from `test-invalid-health-check-response`, whereas the old value (15s) was copied from `test-cannot-connect`. Note that the backend process needn't start in order to correctly diagnose the `cannot-connect` error.