### PR TITLE
adds error classes for additional non-2XX responses

### DIFF
--- a/waiter/src/waiter/auth/kerberos.clj
+++ b/waiter/src/waiter/auth/kerberos.clj
@@ -27,8 +27,6 @@
             [waiter.util.utils :as utils])
   (:import (java.util.concurrent LinkedBlockingQueue ThreadPoolExecutor TimeUnit)))
 
-(def ^:const error-class-prestashed-tickets "waiter.PrestashedTickets")
-
 (defn get-opt-in-accounts
   "Returns the list of users whose tickets are prestashed on host"
   [host]

--- a/waiter/src/waiter/auth/spnego.clj
+++ b/waiter/src/waiter/auth/spnego.clj
@@ -60,10 +60,13 @@
   (log/info "triggering 401 response for spnego authentication" cause)
   (counters/inc! (metrics/waiter-counter "core" "response-status" "401"))
   (meters/mark! (metrics/waiter-meter "core" "response-status-rate" "401"))
-  (-> {:message "Unauthorized"
-       :status http-401-unauthorized}
-    (utils/data->error-response request)
-    (cookies/cookies-response)))
+  (let [waiter-token (get-in request [:waiter-discovery :token])]
+    (cond->
+      (-> {:message "Unauthorized"
+           :status http-401-unauthorized}
+        (utils/data->error-response request)
+        (cookies/cookies-response))
+      waiter-token (assoc :waiter/token waiter-token))))
 
 (defn response-http-401-unauthorized-negotiate
   "Tell the client you'd like them to use kerberos"

--- a/waiter/src/waiter/auth/spnego.clj
+++ b/waiter/src/waiter/auth/spnego.clj
@@ -32,8 +32,6 @@
            (org.ietf.jgss GSSContext GSSCredential GSSException GSSManager)))
 
 (def ^:const negotiate-prefix "Negotiate ")
