### PR TITLE
removes OIDC auth cookies from request sent to the backend

### DIFF
--- a/waiter/src/waiter/auth/authentication.clj
+++ b/waiter/src/waiter/auth/authentication.clj
@@ -29,7 +29,13 @@
 
 (def ^:const AUTH-COOKIE-EXPIRES-AT "x-auth-expires-at")
 
+(def ^:const AUTH-COOKIE-EXPIRES-AT-ENTRY-PREFIX (str AUTH-COOKIE-EXPIRES-AT "="))
+
 (def ^:const AUTH-COOKIE-NAME "x-waiter-auth")
+
+(def ^:const AUTH-COOKIE-NAME-ENTRY-PREFIX (str AUTH-COOKIE-NAME "="))
+
+(def ^:const OIDC-CHALLENGE-COOKIE-PREFIX "x-waiter-oidc-challenge-")
 
 (def ^:const auth-expires-at-uri "/.well-known/auth/expires-at")
 
@@ -157,9 +163,9 @@
 (defn remove-auth-cookie
   "Removes the auth cookies"
   [cookie-string]
-  (-> cookie-string
-    (cookie-support/remove-cookie AUTH-COOKIE-EXPIRES-AT)
-    (cookie-support/remove-cookie AUTH-COOKIE-NAME)))
+  (when cookie-string
+    (->> [AUTH-COOKIE-EXPIRES-AT-ENTRY-PREFIX AUTH-COOKIE-NAME-ENTRY-PREFIX OIDC-CHALLENGE-COOKIE-PREFIX]
+      (cookie-support/remove-cookies cookie-string))))
 
 (defn select-auth-header
   "Filters and return the first authorization header that passes the predicate."

--- a/waiter/src/waiter/auth/oidc.clj
+++ b/waiter/src/waiter/auth/oidc.clj
@@ -35,7 +35,7 @@
 
 (def ^:const content-security-policy-value "default-src 'none'; frame-ancestors 'none'")
 
-(def ^:const oidc-challenge-cookie-prefix "x-waiter-oidc-challenge-")
+(def ^:const oidc-challenge-cookie-prefix auth/OIDC-CHALLENGE-COOKIE-PREFIX)
 
 (def ^:const oidc-callback-uri "/oidc/v1/callback")
 

--- a/waiter/src/waiter/cookie_support.clj
+++ b/waiter/src/waiter/cookie_support.clj
@@ -51,11 +51,14 @@
       (when-let [^String value (second (re-find name-regex cookie-string))]
         (-> value url-decode strip-double-quotes)))))
 
-(defn remove-cookie
-  "Removes the specified cookie"
-  [cookie-string cookie-name]
+(defn remove-cookies
+  "Removes the entries in the cookie string with the specified prefixes."
+  [cookie-string cookie-name-prefixes]
   (when cookie-string
-    (str/replace cookie-string (re-pattern (str "(?i)(^" cookie-name "=[^;]+(; )?)|(; " cookie-name "=[^;]+)")) "")))
+    ;; cookie pairs are separated by a semicolon and a space ('; ').
+    (->> (str/split cookie-string #"; ")
+      (remove (fn [entry] (some #(str/starts-with? entry %) cookie-name-prefixes)))
+      (str/join "; "))))
 
 (defn encode-cookie
   "Encodes the cookie value."

--- a/waiter/test/waiter/auth/authenticator_test.clj
+++ b/waiter/test/waiter/auth/authenticator_test.clj
@@ -481,3 +481,21 @@
       (is (= http-400-bad-request response-status))
       (is (= http-400-bad-request (.getStatusCode upgrade-response)))
       (is (str/includes? (.getStatusReason upgrade-response) "An authentication disabled token may not be combined with on-the-fly headers")))))
+
+(deftest test-remove-auth-cookie
+  (doseq [{:keys [cookie-string expected] :as test-case}
+          [{:cookie-string nil :expected nil}
+           {:cookie-string "" :expected ""}
+           {:cookie-string "a=b" :expected "a=b"}
+           {:cookie-string "a=b; c=d" :expected "a=b; c=d"}
+           {:cookie-string "a=b; x-auth-expires-at=1234; c=d" :expected "a=b; c=d"}
+           {:cookie-string "a=b; x-auth-expires-at=1234; c=d; x-waiter-auth=1234" :expected "a=b; c=d"}
+           {:cookie-string "x-auth-expires-at=1234; a=b" :expected "a=b"}
+           {:cookie-string "x-waiter-auth=1234; a=b" :expected "a=b"}
+           {:cookie-string "a=b; x-waiter-auth=1234" :expected "a=b"}
+           {:cookie-string "x-waiter-auth-a1b2c3=1234; a=b" :expected "x-waiter-auth-a1b2c3=1234; a=b"}
+           {:cookie-string "a-x-waiter-auth=1234; a=b" :expected "a-x-waiter-auth=1234; a=b"}
+           {:cookie-string "a=b; c-x-auth-expires-at=1234" :expected "a=b; c-x-auth-expires-at=1234"}
+           {:cookie-string "a=b; x-auth-expires-at-c=1234" :expected "a=b; x-auth-expires-at-c=1234"}
+           {:cookie-string "x-waiter-oidc-challenge-a1b2c3=123; x-waiter-oidc-challenge-3cb2a1=321; a=b" :expected "a=b"}]]
+    (is (= expected (remove-auth-cookie cookie-string)) (str test-case))))

--- a/waiter/test/waiter/auth/oidc_test.clj
+++ b/waiter/test/waiter/auth/oidc_test.clj
@@ -696,3 +696,33 @@
     (is (false? (too-many-oidc-challenge-cookies? {:headers {"cookie" cookie-str}} 6)))
     (is (true? (too-many-oidc-challenge-cookies? {:headers {"cookie" cookie-str}} 5)))
     (is (true? (too-many-oidc-challenge-cookies? {:headers {"cookie" cookie-str}} 1)))))
