### PR TITLE
adds status field to service instance

### DIFF
--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -116,7 +116,8 @@
    port
    extra-ports
    ^String log-directory
-   ^String message])
+   ^String message
+   ^String status])
 
 (defn make-ServiceInstance [value-map]
   (map->ServiceInstance (merge {:extra-ports [] :flags #{}} value-map)))
@@ -579,8 +580,8 @@
     (let [{healthy-instances true, unhealthy-instances false} (group-by (comp boolean :healthy?) service-instances)]
       (log/trace "retrieve-instances-for-service" service-id "has" (count healthy-instances) "healthy instance(s)"
                  "and" (count unhealthy-instances) " unhealthy instance(s).")
-      {:healthy-instances (vec healthy-instances)
-       :unhealthy-instances (vec unhealthy-instances)})))
+      {:healthy-instances (->> healthy-instances (map #(utils/assoc-if-absent % :status "Healthy")) (vec))
+       :unhealthy-instances (->> unhealthy-instances (map #(utils/assoc-if-absent % :status "Unhealthy")) (vec))})))
 
 (defn start-health-checks
   "Takes a map from service -> service instances and replaces each active instance with a ref which performs a

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -580,8 +580,8 @@
     (let [{healthy-instances true, unhealthy-instances false} (group-by (comp boolean :healthy?) service-instances)]
       (log/trace "retrieve-instances-for-service" service-id "has" (count healthy-instances) "healthy instance(s)"
                  "and" (count unhealthy-instances) " unhealthy instance(s).")
-      {:healthy-instances (->> healthy-instances (map #(utils/assoc-if-absent % :status "Healthy")) (vec))
-       :unhealthy-instances (->> unhealthy-instances (map #(utils/assoc-if-absent % :status "Unhealthy")) (vec))})))
+      {:healthy-instances (mapv #(utils/assoc-if-absent % :status "Healthy") healthy-instances)
+       :unhealthy-instances (mapv #(utils/assoc-if-absent % :status "Unhealthy") unhealthy-instances)})))
 
 (defn start-health-checks
   "Takes a map from service -> service instances and replaces each active instance with a ref which performs a

--- a/waiter/test/waiter/instance_tracker_test.clj
+++ b/waiter/test/waiter/instance_tracker_test.clj
@@ -219,8 +219,8 @@
             router-state-chan (au/latest-chan)
             watch-chans (create-watch-chans 10)
             started-at (t/minus (clock) (t/hours 1))
-            inst-1-original (scheduler/->ServiceInstance "s1.i1" "s1" started-at nil nil #{} nil "host" 123 [] "/log" "test")
-            inst-1-changed (scheduler/->ServiceInstance "s1.i1" "s1" started-at nil nil #{} nil "different-host" 123 [] "/log" "test")
+            inst-1-original (scheduler/->ServiceInstance "s1.i1" "s1" started-at nil nil #{} nil "host" 123 [] "/log" "test" nil)
+            inst-1-changed (scheduler/->ServiceInstance "s1.i1" "s1" started-at nil nil #{} nil "different-host" 123 [] "/log" "test" nil)
             {:keys [exit-chan go-chan instance-watch-channels-update-chan]}
             (start-instance-tracker clock router-state-chan ev-handler)]
         (async/>!! router-state-chan {:service-id->failed-instances {}

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -69,7 +69,8 @@
                         1234
                         []
                         "log-dir"
-                        "instance-message")]
+                        "instance-message"
+                        nil)]
     (testing (str "Test record ServiceInstance")
       (is (= "instance-id" (:id test-instance)))
       (is (= "service-id" (:service-id test-instance)))
@@ -283,9 +284,9 @@
                                                      "health-check-port-index" 2
                                                      "health-check-url" (str "/" id)})
         started-at (t/minus (clock) (t/hours 1))
-        instance1 (->ServiceInstance "s1.i1" "s1" started-at nil nil #{} nil "host" 123 [] "/log" "test")
-        instance2 (->ServiceInstance "s1.i2" "s1" started-at true nil #{} nil "host" 123 [] "/log" "test")
-        instance3 (->ServiceInstance "s1.i3" "s1" started-at nil nil #{} nil "host" 123 [] "/log" "test")
+        instance1 (->ServiceInstance "s1.i1" "s1" started-at nil nil #{} nil "host" 123 [] "/log" "test" "Unhealthy")
+        instance2 (->ServiceInstance "s1.i2" "s1" started-at true nil #{} nil "host" 123 [] "/log" "test" "Healthy")
+        instance3 (->ServiceInstance "s1.i3" "s1" started-at nil nil #{} nil "host" 123 [] "/log" "test" "Unhealthy")
         get-service->instances (constantly
                                  {(->Service "s1" {} {} {}) {:active-instances [instance1 instance2 instance3]
                                                              :failed-instances []}


### PR DESCRIPTION
## Changes proposed in this PR

- adds status field to service instance

## Why are we making these changes?

We would like to have a status report on each instance currently running. This is useful summary information provided to service owners. A CLI or UI can also leverage their information when providing status about instances.