-(def ^:const error-class-kerberos-negotiate "waiter.KerberosNegotiate")
-(def ^:const error-class-kerberos-queue-length "waiter.KerberosQueueLength")
 
 (defn- negotiate-token?
   "Predicate to determine if an authorization header represents a spnego negotiate token."

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1193,7 +1193,9 @@
                                             (when-not (contains? authentication-providers authentication)
                                               (throw (ex-info (str "authentication must be one of: '"
                                                                    (str/join "', '" (sort authentication-providers)) "'")
-                                                              {:authentication authentication :status http-400-bad-request}))))
+                                                              {:authentication authentication
+                                                               :error-class "waiter.UnsupportedAuth"
+                                                               :status http-400-bad-request}))))
                                           (sd/validate service-description-builder service-description {}))))
    :waiter-request?-fn (pc/fnk [[:state waiter-hostnames]]
                          (let [local-router (InetAddress/getLocalHost)

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1194,7 +1194,7 @@
                                               (throw (ex-info (str "authentication must be one of: '"
                                                                    (str/join "', '" (sort authentication-providers)) "'")
                                                               {:authentication authentication
-                                                               :error-class "waiter.UnsupportedAuth"
+                                                               :error-class error-class-unsupported-auth
                                                                :status http-400-bad-request}))))
                                           (sd/validate service-description-builder service-description {}))))
    :waiter-request?-fn (pc/fnk [[:state waiter-hostnames]]

--- a/waiter/src/waiter/cors.clj
+++ b/waiter/src/waiter/cors.clj
@@ -61,7 +61,8 @@
         (let [{:keys [headers request-method]} request
               {:strs [origin]} headers]
           (when (str/blank? origin)
-            (throw (ex-info "No origin provided" {:status http-403-forbidden})))
+            (throw (ex-info "No origin provided" {:error-class "waiter.CorsPreflightForbidden"
+                                                  :status http-403-forbidden})))
           (let [{:keys [allowed? allowed-methods summary]}
                 (if (waiter-request? request)
                   {:allowed? true :summary {:type "waiter-request"}}
@@ -72,6 +73,7 @@
             (when-not allowed?
               (log/info "cors preflight request not allowed" summary)
               (throw (ex-info "Cross-origin request not allowed" {:cors-checks summary
+                                                                  :error-class "waiter.CorsPreflightForbidden"
                                                                   :origin origin
                                                                   :request-method request-method
                                                                   :status http-403-forbidden
@@ -120,6 +122,7 @@
               (log/info "cors request not allowed" summary)
               (throw (ex-info "Cross-origin request not allowed"
                               {:cors-checks summary
+                               :error-class "waiter.CorsRequestForbidden"
                                :origin origin
                                :request-method request-method
                                :status http-403-forbidden

--- a/waiter/src/waiter/cors.clj
+++ b/waiter/src/waiter/cors.clj
@@ -61,7 +61,7 @@
         (let [{:keys [headers request-method]} request
               {:strs [origin]} headers]
           (when (str/blank? origin)
-            (throw (ex-info "No origin provided" {:error-class "waiter.CorsPreflightForbidden"
+            (throw (ex-info "No origin provided" {:error-class error-class-cors-preflight-forbidden
                                                   :status http-403-forbidden})))
           (let [{:keys [allowed? allowed-methods summary]}
                 (if (waiter-request? request)
@@ -73,7 +73,7 @@
             (when-not allowed?
               (log/info "cors preflight request not allowed" summary)
               (throw (ex-info "Cross-origin request not allowed" {:cors-checks summary
-                                                                  :error-class "waiter.CorsPreflightForbidden"
+                                                                  :error-class error-class-cors-preflight-forbidden
                                                                   :origin origin
                                                                   :request-method request-method
                                                                   :status http-403-forbidden
@@ -122,7 +122,7 @@
               (log/info "cors request not allowed" summary)
               (throw (ex-info "Cross-origin request not allowed"
                               {:cors-checks summary
-                               :error-class "waiter.CorsRequestForbidden"
+                               :error-class error-class-cors-request-forbidden
                                :origin origin
                                :request-method request-method
                                :status http-403-forbidden

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -328,6 +328,7 @@
                   (and auth-user (can-run-as? auth-user run-as-user)))
       (throw (ex-info "Authenticated user cannot run service"
                       {:authenticated-user auth-user
+                       :error-class "waiter.ServiceForbidden"
                        :log-level :warn
                        :run-as-user run-as-user
                        :service-description service-description
@@ -336,6 +337,7 @@
     (when-not (request-authorized? auth-user permitted-user)
       (throw (ex-info "This user isn't allowed to invoke this service"
                       {:authenticated-user auth-user
+                       :error-class "waiter.ServiceForbidden"
                        :log-level :warn
                        :service-description service-description
                        :service-id service-id

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -328,7 +328,7 @@
                   (and auth-user (can-run-as? auth-user run-as-user)))
       (throw (ex-info "Authenticated user cannot run service"
                       {:authenticated-user auth-user
-                       :error-class "waiter.ServiceForbidden"
+                       :error-class error-class-service-forbidden
                        :log-level :warn
                        :run-as-user run-as-user
                        :service-description service-description
@@ -337,7 +337,7 @@
     (when-not (request-authorized? auth-user permitted-user)
       (throw (ex-info "This user isn't allowed to invoke this service"
                       {:authenticated-user auth-user
-                       :error-class "waiter.ServiceForbidden"
+                       :error-class error-class-service-forbidden
                        :log-level :warn
                        :service-description service-description
                        :service-id service-id

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -56,6 +56,8 @@
 
 (def ^:const error-class-maintenance "waiter.Maintenance")
 (def ^:const error-class-queue-length "waiter.QueueLength")
+(def ^:const error-class-stream-failure "waiter.StreamFailure")
+(def ^:const error-class-stream-timeout "waiter.StreamTimeout")
 (def ^:const error-class-suspended "waiter.Suspended")
 
 (defn make-auth-user-map
@@ -305,6 +307,7 @@
         (let [byte-buffer (ByteBuffer/wrap buffer-bytes 0 bytes-read)]
           (when-not (au/timed-offer!! body-ch byte-buffer streaming-timeout-ms)
             (let [description-map {:bytes-pending bytes-read
+                                   :error-class error-class-stream-timeout
                                    :status http-503-service-unavailable
                                    :streaming-timeout-ms streaming-timeout-ms}]
               (log/error "unable to stream request bytes" description-map)
@@ -555,7 +558,8 @@
                                                      :bytes-pending bytes-read
                                                      :bytes-streamed bytes-streamed
                                                      :correlation-id (cid/get-correlation-id)
-                                                     :error-cause :client-error}
+                                                     :error-cause :client-error
+                                                     :error-class error-class-stream-failure}
                                                     error)]
                                     (meters/mark! stream-back-pressure)
                                     (deliver reservation-status-promise :client-error)
@@ -576,7 +580,8 @@
                           (catch Exception e
                             (histograms/update! (metrics/service-histogram service-id "response-size") bytes-streamed)
                             ; Handle lower down
-                            (throw (ex-info (str "error occurred after streaming " bytes-streamed " bytes in response") {} e))))]
+                            (throw (ex-info (str "error occurred after streaming " bytes-streamed " bytes in response")
+                                            (or (ex-data e) {}) e))))]
                     (let [bytes-reported-to-statsd'
                           (let [unreported-bytes (- bytes-streamed' bytes-reported-to-statsd)]
                             (if (or (and (not more-bytes-possibly-available?) (pos? unreported-bytes))

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -54,12 +54,6 @@
            (org.eclipse.jetty.websocket.api UpgradeException)
            (org.eclipse.jetty.websocket.servlet ServletUpgradeResponse)))
 
-(def ^:const error-class-maintenance "waiter.Maintenance")
-(def ^:const error-class-queue-length "waiter.QueueLength")
-(def ^:const error-class-stream-failure "waiter.StreamFailure")
-(def ^:const error-class-stream-timeout "waiter.StreamTimeout")
-(def ^:const error-class-suspended "waiter.Suspended")
-
 (defn make-auth-user-map
   "Creates a map containing the username and principal from a request"
   [{:keys [authorization/metadata authorization/principal]}]

--- a/waiter/src/waiter/service.clj
+++ b/waiter/src/waiter/service.clj
@@ -273,7 +273,7 @@
                          :error-message (utils/message instance)}
                         (and service-deployment-error-msg service-deployment-error-details)
                         (-> (assoc :error-message service-deployment-error-msg)
-                            (update :error-map #(merge {:error-class "waiter.DeploymentError"} service-deployment-error-details %))))]
+                            (update :error-map #(merge {:error-class error-class-deployment-error} service-deployment-error-details %))))]
                   (ex-info (str deployment-error-prefix error-message) error-map))
                 (if-not (t/before? (t/now) expiry-time)
                   (do
@@ -292,7 +292,7 @@
                                       " Check that your service is able to start properly!")
                                     (when (and (pos? outstanding-requests) (pos? healthy-instances))
                                       " Check that your service is able to scale properly!"))
-                               {:error-class "waiter.RequestTimeout"
+                               {:error-class error-class-request-timeout
                                 :outstanding-requests outstanding-requests
                                 :requests-waiting-to-stream requests-waiting-to-stream
                                 :service-id service-id

--- a/waiter/src/waiter/status_codes.clj
+++ b/waiter/src/waiter/status_codes.clj
@@ -89,3 +89,20 @@
 (def ^:const envoy-upstream-connection-failure "UF")
 (def ^:const envoy-upstream-connection-termination "UC")
 (def ^:const envoy-upstream-request-timeout "UT")
+
+;; waiter error class constants
+(def ^:const error-class-cors-preflight-forbidden "waiter.CorsPreflightForbidden")
+(def ^:const error-class-cors-request-forbidden "waiter.CorsRequestForbidden")
+(def ^:const error-class-deployment-error "waiter.DeploymentError")
+(def ^:const error-class-kerberos-negotiate "waiter.KerberosNegotiate")
+(def ^:const error-class-kerberos-queue-length "waiter.KerberosQueueLength")
+(def ^:const error-class-maintenance "waiter.Maintenance")
+(def ^:const error-class-prestashed-tickets "waiter.PrestashedTickets")
+(def ^:const error-class-queue-length "waiter.QueueLength")
+(def ^:const error-class-request-timeout "waiter.RequestTimeout")
+(def ^:const error-class-stream-failure "waiter.StreamFailure")
+(def ^:const error-class-stream-timeout "waiter.StreamTimeout")
+(def ^:const error-class-service-forbidden "waiter.ServiceForbidden")
+(def ^:const error-class-suspended "waiter.Suspended")
+(def ^:const error-class-unsupported-auth "waiter.UnsupportedAuth")
+

--- a/waiter/test/waiter/auth/spnego_test.clj
+++ b/waiter/test/waiter/auth/spnego_test.clj
@@ -48,13 +48,19 @@
 
       (testing "spnego authentication disabled"
         (with-redefs [too-many-pending-auth-requests? (constantly true)]
-          (let [request (assoc-in standard-request
-                          [:waiter-discovery :service-description-template "env" "USE_SPNEGO_AUTH"] "false")
+          (let [request (assoc-in standard-request [:waiter-discovery :service-description-template "env" "USE_SPNEGO_AUTH"] "false")
                 handler (require-gss request-handler thread-pool max-queue-length password)]
             (is (= {:body "Unauthorized"
                     :headers {"content-type" "text/plain"}
                     :status http-401-unauthorized
                     :waiter/response-source :waiter}
+                   (handler request))))))
+
+      (testing "spnego authentication failed with waiter token"
+        (with-redefs [too-many-pending-auth-requests? (constantly false)]
+          (let [request (assoc-in standard-request [:waiter-discovery :token] "test-token")
+                handler (require-gss request-handler thread-pool max-queue-length password)]
+            (is (= (assoc standard-401-response :waiter/token "test-token")
                    (handler request))))))
 
       (testing "too many pending kerberos requests"


### PR DESCRIPTION
## Changes proposed in this PR

- adds error classes for additional non-2XX responses

## Why are we making these changes?

Improves the information available in the request log and makes it easier to track why certain response codes were emitted for requests.

