### PR TITLE
adds support for ping after kill operation

### DIFF
--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -582,7 +582,27 @@ class WaiterCliTest(util.WaiterTest):
             self.assertIn(service_id, cli.stdout(cp))
             self.assertIn('Successfully killed', cli.stdout(cp))
             self.assertIn('timeout=30000', cli.stderr(cp))
+            self.assertNotIn('Pinging service', cli.stdout(cp))
+            self.assertNotIn('Pinging token', cli.stdout(cp))
             util.wait_until_no_services_for_token(self.waiter_url, token_name)
+        finally:
+            util.delete_token(self.waiter_url, token_name, kill_services=True)
+
+    def test_kill_token_and_then_ping(self):
+        token_name = self.token_name()
+        util.post_token(self.waiter_url, token_name, util.minimal_service_description())
+        try:
+            service_id = util.ping_token(self.waiter_url, token_name)
+            self.assertEqual(1, len(util.services_for_token(self.waiter_url, token_name)))
+            cp = cli.kill(self.waiter_url, token_name, flags="-v", kill_flags="--ping")
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            self.assertIn('Killing service', cli.stdout(cp))
+            self.assertIn(service_id, cli.stdout(cp))
+            self.assertIn('Successfully killed', cli.stdout(cp))
+            self.assertIn('timeout=30000', cli.stderr(cp))
+            self.assertIn('Pinging token', cli.stdout(cp))
+            self.assertIn('Ping successful', cli.stdout(cp))
+            self.assertEqual(1, len(util.wait_until_services_for_token(self.waiter_url, token_name, 1)))
         finally:
             util.delete_token(self.waiter_url, token_name, kill_services=True)
 
@@ -593,6 +613,8 @@ class WaiterCliTest(util.WaiterTest):
             cp = cli.kill(self.waiter_url, token_name)
             self.assertEqual(1, cp.returncode, cp.stderr)
             self.assertIn('There are no services using token', cli.stdout(cp))
+            self.assertNotIn('Pinging service', cli.stdout(cp))
+            self.assertNotIn('Pinging token', cli.stdout(cp))
         finally:
             util.delete_token(self.waiter_url, token_name)
 
@@ -608,6 +630,8 @@ class WaiterCliTest(util.WaiterTest):
             self.assertIn('Killing service', cli.stdout(cp))
             self.assertIn(service_id, cli.stdout(cp))
             self.assertIn('Successfully killed', cli.stdout(cp))
+            self.assertNotIn('Pinging service', cli.stdout(cp))
+            self.assertNotIn('Pinging token', cli.stdout(cp))
             self.assertIn(f'timeout={timeout * 1000}', cli.stderr(cp))
             util.wait_until_no_services_for_token(self.waiter_url, token_name)
         finally:
@@ -628,6 +652,8 @@ class WaiterCliTest(util.WaiterTest):
             self.assertEqual(2, cli.stdout(cp).count('Successfully killed'))
             self.assertIn(service_id_1, cli.stdout(cp))
             self.assertIn(service_id_2, cli.stdout(cp))
+            self.assertNotIn('Pinging service', cli.stdout(cp))
+            self.assertNotIn('Pinging token', cli.stdout(cp))
             util.wait_until_no_services_for_token(self.waiter_url, token_name)
         finally:
             util.delete_token(self.waiter_url, token_name, kill_services=True)
@@ -651,6 +677,8 @@ class WaiterCliTest(util.WaiterTest):
             self.assertIn(service_id_1, stdout)
             self.assertIn(service_id_2, stdout)
             self.assertLess(stdout.index(service_id_2), stdout.index(service_id_1))
+            self.assertNotIn('Pinging service', stdout)
+            self.assertNotIn('Pinging token', cli.stdout(cp))
             util.wait_until_routers_recognize_service_killed(self.waiter_url, service_id_1)
             util.wait_until_routers_recognize_service_killed(self.waiter_url, service_id_2)
 
