### PR TITLE
cli: add additional-clusters field for local config

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -38,6 +38,26 @@ There is a sample `.waiter.json` file included in this directory, which looks so
 Each entry in the `clusters` array conforms to a cluster specification ("spec"). 
 A cluster spec requires a name and a url pointing to a Waiter cluster.
 
+Your local configuration file is automatically merged with the configuration found in the `waiter` install directory
+(if one is found there). However, since the `clusters` property contains a list of clusters, if it is set in the local
+configuration file, then it _replaces_ the value from the central configuration.
+
+If you would like to _add_ clusters rather than _replace_ them, you can instead set the `additional-clusters` property.
+The list of additional clusters will be prepended to the centralized list, allowing your local custom clusters
+to take precedence over any centrally-configured clusters.
+
+```json
+{
+  "additional-clusters": [
+    {
+      "name": "dev2",
+      "url": "http://127.0.0.1:22322/",
+      "disabled": false
+    }
+  ]
+}
+```
+
 ### Commands
 
 The fastest way to learn more about `waiter` is with the `-h` (or `--help`) option.

--- a/cli/waiter/configuration.py
+++ b/cli/waiter/configuration.py
@@ -56,6 +56,15 @@ def __load_local_config(config_path):
     return config_path, config
 
 
+def __prepend_additional_clusters(config):
+    """Prepend user's local additional-clusters to the base config clusters."""
+    if 'additional-clusters' in config:
+        clusters = config.get('clusters', [])
+        additional_clusters = config.get('additional-clusters', [])
+        config['clusters'] = additional_clusters + clusters
+        del config['additional-clusters']
+
+
 def load_config_with_defaults(config_path=None):
     """Loads the configuration map to use, merging in the defaults"""
     base_config = __load_base_config()
@@ -64,5 +73,6 @@ def load_config_with_defaults(config_path=None):
     config_path, config = __load_local_config(config_path)
     config = config or {}
     config = deep_merge(base_config, config)
+    __prepend_additional_clusters(config)
     logging.debug(f'using configuration: {config}')
     return config


### PR DESCRIPTION
## Changes proposed in this PR

Add `additional-clusters` field for cli local config.

## Why are we making these changes?

Allows users to extend (prepend) their own clusters to the centrally-configured list of clusters.
