### PR TITLE
reclassifies fast and slow tests

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -1414,7 +1414,7 @@
           (doseq [service-id service-ids]
             (delete-service waiter-url service-id)))))))
 
-(deftest ^:parallel ^:integration-slow test-image-field-validation
+(deftest ^:parallel ^:integration-fast test-image-field-validation
   (testing-using-waiter-url
     (let [make-kitchen-request-fn
           (fn [image-name expected-status]
@@ -1602,7 +1602,7 @@
                 response (make-request waiter-url-for-port "/")]
             (assert-response-status response http-200-ok)))))))
 
-(deftest ^:parallel ^:integration-slow test-grace-period-disabled
+(deftest ^:parallel ^:integration-fast test-grace-period-disabled
   (testing-using-waiter-url
     (let [{:keys [cookies request-headers service-id] :as response}
           (make-request-with-debug-info

--- a/waiter/integration/waiter/grpc_test.clj
+++ b/waiter/integration/waiter/grpc_test.clj
@@ -540,7 +540,7 @@
             (assert-grpc-server-exit-status status assertion-message)
             (is (nil? reply) assertion-message)))))))
 
-(deftest ^:parallel ^:integration-fast test-grpc-bidi-streaming-successful
+(deftest ^:parallel ^:integration-slow test-grpc-bidi-streaming-successful
   (testing-using-waiter-url
     (let [{:keys [h2c-port host request-headers service-id]} (start-courier-instance waiter-url)
           correlation-id-prefix (rand-name)]
@@ -967,7 +967,7 @@
                   (is (= (reduce + (map count messages)) (.getTotalLength summary)) assertion-message))
                 (assert-request-state grpc-client request-headers service-id correlation-id true ::success)))))))))
 
-(deftest ^:parallel ^:integration-fast test-grpc-client-streaming-client-cancellation
+(deftest ^:parallel ^:integration-slow test-grpc-client-streaming-client-cancellation
   (testing-using-waiter-url
     (when (grpc-cancellations-supported? waiter-url)
       (let [{:keys [h2c-port host request-headers service-id]} (start-courier-instance waiter-url)
@@ -1187,7 +1187,7 @@
               ;; response payload ends with the 8 bytes "received" (ascii/utf8)
               (is (= received-msg-bytes (take-last 8 response-body-bytes))))))))))
 
