### PR TITLE
adds support for configuring environment variables by default in Raven sidecar

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -520,7 +520,10 @@
                                  :pod-suffix-length 5
                                  :raven-sidecar {:cmd ["/opt/waiter/raven/bin/raven-start"]
                                                  ;; environment variables use by provided predicate functions
-                                                 :env-vars {;; flag env vars set to a "true"-like value enable raven,
+                                                 :env-vars {;; The default env vars configured in the Raven sidecar.
+                                                            ;; These may be overridden by user-provided env vars in the service description.
+                                                            :defaults {}
+                                                            ;; flag env vars set to a "true"-like value enable raven,
                                                             ;; "false"-like values disable raven
                                                             :flags ["RAVEN_ENABLED"]
                                                             ;; configuring a raven feature implicitly enables raven

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -1095,9 +1095,10 @@
              [:spec :template :spec :containers]
              conj
              (let [{:keys [cmd resources image]} raven-sidecar
+                   raven-base-env (get-in raven-sidecar [:env-vars :defaults])
                    user-env (:env service-description)
-                   env-map (-> user-env
-                               (merge base-env)
+                   env-map (-> raven-base-env
+                               (merge user-env base-env)
                                (assoc "FORCE_TLS_TERMINATION" (str force-tls?)
                                       "HEALTH_CHECK_PORT_INDEX" (str health-check-port-index)
                                       "HEALTH_CHECK_PROTOCOL" health-check-proto

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -280,7 +280,9 @@
     (let [service-id "proxy-test-service-id"
           custom-raven-flag "MY_RAVEN_FLAG"
           scheduler (make-dummy-scheduler [service-id] {:raven-sidecar {:cmd ["/opt/waiter/raven/bin/raven-start"]
-                                                                        :env-vars {:flags [custom-raven-flag]}
+                                                                        :env-vars {:defaults {"PORT0" "P0"
+                                                                                              "RAVEN_E1" "V1"}
+                                                                                   :flags [custom-raven-flag]}
                                                                         :image "twosigma/waiter-raven"
                                                                         :predicate-fn raven-sidecar-opt-in?
                                                                         :resources {:cpu 0.1 :mem 256}}})
@@ -307,6 +309,9 @@
 
       (testing "sidecar container has unique entries in environment"
         (is (= (count sidecar-env) (-> sidecar-container :env count))))
+
+      (testing "configure default variables are present in environment"
+        (is (some #(and (contains? #{"RAVEN_E1"} (:name %)) (= "V1" (:value %))) (:env sidecar-container))))
 
       (testing "user defined environment variables are correctly overwritten"
         (is (not-any? #(and (contains? #{"PORT0" "SERVICE_PORT"} (:name %))


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for configuring environment variables by default in Raven sidecar

## Why are we making these changes?


