### PR TITLE
Token syncer: sync when user editable token fields are the same even when mismatching metadata fields

### DIFF
--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -1086,8 +1086,9 @@
                                                      "last-update-user" "foo-user"}
                                          "root" (first waiter-urls))
                     sync-result (pc/map-from-keys
-                                  (constantly {:code :error/token-sync
-                                               :details {:message "token contents match, but were edited by different users"}})
+                                  (constantly {:code :success/sync-update
+                                               :details {:etag token-etag
+                                                         :status 200}})
                                   (rest waiter-urls))
                     expected-result {:details {token-name {:latest {:cluster-url (first waiter-urls)
                                                                     :description latest-description
@@ -1102,24 +1103,14 @@
                                                         :selected {:count 1 :value #{token-name}}
                                                         :total {:count 1 :value #{token-name}}}}}]
                 (is (= expected-result actual-result))
-                (doall
-                  (map-indexed
-                    (fn [index waiter-url]
-                      (let [token-etag (token->etag waiter-api waiter-url token-name)]
-                        (is (= {:description (assoc basic-description
-                                               "cluster" (waiter-url->cluster waiter-url)
-                                               "last-update-time" (- last-update-time-ms index)
-                                               "last-update-user" (str "auth-user-" index)
-                                               "owner" "test-user"
-                                               "previous" {"last-update-time" (- current-time-ms 30000)
-                                                           "last-update-user" "foo-user"}
-                                               "root" waiter-url)
-                                :headers {"content-type" "application/json"
-                                          "etag" token-etag}
-                                :status 200
-                                :token-etag token-etag}
-                               (load-token waiter-url token-name)))))
-                    waiter-urls))))))
+                (for [waiter-url waiter-urls]
+                  (let [token-etag (token->etag waiter-api waiter-url token-name)]
+                    (is (= {:description latest-description
+                            :headers {"content-type" "application/json"
+                                      "etag" token-etag}
+                            :status 200
+                            :token-etag token-etag}
+                           (load-token waiter-url token-name)))))))))
         (finally
           (cleanup-token waiter-api waiter-urls token-name))))))
 
@@ -1164,7 +1155,9 @@
                                                      "last-update-user" "foo-user"}
                                          "root" (first waiter-urls))
                     sync-result (pc/map-from-keys
-                                  (constantly {:code :success/skip-token-sync})
+                                  (constantly {:code :success/sync-update
+                                               :details {:etag token-etag
+                                                         :status 200}})
                                   (rest waiter-urls))
                     expected-result {:details {token-name {:latest {:cluster-url (first waiter-urls)
                                                                     :description latest-description
@@ -1179,24 +1172,14 @@
                                                         :selected {:count 1 :value #{token-name}}
                                                         :total {:count 1 :value #{token-name}}}}}]
                 (is (= expected-result actual-result))
-                (doall
-                  (map-indexed
-                    (fn [index waiter-url]
-                      (let [token-etag (token->etag waiter-api waiter-url token-name)]
-                        (is (= {:description (assoc basic-description
-                                               "cluster" (waiter-url->cluster waiter-url)
-                                               "last-update-time" (- last-update-time-ms index)
-                                               "last-update-user" "auth-user"
-                                               "owner" "test-user"
-                                               "previous" {"last-update-time" (- current-time-ms 30000)
-                                                           "last-update-user" "foo-user"}
-                                               "root" waiter-url)
-                                :headers {"content-type" "application/json"
-                                          "etag" token-etag}
-                                :status 200
-                                :token-etag token-etag}
-                               (load-token waiter-url token-name)))))
-                    waiter-urls))))))
+                (for [waiter-url waiter-urls]
+                  (let [token-etag (token->etag waiter-api waiter-url token-name)]
+                    (is (= {:description latest-description
+                            :headers {"content-type" "application/json"
+                                      "etag" token-etag}
+                            :status 200
+                            :token-etag token-etag}
+                           (load-token waiter-url token-name)))))))))
         (finally
           (cleanup-token waiter-api waiter-urls token-name))))))
 

