### PR TITLE
reports deployment error in get service endpoint

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1577,7 +1577,7 @@
                                  user-agent (str "waiter-ping/" user-agent-version)
                                  handler (wrap-descriptor-fn
                                            (fn inner-ping-service-handler [request]
-                                             (let [retrieve-service-status-label-fn #(service/retrieve-service-status-label % (query-state-fn))
+                                             (let [retrieve-service-status-label-fn #(:service-status-label (service/retrieve-service-status-and-deployment-error % (query-state-fn)))
                                                    service-state-fn (partial descriptor/extract-service-state router-id retrieve-service-status-label-fn fallback-state-atom make-inter-router-requests-async-fn)]
                                                (pr/ping-service user-agent process-request-fn service-state-fn health-check-config request))))]
                              (wrap-secure-request-fn

--- a/waiter/src/waiter/service.clj
+++ b/waiter/src/waiter/service.clj
@@ -355,9 +355,13 @@
     (zero? healthy) :service-state-starting
     :else :service-state-running))
 
-(defn retrieve-service-status-label
-  "Returns the status of the specified service."
+(defn retrieve-service-status-and-deployment-error
+  "Returns the deployment-error message of the specified service."
   [service-id {:keys [service-id->deployment-error service-id->instance-counts]}]
   (let [deployment-error (get service-id->deployment-error service-id)
-        instance-counts (get service-id->instance-counts service-id)]
-    (utils/message (resolve-service-status deployment-error instance-counts))))
+        instance-counts (get service-id->instance-counts service-id)
+        service-status (resolve-service-status deployment-error instance-counts)]
+    (cond-> {:service-status-label (utils/message service-status)}
+      (and deployment-error (not= :service-state-running service-status))
+      (assoc :deployment-error-message
+             (str deployment-error-prefix (or (utils/message deployment-error) deployment-error))))))


### PR DESCRIPTION
## Changes proposed in this PR

- reports deployment error in get service endpoint

## Why are we making these changes?

Reporting the deployment error in the API allows service owners to determine why a service is failing to start.

