### PR TITLE
Add ability to consume external metrics for last request time

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -1002,6 +1002,25 @@
                   ;; in order for Waiter to garbage collect its metrics:
                   :transient-metrics-timeout-ms 300000}
 
+ ; Configures how waiter consumes and handles metrics from an external metrics service
+ ; these metrics can be used for waiter to make autoscaling decisions
+ :metrics-consumer {
+                    ; max time to wait for metrics service to establish connection when watch request is made
+                    :connection-timeout-ms 5000
+
+                    ; total allowed time for inactivity on a metrics service watch response stream before terminating
+                    ; and retrying the watch request
+                    :idle-timeout-ms 10000
+
+                    ; metrics services to aggregate metrics from
+                    :metrics-service-urls []
+
+                    ; time before retrying a new watch connection to the metrics service
+                    :retry-delay-ms 1000
+
+                    ; total number of token metrics events that can be buffered before old events are overwritten
+                    :token-metric-chan-buffer-size 4096}
+
  ; ---------- Miscellaneous ----------
 
  ;; Custom components allow sharing of components between the scheduler and service description builder.

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -1013,7 +1013,7 @@
                     :idle-timeout-ms 10000
 
                     ; metrics services to aggregate metrics from
-                    :metrics-service-urls []
+                    :metrics-services []
 
                     ; time before retrying a new watch connection to the metrics service
                     :retry-delay-ms 1000

--- a/waiter/integration/waiter/authentication_test.clj
+++ b/waiter/integration/waiter/authentication_test.clj
@@ -62,22 +62,6 @@
           (assert-response-status response http-400-bad-request)
           (is (str/includes? body error-message)))))))
 
-(defn- retrieve-access-token
-  [realm]
-  (if-let [access-token-url-env (System/getenv "WAITER_TEST_JWT_ACCESS_TOKEN_URL")]
-    (let [access-token-url (str/replace access-token-url-env "{HOST}" realm)
-          access-token-uri (URI. access-token-url)
-          protocol (.getScheme access-token-uri)
-          authority (.getAuthority access-token-uri)
-          path (str (.getPath access-token-uri) "?" (.getQuery access-token-uri))
-          access-token-response (make-request authority path :headers {"x-iam" "waiter"} :protocol protocol)
-          _ (assert-response-status access-token-response http-200-ok)
-          access-token-response-json (-> access-token-response :body str json/read-str)
-          access-token (get access-token-response-json "access_token")]
-      (log/info "retrieved access token" {:access-token access-token :realm realm})
-      access-token)
-    (throw (ex-info "WAITER_TEST_JWT_ACCESS_TOKEN_URL environment variable has not been provided" {}))))
-
 (defmacro assert-auth-cookie
   "Helper macro to assert the value of the set-cookie header."
   [set-cookie assertion-message]

--- a/waiter/integration/waiter/instance_tracker_integration_test.clj
+++ b/waiter/integration/waiter/instance_tracker_integration_test.clj
@@ -94,13 +94,7 @@
   (let [{:keys [body error headers] :as response}
         (make-request router-url "/apps/instances" :async? true :cookies cookies :query-params query-params)
         _ (assert-response-status response 200)
-        json-objects (->> body
-                          utils/chan-to-seq!!
-                          (map (fn [chunk] (-> chunk .getBytes ByteArrayInputStream.)))
-                          Collections/enumeration
-                          SequenceInputStream.
-                          InputStreamReader.
-                          cheshire/parsed-seq)
+        json-objects (utils/chan-to-json-seq!! body)
         id->healthy-instance-atom (atom {})
         initial-event-time-epoch-ms-atom (atom nil)
         query-state-fn (fn []

--- a/waiter/integration/waiter/token_watch_integration_test.clj
+++ b/waiter/integration/waiter/token_watch_integration_test.clj
@@ -1,14 +1,11 @@
 (ns waiter.token-watch-integration-test
-  (:require [cheshire.core :as cheshire]
-            [clojure.core.async :as async]
+  (:require [clojure.core.async :as async]
             [clojure.set :as set]
             [clojure.test :refer :all]
             [waiter.status-codes :refer :all]
             [waiter.util.client-tools :refer :all]
             [waiter.util.utils :as utils]
-            [clojure.tools.logging :as log])
-  (:import (java.io SequenceInputStream InputStreamReader ByteArrayInputStream)
-           (java.util Collections)))
+            [clojure.tools.logging :as log]))
 
 (defn- await-goal-response-for-all-routers
   "Returns true if the goal-response-fn was satisfied with the response from request-fn for all routers before
@@ -118,13 +115,7 @@
   (let [{:keys [body error headers] :as response}
         (make-request router-url "/tokens" :async? true :cookies cookies :query-params query-params)
         _ (assert-response-status response 200)
-        json-objects (->> body
-                          utils/chan-to-seq!!
-                          (map (fn [chunk] (-> chunk .getBytes ByteArrayInputStream.)))
-                          Collections/enumeration
-                          SequenceInputStream.
-                          InputStreamReader.
-                          cheshire/parsed-seq)
+        json-objects (utils/chan-to-json-seq!! body)
         token->index-atom (atom {})
         initial-event-time-epoch-ms-atom (atom nil)
         query-state-fn (fn []

--- a/waiter/integration/waiter/token_watch_integration_test.clj
+++ b/waiter/integration/waiter/token_watch_integration_test.clj
@@ -2,10 +2,10 @@
   (:require [clojure.core.async :as async]
             [clojure.set :as set]
             [clojure.test :refer :all]
+            [clojure.tools.logging :as log]
             [waiter.status-codes :refer :all]
             [waiter.util.client-tools :refer :all]
-            [waiter.util.utils :as utils]
-            [clojure.tools.logging :as log]))
+            [waiter.util.utils :as utils]))
 
 (defn- await-goal-response-for-all-routers
   "Returns true if the goal-response-fn was satisfied with the response from request-fn for all routers before

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1449,10 +1449,13 @@
                                 [[:routines retrieve-latest-descriptor-fn start-new-service-fn]
                                  [:state kv-store fallback-state-atom leader?-fn]
                                  metrics-consumer-maintainer]
-                                (let [{:keys [token-metric-chan-mult]} metrics-consumer-maintainer]
+                                (let [{:keys [token-metric-chan-mult]} metrics-consumer-maintainer
+                                      service-exists? (fn service-exists?
+                                                        [service-id]
+                                                        (descriptor/service-exists? @fallback-state-atom service-id))]
                                   (scheduler/start-new-services-daemon
-                                    retrieve-latest-descriptor-fn kv-store token-metric-chan-mult start-new-service-fn
-                                    leader?-fn fallback-state-atom)))
+                                    retrieve-latest-descriptor-fn service-exists? kv-store token-metric-chan-mult
+                                    start-new-service-fn leader?-fn)))
    :state-sources (pc/fnk [[:scheduler scheduler]
                            [:state query-service-maintainer-chan]
                            autoscaler autoscaling-multiplexer gc-for-transient-metrics interstitial-maintainer

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1336,7 +1336,7 @@
    :metrics-consumer-maintainer (pc/fnk
                                   [[:routines retrieve-descriptor-fn router-metrics-helpers]
                                    [:settings
-                                    [:metrics-consumer connection-timeout-ms metrics-service-urls idle-timeout-ms retry-delay-ms
+                                    [:metrics-consumer connection-timeout-ms metrics-services idle-timeout-ms retry-delay-ms
                                      token-metric-chan-buffer-size]]
                                    [:state clock kv-store local-usage-agent router-id user-agent-version
                                     token-cluster-calculator]]
@@ -1347,7 +1347,7 @@
                                                                              :user-agent (str "waiter-metrics-consumer/" user-agent-version)})]
                                     (metrics-consumer/start-metrics-consumer-maintainer
                                       http-client clock kv-store token-cluster-calculator retrieve-descriptor-fn service-id->metrics-fn
-                                      metrics-consumer/make-metrics-watch-request local-usage-agent router-id metrics-service-urls
+                                      metrics-consumer/make-metrics-watch-request local-usage-agent router-id metrics-services
                                       token-metric-chan-buffer-size retry-delay-ms)))
    ;; This function is defined as a convenience to avoid repeated extraction from daemons/service-chan-maintainer.
    :populate-maintainer-chan! (pc/fnk [service-chan-maintainer]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1445,14 +1445,14 @@
                                 (async/tap router-state-push-mult state-chan)
                                 (maintainer/start-service-chan-maintainer
                                   {} state-chan query-service-maintainer-chan start-service remove-service retrieve-channel)))
