### PR TITLE
moves service-mapping logic to ServiceDescriptionBuilder build() function

### DIFF
--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -856,7 +856,7 @@
                   service-id-prefix source-tokens token-sequence token-service-mapping username]}]
     (let [core-service-description
           (cond-> user-service-description
-            ;; each unique token permutation will create a unique service
+            ;; include token name in the service description to enforce unique token->service mappings
             ;; leverage WAITER_CONFIG_ prefixed environment variables being allowed
             (= "exclusive" token-service-mapping)
             (assoc-token-in-env token-sequence)

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -831,23 +831,37 @@
                              (retrieve-token-update-epoch-time token (token->token-parameters token) version)))
                       (reduce utils/nil-safe-max nil))))))
 
+(defn- assoc-token-in-env
+  "Attaches the token sequence as an environment variable in the service description."
+  [service-description token-sequence]
+  (assoc-in service-description ["env" "WAITER_CONFIG_TOKEN"] (str/join "," token-sequence)))
+
+(defn- assoc-approved-run-as-requester-parameters
+  "Attaches run-as-requester parameters if the services has been approved."
+  [service-description assoc-run-as-user-approved? service-id-prefix username]
+  (let [candidate-service-description (assoc-run-as-requester-fields service-description username)
+        candidate-service-id (service-description->service-id service-id-prefix candidate-service-description)]
+    (if (assoc-run-as-user-approved? candidate-service-id)
+      (do
+        (log/debug "appending run-as-user into pre-approved service" candidate-service-id)
+        candidate-service-description)
+      service-description)))
+
 (defrecord DefaultServiceDescriptionBuilder [kv-store max-constraints-schema metric-group-mappings profile->defaults
                                              service-description-defaults]
   ServiceDescriptionBuilder
 
   (build [this user-service-description
           {:keys [assoc-run-as-user-approved? component->previous-descriptor-fns reference-type->entry
-                  service-id-prefix source-tokens username]}]
+                  service-id-prefix source-tokens token-sequence token-service-mapping username]}]
     (let [core-service-description
-          (if (get user-service-description "run-as-user")
-            user-service-description
-            (let [candidate-service-description (assoc-run-as-requester-fields user-service-description username)
-                  candidate-service-id (service-description->service-id service-id-prefix candidate-service-description)]
-              (if (assoc-run-as-user-approved? candidate-service-id)
-                (do
-                  (log/debug "appending run-as-user into pre-approved service" candidate-service-id)
-                  candidate-service-description)
-                user-service-description)))
+          (cond-> user-service-description
+            ;; each unique token permutation will create a unique service
+            ;; leverage WAITER_CONFIG_ prefixed environment variables being allowed
+            (= "exclusive" token-service-mapping)
+            (assoc-token-in-env token-sequence)
+            (not (contains? user-service-description "run-as-user"))
+            (assoc-approved-run-as-requester-parameters assoc-run-as-user-approved? service-id-prefix username))
           service-id (service-description->service-id service-id-prefix core-service-description)
           service-description (compute-effective this service-id core-service-description)
           reference-type->entry (cond-> (or reference-type->entry {})
@@ -1037,12 +1051,9 @@
   [attach-service-defaults-fn attach-token-defaults-fn token-sequence token->token-data]
   (let [merged-token-data (attach-token-defaults-fn
                             (token-sequence->merged-data token->token-data token-sequence))
-        exclusive-mode? (and (-> token-sequence (remove-service-entry-tokens identity) (seq))
-                             (= "exclusive" (get merged-token-data "service-mapping")))
-        service-description-template (cond-> (select-keys merged-token-data service-parameter-keys)
-                                       ;; each unique token permutation will create a unique service
-                                       ;; leverage WAITER_CONFIG_ prefixed environment variables being allowed
-                                       exclusive-mode? (assoc-in ["env" "WAITER_CONFIG_TOKEN"] (str/join "," token-sequence)))
+        token-service-mapping (when (-> token-sequence (remove-service-entry-tokens identity) (seq))
+                                (get merged-token-data "service-mapping"))
+        service-description-template (select-keys merged-token-data service-parameter-keys)
         source-tokens (mapv #(source-tokens-entry % (token->token-data %)) token-sequence)]
     {:fallback-period-secs (get merged-token-data "fallback-period-secs")
      :service-description-template service-description-template
@@ -1054,7 +1065,8 @@
                                (-> service-description-template
                                  (attach-service-defaults-fn)
                                  (token-preauthorized?)))
-     :token-sequence token-sequence}))
+     :token-sequence token-sequence
+     :token-service-mapping token-service-mapping}))
 
 (defn- prepare-service-description-template-from-tokens
   "Prepares the service description using the token(s)."
@@ -1227,7 +1239,7 @@
      If a non-param on-the-fly header is provided, the username is included as the run-as-user in on-the-fly headers.
      If after the merge a run-as-user is not available, then `username` becomes the run-as-user.
      If after the merge a permitted-user is not available, then `username` becomes the permitted-user."
-    [{:keys [headers service-description-template source-tokens token-authentication-disabled token-preauthorized]}
+    [{:keys [headers service-description-template source-tokens token-authentication-disabled token-preauthorized token-sequence token-service-mapping]}
      waiter-headers passthrough-headers component->previous-descriptor-fns service-id-prefix username
      assoc-run-as-user-approved? service-description-builder]
     (let [headers-without-params (dissoc headers "param")
@@ -1289,6 +1301,8 @@
                                 :reference-type->entry {}
                                 :service-id-prefix service-id-prefix
                                 :source-tokens source-tokens
+                                :token-sequence token-sequence
+                                :token-service-mapping token-service-mapping
                                 :username username})
               service-preauthorized (and token-preauthorized (empty? service-description-based-on-headers))
               service-authentication-disabled (and token-authentication-disabled (empty? service-description-based-on-headers))]

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -319,7 +319,8 @@
                                 (str/includes? token "proser") (assoc "profile" "service")
                                 (str/includes? token "proweb") (assoc "profile" "webapp")
                                 (str/includes? token "run") (assoc "run-as-user" "ruser")
-                                (str/includes? token "shrexc") (assoc "service-mapping" "exclusive"))
+                                (str/includes? token "shrexc") (assoc "service-mapping" "exclusive")
+                                (str/includes? token "shrleg") (assoc "service-mapping" "legacy"))
                               {}))
         build-source-tokens (fn [& tokens]
                               (mapv (fn [token] (source-tokens-entry token (create-token-data token))) tokens))]
