### PR TITLE
CLI subcommand delete respects cluster groups

### DIFF
--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -345,10 +345,10 @@ class temp_base_config_file:
         os.remove(self.path)
 
 
-def delete(waiter_url=None, token_name=None, flags=None, delete_flags=None):
+def delete(waiter_url=None, token_name=None, flags=None, delete_flags=None, stdin=None):
     """Deletes a token via the CLI"""
     args = f"delete {token_name} {delete_flags or ''}"
-    cp = cli(args, waiter_url, flags)
+    cp = cli(args, waiter_url, flags, stdin)
     return cp
 
 

--- a/cli/integration/tests/waiter/test_cli_multi_cluster.py
+++ b/cli/integration/tests/waiter/test_cli_multi_cluster.py
@@ -116,6 +116,46 @@ class MultiWaiterCliTest(util.WaiterTest):
         finally:
             util.delete_token(self.waiter_url_1, token_name, assert_response=True)
 
+    def test_delete_token_in_multiple_cluster_groups(self):
+        token_name = self.token_name()
+        version_1 = str(uuid.uuid4())
+        util.post_token(self.waiter_url_1, token_name, {'version': version_1})
+        try:
+            version_2 = str(uuid.uuid4())
+            util.post_token(self.waiter_url_2, token_name, {'version': version_2})
+            try:
+                config = self.__two_cluster_config()
+                with cli.temp_config_file(config) as path:
+                    # failed delete because the target cluster couldn't be inferred when the token is in mutliple cluster groups
+                    cp = cli.delete(token_name=token_name, flags=f'--config {path}')
+                    self.assertEqual(1, cp.returncode, cp.stderr)
+                    self.assertIn('Could not infer the target cluster for this operation', cli.stderr(cp))
+                    self.assertIn(self.waiter_1_cluster, cli.stderr(cp))
+                    self.assertIn(self.waiter_2_cluster, cli.stderr(cp))
+                    util.load_token(self.waiter_url_1, token_name, expected_status_code=200)
+                    util.load_token(self.waiter_url_2, token_name, expected_status_code=200)
+            finally:
+                util.delete_token(self.waiter_url_2, token_name, assert_response=False)
+        finally:
+            util.delete_token(self.waiter_url_1, token_name, assert_response=True)       
+
+    # def test_delete_token_in_multiple_cluster_groups_force(self):
+
+    # def test_delete_token_in_single_cluster_group(self):
+
+    # def test_delete_token_in_single_cluster_group_force(self):
+
+    # def test_delete_token_in_single_cluster_group_no_data(self):
+
+    # def test_delete_token_sync_disabled(self):
+    
+    
+    # TODO:
+    # 1. second delete results in no op if token is only in one cluster group
+    # 2. if token has syncing turned off, then revert to old way of displaying delete information
+    # 3. deleting token in multiple cluster groups result in an error
+
+
     def test_federated_ping(self):
         # Create in cluster #1
         token_name = self.token_name()

--- a/cli/integration/tests/waiter/test_cli_multi_cluster.py
+++ b/cli/integration/tests/waiter/test_cli_multi_cluster.py
@@ -149,15 +149,16 @@ class MultiWaiterCliTest(util.WaiterTest):
                                 'sync-group': 'production'}]}
         token_name = self.token_name()
         version_1 = str(uuid.uuid4())
-        util.post_token(self.waiter_url_1, token_name, {'version': version_1})
+        util.post_token(self.waiter_url_1, token_name, {'cluster': 'waiter1', 'version': version_1}, update_mode_admin=True)
         try:
             version_2 = str(uuid.uuid4())
-            util.post_token(self.waiter_url_2, token_name, {'version': version_2})
+            util.post_token(self.waiter_url_2, token_name, {'cluster': 'waiter1', 'version': version_2}, update_mode_admin=True)
             try:
                 with cli.temp_config_file(config) as path:
                     # deletes token in the primary cluster only, and relies on token syncer that will sync the delete
                     cp = cli.delete(token_name=token_name, flags=f'--config {path}')
                     self.assertEqual(0, cp.returncode, cp.stderr)
+                    # TODO: figure out why "waiter1" is not deterministic, we should put admin mode and put cluster waiter1?
                     self.assertIn(f'Successfully deleted {token_name} in waiter1.', cli.stdout(cp))
                     util.load_token(self.waiter_url_1, token_name, expected_status_code=404)
                     util.load_token(self.waiter_url_2, token_name, expected_status_code=200)