-(deftest ^:parallel ^:integration-slow test-grpc-health-check-authentication
+(deftest ^:parallel ^:integration-fast test-grpc-health-check-authentication
   (testing-using-waiter-url
     (when (using-k8s? waiter-url)
       (let [courier-command (courier-server-command "${PORT0} ${PORT1} true")

--- a/waiter/integration/waiter/killed_instance_test.clj
+++ b/waiter/integration/waiter/killed_instance_test.clj
@@ -22,7 +22,7 @@
             [waiter.status-codes :refer :all]
             [waiter.util.client-tools :refer :all]))
 
-(deftest ^:parallel ^:integration-slow ^:resource-heavy test-scale-down-via-delegated-kill
+(deftest ^:parallel ^:integration-fast ^:resource-heavy test-scale-down-via-delegated-kill
   ;; relies on simple distribution spreading instances across routers, in particular
   ;; to a router that is not triggering the kills (i.e. the leader performing scaling logic)
   (testing-using-waiter-url

--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -99,14 +99,14 @@
     (delete-service waiter-url service-id)))
 
 ; test that we can provide a custom docker image that contains /tmp/index.html with "Integration Test Image" in it
-(deftest ^:parallel ^:integration-slow test-kubernetes-custom-image
+(deftest ^:parallel ^:integration-fast test-kubernetes-custom-image
   (testing-using-waiter-url
     (when (using-k8s? waiter-url)
       (let [custom-image (System/getenv "INTEGRATION_TEST_CUSTOM_IMAGE")
             _ (is (not (str/blank? custom-image)) "You must provide a custom image in the INTEGRATION_TEST_CUSTOM_IMAGE environment variable")]
         (validate-kubernetes-custom-image waiter-url custom-image)))))
 
-(deftest ^:parallel ^:integration-slow test-kubernetes-image-alias
+(deftest ^:parallel ^:integration-fast test-kubernetes-image-alias
   (testing-using-waiter-url
     (when (using-k8s? waiter-url)
       (let [custom-image (System/getenv "INTEGRATION_TEST_CUSTOM_IMAGE_ALIAS")
@@ -325,7 +325,7 @@
             (is (= current-user pod-namespace))
             (is (= current-user service-account))))))))
 
-(deftest ^:parallel ^:integration-slow ^:resource-heavy test-kubernetes-pod-expiry-failing-instance
+(deftest ^:parallel ^:integration-fast ^:resource-heavy test-kubernetes-pod-expiry-failing-instance
   (testing-using-waiter-url
     (when (using-k8s? waiter-url)
       (let [{:keys [request-headers service-id] :as response}

--- a/waiter/integration/waiter/request_timeout_test.clj
+++ b/waiter/integration/waiter/request_timeout_test.clj
@@ -199,7 +199,7 @@
           (is (str/blank? (:instance-id response))))
         (.await long-request-ended-latch)))))
 
-(deftest ^:parallel ^:integration-fast ^:resource-heavy test-grace-period-with-tokens
+(deftest ^:parallel ^:integration-slow ^:resource-heavy test-grace-period-with-tokens
   (testing-using-waiter-url
     (let [grace-period (t/minutes 2)
           startup-delay-ms (-> grace-period t/in-millis (* 0.75) long)

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -140,7 +140,7 @@
                (and ~deleted ~include-metadata) (assoc :deleted ~deleted))
              (dissoc token-description# :last-update-time :previous))))))
 
-(deftest ^:parallel ^:integration-fast test-token-create-delete
+(deftest ^:parallel ^:integration-slow test-token-create-delete
   (testing-using-waiter-url
     (let [service-id-prefix (rand-name)
           token-prefix (create-token-name waiter-url ".")
@@ -359,7 +359,7 @@
             (assert-response-status response http-404-not-found)
             (is (str/includes? (str body) "Couldn't find token") (str body))))))))
 
-(deftest ^:parallel ^:integration-fast ^:resource-heavy test-service-list-filtering
+(deftest ^:parallel ^:integration-slow ^:resource-heavy test-service-list-filtering
   (testing-using-waiter-url
     (let [service-name (rand-name)
           current-user (retrieve-username)
@@ -1232,7 +1232,7 @@
      (delete-service ~waiter-url service-id#)
      service-id#))
 
-(deftest ^:parallel ^:integration-fast test-token-param-support
+(deftest ^:parallel ^:integration-slow test-token-param-support
   (testing-using-waiter-url
     (let [token (rand-name)
           binary (kitchen-cmd)

--- a/waiter/integration/waiter/trailers_test.clj
+++ b/waiter/integration/waiter/trailers_test.clj
@@ -164,6 +164,6 @@
               (is (= response-trailers (some-> response :trailers))
                   (-> response :headers str)))))))))
 
-(deftest ^:parallel ^:integration-slow ^:resource-heavy test-trailers-support-http-proto-kitchen
+(deftest ^:parallel ^:integration-fast ^:resource-heavy test-trailers-support-http-proto-kitchen
   (testing-using-waiter-url
     (run-kitchen-trailers-support-test waiter-url "http")))

--- a/waiter/integration/waiter/websocket_integration_test.clj
+++ b/waiter/integration/waiter/websocket_integration_test.clj
@@ -598,7 +598,7 @@
         (finally
           (delete-service waiter-url waiter-headers))))))
 
-(deftest ^:parallel ^:integration-slow test-message-size-received-from-backend-exceeds-supported-max
+(deftest ^:parallel ^:integration-fast test-message-size-received-from-backend-exceeds-supported-max
   (testing-using-waiter-url
     (let [^WebSocketClient websocket-client (websocket-client-factory)
           waiter-settings (waiter-settings waiter-url)


### PR DESCRIPTION
## Changes proposed in this PR

- reclassifies fast and slow tests

## Why are we making these changes?

Avoids unnecessary delays while running fast tests as well as getting feedback on tests that run fast.

