### PR TITLE
upgrades to clojure 1.10.3

### DIFF
--- a/token-syncer/project.clj
+++ b/token-syncer/project.clj
@@ -17,7 +17,7 @@
   :dependencies [[twosigma/jet "0.7.10-20200709_171405-gea4b7b6"]
                  [clj-time "0.15.2"]
                  [commons-codec/commons-codec "1.13"]
-                 [org.clojure/clojure "1.10.1"]
+                 [org.clojure/clojure "1.10.3"]
                  [org.clojure/core.async "0.5.527"]
                  [org.clojure/data.json "0.2.6"]
                  [org.clojure/tools.cli "0.4.2"]

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -80,7 +80,7 @@
                                io.netty/netty]]
                  [org.apache.curator/curator-x-discovery "2.11.0"
                   :exclusions [io.netty/netty org.slf4j/slf4j-api]]
-                 [org.clojure/clojure "1.10.1"]
+                 [org.clojure/clojure "1.10.3"]
                  [org.clojure/core.async "1.2.603"
                   :exclusions [org.clojure/clojure org.clojure/tools.reader]]
                  [org.clojure/core.memoize "1.0.236"


### PR DESCRIPTION
## Changes proposed in this PR

- upgrades to clojure 1.10.3

## Why are we making these changes?

Upgrading Clojure to benefit from any bug fixes.

