### PR TITLE
adds endpoint for querying custom component state

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -985,6 +985,8 @@
  ;; Custom components allow sharing of components between the scheduler and service description builder.
  ;; The values in the entries must contain a :factory-fn and the necessary config for the component.
  ;; Components also get passed in the :kv-store-factory, :leader?-fn and :synchronize-fn for use in the factory.
+ ;; Components which contain a :query-state entry that maps to a function which takes include-flags as an argument
+ ;; can have their state queries and viewed at the /state/custom-component/<name> endpoint.
  :custom-components {:in-memory-kv-store {:factory-fn waiter.kv/new-local-kv-store}}
 
  ;; Certain messages that Waiter returns can be customized:

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -119,6 +119,7 @@
                               ["/autoscaler" :state-autoscaler-handler-fn]
                               ["/autoscaling-multiplexer" :state-autoscaling-multiplexer-handler-fn]
                               ["/codahale-reporters" :state-codahale-reporters-handler-fn]
+                              [["/custom-components/" :component-name] :state-custom-component-handler-fn]
                               ["/ejection-expiry" :state-ejection-expiry-handler-fn]
                               ["/entitlement-manager" :state-entitlement-manager-handler-fn]
                               ["/fallback" :state-fallback-handler-fn]
@@ -1718,12 +1719,12 @@
                                          scheduler service-id admin-user?-fn allowed-to-manage-service?-fn generate-log-url-fn request))))
    :sim-request-handler (pc/fnk [] simulator/handle-sim-request)
    :state-all-handler-fn (pc/fnk [[:daemons router-state-maintainer]
-                                  [:state router-id]
+                                  [:state custom-components router-id]
                                   wrap-secure-request-fn]
                            (let [{{:keys [query-state-fn]} :maintainer} router-state-maintainer]
                              (wrap-secure-request-fn
                                (fn state-all-handler-fn [request]
-                                 (handler/get-router-state router-id query-state-fn request)))))
+                                 (handler/get-router-state router-id query-state-fn custom-components request)))))
    :state-autoscaler-handler-fn (pc/fnk [[:daemons autoscaler]
                                          [:state router-id]
                                          wrap-secure-request-fn]
@@ -1745,6 +1746,11 @@
                                               router-id
                                               #(pc/map-vals reporter/state codahale-reporters)
                                               request)))
+   :state-custom-component-handler-fn (pc/fnk [[:state custom-components router-id]
+                                               wrap-secure-request-fn]
+                                        (wrap-secure-request-fn
+                                          (fn custom-component-state-handler-fn [request]
+                                            (handler/get-custom-component-state router-id custom-components request))))
    :state-ejection-expiry-handler-fn (pc/fnk [[:state ejection-expiry-tracker router-id]
                                               wrap-secure-request-fn]
                                        (wrap-secure-request-fn

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -1150,12 +1150,40 @@
            (exec-routes-mapper "/sim")))
     (is (= {:handler :state-all-handler-fn}
            (exec-routes-mapper "/state")))
+    (is (= {:handler :state-autoscaler-handler-fn}
+           (exec-routes-mapper "/state/autoscaler")))
+    (is (= {:handler :state-autoscaling-multiplexer-handler-fn}
+           (exec-routes-mapper "/state/autoscaling-multiplexer")))
+    (is (= {:handler :state-codahale-reporters-handler-fn}
+           (exec-routes-mapper "/state/codahale-reporters")))
+    (is (= {:handler :state-custom-component-handler-fn, :route-params {:component-name "component-1"}}
+           (exec-routes-mapper "/state/custom-components/component-1")))
+    (is (= {:handler :state-ejection-expiry-handler-fn}
+           (exec-routes-mapper "/state/ejection-expiry")))
+    (is (= {:handler :state-entitlement-manager-handler-fn}
+           (exec-routes-mapper "/state/entitlement-manager")))
+    (is (= {:handler :state-fallback-handler-fn}
+           (exec-routes-mapper "/state/fallback")))
+    (is (= {:handler :state-gc-for-broken-services}
+           (exec-routes-mapper "/state/gc-broken-services")))
+    (is (= {:handler :state-gc-for-services}
+           (exec-routes-mapper "/state/gc-services")))
+    (is (= {:handler :state-gc-for-transient-metrics}
+           (exec-routes-mapper "/state/gc-transient-metrics")))
+    (is (= {:handler :state-instance-tracker-fn}
+           (exec-routes-mapper "/state/instance-tracker")))
+    (is (= {:handler :state-interstitial-handler-fn}
+           (exec-routes-mapper "/state/interstitial")))
+    (is (= {:handler :state-jwt-auth-server-handler-fn}
+           (exec-routes-mapper "/state/jwt-auth-server")))
     (is (= {:handler :state-kv-store-handler-fn}
            (exec-routes-mapper "/state/kv-store")))
-    (is (= {:handler :state-local-usage-handler-fn}
-           (exec-routes-mapper "/state/local-usage")))
+    (is (= {:handler :state-launch-metrics-handler-fn}
+           (exec-routes-mapper "/state/launch-metrics")))
     (is (= {:handler :state-leader-handler-fn}
            (exec-routes-mapper "/state/leader")))
+    (is (= {:handler :state-local-usage-handler-fn}
+           (exec-routes-mapper "/state/local-usage")))
     (is (= {:handler :state-maintainer-handler-fn}
            (exec-routes-mapper "/state/maintainer")))
     (is (= {:handler :state-router-metrics-handler-fn}
@@ -1166,6 +1194,12 @@
            (exec-routes-mapper "/state/statsd")))
     (is (= {:handler :state-service-handler-fn, :route-params {:service-id "test-service"}}
            (exec-routes-mapper "/state/test-service")))
+    (is (= {:handler :state-token-validator-fn}
+           (exec-routes-mapper "/state/token-validator")))
+    (is (= {:handler :state-token-watch-maintainer-fn}
+           (exec-routes-mapper "/state/token-watch-maintainer")))
+    (is (= {:handler :state-work-stealing-handler-fn}
+           (exec-routes-mapper "/state/work-stealing")))
     (is (= {:handler :status-handler-fn}
            (exec-routes-mapper "/status")))
     (is (= {:handler :token-handler-fn}


### PR DESCRIPTION
## Changes proposed in this PR

- adds endpoint for querying custom component state

## Why are we making these changes?

We should be able to use the API and query state for any of our components, including the custom components.

### Example output

<img width="489" alt="Screen Shot 2022-02-10 at 6 47 39 AM" src="https://user-images.githubusercontent.com/6611249/153411616-a51166c8-a5a9-4007-ac8c-80faa3c6232c.png">