@@ -946,6 +974,8 @@ class WaiterCliTest(util.WaiterTest):
             cp = cli.kill(self.waiter_url, service_id, kill_flags='--service-id')
             self.assertEqual(0, cp.returncode, cp.stderr)
             self.assertIn('Killing service', cli.stdout(cp))
+            self.assertNotIn('Pinging service', cli.stdout(cp))
+            self.assertNotIn('Pinging token', cli.stdout(cp))
             util.wait_until_no_services_for_token(self.waiter_url, token_name)
         finally:
             util.delete_token(self.waiter_url, token_name)
@@ -954,6 +984,8 @@ class WaiterCliTest(util.WaiterTest):
         cp = cli.kill(self.waiter_url, uuid.uuid4(), kill_flags='--service-id')
         self.assertEqual(1, cp.returncode, cp.stderr)
         self.assertIn('No matching data found', cli.stdout(cp))
+        self.assertNotIn('Pinging service', cli.stdout(cp))
+        self.assertNotIn('Pinging token', cli.stdout(cp))
 
     def test_kill_inactive_service_id(self):
         token_name = self.token_name()
@@ -965,6 +997,8 @@ class WaiterCliTest(util.WaiterTest):
             cp = cli.kill(self.waiter_url, service_id, kill_flags='--service-id')
             self.assertEqual(0, cp.returncode, cp.stderr)
             self.assertIn('cannot be killed because it is already Inactive', cli.stdout(cp))
+            self.assertNotIn('Pinging service', cli.stdout(cp))
+            self.assertNotIn('Pinging token', cli.stdout(cp))
         finally:
             util.delete_token(self.waiter_url, token_name, kill_services=True)
 

--- a/cli/waiter/subcommands/kill.py
+++ b/cli/waiter/subcommands/kill.py
@@ -36,7 +36,7 @@ def register(add_parser):
     ping_group.add_argument('--no-ping', action='store_false', dest='ping_token',
                             help='skips pinging the token/service; pinging the token is disabled by default')
     ping_group.add_argument('--ping', action='store_true', dest='ping_token',
-                            help='pings the token after stopping maintenance.')
+                            help='pings the token/service after killing service(s).')
     parser.set_defaults(ping_token=False)
     parser.add_argument('--ping-timeout', default=300, dest='ping_timeout',
                         help='read timeout (in seconds) for ping request (default=300)', type=check_positive)

--- a/cli/waiter/subcommands/kill.py
+++ b/cli/waiter/subcommands/kill.py
@@ -1,4 +1,4 @@
-from waiter.action import process_kill_request
+from waiter.action import process_kill_request, process_ping_request
 from waiter.util import guard_no_cluster, check_positive
 
 
@@ -9,8 +9,17 @@ def kill(clusters, args, _, __):
     is_service_id = args.get('is-service-id', False)
     force_flag = args.get('force', False)
     timeout_secs = args['timeout']
+    ping_token_name_or_service_id = args.get('ping_token', False)
+
     success = process_kill_request(clusters, token_name_or_service_id, is_service_id, force_flag, timeout_secs)
-    return 0 if success else 1
+    if success and ping_token_name_or_service_id:
+        ping_timeout_secs = args.get('ping_timeout')
+        ping_wait = args.get('ping_wait', True)
+        ping_success = process_ping_request(clusters, token_name_or_service_id, is_service_id,
+                                            ping_timeout_secs, ping_wait)
+        return 0 if ping_success else 1
+    else:
+        return 0 if success else 1
 
 
 def register(add_parser):
@@ -22,4 +31,20 @@ def register(add_parser):
                         dest='is-service-id', action='store_true')
     parser.add_argument('--timeout', '-t', help='timeout (in seconds) for kill to complete',
                         type=check_positive, default=30)
