### PR TITLE
uses JDK17 for github actions workflows

### DIFF
--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '17'
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/integration-fast.yml
+++ b/.github/workflows/integration-fast.yml
@@ -19,10 +19,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup apt dependencies
         run: sudo apt-get install nginx
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '17'
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/integration-slow.yml
+++ b/.github/workflows/integration-slow.yml
@@ -19,10 +19,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup apt dependencies
         run: sudo apt-get install nginx
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '17'
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/token-syncer.yml
+++ b/.github/workflows/token-syncer.yml
@@ -19,10 +19,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup apt dependencies
         run: sudo apt-get install nginx
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '17'
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '17'
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
## Changes proposed in this PR

- uses JDK17 for github actions workflows

## Why are we making these changes?

Upgrading the latest long-term stable release of Java.

