### PR TITLE
adds descriptor entry to identify services using a run-as-user different from token's run-as-user

### DIFF
--- a/waiter/test/waiter/descriptor_test.clj
+++ b/waiter/test/waiter/descriptor_test.clj
@@ -741,6 +741,7 @@
               :on-the-fly? nil
               :passthrough-headers passthrough-headers
               :reference-type->entry {:token {:sources [(reference-tokens-entry test-token token-data-1)]}}
+              :run-as-user-source "unknown"
               :service-authentication-disabled false
               :service-description (merge service-description-defaults service-description-1)
               :service-id (sd/service-description->service-id service-id-prefix service-description-1)
@@ -782,6 +783,7 @@
               :on-the-fly? nil
               :passthrough-headers passthrough-headers
               :reference-type->entry {:token {:sources [(reference-tokens-entry test-token token-data-1)]}}
+              :run-as-user-source "unknown"
               :service-authentication-disabled false
               :service-description (merge (sd/compute-service-defaults
                                             service-description-defaults profile->defaults "webapp")
@@ -827,6 +829,7 @@
               :on-the-fly? nil
               :passthrough-headers passthrough-headers
               :reference-type->entry {:token {:sources [(reference-tokens-entry test-token token-data-1)]}}
+              :run-as-user-source "token"
               :service-authentication-disabled false
               :service-description (-> service-description-defaults
                                      (merge service-description-1)
@@ -883,6 +886,7 @@
               :on-the-fly? nil
               :passthrough-headers passthrough-headers
               :reference-type->entry {:token {:sources [(reference-tokens-entry test-token token-data-1)]}}
+              :run-as-user-source "token"
               :service-authentication-disabled false
               :service-description (-> service-description-defaults
                                      (merge service-description-1)
@@ -927,6 +931,7 @@
               :on-the-fly? nil
               :passthrough-headers passthrough-headers
               :reference-type->entry {:token {:sources [(reference-tokens-entry test-token token-data-1)]}}
+              :run-as-user-source "unknown"
               :service-authentication-disabled false
               :service-description (merge service-description-defaults service-description-1)
               :service-id (sd/service-description->service-id service-id-prefix service-description-1)
@@ -970,6 +975,7 @@
                 :on-the-fly? true
                 :passthrough-headers passthrough-headers
                 :reference-type->entry {:token {:sources [(reference-tokens-entry test-token token-data-1)]}}
+                :run-as-user-source "unknown"
                 :service-authentication-disabled false
                 :service-description (merge service-description-defaults expected-core-service-description)
                 :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)
@@ -1040,6 +1046,7 @@
                 :passthrough-headers passthrough-headers
                 :reference-type->entry {:token {:sources [(reference-tokens-entry test-token-1 token-data-1)
                                                           (reference-tokens-entry test-token-2 token-data-2p)]}}
+                :run-as-user-source "unknown"
                 :service-authentication-disabled false
                 :service-description (merge service-description-defaults expected-core-service-description)
                 :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)
@@ -1067,6 +1074,7 @@
                   :passthrough-headers passthrough-headers
                   :reference-type->entry {:token {:sources [(reference-tokens-entry test-token-1 token-data-1p)
                                                             (reference-tokens-entry test-token-2 token-data-2p)]}}
+                  :run-as-user-source "unknown"
                   :service-authentication-disabled false
                   :service-description (merge service-description-defaults expected-core-service-description)
                   :service-id (sd/service-description->service-id service-id-prefix expected-core-service-description)


### PR DESCRIPTION
## Changes proposed in this PR

- adds descriptor entry to identify services using a runs-as-user different from token's run-as-user
- populates the run-as-user-source as an annotation in replicaset specs

## Why are we making these changes?

We would like to be able to identify services running as a user (e.g. run-as-requester use-cases) other than the `run-as-user` specified on the token. We then populate the value in the descriptor and persist this information as an annotation on Kubernetes pods.

We can only know a service has received its `run-as-user` from the token if it is produced via an exclusive mapping. For legacy use-cases, it is possible for an on-the-fly service to have the same service description as one generated via a token and we cannot know with certainty whether the run-as-user has changed.