+
+(deftest test-remove-challenge-cookies
+  (doseq [{:keys [cookie-string expected] :as test-case}
+          [{:cookie-string nil :expected nil}
+           {:cookie-string "a=b" :expected "a=b"}
+           {:cookie-string "a=b; c=d" :expected "a=b; c=d"}
+           {:cookie-string "x-waiter-oidc-challenge-A1B2C3=1234; a=b" :expected "a=b"}
+           {:cookie-string "a=b; x-waiter-oidc-challenge-A1B2C3=1234" :expected "a=b"}
+           {:cookie-string "x-waiter-oidc-challenge-a1b2c3=1234; a=b" :expected "a=b"}
+           {:cookie-string "a=b; x-waiter-oidc-challenge-a1b2c3=1234" :expected "a=b"}
+           {:cookie-string "a=b; x-waiter-oidc-challenge-a1b2c3=1234" :expected "a=b"}
+           {:cookie-string "x-waiter-oidc-challenge-a1b2c3=123; x-waiter-oidc-challenge-3cb2a1=321; a=b" :expected "a=b"}
+           {:cookie-string "x-waiter-oidc-challenge-a1b2c3=123; a=b; x-waiter-oidc-challenge-3cb2a1=321" :expected "a=b"}
+           {:cookie-string "a=b; x-waiter-oidc-challenge-a1b2c3=123; x-waiter-oidc-challenge-3cb2a1=321" :expected "a=b"}
+           {:cookie-string "x-waiter-oidc-challenge-A1B2C3=1234; a=b; c=d" :expected "a=b; c=d"}
+           {:cookie-string "a=b; x-waiter-oidc-challenge-A1B2C3=1234; c=d" :expected "a=b; c=d"}
+           {:cookie-string "x-waiter-oidc-challenge-a1b2c3=1234; a=b; c=d" :expected "a=b; c=d"}
+           {:cookie-string "a=b; x-waiter-oidc-challenge-a1b2c3=1234; c=d" :expected "a=b; c=d"}
+           {:cookie-string "a=b; c=d; x-waiter-oidc-challenge-a1b2c3=1234" :expected "a=b; c=d"}
+           {:cookie-string "x-waiter-oidc-challenge-a1b2c3=123; x-waiter-oidc-challenge-3cb2a1=321; a=b; c=d" :expected "a=b; c=d"}
+           {:cookie-string "x-waiter-oidc-challenge-a1b2c3=123; a=b; x-waiter-oidc-challenge-3cb2a1=321; c=d" :expected "a=b; c=d"}
+           {:cookie-string "x-waiter-oidc-challenge-a1b2c3=123; a=b; c=d; x-waiter-oidc-challenge-3cb2a1=321" :expected "a=b; c=d"}
+           {:cookie-string "a=b; x-waiter-oidc-challenge-a1b2c3=123; x-waiter-oidc-challenge-3cb2a1=321; c=d" :expected "a=b; c=d"}
+           {:cookie-string "a=b; x-waiter-oidc-challenge-a1b2c3=123; c=d; x-waiter-oidc-challenge-3cb2a1=321" :expected "a=b; c=d"}
+           {:cookie-string "a=b; c=d; x-waiter-oidc-challenge-a1b2c3=123; x-waiter-oidc-challenge-3cb2a1=321" :expected "a=b; c=d"}
+           {:cookie-string "x-waiter-oidc-challenge-a1b2c3=123; x-waiter-oidc-challenge-4d5e6f=456; x-waiter-oidc-challenge-3cb2a1=321; a=b; c=d" :expected "a=b; c=d"}
+           {:cookie-string "x-waiter-oidc-challenge-a1b2c3=123; a=b; x-waiter-oidc-challenge-3cb2a1=321; x-waiter-oidc-challenge-4d5e6f=456; c=d" :expected "a=b; c=d"}
+           {:cookie-string "x-waiter-oidc-challenge-a1b2c3=123; a=b; c=d; x-waiter-oidc-challenge-3cb2a1=321; x-waiter-oidc-challenge-4d5e6f=456" :expected "a=b; c=d"}
+           {:cookie-string "a=b; x-waiter-oidc-challenge-a1b2c3=123; x-waiter-oidc-challenge-3cb2a1=321; c=d; x-waiter-oidc-challenge-4d5e6f=456" :expected "a=b; c=d"}]]
+    (is (= expected (auth/remove-auth-cookie cookie-string)) (str test-case))))