-   :start-new-services-handler (pc/fnk
-                                 [[:routines retrieve-latest-descriptor-fn start-new-service-fn]
-                                  [:state kv-store fallback-state-atom leader?-fn]
-                                  metrics-consumer-maintainer]
-                                 (let [{:keys [token-metric-chan-mult]} metrics-consumer-maintainer]
-                                   (scheduler/start-new-services-handler
-                                     retrieve-latest-descriptor-fn kv-store token-metric-chan-mult start-new-service-fn
-                                     leader?-fn fallback-state-atom)))
+   :start-new-services-daemon (pc/fnk
+                                [[:routines retrieve-latest-descriptor-fn start-new-service-fn]
+                                 [:state kv-store fallback-state-atom leader?-fn]
+                                 metrics-consumer-maintainer]
+                                (let [{:keys [token-metric-chan-mult]} metrics-consumer-maintainer]
+                                  (scheduler/start-new-services-daemon
+                                    retrieve-latest-descriptor-fn kv-store token-metric-chan-mult start-new-service-fn
+                                    leader?-fn fallback-state-atom)))
    :state-sources (pc/fnk [[:scheduler scheduler]
                            [:state query-service-maintainer-chan]
                            autoscaler autoscaling-multiplexer gc-for-transient-metrics interstitial-maintainer

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -366,7 +366,7 @@
     (timers/start-stop-time!
       request->descriptor-timer
       (let [auth-user (:authorization/user request)
-            service-approved? (fn service-approved? [service-id] (assoc-run-as-user-approved? request service-id))
+            service-approved? (fn req-service-approved [service-id] (assoc-run-as-user-approved? request service-id))
             latest-descriptor (compute-descriptor
                                 attach-service-defaults-fn attach-token-defaults-fn service-id-prefix kv-store
                                 waiter-hostnames request service-description-builder service-approved?)
@@ -511,7 +511,8 @@
                         ;; we do not know env from request headers and cannot support parameterized services
                         :headers {"x-waiter-token" token}
                         :request-time (t/now)}
-        service-approved? (fn service-approved? [service-id] (assoc-run-as-user-approved? pseudo-request service-id))]
+        service-approved? (fn latest-service-approved? [service-id]
+                            (assoc-run-as-user-approved? pseudo-request service-id))]
     (compute-descriptor
       attach-service-defaults-fn attach-token-defaults-fn service-id-prefix kv-store
       waiter-hostnames pseudo-request service-description-builder service-approved?)))

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -502,3 +502,16 @@
                         :headers {"x-waiter-token" token}
                         :request-time (t/now)}]
     (request->descriptor-fn pseudo-request)))
