### PR TITLE
adds WAITER_RAVEN_PORT to main container when Raven sidecar is present

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -1240,17 +1240,18 @@
         port->protocol (cond-> {(port->key service-port) actual-backend-proto}
                          health-check-port
                          (assoc (port->key health-check-port) actual-health-check-proto))
-        env (into [;; We set these two "MESOS_*" variables to improve interoperability.
-                   ;; New clients should prefer using WAITER_SANDBOX.
-                   {:name "MESOS_DIRECTORY" :value home-path}
-                   {:name "MESOS_SANDBOX" :value home-path}
-                   {:name "WAITER_SANDBOX" :value home-path}
-                   ;; Number of seconds to wait after receiving a sigterm
-                   ;; before sending a sigkill to the user's process.
-                   ;; This is handled by the waiter-k8s-init script,
-                   ;; separately from the pod's grace period,
-                   ;; in order to provide extra time for logs to sync to an s3 bucket.
-                   {:name "WAITER_GRACE_SECS" :value (str configured-pod-sigkill-delay-secs)}]
+        env (into (cond-> [;; We set these two "MESOS_*" variables to improve interoperability.
+                           ;; New clients should prefer using WAITER_SANDBOX.
+                           {:name "MESOS_DIRECTORY" :value home-path}
+                           {:name "MESOS_SANDBOX" :value home-path}
+                           {:name "WAITER_SANDBOX" :value home-path}
+                           ;; Number of seconds to wait after receiving a sigterm
+                           ;; before sending a sigkill to the user's process.
+                           ;; This is handled by the waiter-k8s-init script,
+                           ;; separately from the pod's grace period,
+                           ;; in order to provide extra time for logs to sync to an s3 bucket.
+                           {:name "WAITER_GRACE_SECS" :value (str configured-pod-sigkill-delay-secs)}]
+                    has-raven? (conj {:name "WAITER_RAVEN_PORT" :value (str service-port)}))
                   (concat
                     (for [[k v] base-env]
                       {:name k :value v})

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -363,7 +363,11 @@
           (is (= service-port (get-in sidecar-container [:ports 0 :containerPort])))
           (is (= (str service-port) env-service-port))
           (is (= port0 (get-in app-container [:ports 0 :containerPort])))
-          (is (= (str port0) env-port0))))
+          (is (= (str port0) env-port0))
+
+          (testing "waiter and raven ports in main container"
+            (is (= (str port0) (get app-env "PORT0" "missing")))
+            (is (= (str service-port) (get app-env "WAITER_RAVEN_PORT" "missing"))))))
 
       (testing "waiter/port-count annotation is correct"
         (let [port-count (get service-description "ports")]


### PR DESCRIPTION
## Changes proposed in this PR

- adds WAITER_RAVEN_PORT to main container when Raven sidecar is present

## Why are we making these changes?

We would like to communicate to the backend service which port Raven sidecar may be running on.

