### PR TITLE
adds defaults to raven-sidecar schema

### DIFF
--- a/waiter/src/waiter/schema.clj
+++ b/waiter/src/waiter/schema.clj
@@ -106,11 +106,12 @@
   (nil? (s/check {(s/required-key :factory-fn) s/Symbol, s/Keyword s/Any} (get config kind))))
 
 (def valid-raven-sidecar-config
-  {:cmd [s/Str]
-   (s/optional-key :env-vars) {(s/optional-key :flags) [s/Str]
-                               (s/optional-key :features) [s/Str]
-                               (s/optional-key :tls-flags) [s/Str]}
-   :image s/Str
+  {:cmd [non-empty-string]
+   (s/optional-key :env-vars) {(s/optional-key :defaults) {non-empty-string non-empty-string}
+                               (s/optional-key :flags) [non-empty-string]
+                               (s/optional-key :features) [non-empty-string]
+                               (s/optional-key :tls-flags) [non-empty-string]}
+   :image non-empty-string
    :predicate-fn s/Symbol
    :resources {:cpu s/Num
                :mem s/Int}})


### PR DESCRIPTION
## Changes proposed in this PR

- adds defaults to raven-sidecar schema

## Why are we making these changes?

Fixes the schema to match the ability to configure the default environment for Raven sidecar.

The change was missed during the PR https://github.com/twosigma/waiter/pull/1490
