### PR TITLE
Increase streaming-timeout for instance watch integration test client

### DIFF
--- a/waiter/integration/waiter/instance_tracker_integration_test.clj
+++ b/waiter/integration/waiter/instance_tracker_integration_test.clj
@@ -419,6 +419,7 @@
       (testing "streams updated healthy instances for service-ids that match service description filter"
         (let [watch (start-watch waiter-url cookies
                                  :query-params {"metadata.foo" "random-value-required"
+                                                "streaming-timeout" "120000"
                                                 "watch" "true"})
               {:keys [service-id] :as response}
               (make-request-with-debug-info


### PR DESCRIPTION
## Changes proposed in this PR

- default streaming-timeout is set to 20,000 ms. Because the test watch client does not handle disconnects, we should increase this timeout to 120,000 ms.

## Why are we making these changes?