+
+(defn retrieve-latest-descriptor
+  "Retrieves the latest descriptor for run-as-user and token."
+  [attach-service-defaults-fn attach-token-defaults-fn service-id-prefix kv-store waiter-hostnames service-description-builder
+   assoc-run-as-user-approved? run-as-user token]
+  (let [pseudo-request {:authorization/user run-as-user
+                        ;; we do not know env from request headers and cannot support parameterized services
+                        :headers {"x-waiter-token" token}
+                        :request-time (t/now)}
+        service-approved? (fn service-approved? [service-id] (assoc-run-as-user-approved? pseudo-request service-id))]
+    (compute-descriptor
+      attach-service-defaults-fn attach-token-defaults-fn service-id-prefix kv-store
+      waiter-hostnames pseudo-request service-description-builder service-approved?)))

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -807,7 +807,7 @@
       (utils/clj->streaming-json-response {:details (merge (->> ["autoscaler" "autoscaling-multiplexer" "codahale-reporters"
                                                                  "ejection-expiry" "entitlement-manager" "fallback"
                                                                  "gc-broken-services" "gc-services" "gc-transient-metrics" "instance-tracker" "interstitial"
-                                                                 "jwt-auth-server" "kv-store" "launch-metrics" "leader" "local-usage"
+                                                                 "jwt-auth-server" "kv-store" "launch-metrics" "leader" "local-usage" "metrics-consumer"
                                                                  "maintainer" "router-metrics" "scheduler" "service-description-builder"
                                                                  "service-maintainer" "statsd" "token-validator" "token-watch-maintainer" "work-stealing"]
                                                              (pc/map-from-keys make-url))

--- a/waiter/src/waiter/metrics_consumer.clj
+++ b/waiter/src/waiter/metrics_consumer.clj
@@ -180,8 +180,8 @@
           (fn query-metrics-consumer-maintainer-fn
             [include-flags]
             (let [{:keys [last-token-event-time]} @state-atom]
-              (cond-> {:last-token-event-time last-token-event-time
-                       :buffer-state {:token-metric-chan-count (.count token-metric-chan-buffer)}
+              (cond-> {:buffer-state {:token-metric-chan-count (.count token-metric-chan-buffer)}
+                       :last-token-event-time last-token-event-time
                        :supported-include-params ["watches-state"]}
                 (contains? include-flags "watches-state")
                 (assoc :watches-state

--- a/waiter/src/waiter/metrics_consumer.clj
+++ b/waiter/src/waiter/metrics_consumer.clj
@@ -1,0 +1,190 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns waiter.metrics-consumer
+  (:require [clj-time.core :as t]
+            [clj-time.format :as f]
+            [clojure.core.async :as async]
+            [clojure.set :as set]
+            [clojure.tools.logging :as log]
+            [clojure.walk :as walk]
+            [metrics.meters :as meters]
+            [plumbing.core :as pc]
+            [waiter.correlation-id :as cid]
+            [waiter.metrics :as metrics]
+            [waiter.service-description :as sd]
+            [waiter.token :as token]
+            [waiter.util.http-utils :as hu]
+            [waiter.util.utils :as utils]))
+
+(defn make-metrics-watch-request
+  "Creates a watch request to a metrics service and pushes token events to the provided event-chan. If the watch request
+  fails for any reason, it will retry after the retry-delay-ms. The metrics service needs to stream chunked json on the
+  /token-stats?watch=true endpoint. Each json blob has the structure:
+  {:object [
+    {:token \"token\"
+     :lastRequestTime iso-time-string}
+    ...]
+   :type \"initial\" or \"update\"}
+
+  A map is returned with keys:
+  :exit-chan is a channel that when a message is pushed to, terminates the watch immediately and go-chan
+  :go-chan channel closed when watch is terminated (used primarily for cleaning up tests)
+  :query-state-fn function called with include flags for introspecting the state of the watch (e.g. last-event-time)"
+  [http-client http-streaming-request-async-fn router-id cur-cid metrics-service-url event-chan clock retry-delay-ms]
+  (cid/with-correlation-id
+    (str cur-cid ".metrics-watch." metrics-service-url)
+    (let [exit-chan (async/promise-chan)
+          exit-chan-mult (async/mult exit-chan)
+          state-atom (atom {:last-event-time nil
+                            :last-watch-time nil})
+          metrics-endpoint (str metrics-service-url "/token-stats")
+          query-string (str "watch=true&watcher=" router-id)
+          query-state-fn
+          (fn query-metrics-watch-fn
+            [_]
+            (let [{:keys [last-event-time last-watch-time]} @state-atom]
+              {:endpoint metrics-endpoint
+               :last-event-time last-event-time
+               :last-watch-time last-watch-time
+               :supported-include-params []}))
+          go-chan
+          (async/go-loop []
+            (try
+              (log/info "starting watch on metrics service:" {:metrics-endpoint metrics-endpoint})
+              (let [abort-ch (async/promise-chan)
+                    {:keys [body-chan error-chan] :as res}
+                    (async/<! (http-streaming-request-async-fn http-client metrics-endpoint
+                                                               :abort-ch abort-ch
+                                                               :query-string query-string))]
+                ; when async chan is triggered, we want to also trigger the abort channel on the watch connection
+                (async/tap exit-chan-mult abort-ch)
+                (when (instance? Throwable res)
+                  (throw res))
+                (swap! state-atom assoc :last-watch-time (clock))
+                (doseq [{:strs [object type]} (utils/chan-to-json-seq!! body-chan)]
+                  (meters/mark! (metrics/waiter-meter "core" "metrics-consumer" metrics-service-url "event-rate"))
+                  (if (contains? #{"initial" "update"} type)
+                    (do
+                      (log/info "received event payload" {:count (count object) :type type})
+                      (swap! state-atom assoc :last-event-time (clock))
+                      (doseq [event object]
+                        (async/put! event-chan event)))
+                    (log/warn "received unknown metrics event" {:type type})))
+                (log/warn "watch request was closed unexpectedly" {:error-chan (when error-chan (async/<! error-chan))
+                                                                   :metrics-endpoint metrics-endpoint}))
+              (catch Exception e
+                (log/error e "watch request to external request metrics service failed. Going to start retrying"
+                           {:metrics-service-url metrics-service-url})))
+            ; unnecessary to do exponential backoff because there is a static number of clients (waiter routers) making watch requests
+            (log/info (str "waiting " retry-delay-ms " ms before attempting to make the watch connection"))
+            (let [timeout-ch (async/timeout retry-delay-ms)
+                  [msg current-chan]
+                  (async/alts! [exit-chan timeout-ch] :priority true)]
+              (condp = current-chan
+                exit-chan (log/warn "exiting watch because exit chan was triggered" {:msg msg})
+                timeout-ch (recur))))]
+      {:exit-chan exit-chan
+       :go-chan go-chan
+       :query-state-fn query-state-fn})))
+
+(defn start-metrics-consumer-maintainer
+  "Initializes all external metrics service watch connections and filters/processes metric events that are then exposed
+  for other components to listen on to with `async/tap`.
+
+  Returns a map with keys:
+  :exit-chan is as channel that when message is pushed to it, causes all watch connections to be terminated
+  :query-state-fn is a query function for introspecting the state of the metrics events channels and watches
+  :token-metric-chan-mult is a mult for other components to listen in on when last-request-time was updated for a token"
+  [http-client clock kv-store token-cluster-calculator retrieve-descriptor-fn service-id->metrics-fn
+   make-metrics-watch-request-fn local-usage-agent router-id metrics-service-urls token-metric-chan-buffer-size
+   retry-delay-ms]
+  (cid/with-correlation-id
+    "metrics-consumer-maintainer"
+    (let [exit-chan (async/promise-chan)
+          exit-mult (async/mult exit-chan)
+          correlation-id (cid/get-correlation-id)
+          default-cluster (token/get-default-cluster token-cluster-calculator)
+          state-atom (atom {:last-token-event-time nil})
+          token-metric-chan-buffer (async/buffer token-metric-chan-buffer-size)
+          token-metric-chan
+          (async/chan
+            token-metric-chan-buffer
+            (comp
+              (map (fn format-event
+                     [raw-event]
+                     (let [event (walk/keywordize-keys raw-event)
+                           kabob-event (set/rename-keys event {:lastRequestTime :last-request-time})]
+                       (update kabob-event :last-request-time f/parse))))
+              (filter (fn token-in-same-cluster?
+                        [{:keys [token]}]
+                        (let [token-parameters (sd/token->token-parameters kv-store token :error-on-missing false)
+                              token-cluster (get token-parameters "cluster")]
+                          (and (some? token-parameters)
+                               (= token-cluster default-cluster)))))
+              ; TODO: bypass only supports non run-as-requester and parameterized services
+              (filter (fn token-bypass-eligible-service-description?
+                        [{:keys [token]}]
+                        (when-let [{:strs [run-as-user] :as service-description-template}
+                                   (sd/token->service-parameter-template kv-store token :error-on-missing false)]
+                          (and run-as-user
+                               (not (sd/run-as-requester? service-description-template))
+                               (not (sd/requires-parameters? service-description-template))))))
+              (filter (fn is-new-last-request-time?
+                        [{:keys [token last-request-time]}]
+                        (let [{:strs [run-as-user]}
+                              (sd/token->service-parameter-template kv-store token :error-on-missing false)
+                              {:keys [descriptor]} (retrieve-descriptor-fn run-as-user token)
+                              {fallback-service-id :service-id} descriptor
+                              stored-last-request-time (get-in (service-id->metrics-fn) [fallback-service-id "last-request-time"])
+                              new-last-request-time? (or (nil? stored-last-request-time)
+                                                         (t/before? stored-last-request-time last-request-time))]
+                          (when new-last-request-time?
+                            (cid/cinfo correlation-id "updating last request time for service" {:service-id fallback-service-id
+                                                                                                :last-request-time last-request-time})
+                            (send local-usage-agent metrics/update-last-request-time-usage-metric fallback-service-id last-request-time)
+                            (swap! state-atom assoc :last-token-event-time (clock)))
+                          new-last-request-time?))))
+            (fn metric-chan-ex-handler
+              [e]
+              (cid/cerror correlation-id e "unexpected error when transforming token metric event")))
+          metrics-service-url->watch
+          (pc/map-from-keys
+            (fn [metrics-service-url]
+              (let [{:keys [exit-chan] :as watch}
+                    (make-metrics-watch-request-fn
+                      http-client hu/http-streaming-request-async router-id correlation-id metrics-service-url
+                      token-metric-chan clock retry-delay-ms)]
+                (async/tap exit-mult exit-chan)
+                watch))
+            metrics-service-urls)
+          query-state-fn
+          (fn query-metrics-consumer-maintainer-fn
+            [include-flags]
+            (let [{:keys [last-token-event-time]} @state-atom]
+              (cond-> {:last-token-event-time last-token-event-time
+                       :buffer-state {:token-metric-chan-count (.count token-metric-chan-buffer)}
+                       :supported-include-params ["watches-state"]}
+                (contains? include-flags "watches-state")
+                (assoc :watches-state
+                       (pc/map-vals
+                         (fn [{:keys [query-state-fn]}]
+                           (query-state-fn include-flags))
+                         metrics-service-url->watch)))))]
+      (metrics/waiter-gauge #(.count token-metric-chan-buffer)
+                            "core" "metrics-consumer" "token-metric-chan-count")
+      {:exit-chan exit-chan
+       :query-state-fn query-state-fn
+       :token-metric-chan-mult (async/mult token-metric-chan)})))

--- a/waiter/src/waiter/metrics_consumer.clj
+++ b/waiter/src/waiter/metrics_consumer.clj
@@ -126,10 +126,9 @@
             token-metric-chan-buffer
             (comp
               (map (fn format-event
-                     [raw-event]
-                     (let [event (walk/keywordize-keys raw-event)
-                           kabob-event (set/rename-keys event {:lastRequestTime :last-request-time})]
-                       (update kabob-event :last-request-time f/parse))))
+                     [{:strs [lastRequestTime token]}]
+                     {:last-request-time (f/parse lastRequestTime)
+                      :token token}))
               (filter (fn token-in-same-cluster?
                         [{:keys [token]}]
                         (let [token-parameters (sd/token->token-parameters kv-store token :error-on-missing false)

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -27,7 +27,6 @@
             [slingshot.slingshot :as ss]
             [waiter.config :as config]
             [waiter.correlation-id :as cid]
-            [waiter.descriptor :as descriptor]
             [waiter.headers :as headers]
             [waiter.metrics :as metrics]
             [waiter.request-log :as rlog]
@@ -678,8 +677,8 @@
     "start-new-services-goroutine"
     (let [correlation-id (cid/get-correlation-id)
           process-token-event-ch-buffer (async/sliding-buffer 1000)
-          process-events-fn
-          (fn process-events [events]
+          process-events!-fn
+          (fn process-events! [events]
             (filter
               (fn latest-service-does-not-exist?
                 [{:keys [token]}]
@@ -698,7 +697,7 @@
           (async/chan
             process-token-event-ch-buffer
             (comp
-              (map process-events-fn)
+              (map process-events!-fn)
               (filter seq))
             (fn process-token-event-ch-ex-handler
               [e]

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -673,7 +673,7 @@
 
   Returns a map with keys:
   :process-token-event-ch is a channel where messages are pushed to it when a service was started for a token event."
-  [retrieve-latest-descriptor-fn kv-store token-metric-chan-mult start-new-service-fn leader?-fn fallback-state-atom]
+  [retrieve-latest-descriptor-fn service-exists? kv-store token-metric-chan-mult start-new-service-fn leader?-fn]
   (cid/with-correlation-id
     "start-new-services-goroutine"
     (let [correlation-id (cid/get-correlation-id)
@@ -688,7 +688,7 @@
                         (sd/token->service-parameter-template kv-store token :error-on-missing false)
                         {:keys [service-id] :as latest-descriptor}
                         (retrieve-latest-descriptor-fn run-as-user token)
-                        service-does-not-exist? (not (descriptor/service-exists? @fallback-state-atom service-id))]
+                        service-does-not-exist? (not (service-exists? service-id))]
                     (when service-does-not-exist?
                       (cid/cinfo correlation-id "starting" {:service-id (get latest-descriptor :service-id)})
                       (start-new-service-fn latest-descriptor))

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -666,7 +666,7 @@
                         service
                         (assoc instances :active-instances active-instances))))))))
 
-(defn start-new-services-handler
+(defn start-new-services-daemon
   "Listens on token-metric-chan-mult and determines whether to trigger start new services for a token. Only the leader
   router starts new services. Tokens with new last-request-time pointing to a service descriptor that does not exist will
   have the latest service started.
@@ -678,22 +678,28 @@
     "start-new-services-goroutine"
     (let [correlation-id (cid/get-correlation-id)
           process-token-event-ch-buffer (async/sliding-buffer 1000)
+          process-events-fn
+          (fn process-events [events]
+            (filter
+              (fn latest-service-does-not-exist?
+                [{:keys [token]}]
+                (when (leader?-fn)
+                  (let [{:strs [run-as-user]}
+                        (sd/token->service-parameter-template kv-store token :error-on-missing false)
+                        {:keys [service-id] :as latest-descriptor}
+                        (retrieve-latest-descriptor-fn run-as-user token)
+                        service-does-not-exist? (not (descriptor/service-exists? @fallback-state-atom service-id))]
+                    (when service-does-not-exist?
+                      (cid/cinfo correlation-id "starting" {:service-id (get latest-descriptor :service-id)})
+                      (start-new-service-fn latest-descriptor))
+                    service-does-not-exist?)))
+              events))
           process-token-event-ch
           (async/chan
             process-token-event-ch-buffer
             (comp
-              (filter (fn latest-service-does-not-exist?
-                        [{:keys [token]}]
-                        (when (leader?-fn)
-                          (let [{:strs [run-as-user]}
-                                (sd/token->service-parameter-template kv-store token :error-on-missing false)
-                                {:keys [service-id] :as latest-descriptor}
-                                (retrieve-latest-descriptor-fn run-as-user token)
-                                service-does-not-exist? (not (descriptor/service-exists? @fallback-state-atom service-id))]
-                            (when service-does-not-exist?
-                              (cid/cinfo correlation-id "starting" {:service-id (get latest-descriptor :service-id)})
-                              (start-new-service-fn latest-descriptor))
-                            service-does-not-exist?)))))
+              (map process-events-fn)
+              (filter seq))
             (fn process-token-event-ch-ex-handler
               [e]
               (cid/cerror correlation-id e "unexpected error when processing new token metric")))]

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -91,8 +91,8 @@
                                      (s/required-key :transient-metrics-timeout-ms) schema/positive-int}
    (s/required-key :metrics-consumer) {(s/required-key :connection-timeout-ms) schema/non-negative-num
                                        (s/required-key :idle-timeout-ms) schema/non-negative-num
-                                       (s/required-key :metrics-services) [{(s/required-key :url) schema/non-empty-string
-                                                                            (s/required-key :cluster) schema/non-empty-string}]
+                                       (s/required-key :metrics-services) [{(s/required-key :cluster) schema/non-empty-string
+                                                                            (s/required-key :url) schema/non-empty-string}]
                                        (s/required-key :retry-delay-ms) schema/non-negative-num
                                        (s/required-key :token-metric-chan-buffer-size) schema/positive-int}
    (s/required-key :password-store-config) (s/constrained

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -89,6 +89,11 @@
                                                                                       s/Any s/Any}}
                                      (s/required-key :router-update-interval-ms) schema/positive-int
                                      (s/required-key :transient-metrics-timeout-ms) schema/positive-int}
+   (s/required-key :metrics-consumer) {(s/required-key :connection-timeout-ms) schema/non-negative-num
+                                       (s/required-key :idle-timeout-ms) schema/non-negative-num
+                                       (s/required-key :metrics-service-urls) [schema/non-empty-string]
+                                       (s/required-key :retry-delay-ms) schema/non-negative-num
+                                       (s/required-key :token-metric-chan-buffer-size) schema/positive-int}
    (s/required-key :password-store-config) (s/constrained
                                              {:kind s/Keyword
                                               s/Keyword schema/require-symbol-factory-fn}
@@ -359,6 +364,11 @@
                     :codahale-reporters {}
                     :router-update-interval-ms 5000
                     :transient-metrics-timeout-ms 300000}
+   :metrics-consumer {:connection-timeout-ms 5000
+                      :idle-timeout-ms 10000
+                      :metrics-service-urls []
+                      :retry-delay-ms 1000
+                      :token-metric-chan-buffer-size 16384}
    :password-store-config {:kind :configured
                            :configured {:factory-fn 'waiter.password-store/configured-provider
                                         :passwords ["open-sesame"]}}

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -91,7 +91,8 @@
                                      (s/required-key :transient-metrics-timeout-ms) schema/positive-int}
    (s/required-key :metrics-consumer) {(s/required-key :connection-timeout-ms) schema/non-negative-num
                                        (s/required-key :idle-timeout-ms) schema/non-negative-num
-                                       (s/required-key :metrics-service-urls) [schema/non-empty-string]
+                                       (s/required-key :metrics-services) [{(s/required-key :url) schema/non-empty-string
+                                                                            (s/required-key :cluster) schema/non-empty-string}]
                                        (s/required-key :retry-delay-ms) schema/non-negative-num
                                        (s/required-key :token-metric-chan-buffer-size) schema/positive-int}
    (s/required-key :password-store-config) (s/constrained
@@ -366,7 +367,7 @@
                     :transient-metrics-timeout-ms 300000}
    :metrics-consumer {:connection-timeout-ms 5000
                       :idle-timeout-ms 10000
-                      :metrics-service-urls []
+                      :metrics-services []
                       :retry-delay-ms 1000
                       :token-metric-chan-buffer-size 16384}
    :password-store-config {:kind :configured

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -1137,7 +1137,7 @@
 (defn using-metrics-service?
   "Returns true if Waiter is configured to use external metrics services"
   [waiter-url]
-  (< 0 (count (setting waiter-url [:metrics-consumer :metrics-service-urls]))))
+  (< 0 (count (setting waiter-url [:metrics-consumer :metrics-services]))))
 
 (defn get-raven-sidecar-flag
   "Fetches (from the k8s scheduler config) the env var name for enabling the raven sidecar."

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -591,6 +591,24 @@
     :protocol protocol
     :query-params query-params))
 
+(defn retrieve-access-token
+  "Make request to WAITER_TEST_JWT_ACCESS_TOKEN_URL for the access token using the provided realm as the host. Return
+  the access token."
+  [realm]
+  (if-let [access-token-url-env (System/getenv "WAITER_TEST_JWT_ACCESS_TOKEN_URL")]
+    (let [access-token-url (str/replace access-token-url-env "{HOST}" realm)
+          access-token-uri (URI. access-token-url)
+          protocol (.getScheme access-token-uri)
+          authority (.getAuthority access-token-uri)
+          path (str (.getPath access-token-uri) "?" (.getQuery access-token-uri))
+          access-token-response (make-request authority path :headers {"x-iam" "waiter"} :protocol protocol)
+          _ (assert-response-status access-token-response http-200-ok)
+          access-token-response-json (-> access-token-response :body str json/read-str)
+          access-token (get access-token-response-json "access_token")]
+      (log/info "retrieved access token" {:access-token access-token :realm realm})
+      access-token)
+    (throw (ex-info "WAITER_TEST_JWT_ACCESS_TOKEN_URL environment variable has not been provided" {}))))
+
 (defn retrieve-service-id [waiter-url waiter-headers &
                            {:keys [cookies verbose] :or {cookies [] verbose false}}]
   (let [service-id-result (make-request waiter-url "/service-id" :cookies cookies :headers waiter-headers)
@@ -1115,6 +1133,11 @@
   [waiter-url]
   (and (using-k8s? waiter-url)
        (contains? (get-kubernetes-scheduler-settings waiter-url) :raven-sidecar)))
+
+(defn using-metrics-service?
+  "Returns true if Waiter is configured to use external metrics services"
+  [waiter-url]
+  (< 0 (count (setting waiter-url [:metrics-consumer :metrics-service-urls]))))
 
 (defn get-raven-sidecar-flag
   "Fetches (from the k8s scheduler config) the env var name for enabling the raven sidecar."

--- a/waiter/src/waiter/util/date_utils.clj
+++ b/waiter/src/waiter/util/date_utils.clj
@@ -22,6 +22,7 @@
 
 (def formatter-iso8601 (:date-time f/formatters))
 (def formatter-rfc822 (:rfc822 f/formatters))
+(def formatter-year-month-day (:year-month-day f/formatters))
 
 (defn date-to-str
   ([^DateTime date-time]

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -14,7 +14,8 @@
 ;; limitations under the License.
 ;;
 (ns waiter.util.utils
-  (:require [clojure.core.async :as async]
+  (:require [cheshire.core :as cheshire]
+            [clojure.core.async :as async]
             [clojure.data.json :as json]
             [clojure.java.io :as io]
             [clojure.pprint :as pprint]
@@ -30,13 +31,13 @@
             [waiter.util.http-utils :as hu])
   (:import (clojure.core.async.impl.channels ManyToManyChannel)
            (clojure.lang ExceptionInfo)
-           (java.io OutputStreamWriter)
+           (java.io OutputStreamWriter ByteArrayInputStream SequenceInputStream InputStreamReader)
            (java.lang Process)
            (java.net ServerSocket URI)
            (java.nio ByteBuffer)
            (java.nio.charset StandardCharsets)
            (java.security MessageDigest)
-           (java.util Base64 UUID)
+           (java.util Base64 Collections UUID)
            (java.util.concurrent ThreadLocalRandom)
            (java.util.regex Pattern)
            (javax.servlet ServletResponse)
@@ -878,6 +879,18 @@
   (lazy-seq
     (when-some [v (async/<!! c)]
       (cons v (chan-to-seq!! c)))))
+
+(defn chan-to-json-seq!!
+  "Takes a channel of string fragments and returns a lazy sequence of parsed json blobs"
+  [c]
+  (->> c
+       chan-to-seq!!
+       (map (fn [chunk] (-> chunk .getBytes ByteArrayInputStream.)))
+       Collections/enumeration
+       SequenceInputStream.
+       ; need to convert channel to an InputStreamReader to use underlying stream json parsing library
+       InputStreamReader.
+       cheshire/parsed-seq))
 
 (defn send-event-to-channels!
   "Given a list of watch channels and the event to send to each channel, send the event in a non blocking fashion and

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -31,7 +31,7 @@
             [waiter.util.http-utils :as hu])
   (:import (clojure.core.async.impl.channels ManyToManyChannel)
            (clojure.lang ExceptionInfo)
-           (java.io OutputStreamWriter ByteArrayInputStream SequenceInputStream InputStreamReader)
+           (java.io ByteArrayInputStream InputStreamReader OutputStreamWriter SequenceInputStream)
            (java.lang Process)
            (java.net ServerSocket URI)
            (java.nio ByteBuffer)

--- a/waiter/test/waiter/metrics_consumer_test.clj
+++ b/waiter/test/waiter/metrics_consumer_test.clj
@@ -1,0 +1,304 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns waiter.metrics-consumer-test
+  (:require [clj-time.core :as t]
+            [clojure.core.async :as async]
+            [clojure.test :refer :all]
+            [plumbing.core :as pc]
+            [waiter.kv :as kv]
+            [waiter.metrics-consumer :refer :all]
+            [waiter.token :as tk]
+            [waiter.util.client-tools :refer :all]
+            [waiter.util.date-utils :as du]
+            [waiter.util.http-utils :as hu])
+  (:import (org.joda.time DateTime)))
+
+(def ^:const history-length 5)
+(def ^:const limit-per-owner 10)
+
+(let [lock (Object.)]
+  (defn- synchronize-fn
+    [_ f]
+    (locking lock
+      (f))))
+
+(let [current-time (t/now)]
+  (defn- clock [] current-time)
+
+  (defn- clock-millis [] (.getMillis ^DateTime (clock))))
+
+(defn drain-channel!
+  "Eagerly polls as many messages from a channel until unsuccessful"
+  [chan]
+  (loop [msg (async/poll! chan)
+         result []]
+    (if (nil? msg)
+      result
+      (recur (async/poll! chan)
+             (conj result msg)))))
+
+(defmacro assert-expected-blobs-from-event-chan-and-cleanup
+  [body-chan-messages expected-blobs body-chan event-chan error-chan exit-chan go-chan expected-endpoint query-state-fn]
+  `(let [body-chan-messages# ~body-chan-messages
+         expected-blobs# ~expected-blobs
+         body-chan# ~body-chan
+         event-chan# ~event-chan
+         error-chan# ~error-chan
+         exit-chan# ~exit-chan
+         go-chan# ~go-chan
+         expected-endpoint# ~expected-endpoint
+         query-state-fn# ~query-state-fn]
+     ; push all the json string fragments to the body-chan
+     (doseq [json-str# body-chan-messages#]
+       (async/>!! body-chan# json-str#))
+
+     ; expect each blob to be in event-chan and properly mapped
+     (doseq [expected-blob# expected-blobs#]
+       (let [blob# (async/<!! event-chan#)]
+         (is (= expected-blob# blob#))))
+
+     ; last-event-time and last-watch-time should be set to the clock due to new events
+     (is (= {:endpoint expected-endpoint#
+             :last-event-time (clock)
+             :last-watch-time (clock)
+             :supported-include-params []}
+            (query-state-fn# #{})))
+
+     (async/close! body-chan#)
+     (async/close! error-chan#)
+     (async/>!! exit-chan# :exit)
+     (async/<!! go-chan#)
+     (async/close! event-chan#)))
+
+(deftest test-make-metrics-watch-request
+  (let [http-client (hu/http-client-factory {})
+        retry-delay-ms 100
+        body-chan-messages ["{\"type\":\"initial\",\"object\":[{\"token\":\"t1\",\"lastRequestTime\":\"1\"}]}"
+                            "{\"type\":\"unknown\",\"object\":[{\"token\":\"t6\",\"lastRequestTime\":\"1\"},{\"token\":\"t5\",\"lastRequestTime\":\"1\"}]}"
+                            "{\"type\":\"update\",\"object\":[{\"token\":\"t2\",\"lastRequestTime\":\"1\"},{\"token\":\"t3\",\"lastRequestTime\":\"1\"}]}"]
+        ; t5 and t6 are filtered out because the event type was "unknown"
+        expected-blobs [{"token" "t1"
+                         "lastRequestTime" "1"}
+                        {"token" "t2"
+                         "lastRequestTime" "1"}
+                        {"token" "t3"
+                         "lastRequestTime" "1"}]]
+
+    (testing "json fragments are parsed and immediately pushed to the event-chan if valid"
+      (let [body-chan (async/chan 100)
+            event-chan (async/chan 100)
+            error-chan (async/promise-chan)
+            expected-metrics-service-url "http://metrics-service-url.com"
+            expected-endpoint (str expected-metrics-service-url "/token-stats")
+            http-streaming-request-async-fn (constantly (async/go {:body-chan body-chan :error-chan error-chan}))
+            {:keys [exit-chan go-chan query-state-fn]}
+            (make-metrics-watch-request
+              http-client http-streaming-request-async-fn "router-id" "cur-cid" expected-metrics-service-url event-chan clock
+              retry-delay-ms)]
+
+        (assert-expected-blobs-from-event-chan-and-cleanup
+          body-chan-messages expected-blobs body-chan event-chan error-chan exit-chan go-chan expected-endpoint query-state-fn)))
+
+    (testing "watch requests are retried after immediate error when making the request"
+      (let [http-client (hu/http-client-factory {})
+            body-chan (async/chan 100)
+            event-chan (async/chan 100)
+            error-chan (async/promise-chan)
+            expected-metrics-service-url "http://metrics-service-url.com"
+            expected-endpoint (str expected-metrics-service-url "/token-stats")
+            call-count (atom 0)
+            http-streaming-request-async-fn
+            (fn [_ _ & {}]
+              (async/go
+                (swap! call-count inc)
+                (if (> @call-count 1)
+                  {:body-chan body-chan :error-chan error-chan}
+                  (ex-info "error immediately at first" {}))))
+
+            {:keys [exit-chan go-chan query-state-fn]}
+            (make-metrics-watch-request
+              http-client http-streaming-request-async-fn "router-id" "cur-cid" expected-metrics-service-url event-chan clock
+              retry-delay-ms)]
+
+        (assert-expected-blobs-from-event-chan-and-cleanup
+          body-chan-messages expected-blobs body-chan event-chan error-chan exit-chan go-chan expected-endpoint query-state-fn)))
+
+    (testing "watch requests are retried after error while streaming"
+      (let [http-client (hu/http-client-factory {})
+            body-chan (async/chan 100)
+            bad-body-chan (async/chan 100)
+            event-chan (async/chan 100)
+            error-chan (async/promise-chan)
+            expected-metrics-service-url "http://metrics-service-url.com"
+            expected-endpoint (str expected-metrics-service-url "/token-stats")
+            call-count (atom 0)
+            http-streaming-request-async-fn
+            (fn [_ _ & {}]
+              (async/go
+                (swap! call-count inc)
+                {:body-chan (if (> @call-count 1) body-chan bad-body-chan)
+                 :error-chan error-chan}))
+
+            {:keys [exit-chan go-chan query-state-fn]}
+            (make-metrics-watch-request
+              http-client http-streaming-request-async-fn "router-id" "cur-cid" expected-metrics-service-url event-chan clock
+              retry-delay-ms)]
+
+        ; push unfinished fragment to json string and close the body chan
+        (async/>!! bad-body-chan "{\"type\":\"initial\",\"object\":")
+        (async/close! bad-body-chan)
+
+        (assert-expected-blobs-from-event-chan-and-cleanup
+          body-chan-messages expected-blobs body-chan event-chan error-chan exit-chan go-chan expected-endpoint query-state-fn)))))
+
+(deftest test-start-metrics-consumer-maintainer
+  (let [default-cluster "cluster1"
+        unknown-cluster "not-default-cluster"
+        kv-store (kv/->LocalKeyValueStore (atom {}))
+        token-metric-chan-buffer-size 1000
+        connection-timeout-ms 1001
+        idle-timeout-ms 1002
+        http-client (hu/http-client-factory {:conn-timeout connection-timeout-ms :socket-timeout idle-timeout-ms})
+
+        token-different-cluster "token-different-cluster"
+        token-different-cluster-service-desc {"cpus" 1 "run-as-user" "user-1"}
+        token-different-cluster-metadata {"cluster" unknown-cluster "last-update-time" (clock) "owner" "owner1"}
+        _ (tk/store-service-description-for-token
+            synchronize-fn kv-store history-length limit-per-owner token-different-cluster token-different-cluster-service-desc
+            token-different-cluster-metadata)
+
+        valid-bypass-token "valid-bypass-token"
+        valid-bypass-token-service-desc {"cpus" 1 "run-as-user" "user-1"}
+        valid-bypass-token-metadata {"cluster" default-cluster "last-update-time" (clock) "owner" "owner1"}
+        _ (tk/store-service-description-for-token
+            synchronize-fn kv-store history-length limit-per-owner valid-bypass-token valid-bypass-token-service-desc
+            valid-bypass-token-metadata)
+
+        token-run-as-requester "token-run-as-requester"
+        token-run-as-requester-service-desc {"cpus" 1 "run-as-user" "*"}
+        token-run-as-requester-metadata {"cluster" default-cluster "last-update-time" (clock) "owner" "owner1"}
+        _ (tk/store-service-description-for-token
+            synchronize-fn kv-store history-length limit-per-owner token-run-as-requester token-run-as-requester-service-desc
+            token-run-as-requester-metadata)
+
+        token-parameterized "token-run-as-requester"
+        token-parameterized-service-desc {"cpus" 1 "run-as-user" "user-1" "allowed-params" ["test"]}
+        token-parameterized-metadata {"cluster" default-cluster "last-update-time" (clock) "owner" "owner1"}
+        _ (tk/store-service-description-for-token
+            synchronize-fn kv-store history-length limit-per-owner token-parameterized token-parameterized-service-desc
+            token-parameterized-metadata)
+
+        token-not-stored "token-not-stored"
+
+        token-cluster-calculator (tk/new-configured-cluster-calculator {:default-cluster default-cluster
+                                                                        :host->cluster {}})
+        retrieve-descriptor-fn (fn [_ _]
+                                 ; latest descriptor not used, so no need to specify it
+                                 {:descriptor {:service-id "service-id-1"}})
+        make-service-id->metrics-fn (fn make-service-id->metrics-fn
+                                      [local-agent]
+                                      (fn []
+                                        (await local-agent)
+                                        @local-agent))
+        router-id "router-id-1"
+        metrics-service-urls ["https://metrics-service1.com" "https://metrics-service2.com"]
+        retry-delay-ms 1003
+        new-last-request-time (t/plus (clock) (t/seconds 1))
+        make-metrics-watch-request-factory-fn
+        (fn make-metrics-watch-request-factory-fn
+          [raw-events]
+          (let [trigger-ch (async/promise-chan)]
+            {:make-metrics-watch-request-fn
+             (fn make-metrics-watch-request-fn
+               [http-client http-fn actual-router-id _ actual-metrics-service-url token-metric-chan _ actual-retry-delay-ms]
+               (is (= router-id actual-router-id))
+               (is (contains? (set metrics-service-urls) actual-metrics-service-url))
+               (is (= hu/http-streaming-request-async http-fn))
+               (is (= connection-timeout-ms (.getConnectTimeout http-client)))
+               (is (= idle-timeout-ms (.getIdleTimeout http-client)))
+               (is (= retry-delay-ms actual-retry-delay-ms))
+               {:exit-chan (async/promise-chan)
+                :go-chan (async/go
+                           (async/<! trigger-ch)
+                           (doseq [event raw-events]
+                             (async/put! token-metric-chan event)))
+                :query-state-fn (constantly {})})
+             :trigger-ch trigger-ch}))]
+
+    (testing "token-metric-chan supports multiple metrics services"
+      (let [local-usage-agent (agent {"service-id-1" {"last-request-time" (clock)}})
+            raw-events [{"token" token-different-cluster
+                         "lastRequestTime" (du/date-to-str (clock))}
+                        {"token" token-run-as-requester
+                         "lastRequestTime" (du/date-to-str (clock))}
+                        {"token" token-parameterized
+                         "lastRequestTime" (du/date-to-str (clock))}
+                        {"token" token-not-stored
+                         "lastRequestTime" (du/date-to-str (clock))}
+                        {"token" valid-bypass-token
+                         "lastRequestTime" (du/date-to-str new-last-request-time)}]
+            {:keys [make-metrics-watch-request-fn trigger-ch]} (make-metrics-watch-request-factory-fn raw-events)
+            {:keys [exit-chan query-state-fn token-metric-chan-mult]}
+            (start-metrics-consumer-maintainer
+              http-client clock kv-store token-cluster-calculator retrieve-descriptor-fn (make-service-id->metrics-fn local-usage-agent)
+              make-metrics-watch-request-fn local-usage-agent router-id metrics-service-urls token-metric-chan-buffer-size
+              retry-delay-ms)
+            listener-ch (async/chan 1)]
+        (async/tap token-metric-chan-mult listener-ch)
+        (async/>!! trigger-ch :start)
+        (async/<!! (async/timeout 500))
+        ; shows up once with multiple metrics service because "service-id->metrics-fn" got updated and remove duplicate event
+        (is (= [{:token valid-bypass-token
+                 :last-request-time new-last-request-time}]
+               (drain-channel! listener-ch)))
+        (is (= {:buffer-state {:token-metric-chan-count 0}
+                :last-token-event-time (clock)
+                :supported-include-params ["watches-state"]
+                :watches-state (pc/map-from-keys (constantly {}) metrics-service-urls)}
+               (query-state-fn #{"watches-state"})))
+        (await local-usage-agent)
+        (is (= new-last-request-time
+               (get-in @local-usage-agent ["service-id-1" "last-request-time"])))
+        (async/>!! exit-chan :exit)))
+
+    (testing "token-metric-chan does not update last-request-time if not strictly after the previous last-request-time"
+      (let [local-usage-agent (agent {"service-id-1" {"last-request-time" (clock)}})
+            raw-events [{"token" valid-bypass-token
+                         ; last-request-time is fixed to current time
+                         "lastRequestTime" (du/date-to-str (clock))}
+                        {"token" valid-bypass-token
+                         ; last-request-time is fixed to previous time
+                         "lastRequestTime" (du/date-to-str (t/minus (clock) (t/seconds 1)))}]
+            {:keys [make-metrics-watch-request-fn trigger-ch]} (make-metrics-watch-request-factory-fn raw-events)
+            {:keys [exit-chan query-state-fn token-metric-chan-mult]}
+            (start-metrics-consumer-maintainer
+              http-client clock kv-store token-cluster-calculator retrieve-descriptor-fn (make-service-id->metrics-fn local-usage-agent)
+              make-metrics-watch-request-fn local-usage-agent router-id metrics-service-urls token-metric-chan-buffer-size
+              retry-delay-ms)
+            listener-ch (async/chan 1000)]
+        (async/tap token-metric-chan-mult listener-ch)
+        (async/>!! trigger-ch :start)
+        (async/<!! (async/timeout 500))
+        (is (= [] (drain-channel! listener-ch)))
+        (is (= {:buffer-state {:token-metric-chan-count 0}
+                :last-token-event-time nil
+                :supported-include-params ["watches-state"]
+                :watches-state (pc/map-from-keys (constantly {}) metrics-service-urls)}
+               (query-state-fn #{"watches-state"})))
+        (await local-usage-agent)
+        (is (= (clock)
+               (get-in @local-usage-agent ["service-id-1" "last-request-time"])))
+        (async/>!! exit-chan :exit)))))


### PR DESCRIPTION
## Changes proposed in this PR

- ability to watch on external metrics service to update `last-request-time` metric and start new services with new request times.

## Why are we making these changes?

- we want to be able to trigger various parts of the service lifecycle off of external metrics
