### PR TITLE
adds header counts and cookie length to the request log

### DIFF
--- a/waiter/src/waiter/request_log.clj
+++ b/waiter/src/waiter/request_log.clj
@@ -31,16 +31,18 @@
   "Convert a request into a context suitable for logging."
   [{:keys [client-protocol headers internal-protocol query-string remote-addr request-id
            request-method request-time server-port uri] :as request}]
-  (let [{:strs [content-length content-type host origin referer user-agent x-cid x-forwarded-for]} headers
+  (let [{:strs [content-length content-type cookie host origin referer user-agent x-cid x-forwarded-for]} headers
         remote-address (or x-forwarded-for remote-addr)]
     (cond-> {:cid x-cid
              :host host
              :path uri
+             :request-header-count (count headers)
              :request-id request-id
              :scheme (-> request utils/request->scheme name)}
       origin (assoc :origin origin)
       request-method (assoc :method (-> request-method name str/upper-case))
       client-protocol (assoc :client-protocol client-protocol)
+      cookie (assoc :cookie-header-length (-> cookie (str) (count)))
       internal-protocol (assoc :internal-protocol internal-protocol)
       query-string (assoc :query-string query-string)
       remote-address (assoc :remote-addr remote-address)
@@ -64,7 +66,7 @@
         {:strs [image metric-group profile run-as-user version]} service-description
         {:strs [content-length content-type grpc-status location server x-raven-response-flags x-waiter-operation-result]} headers
         {:keys [k8s/node-name k8s/pod-name]} instance]
-    (cond-> {}
+    (cond-> {:response-header-count (count headers)}
       status (assoc :status status)
       method (assoc :authentication-method (name method))
       backend-response-latency-ns (assoc :backend-response-latency-ns backend-response-latency-ns)

--- a/waiter/test/waiter/request_log_test.clj
+++ b/waiter/test/waiter/request_log_test.clj
@@ -23,6 +23,7 @@
   (let [request {:client-protocol "HTTP/2.0"
                  :headers {"content-length" "20"
                            "content-type" "application/json"
+                           "cookie" "a=b; c=d; e=f; g=h"
                            "host" "host"
                            "origin" "www.origin.org"
                            "referer" "https://test.com/referer"
@@ -39,6 +40,7 @@
                  :uri "/"}]
     (is (= {:cid "123"
             :client-protocol "HTTP/2.0"
+            :cookie-header-length 18
             :host "host"
             :internal-protocol "HTTP/1.1"
             :method "POST"
@@ -49,6 +51,7 @@
             :remote-addr "127.0.0.1"
             :request-content-length "20"
             :request-content-type "application/json"
+            :request-header-count 8
             :request-id "abc"
             :request-time "2018-04-11T00:00:00.000Z"
             :scheme "http"
@@ -118,6 +121,7 @@
             :request-type "test-request"
             :response-content-length "40"
             :response-content-type "application/xml"
+            :response-header-count 7
             :response-location "/foo/bar"
             :run-as-user "john.doe"
             :server "foo-bar"
@@ -214,9 +218,11 @@
                 :k8s-pod-name "test-pod-name"
                 :latest-service-id "latest-service-id"
                 :metric-group "service-metric-group"
+                :request-header-count 6
                 :request-type "test-request"
                 :response-content-length "40"
                 :response-content-type "application/xml"
+                :response-header-count 5
                 :response-location "/foo/bar"
                 :run-as-user "john.doe"
                 :server "foo-bar"
@@ -250,7 +256,9 @@
                 :path "/path"
                 :remote-addr "127.0.0.1"
                 :request-content-type "text/plain"
+                :request-header-count 3
                 :request-id "abc"
+                :response-header-count 0
                 :scheme "http"
                 :status http-200-ok}
                (dissoc log-entry :handle-request-latency-ns)))))))


### PR DESCRIPTION
## Changes proposed in this PR

- adds header counts and cookie length to the request log

## Why are we making these changes?

Including header counts and cookie length gives us a sense of the header data we are receiving in requests and can help inspect with `431` responses from backends.


