### PR TITLE
avoids merge when old entry is an empty map

### DIFF
--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -404,7 +404,7 @@
             provided-param-value (get provided-params parameter-key)]
         (recur remaining-parameter-keys
                (cond-> loop-params
-                 (and (map? default-param-value) (map? provided-param-value))
+                 (and (map? default-param-value) (seq default-param-value) (map? provided-param-value))
                  (assoc parameter-key (merge default-param-value provided-param-value)))))
       loop-params)))
 


### PR DESCRIPTION
## Changes proposed in this PR

- avoids merge when old entry is an empty map

## Why are we making these changes?

Micro-optimization: Avoids creating a new map if the output is not going to change.
