### PR TITLE
waiter cli show subcommand displays token per cluster group

### DIFF
--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1499,7 +1499,6 @@ class WaiterCliTest(util.WaiterTest):
         iso_8601_time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
         custom_fields = {
             'owner': getpass.getuser(),
-            'cluster': 'test_show_service_current',
             'root': 'test_show_service_current',
             'last-update-user': getpass.getuser(),
             'last-update-time': iso_8601_time

--- a/cli/integration/tests/waiter/test_cli_multi_cluster.py
+++ b/cli/integration/tests/waiter/test_cli_multi_cluster.py
@@ -64,7 +64,7 @@ class MultiWaiterCliTest(util.WaiterTest):
         finally:
             util.delete_token(self.waiter_url_1, token_name)
 
-    def __test_show_single_cluster_group(self, no_services=False):
+    def __test_show_single_cluster_group(self, no_services=False, enforce_cluster=False):
         config = {'clusters': [{'name': 'waiter1',
                                 'url': self.waiter_url_1,
                                 'default-for-create': True,
@@ -84,9 +84,14 @@ class MultiWaiterCliTest(util.WaiterTest):
             try:
                 service_id_2 = util.ping_token(self.waiter_url_2, token_name)
                 with cli.temp_config_file(config) as path:
-                    cp = cli.show(token_name=token_name, flags='--config %s' % path, show_flags='--no-services' if no_services else '')
+                    show_flags = '--no-services' if no_services else ''
+                    cli_flags = f'--config {path}' + (' --cluster waiter1' if enforce_cluster else '')
+                    cp = cli.show(token_name=token_name, flags=cli_flags, show_flags=show_flags)
                     self.assertEqual(0, cp.returncode, cp.stderr)
-                    self.assertIn(f'production / {token_name}', cli.stdout(cp))
+                    if enforce_cluster:
+                        self.assertIn(f'waiter1 / {token_name}', cli.stdout(cp))                    
+                    else:
+                        self.assertIn(f'production / {token_name}', cli.stdout(cp))
                     self.assertIn(version_1, cli.stdout(cp))
                     self.assertEqual(1, cli.stdout(cp).count(token_name))
 
@@ -94,15 +99,26 @@ class MultiWaiterCliTest(util.WaiterTest):
                         self.assertNotIn(service_id_1, cli.stdout(cp))
                         self.assertNotIn(service_id_2, cli.stdout(cp))
                     else:
+                        if enforce_cluster:
+                            expected_service_count = 1
+                            expected_inst_count = 1
+                            expected_total_mem = token_1['mem']
+                            expected_total_cpus = token_1['cpus']
+                        else:
+                            expected_service_count = 2
+                            expected_inst_count = 2
+                            expected_total_mem = token_1["mem"] + token_2["mem"]
+                            expected_total_cpus = token_1["cpus"] + token_2["cpus"]
+                            self.assertEqual(1, cli.stdout(cp).count(service_id_2))
+                            self.assertIsNotNone(re.search(f'^{service_id_2}\\s+waiter2[^\\n]+Running[^\\n]+Not Current$', cli.stdout(cp), re.MULTILINE))
+
+                        self.assertIsNotNone(re.search(f'^# Services\\s+{expected_service_count}$', cli.stdout(cp), re.MULTILINE))
+                        self.assertIsNotNone(re.search(f'^# Failing\\s+0$', cli.stdout(cp), re.MULTILINE))
+                        self.assertIsNotNone(re.search(f'^# Instances\\s+{expected_inst_count}$', cli.stdout(cp), re.MULTILINE))
+                        self.assertIsNotNone(re.search(f'^Total Memory\\s+{expected_total_mem} MiB$', cli.stdout(cp), re.MULTILINE))
+                        self.assertIsNotNone(re.search(f'^Total CPUs\\s+{expected_total_cpus}$', cli.stdout(cp), re.MULTILINE))
                         self.assertEqual(1, cli.stdout(cp).count(service_id_1))
-                        self.assertEqual(1, cli.stdout(cp).count(service_id_2))
-                        self.assertIsNotNone(re.search('^# Services\\s+2$', cli.stdout(cp), re.MULTILINE))
-                        self.assertIsNotNone(re.search('^# Failing\\s+0$', cli.stdout(cp), re.MULTILINE))
-                        self.assertIsNotNone(re.search('^# Instances\\s+2$', cli.stdout(cp), re.MULTILINE))
-                        self.assertIsNotNone(re.search(f'^Total Memory\\s+{token_1["mem"] + token_2["mem"]} MiB$', cli.stdout(cp), re.MULTILINE))
-                        self.assertIsNotNone(re.search(f'^Total CPUs\\s+{token_1["cpus"] + token_2["cpus"]}$', cli.stdout(cp), re.MULTILINE))
                         self.assertIsNotNone(re.search(f'^{service_id_1}\\s+waiter1[^\\n]+Running[^\\n]+Current$', cli.stdout(cp), re.MULTILINE))
-                        self.assertIsNotNone(re.search(f'^{service_id_2}\\s+waiter2[^\\n]+Running[^\\n]+Not Current$', cli.stdout(cp), re.MULTILINE))
             finally:
                 util.delete_token(self.waiter_url_2, token_name, assert_response=True, kill_services=True)
         finally:
@@ -113,8 +129,11 @@ class MultiWaiterCliTest(util.WaiterTest):
 
     def test_show_single_cluster_group_no_services(self):
         self.__test_show_single_cluster_group(no_services=True)
+    
+    def test_show_single_cluster_group_enforce_cluster(self):
+        self.__test_show_single_cluster_group(enforce_cluster=True)
 
-    def __test_show_multiple_cluster_groups(self, no_services=False):
+    def __test_show_multiple_cluster_groups(self, no_services=False, enforce_cluster=False):
         config = {'clusters': [{'name': 'waiter1',
                                 'url': self.waiter_url_1,
                                 'default-for-create': True,
@@ -134,27 +153,36 @@ class MultiWaiterCliTest(util.WaiterTest):
             try:
                 service_id_2 = util.ping_token(self.waiter_url_2, token_name)
                 with cli.temp_config_file(config) as path:
-                    cp = cli.show(token_name=token_name, flags='--config %s' % path, show_flags='--no-services' if no_services else '')
+                    show_flags = '--no-services' if no_services else ''
+                    cli_flags = f'--config {path}' + (' --cluster waiter1' if enforce_cluster else '')
+                    cp = cli.show(token_name=token_name, flags=cli_flags, show_flags=show_flags)
                     self.assertEqual(0, cp.returncode, cp.stderr)
-                    self.assertIn(f'production / {token_name}', cli.stdout(cp))
-                    self.assertIn(f'staging / {token_name}', cli.stdout(cp))
                     self.assertEqual(1, len(re.findall(f'^Version\\s+{version_1}$', cli.stdout(cp), re.MULTILINE)))
-                    self.assertEqual(1, len(re.findall(f'^Version\\s+{version_2}$', cli.stdout(cp), re.MULTILINE)))
-                    self.assertEqual(2, cli.stdout(cp).count(token_name))
-
+                    if enforce_cluster:
+                        expected_token_count = 1
+                        self.assertIn(f'waiter1 / {token_name}', cli.stdout(cp))
+                        self.assertEqual(1, cli.stdout(cp).count(token_name))
+                    else:
+                        expected_token_count = 2
+                        self.assertIn(f'production / {token_name}', cli.stdout(cp))
+                        self.assertIn(f'staging / {token_name}', cli.stdout(cp))
+                        self.assertEqual(1, len(re.findall(f'^Version\\s+{version_2}$', cli.stdout(cp), re.MULTILINE)))
+                        self.assertEqual(2, cli.stdout(cp).count(token_name))
                     if no_services:
                         self.assertNotIn(service_id_1, cli.stdout(cp))
                         self.assertNotIn(service_id_2, cli.stdout(cp))
                     else:
                         self.assertEqual(1, cli.stdout(cp).count(service_id_1))
-                        self.assertEqual(1, cli.stdout(cp).count(service_id_2))
-                        self.assertEqual(2, len(re.findall('^# Services\\s+1$', cli.stdout(cp), re.MULTILINE)))
-                        self.assertEqual(2, len(re.findall('^# Failing\\s+0$', cli.stdout(cp), re.MULTILINE)))
-                        self.assertEqual(2, len(re.findall('^# Instances\\s+1$', cli.stdout(cp), re.MULTILINE)))
-                        self.assertEqual(2, len(re.findall(f'^Total Memory\\s+{token_1["mem"]} MiB$', cli.stdout(cp), re.MULTILINE)))
-                        self.assertEqual(2, len(re.findall(f'^Total CPUs\\s+{token_1["cpus"]}$', cli.stdout(cp), re.MULTILINE)))
+                        self.assertEqual(expected_token_count, len(re.findall('^# Services\\s+1$', cli.stdout(cp), re.MULTILINE)))
+                        self.assertEqual(expected_token_count, len(re.findall('^# Failing\\s+0$', cli.stdout(cp), re.MULTILINE)))
+                        self.assertEqual(expected_token_count, len(re.findall('^# Instances\\s+1$', cli.stdout(cp), re.MULTILINE)))
+                        self.assertEqual(expected_token_count, len(re.findall(f'^Total Memory\\s+{token_1["mem"]} MiB$', cli.stdout(cp), re.MULTILINE)))
+                        self.assertEqual(expected_token_count, len(re.findall(f'^Total CPUs\\s+{token_1["cpus"]}$', cli.stdout(cp), re.MULTILINE)))
                         self.assertIsNotNone(re.search(f'^{service_id_1}\\s+waiter1[^\\n]+Running[^\\n]+Current$', cli.stdout(cp), re.MULTILINE))
-                        self.assertIsNotNone(re.search(f'^{service_id_2}\\s+waiter2[^\\n]+Running[^\\n]+Current$', cli.stdout(cp), re.MULTILINE))
+                        if not enforce_cluster:
+                            self.assertEqual(1, cli.stdout(cp).count(service_id_2))
+                            self.assertEqual(1, cli.stdout(cp).count(service_id_2))
+                            self.assertIsNotNone(re.search(f'^{service_id_2}\\s+waiter2[^\\n]+Running[^\\n]+Current$', cli.stdout(cp), re.MULTILINE))
             finally:
                 util.delete_token(self.waiter_url_2, token_name, assert_response=True, kill_services=True)
         finally:
@@ -165,6 +193,9 @@ class MultiWaiterCliTest(util.WaiterTest):
 
     def test_show_multiple_cluster_groups_no_services(self):
         self.__test_show_multiple_cluster_groups(no_services=True)
+
+    def test_show_multiple_cluster_groups_enforce_cluster(self):
+        self.__test_show_multiple_cluster_groups(enforce_cluster=True)
 
     def test_federated_delete(self):
         # Create in cluster #1

--- a/cli/integration/tests/waiter/test_cli_multi_cluster.py
+++ b/cli/integration/tests/waiter/test_cli_multi_cluster.py
@@ -94,7 +94,6 @@ class MultiWaiterCliTest(util.WaiterTest):
                         self.assertIn(f'production / {token_name}', cli.stdout(cp))
                     self.assertIn(version_1, cli.stdout(cp))
                     self.assertEqual(1, cli.stdout(cp).count(token_name))
-
                     if no_services:
                         self.assertNotIn(service_id_1, cli.stdout(cp))
                         self.assertNotIn(service_id_2, cli.stdout(cp))
@@ -111,7 +110,6 @@ class MultiWaiterCliTest(util.WaiterTest):
                             expected_total_cpus = token_1["cpus"] + token_2["cpus"]
                             self.assertEqual(1, cli.stdout(cp).count(service_id_2))
                             self.assertIsNotNone(re.search(f'^{service_id_2}\\s+waiter2[^\\n]+Running[^\\n]+Not Current$', cli.stdout(cp), re.MULTILINE))
-
                         self.assertIsNotNone(re.search(f'^# Services\\s+{expected_service_count}$', cli.stdout(cp), re.MULTILINE))
                         self.assertIsNotNone(re.search(f'^# Failing\\s+0$', cli.stdout(cp), re.MULTILINE))
                         self.assertIsNotNone(re.search(f'^# Instances\\s+{expected_inst_count}$', cli.stdout(cp), re.MULTILINE))

--- a/cli/waiter/subcommands/show.py
+++ b/cli/waiter/subcommands/show.py
@@ -79,7 +79,9 @@ def show(clusters, args, _, enforce_cluster):
         display_data(args, query_result)
     elif enforce_cluster:
         for cluster_name, entities in query_result['clusters'].items():
-            print(tabulate_token(cluster_name, entities['token'], token_name, entities.get('services', []), entities['etag']))
+            services = [{'cluster': cluster_name, **service}
+                        for service in entities.get('services', [])]
+            print(tabulate_token(cluster_name, entities['token'], token_name, services, entities['etag']))
             print()
     else:
         clusters_in_result = [cluster

--- a/cli/waiter/subcommands/show.py
+++ b/cli/waiter/subcommands/show.py
@@ -1,11 +1,12 @@
 from tabulate import tabulate
+from functools import reduce
 
 from waiter import terminal
 from waiter.data_format import display_data
 from waiter.format import format_field_name, format_mem_field, format_timestamp_string
 
 from waiter.display import tabulate_token_services
-from waiter.querying import print_no_data, query_token
+from waiter.querying import get_target_cluster_from_token, print_no_data, query_token
 from waiter.util import guard_no_cluster
 
 
@@ -14,6 +15,8 @@ def tabulate_token(cluster_name, token, token_name, services, token_etag):
     table = [['Owner', token['owner']]]
     if token.get('name'):
         table.append(['Name', token['name']])
+    if token.get('cluster'):
+        table.append(['Primary Cluster', token['cluster']])
     if token.get('cpus'):
         table.append(['CPUs', token['cpus']])
     if token.get('mem'):
@@ -27,9 +30,9 @@ def tabulate_token(cluster_name, token, token_name, services, token_etag):
     if token.get('permitted-user'):
         table.append(['Permitted user(s)', token['permitted-user']])
 
-    explicit_keys = ('cmd', 'cmd-type', 'cpus', 'env', 'health-check-url', 'last-update-time',
+    explicit_keys = ('cluster', 'cmd', 'cmd-type', 'cpus', 'env', 'health-check-url', 'last-update-time',
                      'last-update-user', 'mem', 'name', 'owner', 'permitted-user', 'ports')
-    ignored_keys = ('cluster', 'previous', 'root')
+    ignored_keys = ('previous', 'root')
     for key, value in token.items():
         if key not in (explicit_keys + ignored_keys):
             table.append([format_field_name(key), value])
@@ -48,7 +51,7 @@ def tabulate_token(cluster_name, token, token_name, services, token_etag):
     table_text = tabulate(table, tablefmt='plain')
     last_update_time = format_timestamp_string(token['last-update-time'])
     last_update_user = f' ({token["last-update-user"]})' if 'last-update-user' in token else ''
-    column_names = ['Service Id', 'Run as user', 'Instances', 'CPUs', 'Memory', 'Version', 'Status', 'Last request',
+    column_names = ['Service Id', 'Cluster', 'Run as user', 'Instances', 'CPUs', 'Memory', 'Version', 'Status', 'Last request',
                     'Current?']
     service_table, _ = tabulate_token_services(services, token_name, token_etag=token_etag, column_names=column_names)
     return f'\n' \
@@ -76,9 +79,23 @@ def show(clusters, args, _, __):
     if as_json or as_yaml:
         display_data(args, query_result)
     else:
-        for cluster_name, entities in sorted(query_result['clusters'].items()):
-            services = entities['services'] if include_services else []
-            print(tabulate_token(cluster_name, entities['token'], token_name, services, entities['etag']))
+        clusters_in_result = [cluster
+                              for cluster in clusters
+                              if cluster['name'] in query_result['clusters']]
+        def add_cluster_to_cluster_group_dict(cluster_groups, cluster):
+            cluster_name = cluster.get('name')
+            cluster_group_name = cluster.get('sync-group', cluster_name)
+            clusters_in_group = [*cluster_groups.get(cluster_group_name, []), cluster]
+            return {**cluster_groups, f'{cluster_group_name}': clusters_in_group}
+        cluster_group_name_to_clusters = reduce(add_cluster_to_cluster_group_dict, clusters_in_result, dict())
+
+        for cluster_group_name, cluster_group_clusters in cluster_group_name_to_clusters.items():
+            primary_cluster = get_target_cluster_from_token(cluster_group_clusters, token_name, False)
+            entities = query_result['clusters'][primary_cluster['name']]
+            all_services_in_cluster_group = [{'cluster': cluster['name'], **service}
+                                             for cluster in cluster_group_clusters
+                                             for service in query_result['clusters'][cluster['name']]['services']]
+            print(tabulate_token(cluster_group_name, entities['token'], token_name, all_services_in_cluster_group, entities['etag']))
             print()
 
     if query_result['count'] > 0:

--- a/cli/waiter/subcommands/show.py
+++ b/cli/waiter/subcommands/show.py
@@ -78,10 +78,9 @@ def show(clusters, args, _, enforce_cluster):
     if as_json or as_yaml:
         display_data(args, query_result)
     elif enforce_cluster:
-        cluster_name = clusters[0]['name']
-        entities = query_result['clusters'][cluster_name]
-        print(tabulate_token(cluster_name, entities['token'], token_name, entities.get('services', []), entities['etag']))
-        print()
+        for cluster_name, entities in query_result['clusters'].items():
+            print(tabulate_token(cluster_name, entities['token'], token_name, entities.get('services', []), entities['etag']))
+            print()
     else:
         clusters_in_result = [cluster
                               for cluster in clusters

--- a/cli/waiter/subcommands/show.py
+++ b/cli/waiter/subcommands/show.py
@@ -75,7 +75,7 @@ def show(clusters, args, _, __):
     include_services = not args.get('no-services')
 
     query_result = query_token(clusters, token_name, include_services=include_services)
-
+    # TODO: what if --cluster is specified?
     if as_json or as_yaml:
         display_data(args, query_result)
     else:
@@ -94,7 +94,7 @@ def show(clusters, args, _, __):
             entities = query_result['clusters'][primary_cluster['name']]
             all_services_in_cluster_group = [{'cluster': cluster['name'], **service}
                                              for cluster in cluster_group_clusters
-                                             for service in query_result['clusters'][cluster['name']]['services']]
+                                             for service in query_result['clusters'][cluster['name']].get('services', [])]
             print(tabulate_token(cluster_group_name, entities['token'], token_name, all_services_in_cluster_group, entities['etag']))
             print()
 


### PR DESCRIPTION
## Changes proposed in this PR

- waiter show collapses tokens if they are in the same cluster group
- single cluster group scenario:
![Screenshot from 2022-01-14 12-43-41](https://user-images.githubusercontent.com/8290559/149568438-57bb9b1b-25cb-4871-9de3-8cd41da4b703.png)

- multi cluster group scenario:
![Screenshot from 2022-01-14 12-43-14](https://user-images.githubusercontent.com/8290559/149568397-6c1c293d-60bb-45d5-b07b-437a90a7457c.png)


## Why are we making these changes?
- collapsing when doing `waiter show [token]` will simplify the view in multi waiter cluster group scenarios.
- users can continue to view just a single cluster by enforcing it with `waiter --cluster waiter1 show [token]` as an example
