### PR TITLE
adds support for loading parameters in /tokens endpoint

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -2258,21 +2258,21 @@
                 (is (contains? token-set token-2) (str token-set))))
 
             (testing "parameter loading"
-              (let [token-map (retrieve-tokens {"include" ["param.cpus"] "permitted-user" "*"} :mode :token-params)]
+              (let [token-map (retrieve-tokens {"parameters" ["cpus"] "permitted-user" "*"} :mode :token-params)]
                 (is (utils/sub-map? {token-1 {}} token-map) (str token-map)))
-              (let [token-map (retrieve-tokens {"include" ["param.load-balancing"] "permitted-user" "*"} :mode :token-params)]
+              (let [token-map (retrieve-tokens {"parameters" ["load-balancing"] "permitted-user" "*"} :mode :token-params)]
                 (is (utils/sub-map? {token-1 {:load-balancing "oldest"}} token-map) (str token-map)))
-              (let [token-map (retrieve-tokens {"include" ["param.permitted-user"] "permitted-user" "*"} :mode :token-params)]
+              (let [token-map (retrieve-tokens {"parameters" ["permitted-user"] "permitted-user" "*"} :mode :token-params)]
                 (is (utils/sub-map? {token-1 {:permitted-user "*"}} token-map) (str token-map)))
-              (let [token-map (retrieve-tokens {"include" ["param.load-balancing" "param.permitted-user"] "permitted-user" "*"} :mode :token-params)]
+              (let [token-map (retrieve-tokens {"parameters" ["load-balancing" "permitted-user"] "permitted-user" "*"} :mode :token-params)]
                 (is (utils/sub-map? {token-1 {:load-balancing "oldest" :permitted-user "*"}} token-map) (str token-map)))
-              (let [token-map (retrieve-tokens {"include" ["param.env" "param.metadata"] "permitted-user" "*"} :mode :token-params)]
+              (let [token-map (retrieve-tokens {"parameters" ["env" "metadata"] "permitted-user" "*"} :mode :token-params)]
                 (is (utils/sub-map? {token-1 {:env {:FLAG "true"} :metadata {:flag "false"}}} token-map) (str token-map)))
-              (let [token-map (retrieve-tokens {"include" ["param.env.flag" "param.metadata.flag"] "permitted-user" "*"} :mode :token-params)]
+              (let [token-map (retrieve-tokens {"parameters" ["env.flag" "metadata.flag"] "permitted-user" "*"} :mode :token-params)]
                 (is (utils/sub-map? {token-1 {:metadata {:flag "false"}}} token-map) (str token-map)))
-              (let [token-map (retrieve-tokens {"include" ["param.env.FLAG" "param.metadata.FLAG"] "permitted-user" "*"} :mode :token-params)]
+              (let [token-map (retrieve-tokens {"parameters" ["env.FLAG" "metadata.FLAG"] "permitted-user" "*"} :mode :token-params)]
                 (is (utils/sub-map? {token-1 {:env {:FLAG "true"}}} token-map) (str token-map)))
-              (let [token-map (retrieve-tokens {"include" ["param.env.FOO" "param.metadata.bar"] "permitted-user" "*"} :mode :token-params)]
+              (let [token-map (retrieve-tokens {"parameters" ["env.FOO" "metadata.bar"] "permitted-user" "*"} :mode :token-params)]
                 (is (utils/sub-map? {token-1 {}} token-map) (str token-map))))
 
             (finally

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -2168,18 +2168,20 @@
 
 (deftest ^:parallel ^:integration-fast test-token-list-filtering
   (testing-using-waiter-url
-    (let [retrieve-tokens (fn [query-params]
+    (let [retrieve-tokens (fn [query-params & {:keys [mode] :or {mode :token-params}}]
                             (let [tokens-response (make-request waiter-url "/tokens" :query-params query-params)]
                               (assert-response-status tokens-response http-200-ok)
-                              (->> tokens-response
-                                :body
-                                (try-parse-json)
-                                (walk/keywordize-keys)
-                                (map :token)
-                                (set))))
-          token-1 (rand-name)
+                              (let [entries (->> tokens-response
+                                              :body
+                                              (try-parse-json)
+                                              (walk/keywordize-keys))]
+                                (if (= mode :token-params)
+                                  (pc/for-map [{:keys [parameters token]} entries] token parameters)
+                                  (set (map :token entries))))))
+          base-name (rand-name)
+          token-1 (str base-name "-1")
           description-1 {:env {"FLAG" "true"} :load-balancing "oldest" :metadata {"flag" "false"} :name "test-token-1" :permitted-user "*" :token token-1}
-          token-2 (rand-name)
+          token-2 (str base-name "-2")
           description-2 {:env {"FLAG" "false"} :load-balancing "youngest" :metadata {"flag" "true"} :name "test-token-2" :token token-2}]
       (testing "invalid authentication and health-check-authentication"
         (try
@@ -2254,6 +2256,24 @@
               (let [token-set (retrieve-tokens {"permitted-user" ["" "*"]})]
                 (is (contains? token-set token-1) (str token-set))
                 (is (contains? token-set token-2) (str token-set))))
+
+            (testing "parameter loading"
+              (let [token-map (retrieve-tokens {"include" ["param.cpus"] "permitted-user" "*"} :mode :token-params)]
+                (is (utils/sub-map? {token-1 {}} token-map) (str token-map)))
+              (let [token-map (retrieve-tokens {"include" ["param.load-balancing"] "permitted-user" "*"} :mode :token-params)]
+                (is (utils/sub-map? {token-1 {:load-balancing "oldest"}} token-map) (str token-map)))
+              (let [token-map (retrieve-tokens {"include" ["param.permitted-user"] "permitted-user" "*"} :mode :token-params)]
+                (is (utils/sub-map? {token-1 {:permitted-user "*"}} token-map) (str token-map)))
+              (let [token-map (retrieve-tokens {"include" ["param.load-balancing" "param.permitted-user"] "permitted-user" "*"} :mode :token-params)]
+                (is (utils/sub-map? {token-1 {:load-balancing "oldest" :permitted-user "*"}} token-map) (str token-map)))
+              (let [token-map (retrieve-tokens {"include" ["param.env" "param.metadata"] "permitted-user" "*"} :mode :token-params)]
+                (is (utils/sub-map? {token-1 {:env {:FLAG "true"} :metadata {:flag "false"}}} token-map) (str token-map)))
+              (let [token-map (retrieve-tokens {"include" ["param.env.flag" "param.metadata.flag"] "permitted-user" "*"} :mode :token-params)]
+                (is (utils/sub-map? {token-1 {:metadata {:flag "false"}}} token-map) (str token-map)))
+              (let [token-map (retrieve-tokens {"include" ["param.env.FLAG" "param.metadata.FLAG"] "permitted-user" "*"} :mode :token-params)]
+                (is (utils/sub-map? {token-1 {:env {:FLAG "true"}}} token-map) (str token-map)))
+              (let [token-map (retrieve-tokens {"include" ["param.env.FOO" "param.metadata.bar"] "permitted-user" "*"} :mode :token-params)]
+                (is (utils/sub-map? {token-1 {}} token-map) (str token-map))))
 
             (finally
               (delete-token-and-assert waiter-url token-2)))

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -658,14 +658,12 @@
 (defn extract-token-data-param-vals
   "Extracts the values of parameters from the provided token description."
   [token-description display-params-keys]
-  (loop [[entry-keys & remaining-keys] display-params-keys
-         result-map {}]
-    (if entry-keys
-      (recur remaining-keys
-             (let [entry-val (get-in token-description entry-keys)]
-               (cond-> result-map
-                 (some? entry-val) (assoc-in entry-keys entry-val))))
-      result-map)))
+  (reduce (fn extract-token-data-param-vals-reducer [result-map entry-keys]
+            (let [entry-val (get-in token-description entry-keys)]
+              (cond-> result-map
+                (some? entry-val) (assoc-in entry-keys entry-val))))
+          {}
+          display-params-keys))
 
 (defn handle-list-tokens-request
   [retrieve-descriptor-fn kv-store entitlement-manager streaming-timeout-ms tokens-watch-channels-update-chan

--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -647,12 +647,11 @@
         (utils/exception->response ex request)))))
 
 (defn extract-token-data-param-keys
-  "Extracts the names of parameters from the list of include parameters."
-  [include-params]
-  (->> include-params
-    (filter #(str/starts-with? (str %) "param."))
+  "Extracts the parameters (with paths) from the list of include parameters."
+  [parameters]
+  (->> parameters
     (set)
-    (map #(-> % (str/split #"\.") (rest) (vec)))
+    (map #(-> % (str/split #"\.") (vec)))
     (filter #(contains? sd/token-data-keys (first %)))
     (vec)))
 
@@ -690,10 +689,10 @@
                           (string? owner-param) #{owner-param}
                           (coll? owner-param) (set owner-param)
                           :else (list-token-owners kv-store))
-                 include-param (get request-params "include")
+                 display-param (get request-params "parameters")
                  display-params-keys (-> (cond
-                                           (string? include-param) [include-param]
-                                           (coll? include-param) include-param
+                                           (string? display-param) [display-param]
+                                           (coll? display-param) display-param
                                            :else [])
                                        (extract-token-data-param-keys))
                  service-description-filter-predicate (-> (dissoc request-params "deleted" "maintenance" "owner" "previous")

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -76,6 +76,20 @@
   [pred map]
   `(into {} (filter ~pred ~map)))
 
+(defn sub-map?
+  "Returns true if the map mc is a subset of the map mf."
+  [mc mf]
+  (if (= mc mf)
+    true
+    (loop [[[k v] & rem-key-val] (seq mc)]
+      (let [vf (get mf k)
+            val-match? (if (and (map? v) (map? vf))
+                         (sub-map? v vf)
+                         (= v vf))]
+        (if (or (not val-match?) (nil? rem-key-val))
+          val-match?
+          (recur rem-key-val))))))
+
 (defn is-uuid?
   "Returns true if `s` is an uuid"
   [s]

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -3190,3 +3190,30 @@
         (is (au/chan? watch-chan))
         (async/put! watch-chan initial-event)
         (is (nil? (async/<!! body)))))))
+
+(deftest test-extract-token-data-param-keys
+  (is (= [] (extract-token-data-param-keys nil)))
+  (is (= [] (extract-token-data-param-keys [])))
+  (is (= [] (extract-token-data-param-keys ["fie""cpus" "env.FOO"])))
+  (is (= [["cpus"]] (extract-token-data-param-keys ["fie""param.bar" "param.cpus"])))
+  (is (= [["env" "FOO"]] (extract-token-data-param-keys ["fie""param.bar" "param.env.FOO"])))
+  (is (= [["metadata" "bar"]] (extract-token-data-param-keys ["fie""param.bar" "param.metadata.bar"])))
+  (is (= #{["cpus"] ["mem"]}
+         (set (extract-token-data-param-keys ["fie""param.bar" "param.cpus" "param.mem"]))))
+  (is (= #{["cpus"] ["env" "FOO"] ["metadata" "bar"]}
+         (set (extract-token-data-param-keys ["fie""param.bar" "param.cpus" "param.env.FOO" "param.metadata.bar"])))))
+
+(deftest test-extract-token-data-param-vals
+  (is (= {} (extract-token-data-param-vals {} [])))
+  (is (= {} (extract-token-data-param-vals {} [["cpus"]])))
+  (is (= {} (extract-token-data-param-vals {"mem" 1024} [["cpus"]])))
+  (is (= {} (extract-token-data-param-vals {"cpus" 1 "mem" 1024} [["env" "FOO"]])))
+  (is (= {} (extract-token-data-param-vals {"cpus" 1 "mem" 1024} [["metadata" "bar"]])))
+  (is (= {"mem" 1024}
+         (extract-token-data-param-vals {"cpus" 1 "mem" 1024} [["mem"]])))
+  (is (= {"cpus" 1 "mem" 1024}
+         (extract-token-data-param-vals {"cpus" 1 "mem" 1024} [["cpus"] ["mem"]])))
+  (is (= {"mem" 1024}
+         (extract-token-data-param-vals {"cpus" 1 "mem" 1024 "env" {"BAR" "b1"}} [["mem"] ["env" "FOO"]])))
+  (is (= {"env" {"FOO" "f1"} "mem" 1024}
+         (extract-token-data-param-vals {"cpus" 1 "mem" 1024 "env" {"BAR" "b1" "FOO" "f1"}} [["mem"] ["env" "FOO"]]))))

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -3194,14 +3194,13 @@
 (deftest test-extract-token-data-param-keys
   (is (= [] (extract-token-data-param-keys nil)))
   (is (= [] (extract-token-data-param-keys [])))
-  (is (= [] (extract-token-data-param-keys ["fie""cpus" "env.FOO"])))
-  (is (= [["cpus"]] (extract-token-data-param-keys ["fie""param.bar" "param.cpus"])))
-  (is (= [["env" "FOO"]] (extract-token-data-param-keys ["fie""param.bar" "param.env.FOO"])))
-  (is (= [["metadata" "bar"]] (extract-token-data-param-keys ["fie""param.bar" "param.metadata.bar"])))
+  (is (= [["cpus"]] (extract-token-data-param-keys ["fie" "bar" "cpus"])))
+  (is (= [["env" "FOO"]] (extract-token-data-param-keys ["fie" "bar" "env.FOO"])))
+  (is (= [["metadata" "bar"]] (extract-token-data-param-keys ["fie" "bar" "metadata.bar"])))
   (is (= #{["cpus"] ["mem"]}
-         (set (extract-token-data-param-keys ["fie""param.bar" "param.cpus" "param.mem"]))))
+         (set (extract-token-data-param-keys ["fie" "bar" "cpus" "mem"]))))
   (is (= #{["cpus"] ["env" "FOO"] ["metadata" "bar"]}
-         (set (extract-token-data-param-keys ["fie""param.bar" "param.cpus" "param.env.FOO" "param.metadata.bar"])))))
+         (set (extract-token-data-param-keys ["fie" "bar" "cpus" "env.FOO" "metadata.bar"])))))
 
 (deftest test-extract-token-data-param-vals
   (is (= {} (extract-token-data-param-vals {} [])))


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for loading parameters in /tokens endpoint

## Why are we making these changes?

We would like to avoid an N+1 query pattern to perform a search on tokens and then another set of token retrievals to load information of specific fields.

