### PR TITLE
ensures every router knows about service in test-basic-functionality

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -56,10 +56,11 @@
 
 (deftest ^:parallel ^:integration-fast test-basic-functionality
   (testing-using-waiter-url
-    (let [{:keys [service-id request-headers]} (make-request-with-debug-info
-                                                 {:x-waiter-name (rand-name)}
-                                                 #(make-kitchen-request waiter-url % :path "/hello"))
+    (let [{:keys [cookies service-id request-headers]}
+          (make-request-with-debug-info {:x-waiter-name (rand-name)} #(make-kitchen-request waiter-url % :path "/hello"))
           request-headers (dissoc request-headers "x-cid")]
+
+      (assert-service-healthy-on-all-routers waiter-url service-id cookies)
 
       (let [service-settings (service-settings waiter-url service-id)]
         (testing "instances are non-null"


### PR DESCRIPTION
## Changes proposed in this PR

- ensures every router knows about service in test-basic-functionality

## Why are we making these changes?


