### PR TITLE
adds support for default service-mapping that dynamically determines when to use exclusive mode

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1986,7 +1986,7 @@
         (let [{:keys [body] :as response} (post-token waiter-url (assoc token-description :service-mapping "on"))]
           (assert-response-status response http-400-bad-request)
           (is (str/includes? (str body) "Validation failed for token"))
-          (is (str/includes? (str body) "service-mapping must be one of legacy or exclusive"))))
+          (is (str/includes? (str body) "service-mapping must be one of default, exclusive or legacy"))))
 
       (testing "invalid env in exclusive service-mapping"
         (let [{:keys [body] :as response} (post-token waiter-url (assoc token-description :env {"WAITER_CONFIG_TOKEN" token} :service-mapping "exclusive"))]

--- a/waiter/src/waiter/config.clj
+++ b/waiter/src/waiter/config.clj
@@ -13,7 +13,9 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(ns waiter.config)
+(ns waiter.config
+  (:require [clj-time.coerce :as tc]
+            [waiter.util.date-utils :as du]))
 
 (def ^:private config-promise (promise))
 
@@ -36,3 +38,11 @@
   []
   {:pre [(realized? config-promise)]}
   (get-in @config-promise [:waiter-principal]))
+
+(defn retrieve-exclusive-promotion-start-epoch-time
+  "Retrieves the configured (or system default) exclusive promotion start epoch time."
+  []
+  {:pre [(realized? config-promise)]}
+  (let [default-exclusive-promotion-start-time "2022-02-01T00:00:00.000Z"
+        exclusive-promotion-start-time (get-in @config-promise [:token-config :exclusive-promotion-start-time] default-exclusive-promotion-start-time)]
+    (-> exclusive-promotion-start-time (du/str-to-date) (tc/to-long))))

--- a/waiter/src/waiter/config.clj
+++ b/waiter/src/waiter/config.clj
@@ -43,6 +43,6 @@
   "Retrieves the configured (or system default) exclusive promotion start epoch time."
   []
   {:pre [(realized? config-promise)]}
-  (let [default-exclusive-promotion-start-time "2022-02-01T00:00:00.000Z"
+  (let [default-exclusive-promotion-start-time "2050-06-01T00:00:00.000Z"
         exclusive-promotion-start-time (get-in @config-promise [:token-config :exclusive-promotion-start-time] default-exclusive-promotion-start-time)]
     (-> exclusive-promotion-start-time (du/str-to-date) (tc/to-long))))

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -845,19 +845,6 @@
   (let [exclusive-promotion-start-epoch-time (config/retrieve-exclusive-promotion-start-epoch-time)]
     (< exclusive-promotion-start-epoch-time reference-update-epoch-time)))
 
-(defn adjust-waiter-config-token
-  "Dissociates the exclusive mapping token from the environment variable if it was added as part of default promotion after the promotion start time."
-  [{:keys [env] :as service-description} token-service-mapping reference-update-epoch-time]
-  (let [remove-waiter-config-token (and (= "default" token-service-mapping)
-                                        (not (promote-default-to-exclusive? reference-update-epoch-time)))]
-    (cond-> service-description
-      remove-waiter-config-token
-      (utils/dissoc-in waiter-config-token-path)
-      (and remove-waiter-config-token
-           (= 1 (count env))
-           (some? (get-in env waiter-config-token-path)))
-      (dissoc "env"))))
-
 (defn- assoc-approved-run-as-requester-parameters
   "Attaches run-as-requester parameters if the services has been approved."
   [service-description assoc-run-as-user-approved? service-id-prefix username]

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -184,16 +184,17 @@
                                                                           {:kind s/Keyword
                                                                            s/Keyword schema/require-symbol-factory-fn}
                                                                           schema/contains-kind-sub-map?)
+                                   (s/optional-key :exclusive-promotion-start-time) schema/non-empty-string
                                    (s/required-key :history-length) schema/positive-int
                                    (s/required-key :limit-per-owner) schema/positive-int
-                                   (s/required-key :validator) (s/constrained
-                                                                 {:kind s/Keyword
-                                                                  s/Keyword schema/require-symbol-factory-fn}
-                                                                 schema/contains-kind-sub-map?)
                                    (s/required-key :token-defaults) {(s/required-key "fallback-period-secs") schema/non-negative-int
                                                                      (s/required-key "https-redirect") s/Bool
                                                                      (s/optional-key "service-mapping") schema/non-empty-string
-                                                                     (s/required-key "stale-timeout-mins") schema/non-negative-int}}
+                                                                     (s/required-key "stale-timeout-mins") schema/non-negative-int}
+                                   (s/required-key :validator) (s/constrained
+                                                                 {:kind s/Keyword
+                                                                  s/Keyword schema/require-symbol-factory-fn}
+                                                                 schema/contains-kind-sub-map?)}
    (s/required-key :watch-config) {(s/required-key :tokens) {(s/required-key :channels-update-chan-buffer-size) schema/non-negative-int
                                                              (s/required-key :tokens-update-chan-buffer-size) schema/non-negative-int
                                                              (s/required-key :watch-refresh-timeout-ms) schema/non-negative-int}}
