### PR TITLE
fixes handling of grpc-status headers

### DIFF
--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -658,7 +658,7 @@
   (if trailers
     (let [correlation-id (cid/get-correlation-id)
           trailers-copy-ch (async/chan 1)
-          {:keys [grpc-status] :as grpc-headers} (select-keys headers ["grpc-message" "grpc-status"])]
+          {:strs [grpc-status] :as grpc-headers} (select-keys headers ["grpc-message" "grpc-status"])]
       (if (hu/grpc-status-success? grpc-status)
         (do
           (async/go


### PR DESCRIPTION
## Changes proposed in this PR

- fixes propagation of grpc-status headers as trailers in grpc responses

## Why are we making these changes?

Without propagation of the grpc-status in trailers, gRPC clients complain about gRPC responses.
