### PR TITLE
makes the authenticate-request function pluggable in kerberos authenticator

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -589,6 +589,8 @@
                                :authorizer {:kind :kerberos
                                             :kerberos {;; kerberos-prestash determines user authorization via the presence of prestashed tickets
                                                        :factory-fn waiter.auth.kerberos/kerberos-authorizer
+                                                       ;; pluggable function used to authenticate requests
+                                                       :authenticate-request-fn waiter.auth.spnego/authenticate-request
                                                        ;; the minimum interval after which prestash kerberos tickets needs to refreshed
                                                        :prestash-cache-min-refresh-ms 100
                                                        ;; the maximum interval after which prestash kerberos tickets are forcibly refreshed

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -591,6 +591,8 @@
                                                        :factory-fn waiter.auth.kerberos/kerberos-authorizer
                                                        ;; pluggable function used to authenticate requests
                                                        :authenticate-request-fn waiter.auth.spnego/authenticate-request
+                                                       ;; pluggable parameters passed to the function used to authenticate requests
+                                                       :authenticate-request-fn-context {}
                                                        ;; the minimum interval after which prestash kerberos tickets needs to refreshed
                                                        :prestash-cache-min-refresh-ms 100
                                                        ;; the maximum interval after which prestash kerberos tickets are forcibly refreshed

--- a/waiter/src/waiter/auth/kerberos.clj
+++ b/waiter/src/waiter/auth/kerberos.clj
@@ -119,9 +119,11 @@
 
 (defn kerberos-authenticator
   "Factory function for creating Kerberos authenticator middleware"
-  [{:keys [authenticate-request-fn concurrency-level keep-alive-mins max-queue-length password]
-    :or {authenticate-request-fn 'waiter.auth.spnego/authenticate-request}}]
-  {:pre [(not-empty password)
+  [{:keys [authenticate-request-fn authenticate-request-fn-context concurrency-level keep-alive-mins max-queue-length password]
+    :or {authenticate-request-fn 'waiter.auth.spnego/authenticate-request
+         authenticate-request-fn-context {}}}]
+  {:pre [(map? authenticate-request-fn-context)
+         (not-empty password)
          (integer? concurrency-level)
          (pos? concurrency-level)
          (integer? keep-alive-mins)
@@ -130,7 +132,9 @@
          (pos? max-queue-length)]}
   (let [queue (LinkedBlockingQueue.)
         executor (ThreadPoolExecutor. concurrency-level concurrency-level keep-alive-mins TimeUnit/MINUTES queue)
-        resolved-authenticate-request-fn (utils/resolve-symbol! authenticate-request-fn)]
+        resolved-authenticate-request-fn (utils/resolve-symbol! authenticate-request-fn)
+        wrapped-authenticate-request-fn (fn wrapped-authenticate-request-fn [request]
+                                          (resolved-authenticate-request-fn authenticate-request-fn-context request))]
     (metrics/waiter-gauge #(.getActiveCount executor)
                           "core" "kerberos" "throttle" "active-thread-count")
     (metrics/waiter-gauge #(- concurrency-level (.getActiveCount executor))
@@ -141,7 +145,7 @@
                           "core" "kerberos" "throttle" "pending-task-count")
     (metrics/waiter-gauge #(.getTaskCount executor)
                           "core" "kerberos" "throttle" "scheduled-task-count")
-    (->KerberosAuthenticator resolved-authenticate-request-fn executor max-queue-length password)))
+    (->KerberosAuthenticator wrapped-authenticate-request-fn executor max-queue-length password)))
 
 (defrecord KerberosAuthorizer
   [prestash-cache query-chan]

--- a/waiter/src/waiter/auth/spnego.clj
+++ b/waiter/src/waiter/auth/spnego.clj
@@ -123,7 +123,7 @@
 
 (defn authenticate-request
   "Authenticates the request by extracting the Kerberos negotiate token and then using a GSSContext."
-  [request]
+  [_ request]
   (let [input-token (decode-input-token request)]
     (authenticate-token input-token)))
 

--- a/waiter/src/waiter/auth/spnego.clj
+++ b/waiter/src/waiter/auth/spnego.clj
@@ -45,15 +45,17 @@
     (some-> negotiate-token (str/split #" " 2) last str .getBytes b64/decode)))
 
 (defn encode-output-token
-  "Take a token from a gss accept context call and encode it for use in a -authenticate header"
+  "Take a token from a gss accept context call and encode it for use in a www-authenticate header"
   [token]
   (str negotiate-prefix (String. ^bytes (b64/encode token))))
 
 (defn do-gss-auth-check
-  [^GSSContext gss-context req]
-  (when-let [intok (decode-input-token req)]
-    (when-let [ntok (.acceptSecContext gss-context intok 0 (alength intok))]
-      (encode-output-token ntok))))
+  "Returns a string containing the token to be sent to the peer for use in a www-authenticate header.
+   null indicates that no token is generated"
+  [^GSSContext gss-context input-token]
+  (when input-token
+    (when-let [output-token (.acceptSecContext gss-context input-token 0 (alength input-token))]
+      (encode-output-token output-token))))
 
 (defn- response-http-401-unauthorized
   [request cause]
@@ -105,8 +107,25 @@
     gss))
 
 (defn gss-get-principal
+  "Returns the name of the context initiator, i.e. the authenticated principal."
   [^GSSContext gss]
   (str (.getSrcName gss)))
+
+(defn authenticate-token
+  "Authenticates the input token and returns map containing a principal and a negotiate token for use in www-authenticate header."
+  [input-token]
+  (let [^GSSContext gss-context (gss-context-init)
+        token (do-gss-auth-check gss-context input-token)
+        principal (when (.isEstablished gss-context)
+                    (gss-get-principal gss-context))]
+    {:principal principal
+     :token token}))
+
+(defn authenticate-request
+  "Authenticates the request by extracting the Kerberos negotiate token and then using a GSSContext."
+  [request]
+  (let [input-token (decode-input-token request)]
+    (authenticate-token input-token)))
 
 (defn too-many-pending-auth-requests?
   "Returns true if there are too many pending Kerberos auth requests."
@@ -128,12 +147,7 @@
           current-correlation-id
           (try
             (timers/stop timer-context)
-            (let [^GSSContext gss-context (gss-context-init)
-                  token (do-gss-auth-check gss-context request)
-                  principal (when (.isEstablished gss-context)
-                              (gss-get-principal gss-context))]
-              (async/>!! response-chan {:principal principal
-                                        :token token}))
+            (async/>!! response-chan (authenticate-request request))
             (catch GSSException ex
               (log/error ex "gss exception during kerberos auth")
               (async/>!! response-chan

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -277,6 +277,7 @@
   {:authenticator-config {:jwt :disabled
                           :kind :one-user
                           :kerberos {:factory-fn 'waiter.auth.kerberos/kerberos-authenticator
+                                     :authenticate-request-fn 'waiter.auth.spnego/authenticate-request
                                      :concurrency-level 20
                                      :keep-alive-mins 5
                                      :max-queue-length 1000}

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -278,6 +278,7 @@
                           :kind :one-user
                           :kerberos {:factory-fn 'waiter.auth.kerberos/kerberos-authenticator
                                      :authenticate-request-fn 'waiter.auth.spnego/authenticate-request
+                                     :authenticate-request-fn-context {}
                                      :concurrency-level 20
                                      :keep-alive-mins 5
                                      :max-queue-length 1000}

--- a/waiter/test/waiter/auth/spnego_test.clj
+++ b/waiter/test/waiter/auth/spnego_test.clj
@@ -49,7 +49,7 @@
       (testing "spnego authentication disabled"
         (with-redefs [too-many-pending-auth-requests? (constantly true)]
           (let [request (assoc-in standard-request [:waiter-discovery :service-description-template "env" "USE_SPNEGO_AUTH"] "false")
-                handler (require-gss request-handler thread-pool max-queue-length password)]
+                handler (require-gss request-handler authenticate-request thread-pool max-queue-length password)]
             (is (= {:body "Unauthorized"
                     :headers {"content-type" "text/plain"}
                     :status http-401-unauthorized
@@ -59,13 +59,13 @@
       (testing "spnego authentication failed with waiter token"
         (with-redefs [too-many-pending-auth-requests? (constantly false)]
           (let [request (assoc-in standard-request [:waiter-discovery :token] "test-token")
-                handler (require-gss request-handler thread-pool max-queue-length password)]
+                handler (require-gss request-handler authenticate-request thread-pool max-queue-length password)]
             (is (= (assoc standard-401-response :waiter/token "test-token")
                    (handler request))))))
 
       (testing "too many pending kerberos requests"
         (with-redefs [too-many-pending-auth-requests? (constantly true)]
-          (let [handler (require-gss request-handler thread-pool max-queue-length password)]
+          (let [handler (require-gss request-handler authenticate-request thread-pool max-queue-length password)]
             (is (= {:body "Too many Kerberos authentication requests"
                     :error-class error-class-kerberos-queue-length
                     :headers {"content-type" "text/plain"}
@@ -75,7 +75,7 @@
 
       (testing "standard 401 response on missing authorization header"
         (with-redefs [too-many-pending-auth-requests? (constantly false)]
-          (let [handler (require-gss request-handler thread-pool max-queue-length password)]
+          (let [handler (require-gss request-handler authenticate-request thread-pool max-queue-length password)]
             (is (= standard-401-response (handler standard-request))))))
 
       (testing "kerberos authentication path"
@@ -84,9 +84,9 @@
                 error-object (Object.)]
 
             (testing "401 response on failed authentication"
-              (with-redefs [populate-gss-credentials (fn [_ _ response-chan]
+              (with-redefs [populate-gss-credentials (fn [_ _ _ response-chan]
                                                        (async/>!! response-chan {:foo :bar}))]
-                (let [handler (require-gss request-handler thread-pool max-queue-length password)
+                (let [handler (require-gss request-handler authenticate-request thread-pool max-queue-length password)
                       response (handler auth-request)
                       response (if (map? response)
                                  response
@@ -94,9 +94,9 @@
                   (is (= standard-401-response response)))))
 
             (testing "401 response on missing authorization header"
-              (with-redefs [populate-gss-credentials (fn [_ _ response-chan]
+              (with-redefs [populate-gss-credentials (fn [_ _ _ response-chan]
                                                        (async/>!! response-chan {:foo :bar}))]
-                (let [handler (require-gss request-handler thread-pool max-queue-length password)
+                (let [handler (require-gss request-handler authenticate-request thread-pool max-queue-length password)
                       response (handler standard-request)
                       response (if (map? response)
                                  response
@@ -104,9 +104,9 @@
                   (is (= standard-401-response response)))))
 
             (testing "401 response on invalid authorization header"
-              (with-redefs [populate-gss-credentials (fn [_ _ response-chan]
+              (with-redefs [populate-gss-credentials (fn [_ _ _ response-chan]
                                                        (async/>!! response-chan {:foo :bar}))]
-                (let [handler (require-gss request-handler thread-pool max-queue-length password)
+                (let [handler (require-gss request-handler authenticate-request thread-pool max-queue-length password)
                       auth-request (update standard-request :headers assoc "authorization" "Bearer foo-bar")
                       response (handler auth-request)
                       response (if (map? response)
@@ -115,9 +115,9 @@
                   (is (= standard-401-response response)))))
 
             (testing "error object on exception"
-              (with-redefs [populate-gss-credentials (fn [_ _ response-chan]
+              (with-redefs [populate-gss-credentials (fn [_ _ _ response-chan]
                                                        (async/>!! response-chan {:error error-object}))]
-                (let [handler (require-gss request-handler thread-pool max-queue-length password)
+                (let [handler (require-gss request-handler authenticate-request thread-pool max-queue-length password)
                       response (handler auth-request)
                       response (if (map? response)
                                  response
@@ -125,10 +125,10 @@
                   (is (= error-object response)))))
 
             (testing "successful authentication - principal and token"
-              (with-redefs [populate-gss-credentials (fn [_ _ response-chan]
+              (with-redefs [populate-gss-credentials (fn [_ _ _ response-chan]
                                                        (async/>!! response-chan {:principal auth-principal
                                                                                  :token "test-token"}))]
-                (let [handler (require-gss request-handler thread-pool max-queue-length password)
+                (let [handler (require-gss request-handler authenticate-request thread-pool max-queue-length password)
                       response (handler auth-request)
                       response (if (map? response)
                                  response
@@ -141,10 +141,10 @@
                          (utils/dissoc-in response [:headers "set-cookie"]))))))
 
             (testing "successful authentication - principal and token - multiple authorization header"
-              (with-redefs [populate-gss-credentials (fn [_ _ response-chan]
+              (with-redefs [populate-gss-credentials (fn [_ _ _ response-chan]
                                                        (async/>!! response-chan {:principal auth-principal
                                                                                  :token "test-token"}))]
-                (let [handler (require-gss request-handler thread-pool max-queue-length password)
+                (let [handler (require-gss request-handler authenticate-request thread-pool max-queue-length password)
                       auth-request (update standard-request :headers
                                            assoc "authorization" "Bearer fee-fie,Negotiate foo-bar")
                       response (handler auth-request)
@@ -159,9 +159,9 @@
                          (utils/dissoc-in response [:headers "set-cookie"]))))))
 
             (testing "successful authentication - principal only"
-              (with-redefs [populate-gss-credentials (fn [_ _ response-chan]
+              (with-redefs [populate-gss-credentials (fn [_ _ _ response-chan]
                                                        (async/>!! response-chan {:principal auth-principal}))]
-                (let [handler (require-gss request-handler thread-pool max-queue-length password)
+                (let [handler (require-gss request-handler authenticate-request thread-pool max-queue-length password)
                       response (handler auth-request)
                       response (if (map? response)
                                  response


### PR DESCRIPTION
## Changes proposed in this PR

- makes the authenticate-request function pluggable in kerberos authenticator

## Why are we making these changes?

We would like the ability to customize the mechanism used to perform SPNEGO auth on specific Waiter tokens.
