### PR TITLE
triggers token updates if the cluster field changes

### DIFF
--- a/waiter/src/waiter/token.clj
+++ b/waiter/src/waiter/token.clj
@@ -492,12 +492,15 @@
           new-token-metadata (cond-> new-token-metadata
                                (string? last-update-time)
                                (update "last-update-time" parse-last-update-time))
+          new-token-cluster (get new-token-metadata "cluster")
           new-user-editable-token-data (-> (merge new-service-parameter-template new-token-metadata)
                                            (select-keys sd/token-user-editable-keys))
           existing-token-description (sd/token->token-description kv-store token :include-deleted false)
+          existing-token-cluster (get-in existing-token-description [:token-metadata "cluster"])
           existing-editable-token-data (token-description->editable-token-parameters existing-token-description)
           [overridden-token-data overriding-token-data _] (data/diff existing-editable-token-data new-user-editable-token-data)]
       (if (and (not admin-mode?)
+               (= existing-token-cluster new-token-cluster)
                (= existing-editable-token-data new-user-editable-token-data))
         (-> (utils/clj->json-response
               {:message (str "No changes detected for " token)

--- a/waiter/test/waiter/token_test.clj
+++ b/waiter/test/waiter/token_test.clj
@@ -637,9 +637,9 @@
             (doseq [key sd/service-parameter-keys]
               (is (= (get service-description-2 key) (get body-map key))
                   (str {:body-map body-map :service-description service-description-2})))
-            (doseq [key (-> required-metadata-keys (conj "cluster") (disj "deleted"))]
+            (doseq [key (disj required-metadata-keys "deleted")]
               (is (contains? body-map key) (str "Missing entry for " key " in " body-map)))
-            (doseq [key (-> optional-metadata-keys (disj "cluster") (conj "deleted"))]
+            (doseq [key (conj optional-metadata-keys "deleted")]
               (is (not (contains? body-map key)) (str "Existing entry for " key " in " body-map)))
             (is (not (contains? body-map "deleted"))))))
 
@@ -672,9 +672,9 @@
           (let [body-map (-> body str json/read-str)]
             (doseq [key sd/service-parameter-keys]
               (is (= (get service-description-2 key) (get body-map key))))
-            (doseq [key (-> required-metadata-keys (conj "cluster") (disj "deleted"))]
+            (doseq [key (disj required-metadata-keys "deleted")]
               (is (contains? body-map key) (str "Missing entry for " key)))
-            (doseq [key (-> optional-metadata-keys (disj "cluster") (conj "deleted"))]
+            (doseq [key (conj optional-metadata-keys "deleted")]
               (is (not (contains? body-map key)) (str "Existing entry for " key)))
             (is (not (contains? body-map "deleted"))))))
 
@@ -851,7 +851,7 @@
             (let [body-map (-> body str json/read-str)]
               (doseq [key sd/service-parameter-keys]
                 (is (= (get service-description key) (get body-map key))))
-              (doseq [key (disj sd/user-metadata-keys "cluster" "stale-timeout-mins")]
+              (doseq [key (disj sd/user-metadata-keys "stale-timeout-mins")]
                 (is (= (get service-description key) (get body-map key)) (str key)))
               (doseq [key sd/system-metadata-keys]
                 (is (not (contains? body-map key)) (str key)))))))


### PR DESCRIPTION
## Changes proposed in this PR

- triggers token updates if the cluster field changes

## Why are we making these changes?

We should update the cluster if the values do not match since a user sending a request to a specific cluster is signaling intent to update the cluster parameter.