--- a/cli/integration/tests/waiter/test_cli_multi_cluster.py
+++ b/cli/integration/tests/waiter/test_cli_multi_cluster.py
@@ -158,7 +158,6 @@ class MultiWaiterCliTest(util.WaiterTest):
                     # deletes token in the primary cluster only, and relies on token syncer that will sync the delete
                     cp = cli.delete(token_name=token_name, flags=f'--config {path}')
                     self.assertEqual(0, cp.returncode, cp.stderr)
-                    # TODO: figure out why "waiter1" is not deterministic, we should put admin mode and put cluster waiter1?
                     self.assertIn(f'Successfully deleted {token_name} in waiter1.', cli.stdout(cp))
                     util.load_token(self.waiter_url_1, token_name, expected_status_code=404)
                     util.load_token(self.waiter_url_2, token_name, expected_status_code=200)

--- a/cli/integration/tests/waiter/test_cli_multi_cluster.py
+++ b/cli/integration/tests/waiter/test_cli_multi_cluster.py
@@ -77,7 +77,7 @@ class MultiWaiterCliTest(util.WaiterTest):
                     # Delete the token in both clusters
                     cp = cli.delete(token_name=token_name, flags='--config %s' % path, delete_flags='--force')
                     self.assertEqual(0, cp.returncode, cp.stderr)
-                    self.assertIn('exists in 2 clusters', cli.stdout(cp))
+                    self.assertIn('exists in 2 cluster(s)', cli.stdout(cp))
                     self.assertIn('waiter1', cli.stdout(cp))
                     self.assertIn('waiter2', cli.stdout(cp))
                     self.assertEqual(2, cli.stdout(cp).count('Deleting token'))

--- a/cli/waiter/querying.py
+++ b/cli/waiter/querying.py
@@ -59,9 +59,12 @@ def print_no_instances(service):
     print(f'Check the --include flags for active, failed, and killed instances.')
 
 
-def get_token_on_cluster(cluster, token_name, include_services=False):
+def get_token_on_cluster(cluster, token_name, include_services=False, include_deleted=False):
     """Gets the token with the given name on the given cluster"""
-    token_data, token_etag = get_token(cluster, token_name, include='metadata')
+    include_flags = ['metadata']
+    if include_deleted:
+        include_flags.append('deleted')
+    token_data, token_etag = get_token(cluster, token_name, include=include_flags)
     if token_data:
         data = {'count': 1, 'token': token_data, 'etag': token_etag}
         if include_services:
@@ -72,14 +75,14 @@ def get_token_on_cluster(cluster, token_name, include_services=False):
         return {'count': 0}
 
 
-def query_token(clusters, token, include_services=False):
+def query_token(clusters, token, include_services=False, include_deleted=False):
     """
     Uses query_across_clusters to make the token
     requests in parallel across the given clusters
     """
 
     def submit(cluster, executor):
-        return executor.submit(get_token_on_cluster, cluster, token, include_services)
+        return executor.submit(get_token_on_cluster, cluster, token, include_services, include_deleted)
 
     return query_across_clusters(clusters, submit)
 
@@ -176,6 +179,8 @@ def _get_latest_cluster(clusters, query_result):
     """
     token_descriptions = list(query_result['clusters'].values())
     token_result = max(token_descriptions, key=lambda token: token['token']['last-update-time'])
+    if token_result['token']['deleted']:
+        return None
     cluster_name_goal = token_result['token']['cluster']
     provided_cluster_names = []
     for c in clusters:
@@ -195,7 +200,7 @@ def get_target_cluster_from_token(clusters, token_name, enforce_cluster):
     :param enforce_cluster: boolean describing if cluster was explicitly specified as an cli argument
     :return: Return the target cluster config for various token operations
     """
-    query_result = query_token(clusters, token_name)
+    query_result = query_token(clusters, token_name, include_deleted=True)
     if query_result["count"] == 0:
         raise Exception('The token does not exist. You must create it first.')
     elif enforce_cluster:

--- a/cli/waiter/querying.py
+++ b/cli/waiter/querying.py
@@ -179,7 +179,7 @@ def _get_latest_cluster(clusters, query_result):
     """
     token_descriptions = list(query_result['clusters'].values())
     token_result = max(token_descriptions, key=lambda token: token['token']['last-update-time'])
-    if token_result['token']['deleted']:
+    if token_result['token'].get('deleted', False):
         return None
     cluster_name_goal = token_result['token']['cluster']
     provided_cluster_names = []

--- a/cli/waiter/subcommands/delete.py
+++ b/cli/waiter/subcommands/delete.py
@@ -86,6 +86,7 @@ def delete(clusters, args, _, enforce_cluster):
         cluster = get_target_cluster_from_token(clusters, token_name, enforce_cluster)
         if cluster is None:
             print_no_data(clusters)
+            return 1
         else:
             token_config = query_result['clusters'][cluster['name']]
             token_etag = token_config['etag']

--- a/cli/waiter/subcommands/delete.py
+++ b/cli/waiter/subcommands/delete.py
@@ -65,13 +65,7 @@ def delete(clusters, args, _, enforce_cluster):
     sync_opt_out = any(get_in(token_config, ['token', 'metadata', 'waiter-token-sync-opt-out']) == 'true'
                        for _, token_config in cluster_data_pairs)
 
-    if num_clusters == 1:
-        cluster_name = cluster_data_pairs[0][0]
-        token_etag = cluster_data_pairs[0][1]['etag']
-        cluster = clusters_by_name[cluster_name]
-        success = delete_token_on_cluster(cluster, token_name, token_etag)
-        return 0 if success else 1
-    elif force_delete or sync_opt_out:
+    if force_delete or sync_opt_out:
         cluster_data_pairs = sorted(query_result['clusters'].items())
         clusters_by_name = {c['name']: c for c in clusters}
         num_clusters = len(cluster_data_pairs)
@@ -80,7 +74,7 @@ def delete(clusters, args, _, enforce_cluster):
         print(f'Token {terminal.bold(token_name)} exists in {num_clusters} cluster(s): {", ".join(cluster_names_found)}.')
         overall_success = True
         for cluster_name, data in cluster_data_pairs:
-            if force_delete:
+            if force_delete or (num_clusters == 1):
                 should_delete = True
             else:
                 should_delete = str2bool(input(f'Delete token in {terminal.bold(cluster_name)}? '))

--- a/cli/waiter/subcommands/delete.py
+++ b/cli/waiter/subcommands/delete.py
@@ -2,7 +2,7 @@ import logging
 
 from waiter import http_util, terminal
 from waiter.querying import query_token, print_no_data, get_services_using_token, get_target_cluster_from_token
-from waiter.util import guard_no_cluster, str2bool, response_message, print_error
+from waiter.util import guard_no_cluster, response_message, print_error, get_in, str2bool
 
 
 def delete_token_on_cluster(cluster, token_name, token_etag):
@@ -59,24 +59,42 @@ def delete(clusters, args, _, enforce_cluster):
         print_no_data(clusters)
         return 1
 
-    if force_delete:
+    cluster_data_pairs = sorted(query_result['clusters'].items())
+    num_clusters = len(cluster_data_pairs)
+    clusters_by_name = {c['name']: c for c in clusters}
+    sync_opt_out = any(get_in(token_config, ['token', 'metadata', 'waiter-token-sync-opt-out']) == 'true'
+                       for _, token_config in cluster_data_pairs)
+
+    if num_clusters == 1:
+        cluster_name = cluster_data_pairs[0][0]
+        token_etag = cluster_data_pairs[0][1]['etag']
+        cluster = clusters_by_name[cluster_name]
+        success = delete_token_on_cluster(cluster, token_name, token_etag)
+        return 0 if success else 1
+    elif force_delete or sync_opt_out:
         cluster_data_pairs = sorted(query_result['clusters'].items())
         clusters_by_name = {c['name']: c for c in clusters}
         num_clusters = len(cluster_data_pairs)
         cluster_names_found = [p[0] for p in cluster_data_pairs]
 
-        print(f'Token {terminal.bold(token_name)} exists in {num_clusters} clusters: {", ".join(cluster_names_found)}.')
+        print(f'Token {terminal.bold(token_name)} exists in {num_clusters} cluster(s): {", ".join(cluster_names_found)}.')
         overall_success = True
         for cluster_name, data in cluster_data_pairs:
-            cluster = clusters_by_name[cluster_name]
-            success = delete_token_on_cluster(cluster, token_name, data['etag'])
-            overall_success = overall_success and success
+            if force_delete:
+                should_delete = True
+            else:
+                should_delete = str2bool(input(f'Delete token in {terminal.bold(cluster_name)}? '))
+            if should_delete:
+                cluster = clusters_by_name[cluster_name]
+                success = delete_token_on_cluster(cluster, token_name, data['etag'])
+                overall_success = overall_success and success
     else:
         cluster = get_target_cluster_from_token(clusters, token_name, enforce_cluster)
         if cluster is None:
             print_no_data(clusters)
         else:
-            token_etag = query_result['clusters'][cluster['name']]['etag']
+            token_config = query_result['clusters'][cluster['name']]
+            token_etag = token_config['etag']
             success = delete_token_on_cluster(cluster, token_name, token_etag)
             return 0 if success else 1
 

--- a/cli/waiter/subcommands/delete.py
+++ b/cli/waiter/subcommands/delete.py
@@ -1,8 +1,8 @@
 import logging
 
 from waiter import http_util, terminal
-from waiter.querying import query_token, print_no_data, get_services_using_token, get_target_cluster_from_token
-from waiter.util import guard_no_cluster, response_message, print_error, get_in, str2bool
+from waiter.querying import get_services_using_token, get_target_cluster_from_token, print_no_data, query_token
+from waiter.util import get_in, guard_no_cluster, response_message, print_error, str2bool
 
 
 def delete_token_on_cluster(cluster, token_name, token_etag):

--- a/cli/waiter/subcommands/delete.py
+++ b/cli/waiter/subcommands/delete.py
@@ -82,6 +82,7 @@ def delete(clusters, args, _, enforce_cluster):
                 cluster = clusters_by_name[cluster_name]
                 success = delete_token_on_cluster(cluster, token_name, data['etag'])
                 overall_success = overall_success and success
+        return 0 if overall_success else 1
     else:
         cluster = get_target_cluster_from_token(clusters, token_name, enforce_cluster)
         if cluster is None:

--- a/cli/waiter/util.py
+++ b/cli/waiter/util.py
@@ -12,6 +12,17 @@ TRUE_STRINGS = ('yes', 'true', 'y')
 FALSE_STRINGS = ('no', 'false', 'n')
 
 
+def get_in(obj, keys, default_value=None):
+    """Given a list of keys and a value, return the nested value in the object or the default"""
+    cur_node = obj
+    for key in keys:
+        if key in cur_node:
+            cur_node = cur_node[key]
+        else:
+            return default_value
+    return cur_node
+
+
 def update_in(obj, keys, value):
     """Given a list of keys and a value, return a new object with that value set"""
     cur_node = obj


### PR DESCRIPTION
## Changes proposed in this PR
- deleting a token in a single cluster group will delete the token on the primary cluster and rely on the token syncer to sync the delete. Subsequent deletes for the same token yield a no-op
```
$ cat .waiter.json
{
  "clusters": [
    {
      "name": "WAITER1",
      "url": "http://127.0.0.1:9091/",
      "disabled": false,
      "sync-group": "production",
      "default-for-create": true
    },
    {
      "name": "WAITER2",
      "url": "http://127.0.0.1:9191/",
      "sync-group": "production",
      "disabled": false
    }
  ],
  "metrics": {
    "disabled": true,
    "host": "localhost",
    "port": 8125,
    "line-formats": {
      "count": "{namespace}.{name}:{value}|c"
    }
  }
$ waiter create token --cpus 1 
Attempting to create token on WAITER1...
Successfully created token.
$ waiter --cluster waiter2 create token --cpus 1 
Attempting to create token on WAITER2...
Successfully created token.
$ waiter delete token
Deleting token token in WAITER2...
Successfully deleted token in WAITER2.
$ waiter delete token
No matching data found in WAITER1 / WAITER2.
Do you need to add another cluster to your configuration?
```
- when deleting token in multiple cluster groups, there is an error that is consistent with updating a token in multiple cluster groups
```
$ cat .waiter.json 
{
  "clusters": [
    {
      "name": "WAITER1",
      "url": "http://127.0.0.1:9091/",
      "disabled": false,
      "sync-group": "production",
      "default-for-create": true
    },
    {
      "name": "WAITER2",
      "url": "http://127.0.0.1:9191/",
      "disabled": false
    }
  ],
  "metrics": {
    "disabled": true,
    "host": "localhost",
    "port": 8125,
    "line-formats": {
      "count": "{namespace}.{name}:{value}|c"
    }
  }
}
$ waiter show token

=== WAITER1 / token ===

Last Updated: 8 minutes ago (kevin)

Owner  kevin
CPUs   1.0

<No command specified>


=== WAITER2 / token ===

Last Updated: 5 minutes ago (kevin)

Owner  kevin
CPUs   1.0

<No command specified>

$ waiter delete token
Could not infer the target cluster for this operation because there are multiple cluster groups that contain a description for this token: groups-{0, 'production'} clusters-{'WAITER2', 'WAITER1'}.
Consider specifying with the --cluster flag which cluster you are targeting.
```
- when using the `--force` flag, the token will be deleted on all clusters regardless of cluster group (this is the old behavior and will prevent backwards breaking change)
- if any of the queried tokens has the `waiter-token-sync-opt-out` metadata configured to `true`, then ask the user if they want to delete the token for each cluster

## Why are we making these changes?
- handle cluster groups and token syncing to provide a simpler interface when deleting the token