@@ -332,7 +333,8 @@
                                           "fallback-period-secs" 90
                                           "permitted-user" "*"}}
             service-description-defaults {}
-            token-defaults {"fallback-period-secs" 300}
+            token-defaults {"fallback-period-secs" 300
+                            "service-mapping" "legacy"}
             metric-group-mappings []
             attach-service-defaults-fn #(merge-defaults % service-description-defaults profile->defaults metric-group-mappings)
             attach-token-defaults-fn #(attach-token-defaults % token-defaults profile->defaults)
@@ -360,7 +362,8 @@
                                      :token->token-data {"test-host" (create-token-data "test-host")}
                                      :token-authentication-disabled false
                                      :token-preauthorized false
-                                     :token-sequence ["test-host"]}}
+                                     :token-sequence ["test-host"]
+                                     :token-service-mapping "legacy"}}
                          {:name "prepare-service-description-sources:WITH Waiter Hostname"
                           :waiter-headers {"x-waiter-cmd" "test-cmd"
                                            "x-waiter-cpus" 1
@@ -382,7 +385,8 @@
                                      :token->token-data {},
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
-                                     :token-sequence []}}
+                                     :token-sequence []
+                                     :token-service-mapping nil}}
                          {:name "prepare-service-description-sources:WITH Service Desc specific Waiter Headers"
                           :waiter-headers {"x-waiter-cmd" "test-cmd"
                                            "x-waiter-cpus" 1
@@ -406,7 +410,8 @@
                                      :token->token-data {"test-host" (create-token-data "test-host")}
                                      :token-authentication-disabled false
                                      :token-preauthorized false
-                                     :token-sequence ["test-host"]}}
+                                     :token-sequence ["test-host"]
+                                     :token-service-mapping "legacy"}}
                          {:name "prepare-service-description-sources:WITH Service Desc specific Waiter Headers"
                           :waiter-headers {"x-waiter-cmd" "test-cmd"
                                            "x-waiter-cpus" 1
@@ -427,7 +432,8 @@
                                      :token->token-data {},
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
-                                     :token-sequence []}}
+                                     :token-sequence []
+                                     :token-service-mapping nil}}
                          {:name "prepare-service-description-sources:WITHOUT Service Desc specific Waiter Headers"
                           :waiter-headers {"x-waiter-foo" "bar"
                                            "x-waiter-source" "serv-desc"}
@@ -442,7 +448,8 @@
                                      :token->token-data {"test-host" (create-token-data "test-host")}
                                      :token-authentication-disabled false
                                      :token-preauthorized false
-                                     :token-sequence ["test-host"]}}
+                                     :token-sequence ["test-host"]
+                                     :token-service-mapping "legacy"}}
                          {:name "prepare-service-description-sources:Token in Waiter Headers"
                           :waiter-headers {"x-waiter-foo" "bar"
                                            "x-waiter-source" "serv-desc"
@@ -457,7 +464,8 @@
                                      :token->token-data {"test-token" (create-token-data "test-token")}
                                      :token-authentication-disabled false
                                      :token-preauthorized false
-                                     :token-sequence ["test-token"]}}
+                                     :token-sequence ["test-token"]
+                                     :token-service-mapping "legacy"}}
                          {:name "prepare-service-description-sources:Two tokens in Waiter Headers"
                           :waiter-headers {"x-waiter-foo" "bar"
                                            "x-waiter-source" "serv-desc"
@@ -474,7 +482,8 @@
                                                          "test-token2" (create-token-data "test-token2")}
                                      :token-authentication-disabled false
                                      :token-preauthorized false
-                                     :token-sequence ["test-token" "test-token2"]}}
+                                     :token-sequence ["test-token" "test-token2"]
+                                     :token-service-mapping "legacy"}}
                          {:name "prepare-service-description-sources:Multiple tokens in Waiter Headers"
                           :waiter-headers {"x-waiter-foo" "bar"
                                            "x-waiter-source" "serv-desc"
@@ -494,7 +503,8 @@
                                                          "test-token2" (create-token-data "test-token2")}
                                      :token-authentication-disabled false
                                      :token-preauthorized false
-                                     :token-sequence ["test-token" "test-token2" "test-cpus-token" "test-mem-token"]}}
+                                     :token-sequence ["test-token" "test-token2" "test-cpus-token" "test-mem-token"]
+                                     :token-service-mapping "legacy"}}
                          {:name "prepare-service-description-sources:Using Host with missing values"
                           :waiter-headers {}
                           :passthrough-headers {"host" "test-host"
@@ -508,7 +518,8 @@
                                      :token->token-data {"test-host" (create-token-data "test-host")}
                                      :token-authentication-disabled false
                                      :token-preauthorized false
-                                     :token-sequence ["test-host"]}}
+                                     :token-sequence ["test-host"]
+                                     :token-service-mapping "legacy"}}
                          {:name "prepare-service-description-sources:Using Host without port with missing values"
                           :waiter-headers {}
                           :passthrough-headers {"host" "test-host:1234"
@@ -522,7 +533,8 @@
                                      :token->token-data {"test-host" (create-token-data "test-host")}
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
-                                     :token-sequence ["test-host"]}}
+                                     :token-sequence ["test-host"]
+                                     :token-service-mapping "legacy"}}
                          {:name "prepare-service-description-sources:Using Token with run-as-user"
                           :waiter-headers {"x-waiter-token" "test-token-run"}
                           :passthrough-headers {"host" "test-host:1234"
@@ -537,7 +549,8 @@
                                      :token->token-data {"test-token-run" (create-token-data "test-token-run")}
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
-                                     :token-sequence ["test-token-run"]}}
+                                     :token-sequence ["test-token-run"]
+                                     :token-service-mapping "legacy"}}
                          {:name "prepare-service-description-sources:Using Token with permitted-user"
                           :waiter-headers {"x-waiter-token" "test-token-per-fall"}
                           :passthrough-headers {"host" "test-host:1234"
@@ -551,7 +564,8 @@
                                      :token->token-data {"test-token-per-fall" (create-token-data "test-token-per-fall")}
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
-                                     :token-sequence ["test-token-per-fall"]}}
+                                     :token-sequence ["test-token-per-fall"]
+                                     :token-service-mapping "legacy"}}
                          {:name "prepare-service-description-sources:Using Token with run-as-user and permitted-user and another token"
                           :waiter-headers {"x-waiter-token" "test-token-per-run"}
                           :passthrough-headers {"host" "test-host:1234"
@@ -567,7 +581,8 @@
                                      :token->token-data {"test-token-per-run" (create-token-data "test-token-per-run")}
                                      :token-authentication-disabled false
                                      :token-preauthorized true
-                                     :token-sequence ["test-token-per-run"]}}
+                                     :token-sequence ["test-token-per-run"]
+                                     :token-service-mapping "legacy"}}
                          {:name "prepare-service-description-sources:Using Token with run-as-user and permitted-user"
                           :waiter-headers {"x-waiter-token" "test-token-per-run,test-cpus-token"}
                           :passthrough-headers {"host" "test-host:1234"
@@ -585,7 +600,8 @@
                                                          "test-token-per-run" (create-token-data "test-token-per-run")}
                                      :token-authentication-disabled false
                                      :token-preauthorized false
-                                     :token-sequence ["test-token-per-run" "test-cpus-token"]}}
+                                     :token-sequence ["test-token-per-run" "test-cpus-token"]
+                                     :token-service-mapping "legacy"}}
                          {:name "prepare-service-description-sources:Parse metadata headers"
                           :waiter-headers {"x-waiter-cpus" "1"
                                            "x-waiter-metadata-baz" "quux"
@@ -600,7 +616,8 @@
                                      :token->token-data {},
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
-                                     :token-sequence []}}
+                                     :token-sequence []
+                                     :token-service-mapping nil}}
                          {:name "prepare-service-description-sources:Parse environment headers:valid keys"
                           :waiter-headers {"x-waiter-cpus" "1"
                                            "x-waiter-env-baz" "quux"
@@ -615,7 +632,8 @@
                                      :token->token-data {},
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
-                                     :token-sequence []}}
+                                     :token-sequence []
+                                     :token-service-mapping nil}}
                          {:name "prepare-service-description-sources:Parse param headers:valid keys:host-token"
                           :waiter-headers {"x-waiter-param-bar" "bar-value"
                                            "x-waiter-param-foo" "foo-value"}
@@ -635,7 +653,8 @@
                                      :token->token-data {"test-host-allowed-cpus-mem-per-run" (create-token-data "test-host-allowed-cpus-mem-per-run")}
                                      :token-authentication-disabled false
                                      :token-preauthorized true
-                                     :token-sequence ["test-host-allowed-cpus-mem-per-run"]}}
+                                     :token-sequence ["test-host-allowed-cpus-mem-per-run"]
+                                     :token-service-mapping "legacy"}}
                          {:name "prepare-service-description-sources:Parse param headers:valid keys:host-token:on-the-fly"
                           :waiter-headers {"x-waiter-cpus" "20"
                                            "x-waiter-param-bar" "bar-value"
@@ -657,7 +676,8 @@
                                      :token->token-data {"test-host-allowed-cpus-mem-per-run" (create-token-data "test-host-allowed-cpus-mem-per-run")}
                                      :token-authentication-disabled false
                                      :token-preauthorized true
-                                     :token-sequence ["test-host-allowed-cpus-mem-per-run"]}}
+                                     :token-sequence ["test-host-allowed-cpus-mem-per-run"]
+                                     :token-service-mapping "legacy"}}
                          {:name "prepare-service-description-sources:Parse param headers:valid keys:token-header"
                           :waiter-headers {"x-waiter-param-bar" "bar-value"
                                            "x-waiter-param-foo" "foo-value"
@@ -678,7 +698,8 @@
                                      :token->token-data {"test-host-allowed-cpus-mem-per-run" (create-token-data "test-host-allowed-cpus-mem-per-run")}
                                      :token-authentication-disabled false
                                      :token-preauthorized true
-                                     :token-sequence ["test-host-allowed-cpus-mem-per-run"]}}
+                                     :token-sequence ["test-host-allowed-cpus-mem-per-run"]
+                                     :token-service-mapping "legacy"}}
                          {:name "prepare-service-description-sources:Parse param headers:valid keys"
                           :waiter-headers {"x-waiter-cpus" "1"
                                            "x-waiter-param-baz" "quux"
@@ -693,7 +714,8 @@
                                      :token->token-data {},
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
-                                     :token-sequence []}}
+                                     :token-sequence []
+                                     :token-service-mapping nil}}
                          {:name "prepare-service-description-sources:Parse distinct e and param headers:valid keys"
                           :waiter-headers {"x-waiter-cpus" "1"
                                            "x-waiter-env-baz" "quux"
@@ -712,7 +734,8 @@
                                      :token->token-data {},
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
-                                     :token-sequence []}}
+                                     :token-sequence []
+                                     :token-service-mapping nil}}
                          {:name "prepare-service-description-sources:Parse overlap env and param headers:valid keys"
                           :waiter-headers {"x-waiter-cpus" "1"
                                            "x-waiter-env-baz" "quux"
@@ -731,7 +754,8 @@
                                      :token->token-data {},
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
-                                     :token-sequence []}}
+                                     :token-sequence []
+                                     :token-service-mapping nil}}
                          {:name "prepare-service-description-sources:Parse environment headers:invalid keys"
                           :waiter-headers {"x-waiter-cpus" "1"
                                            "x-waiter-env-1" "quux"
@@ -746,7 +770,8 @@
                                      :token->token-data {},
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
-                                     :token-sequence []}}
+                                     :token-sequence []
+                                     :token-service-mapping nil}}
                          {:name "prepare-service-description-sources:profile:not-preauthorized-missing-permitted-user"
                           :waiter-headers {"x-waiter-token" "test-token-run-proweb"}
                           :passthrough-headers {}
@@ -761,7 +786,8 @@
                                      :token->token-data {"test-token-run-proweb" (create-token-data "test-token-run-proweb")}
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
-                                     :token-sequence ["test-token-run-proweb"]}}
+                                     :token-sequence ["test-token-run-proweb"]
+                                     :token-service-mapping "legacy"}}
                          {:name "prepare-service-description-sources:profile:not-preauthorized-missing-run-as-user"
                           :waiter-headers {"x-waiter-token" "test-token-proser"}
                           :passthrough-headers {}
@@ -775,7 +801,8 @@
                                      :token->token-data {"test-token-proser" (create-token-data "test-token-proser")}
                                      :token-authentication-disabled false,
                                      :token-preauthorized false,
-                                     :token-sequence ["test-token-proser"]}}
+                                     :token-sequence ["test-token-proser"]
+                                     :token-service-mapping "legacy"}}
                          {:name "prepare-service-description-sources:profile:preauthorized-missing-run-as-user"
                           :waiter-headers {"x-waiter-token" "test-token-run-proser"}
                           :passthrough-headers {}
@@ -790,22 +817,36 @@
                                      :token->token-data {"test-token-run-proser" (create-token-data "test-token-run-proser")}
                                      :token-authentication-disabled false,
                                      :token-preauthorized true,
-                                     :token-sequence ["test-token-run-proser"]}}
+                                     :token-sequence ["test-token-run-proser"]
+                                     :token-service-mapping "legacy"}}
+                         {:name "prepare-service-description-sources:service-mapping:legacy"
+                          :waiter-headers {"x-waiter-token" "test-token-shrleg"}
+                          :passthrough-headers {}
+                          :expected {:fallback-period-secs 300
+                                     :headers {}
+                                     :service-description-template {"cmd" "token-user"
+                                                                    "name" "test-token-shrleg"
+                                                                    "version" "token"}
+                                     :source-tokens (build-source-tokens "test-token-shrleg")
+                                     :token->token-data {"test-token-shrleg" (create-token-data "test-token-shrleg")}
+                                     :token-authentication-disabled false
+                                     :token-preauthorized false
+                                     :token-sequence ["test-token-shrleg"]
+                                     :token-service-mapping "legacy"}}
                          {:name "prepare-service-description-sources:service-mapping:exclusive"
                           :waiter-headers {"x-waiter-token" "test-token-shrexc"}
                           :passthrough-headers {}
                           :expected {:fallback-period-secs 300
                                      :headers {}
                                      :service-description-template {"cmd" "token-user"
-                                                                    "env" {"WAITER_CONFIG_TOKEN" "test-token-shrexc"}
                                                                     "name" "test-token-shrexc"
                                                                     "version" "token"}
                                      :source-tokens (build-source-tokens "test-token-shrexc")
                                      :token->token-data {"test-token-shrexc" (create-token-data "test-token-shrexc")}
                                      :token-authentication-disabled false
                                      :token-preauthorized false
-                                     :token-sequence ["test-token-shrexc"]}}
-                         )]
+                                     :token-sequence ["test-token-shrexc"]
+                                     :token-service-mapping "exclusive"}})]
         (doseq [{:keys [expected name passthrough-headers waiter-headers]} test-cases]
           (testing (str "Test " name)
             (let [actual (prepare-service-description-sources
@@ -856,7 +897,8 @@
                           :token->token-data {test-token token-data}
                           :token-authentication-disabled true
                           :token-preauthorized true
-                          :token-sequence [test-token]}]
+                          :token-sequence [test-token]
+                          :token-service-mapping nil}]
             (is (= expected actual))))))
 
     (testing "limited-access token"
@@ -887,7 +929,8 @@
                           :token->token-data {test-token token-data}
                           :token-authentication-disabled false
                           :token-preauthorized true
-                          :token-sequence [test-token]}]
+                          :token-sequence [test-token]
+                          :token-service-mapping nil}]
             (is (= expected actual))))))))
 
 (defn- compute-service-description-helper


### PR DESCRIPTION
## Changes proposed in this PR

- moves service-mapping logic to ServiceDescriptionBuilder build() function

## Why are we making these changes?

Moving the service-mapping computation into the build() function allows delaying the decision of how the service-mapping ensures a unique service-id per token and it also delays what gets presented as the `core-service-description`. The refactoring also helps implement other service mapping schemes which may or may not affect the service-id computation.