--- a/waiter/test/waiter/auth/oidc_test.clj
+++ b/waiter/test/waiter/auth/oidc_test.clj
@@ -700,13 +700,14 @@
 (deftest test-remove-challenge-cookies
   (doseq [{:keys [cookie-string expected] :as test-case}
           [{:cookie-string nil :expected nil}
+           {:cookie-string "" :expected ""}
            {:cookie-string "a=b" :expected "a=b"}
            {:cookie-string "a=b; c=d" :expected "a=b; c=d"}
            {:cookie-string "x-waiter-oidc-challenge-A1B2C3=1234; a=b" :expected "a=b"}
            {:cookie-string "a=b; x-waiter-oidc-challenge-A1B2C3=1234" :expected "a=b"}
            {:cookie-string "x-waiter-oidc-challenge-a1b2c3=1234; a=b" :expected "a=b"}
            {:cookie-string "a=b; x-waiter-oidc-challenge-a1b2c3=1234" :expected "a=b"}
-           {:cookie-string "a=b; x-waiter-oidc-challenge-a1b2c3=1234" :expected "a=b"}
+           {:cookie-string "a=b; c-x-waiter-oidc-challenge-a1b2c3=1234" :expected "a=b; c-x-waiter-oidc-challenge-a1b2c3=1234"}
            {:cookie-string "x-waiter-oidc-challenge-a1b2c3=123; x-waiter-oidc-challenge-3cb2a1=321; a=b" :expected "a=b"}
            {:cookie-string "x-waiter-oidc-challenge-a1b2c3=123; a=b; x-waiter-oidc-challenge-3cb2a1=321" :expected "a=b"}
            {:cookie-string "a=b; x-waiter-oidc-challenge-a1b2c3=123; x-waiter-oidc-challenge-3cb2a1=321" :expected "a=b"}
@@ -715,6 +716,7 @@
            {:cookie-string "x-waiter-oidc-challenge-a1b2c3=1234; a=b; c=d" :expected "a=b; c=d"}
            {:cookie-string "a=b; x-waiter-oidc-challenge-a1b2c3=1234; c=d" :expected "a=b; c=d"}
            {:cookie-string "a=b; c=d; x-waiter-oidc-challenge-a1b2c3=1234" :expected "a=b; c=d"}
+           {:cookie-string "a=b; c=d; x-waiter-oidc-a1b2c3=1234" :expected "a=b; c=d; x-waiter-oidc-a1b2c3=1234"}
            {:cookie-string "x-waiter-oidc-challenge-a1b2c3=123; x-waiter-oidc-challenge-3cb2a1=321; a=b; c=d" :expected "a=b; c=d"}
            {:cookie-string "x-waiter-oidc-challenge-a1b2c3=123; a=b; x-waiter-oidc-challenge-3cb2a1=321; c=d" :expected "a=b; c=d"}
            {:cookie-string "x-waiter-oidc-challenge-a1b2c3=123; a=b; c=d; x-waiter-oidc-challenge-3cb2a1=321" :expected "a=b; c=d"}

--- a/waiter/test/waiter/cookie_support_test.clj
+++ b/waiter/test/waiter/cookie_support_test.clj
@@ -38,14 +38,14 @@
     (is (= "quotes\"abound" (cookie-value cookie-string #"special")))))
 
 (deftest test-remove-cookie
-  (is (= "" (remove-cookie "x-waiter-auth=foo" "x-waiter-auth")))
-  (is (= "bar=baz" (remove-cookie "x-waiter-auth=foo; bar=baz" "x-waiter-auth")))
-  (is (= "bar=baz" (remove-cookie "bar=baz; x-waiter-auth=foo" "x-waiter-auth")))
-  (is (= "bar=\"x-waiter-auth=this is a real cookie\"" (remove-cookie "x-waiter-auth=auth-value; bar=\"x-waiter-auth=this is a real cookie\""
-                                                                      "x-waiter-auth")))
-  (is (= "bar=x-waiter-auth=this is a real cookie" (remove-cookie "x-waiter-auth=auth-value; bar=x-waiter-auth=this is a real cookie"
-                                                                  "x-waiter-auth")))
-  (is (= "a=b; c=d" (remove-cookie "a=b; x-waiter-auth=auth; c=d" "x-waiter-auth"))))
+  (is (= "" (remove-cookies "x-waiter-auth=foo" ["x-waiter-auth="])))
+  (is (= "bar=baz" (remove-cookies "x-waiter-auth=foo; bar=baz" ["x-waiter-auth="])))
+  (is (= "bar=baz" (remove-cookies "bar=baz; x-waiter-auth=foo" ["x-waiter-auth="])))
+  (is (= "bar=\"x-waiter-auth=this is a real cookie\"" (remove-cookies "x-waiter-auth=auth-value; bar=\"x-waiter-auth=this is a real cookie\""
+                                                                       ["x-waiter-auth="])))
+  (is (= "bar=x-waiter-auth=this is a real cookie" (remove-cookies "x-waiter-auth=auth-value; bar=x-waiter-auth=this is a real cookie"
+                                                                   ["x-waiter-auth="])))
+  (is (= "a=b; c=d" (remove-cookies "a=b; x-waiter-auth=auth; c=d" ["x-waiter-auth="]))))
 
 (deftest test-add-encoded-cookie
   (let [cookie-attrs ";Max-Age=864000;Path=/;HttpOnly=true"

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -297,7 +297,7 @@
                              "content-length" "12341234"
                              "content-MD5" "Q2hlY2sgSW50ZWdyaXR5IQ=="
                              "content-type" "application/x-www-form-urlencoded"
-                             "cookie" "$Version=1; Skin=new;"
+                             "cookie" "$Version=1; Skin=new; x-waiter-auth=foo"
                              "date" "Tue, 15 Nov 2015 08:12:31 GMT"
                              "expect" "100-continue"
                              "expires" "2200-08-09"
@@ -342,6 +342,7 @@
                                         (is (= "body" (:body request-config)))
                                         (is (= 654321 (:idle-timeout request-config)))
                                         (is (= (-> passthrough-headers
+                                                   (assoc "cookie" "$Version=1; Skin=new")
                                                    (dissoc "expect" "authorization"
                                                            "connection" "keep-alive" "proxy-authenticate" "proxy-authorization"
                                                            "te" "trailers" "transfer-encoding" "upgrade")


### PR DESCRIPTION
## Changes proposed in this PR

- removes OIDC auth cookies from request sent to the backend

## Why are we making these changes?

The backend is not expected to process OIDC auth cookies generated by Waiter, we should avoid sending them to the backend.