+
+    ping_group = parser.add_mutually_exclusive_group(required=False)
+    ping_group.add_argument('--no-ping', action='store_false', dest='ping_token',
+                            help='skips pinging the token/service; pinging the token is disabled by default')
+    ping_group.add_argument('--ping', action='store_true', dest='ping_token',
+                            help='pings the token after stopping maintenance.')
+    parser.set_defaults(ping_token=False)
+    parser.add_argument('--ping-timeout', default=300, dest='ping_timeout',
+                        help='read timeout (in seconds) for ping request (default=300)', type=check_positive)
+    ping_wait_group = parser.add_mutually_exclusive_group(required=False)
+    ping_wait_group.add_argument('--no-ping-wait', action='store_false', dest='ping_wait',
+                                 help='do not wait for ping request to return')
+    ping_wait_group.add_argument('--ping-wait', action='store_true', dest='ping_wait',
+                                 help='wait for ping request to return (default)')
+    parser.set_defaults(ping_wait=True)
+
     return kill

--- a/cli/waiter/subcommands/ping.py
+++ b/cli/waiter/subcommands/ping.py
@@ -1,7 +1,5 @@
 
-from waiter import http_util, terminal
-from waiter.action import ping_service_on_cluster, ping_token_on_cluster
-from waiter.querying import print_no_data, query_service, query_token
+from waiter.action import process_ping_request
 from waiter.util import check_positive, guard_no_cluster
 
 
@@ -10,47 +8,11 @@ def ping(clusters, args, _, __):
     guard_no_cluster(clusters)
     token_name_or_service_id = args.get('token-or-service-id')
     is_service_id = args.get('is-service-id', False)
-    if is_service_id:
-        query_result = query_service(clusters, token_name_or_service_id)
-    else:
-        query_result = query_token(clusters, token_name_or_service_id)
-
-    if query_result['count'] == 0:
-        print_no_data(clusters)
-        return 1
-
-    timeout = args.get('timeout', None)
+    timeout_secs = args.get('timeout', None)
     wait_for_request = args.get('wait', True)
-    http_util.set_retries(0)
-    cluster_data_pairs = sorted(query_result['clusters'].items())
-    clusters_by_name = {c['name']: c for c in clusters}
-    overall_success = True
-    for cluster_name, data in cluster_data_pairs:
-        cluster = clusters_by_name[cluster_name]
-        if is_service_id:
-            success = ping_service_on_cluster(cluster, token_name_or_service_id, timeout, wait_for_request)
-        else:
-            token_data = data['token']
-            token_etag = data['etag']
-            token_cluster_name = token_data['cluster'].upper()
-            if len(clusters) == 1 or token_explicitly_created_on_cluster(cluster, token_cluster_name):
-                success = ping_token_on_cluster(cluster, token_name_or_service_id, timeout,
-                                                wait_for_request, token_etag)
-            else:
-                print(f'Not pinging token {terminal.bold(token_name_or_service_id)} '
-                      f'in {terminal.bold(cluster_name)} '
-                      f'because it was created in {terminal.bold(token_cluster_name)}.')
-                success = True
-        overall_success = overall_success and success
-    return 0 if overall_success else 1
-
-
-def token_explicitly_created_on_cluster(cluster, token_cluster_name):
-    """Returns true if the given token cluster matches the configured cluster name of the given cluster"""
-    cluster_settings, _ = http_util.make_data_request(cluster, lambda: http_util.get(cluster, '/settings'))
-    cluster_config_name = cluster_settings['cluster-config']['name'].upper()
-    created_on_this_cluster = token_cluster_name == cluster_config_name
-    return created_on_this_cluster
+    ping_success = process_ping_request(clusters, token_name_or_service_id, is_service_id,
+                                        timeout_secs, wait_for_request)
+    return 0 if ping_success else 1
 
 
 def register(add_parser):


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for ping after kill operation

## Why are we making these changes?

We would like the mechanism to restart a service after killing all its current instances. The service owner understand that such an operation can cause in-flight requests to fail.