--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -1097,10 +1097,10 @@
                                      :summary {:sync {:failed #{token-name}
                                                       :unmodified #{}
                                                       :updated #{}}
-                                               :tokens {:pending {:count 0 :value #{}}
+                                               :tokens {:pending {:count 1 :value #{token-name}}
                                                         :previously-synced {:count 0 :value #{}}
                                                         :processed {:count 1 :value #{token-name}}
-                                                        :selected {:count 0 :value #{}}
+                                                        :selected {:count 1 :value #{token-name}}
                                                         :total {:count 1 :value #{token-name}}}}}]
                 (is (= expected-result actual-result))
                 (for [waiter-url waiter-urls]
@@ -1166,10 +1166,10 @@
                                      :summary {:sync {:failed #{}
                                                       :unmodified #{}
                                                       :updated #{token-name}}
-                                               :tokens {:pending {:count 0 :value #{}}
+                                               :tokens {:pending {:count 1 :value #{token-name}}
                                                         :previously-synced {:count 0 :value #{}}
                                                         :processed {:count 1 :value #{token-name}}
-                                                        :selected {:count 0 :value #{}}
+                                                        :selected {:count 1 :value #{token-name}}
                                                         :total {:count 1 :value #{token-name}}}}}]
                 (is (= expected-result actual-result))
                 (for [waiter-url waiter-urls]

--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -1097,10 +1097,10 @@
                                      :summary {:sync {:failed #{token-name}
                                                       :unmodified #{}
                                                       :updated #{}}
-                                               :tokens {:pending {:count 1 :value #{token-name}}
+                                               :tokens {:pending {:count 0 :value #{}}
                                                         :previously-synced {:count 0 :value #{}}
                                                         :processed {:count 1 :value #{token-name}}
-                                                        :selected {:count 1 :value #{token-name}}
+                                                        :selected {:count 0 :value #{}}
                                                         :total {:count 1 :value #{token-name}}}}}]
                 (is (= expected-result actual-result))
                 (for [waiter-url waiter-urls]
@@ -1166,10 +1166,10 @@
                                      :summary {:sync {:failed #{}
                                                       :unmodified #{}
                                                       :updated #{token-name}}
-                                               :tokens {:pending {:count 1 :value #{token-name}}
+                                               :tokens {:pending {:count 0 :value #{}}
                                                         :previously-synced {:count 0 :value #{}}
                                                         :processed {:count 1 :value #{token-name}}
-                                                        :selected {:count 1 :value #{token-name}}
+                                                        :selected {:count 0 :value #{}}
                                                         :total {:count 1 :value #{token-name}}}}}]
                 (is (= expected-result actual-result))
                 (for [waiter-url waiter-urls]

--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -1094,7 +1094,7 @@
                                                                     :description latest-description
                                                                     :token-etag token-etag}
                                                            :sync-result sync-result}}
-                                     :summary {:sync {:failed #{token-name}
+                                     :summary {:sync {:failed #{}
                                                       :unmodified #{}
                                                       :updated #{token-name}}
                                                :tokens {:pending {:count 1 :value #{token-name}}

--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -1096,7 +1096,7 @@
                                                            :sync-result sync-result}}
                                      :summary {:sync {:failed #{token-name}
                                                       :unmodified #{}
-                                                      :updated #{}}
+                                                      :updated #{token-name}}
                                                :tokens {:pending {:count 1 :value #{token-name}}
                                                         :previously-synced {:count 0 :value #{}}
                                                         :processed {:count 1 :value #{token-name}}

--- a/token-syncer/src/token_syncer/commands/syncer.clj
+++ b/token-syncer/src/token_syncer/commands/syncer.clj
@@ -137,7 +137,7 @@
                       :else
                       {:code :success/token-match})]
                 ;; log full token descriptions when there was a syncing error detected
-                (when (str/starts-with? (name code) "error")
+                (when (= (namespace code) "error")
                   (log/error "error when syncing token descriptions: " {:code code
                                                                         :current-token-description description
                                                                         :latest-token-description latest-token-description}))

--- a/token-syncer/src/token_syncer/commands/syncer.clj
+++ b/token-syncer/src/token_syncer/commands/syncer.clj
@@ -139,8 +139,9 @@
                       {:code :success/token-match})]
                 ;; log full token descriptions when there was a syncing error detected
                 (when (str/starts-with? (name code) "error")
-                  (log/error "error sync result token descriptions: " {:current-token-description description
-                                                                       :latest-token-description latest-token-description}))
+                  (log/error "error when syncing token descriptions: " {:code code
+                                                                        :current-token-description description
+                                                                        :latest-token-description latest-token-description}))
                 result)
               (catch Exception ex
                 (log/error ex "unable to sync token on" cluster-url)

--- a/token-syncer/src/token_syncer/commands/syncer.clj
+++ b/token-syncer/src/token_syncer/commands/syncer.clj
@@ -78,8 +78,7 @@
   [{:keys [store-token]} cluster-urls token latest-token-description opt-out-metadata-name cluster-url->token-data]
   (pc/map-from-keys
     (fn [cluster-url]
-      (let [
-            ;; don't include "deleted" system metadata key, this must be considered for determining root-mismatch
+      (let [;; don't include "deleted" system metadata key, this must be considered for determining root-mismatch
             ignored-root-mismatch-equality-comparison-keys ["cluster" "last-update-time" "last-update-user" "previous" "root"]
             cluster-result
             (try


### PR DESCRIPTION
## Changes proposed in this PR

- Previously, we skipped syncing for the case where same user edited token on different roots (e.g. clusters), when they have the same user editable token fields (cpus, mem, etc.) irrespective of system metadata differences (cluster, last-updated-time, etc.). This change makes it so that we still sync the token in this case and choose the latest token description
- Previously, we errored when syncing  for the case where different users edited the the latest token and current token, when they have the same user editable token fields (cpus, mem, etc.) irrespective of system metadata differences (cluster, last-updated-time, etc.). This change makes it so that we still sync the token in this case and choose the latest token description.

## Why are we making these changes?
- this decreases the number of token syncer errors on two scenarios we think its safe to choose the latest description even when different users made the changes or when the root is different.
- the previous sync strategy caused errors to propagate later when one of the tokens would be edited causing the sync operation to fail due to cluster/author differences.