@@ -486,12 +487,12 @@
                                                     :host->cluster {}}}
                   :history-length 5
                   :limit-per-owner 1000
-                  :validator {:kind :default
-                              :default {:factory-fn 'waiter.token-validator/create-default-token-validator}}
                   :token-defaults {"fallback-period-secs" (-> 5 t/minutes t/in-seconds)
                                    "https-redirect" false
                                    "service-mapping" "legacy"
-                                   "stale-timeout-mins" 15}}
+                                   "stale-timeout-mins" 15}
+                  :validator {:kind :default
+                              :default {:factory-fn 'waiter.token-validator/create-default-token-validator}}}
    :watch-config {:tokens {:channels-update-chan-buffer-size 1024
                            :tokens-update-chan-buffer-size 1024
                            :watch-refresh-timeout-ms 10000}}

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -3507,4 +3507,7 @@
                (adjust-waiter-config-token basic-description service-mapping promotion-start-epoch-time)))
         (is (= (cond-> basic-description
                  (= service-mapping "default") (utils/dissoc-in sd/waiter-config-token-path))
-               (adjust-waiter-config-token basic-description service-mapping (dec promotion-start-epoch-time))))))))
+               (adjust-waiter-config-token basic-description service-mapping (dec promotion-start-epoch-time)))))
+      (let [service-description-1 (assoc basic-description "env" {"WAITER_CONFIG_TOKEN" "foo"})]
+        (is (= (dissoc service-description-1 "env")
+               (adjust-waiter-config-token service-description-1 "default" (dec promotion-start-epoch-time))))))))

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -3490,24 +3490,3 @@
   (is (= 20 (retrieve-most-recent-component-update-time {:fee 10 :fie 20 :foe nil})))
   (is (= 30 (retrieve-most-recent-component-update-time {:fee 10 :fie 30 :foe 20})))
   (is (= 30 (retrieve-most-recent-component-update-time {:fee 10 :fie 20 :foe 30}))))
-
-(deftest test-adjust-waiter-config-token
-  (let [basic-description {"cmd" "ls"
-                           "cpus" 1
-                           "env" {"FOO" "BAR"
-                                  "WAITER_CONFIG_TOKEN" "foo"}
-                           "mem" 32}
-        promotion-start-epoch-time (-> (t/now) (t/plus (t/days 1)) (tc/to-long))]
-    (with-redefs [config/retrieve-exclusive-promotion-start-epoch-time (constantly promotion-start-epoch-time)]
-      (doseq [service-mapping ["default" "exclusive" "legacy"]]
-        (is (= basic-description
-               (adjust-waiter-config-token basic-description service-mapping (inc promotion-start-epoch-time))))
-        (is (= (cond-> basic-description
-                 (= service-mapping "default") (utils/dissoc-in sd/waiter-config-token-path))
-               (adjust-waiter-config-token basic-description service-mapping promotion-start-epoch-time)))
-        (is (= (cond-> basic-description
-                 (= service-mapping "default") (utils/dissoc-in sd/waiter-config-token-path))
-               (adjust-waiter-config-token basic-description service-mapping (dec promotion-start-epoch-time)))))
-      (let [service-description-1 (assoc basic-description "env" {"WAITER_CONFIG_TOKEN" "foo"})]
-        (is (= (dissoc service-description-1 "env")
-               (adjust-waiter-config-token service-description-1 "default" (dec promotion-start-epoch-time))))))))


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for a new `default` service-mapping option
- adds the `component->last-update-epoch-time` argument to ServiceDescriptionBuilder#build()
- enables exclusive mode for new versions of services beyond a cutoff date (configured via `service-mapping-exclusive-start-time`)
- adds the `exclusive-promotion-start-time` configuration to settings

## Why are we making these changes?

When we change the default behavior for `service-mapping`, we want existing services to continue to run unaffected (without their service IDs changing to prevent launching bunch of new services). However, we want new services to launch with `exclusive` mode if `service-mapping`.

## How are we affecting the change?

There is a new option for service-mapping: `default` which allows the system to choose whether to use `legacy` mapping or `exclusive` mapping. For "old" versions of services, which we identify using the update time new `component->last-update-epoch-time` dictionary we use `legacy` mode. This allows current services IDs to continue to be valid in the `default` mode. For "new" versions of services (beyond a cut-off date specified by the `exclusive-promotion-start-time` configuration), we switch the service-mapping to `exclusive` mode.
