### PR TITLE
includes java version in server info block

### DIFF
--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -1149,7 +1149,8 @@
                             (update :headers headers/truncate-header-values))
                   (seq trailers)
                   (assoc :trailers (headers/truncate-header-values trailers)))))
-            include-server-info (assoc :server-info {:jetty-version Jetty/VERSION}))
+            include-server-info (assoc :server-info {:java-version (System/getProperty "java.version")
+                                                     :jetty-version Jetty/VERSION}))
           utils/clj->json-response))
     (catch Throwable th
       (utils/exception->response th request))))


### PR DESCRIPTION
## Changes proposed in this PR

- includes java version in server info block

## Why are we making these changes?

We would like to know by querying the Waiter router what version of JDK it is running on.

### Sample output
```
$ curl -s 'http://waiter.localtest.me:9091/status?include=server-info' | jq -rS .
{
  "server-info": {
    "java-version": "11.0.7",
    "jetty-version": "9.4.31.v20200723"
  },
  "status": "ok"
}
```


