### PR TITLE
makes the selection function in composite scheduler configurable

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -396,7 +396,15 @@
                                 ;; The scheduler to use by default if the service does not specify one explicitly.
                                 ;; This is an optional config and can be nil. When provided it must match one of
                                 ;; the component schedulers that have been configured.
-                                :default-scheduler :marathon}
+                                :default-scheduler :marathon
+
+                                ;; The selection function used to determine a scheduler for a given service id can be configured.
+                                ;; This is an optional config and can be nil.
+                                :selector-context {;; a factory function may optionally be provided which accepts a context map
+                                                   ;; and returns a function that takes a service-id as input and returns a scheduler
+                                                   :factory-fn 'waiter.scheduler.composite/create-scheduler-parameter-based-selector
+                                                   ;; additional name-value pairs may be provided as context to the factory function
+                                                   :todo :additional-config}}
 
                     ;; :kind :kubernetes uses Kubernetes (https://kubernetes.io/) for scheduling Waiter services and instances:
                     ;:kind :kubernetes

--- a/waiter/src/waiter/scheduler/composite.clj
+++ b/waiter/src/waiter/scheduler/composite.clj
@@ -148,6 +148,29 @@
     (service-id+scheduler-parameter->scheduler
       service-id->service-description-fn scheduler-id->scheduler default-scheduler service-id)))
 
+(defn- service-id+some-image-parameter->scheduler
+  "Resolves the scheduler for a given service-id using the image parameter in the description.
+   If the service has an image parameter, the image-scheduler is chosen for it.
+   Else the default-scheduler is chosen for the service."
+  [service-id->service-description-fn scheduler-id->scheduler default-scheduler image-scheduler service-id]
+  (let [service-description (service-id->service-description-fn service-id)
+        scheduler-id (if (some? (get service-description "image"))
+                       (name image-scheduler)
+                       (name default-scheduler))]
+    (scheduler-id->scheduler scheduler-id)))
+
+(defn create-some-image-parameter-based-selector
+  "Returns a function that returns the scheduler for a given service-id using the image parameter in the description."
+  [{:keys [default-scheduler image-scheduler scheduler-id->scheduler service-id->service-description-fn]}]
+  {:pre [(some? default-scheduler)
+         (contains? scheduler-id->scheduler (name default-scheduler))
+         (some? image-scheduler)
+         (contains? scheduler-id->scheduler (name image-scheduler))
+         (not= default-scheduler image-scheduler)]}
+  (fn service-id+some-image-parameter->scheduler-fn [service-id]
+    (service-id+some-image-parameter->scheduler
+      service-id->service-description-fn scheduler-id->scheduler default-scheduler image-scheduler service-id)))
+
 (defn invoke-component-factory
   "Creates a component based on the factory-fn specified in the component-config."
   [context {:keys [factory-fn] :as component-config}]


### PR DESCRIPTION
## Changes proposed in this PR

- makes the selection function in composite scheduler configurable 
- adds support for composite scheduler selector based on image parameter

## Why are we making these changes?

We would like to extend the ability of the composite scheduler by making the function to select a scheduler for a given service configurable. This allows supporting multiple variants of the composite scheduler.

