### PR TITLE
Token syncer dry run results in success for storing tokens

### DIFF
--- a/token-syncer/src/token_syncer/main.clj
+++ b/token-syncer/src/token_syncer/main.clj
@@ -69,7 +69,8 @@
                     (fn store-token-dry-run-version [cluster-url token token-etag token-description]
                       (log/info "[dry-run] store-token" token "on" cluster-url "with etag" token-etag
                                 "and description" token-description)
-                      {:status "dry-run"})
+                      {:body {:message "dry-run"}
+                       :status 200})
                     (partial waiter/store-token api-http-client))}))
 
 (def base-command-config


### PR DESCRIPTION
## Changes proposed in this PR
- results in success for storing token whenever running the token syncer in dry run mode (previously resulted in exit code 1 instead of 0)
```
$ waiter create token --metadata.temp "test"
Attempting to create token on WAITER1...
Successfully created token.
$ waiter --cluster WAITER2 create token --metadata.temp "test new"
Attempting to create token on WAITER2...
Successfully created token.
$ lein run -d sync-clusters -l 1 http://localhost:9091 http://localhost:9191
...
2022-01-03 18:18:19 INFO  token-syncer.main - [dry-run] store-token token on http://localhost:9091 with etag E-a829968943925999c1d7a5d494da8d7a and description {metadata {temp test new}, owner kevin, cluster waiter2, root waiter2, last-update-user kevin, last-update-time 1641255413275, previous {}}
2022-01-03 18:18:19 INFO  token-syncer.commands.syncer - http://localhost:9091 sync result is {:code :success/sync-update, :details {:status 200, :etag nil}}
2022-01-03 18:18:19 INFO  token-syncer.commands.syncer - completed syncing tokens (limited to  1 tokens)
2022-01-03 18:18:19 INFO  token-syncer.commands.syncer - sync details: {token {:latest {:cluster-url http://localhost:9191, :description {metadata {temp test new}, owner kevin, cluster waiter2, root waiter2, last-update-user kevin, last-update-time 1641255413275, previous {}}, :token-etag E-e46ed20085c69e871f0506985ac0033f}, :sync-result {http://localhost:9091 {:code :success/sync-update, :details {:status 200, :etag nil}}}}}
2022-01-03 18:18:19 INFO  token-syncer.commands.syncer - sync summary: {:sync {:failed #{}, :unmodified #{}, :updated #{token}}, :tokens {:pending {:count 1, :value #{token}}, :previously-synced {:count 0, :value #{}}, :processed {:count 1, :value #{token}}, :selected {:count 1, :value #{token}}, :total {:count 1, :value #{token}}}}
2022-01-03 18:18:19 INFO  token-syncer.main - token-syncer: sync-clusters: exiting with code 0
```

## Why are we making these changes?
- prevent unnecessary failures from slowing down a token syncer release and giving false errors during dry run mode