### PR TITLE
better deployment error for consistent out-of-memory

### DIFF
--- a/waiter/src/waiter/state/maintainer.clj
+++ b/waiter/src/waiter/state/maintainer.clj
@@ -488,8 +488,8 @@
           no-instances-flagged-with? (fn [flag] (every? #(not (contains? % flag)) failed-instance-flags))
           all-instances-exited-similarly? (and first-exit-code (every? #(= first-exit-code %) (map :exit-code failed-instances)))
           deployment-error (cond
-                             (and has-failed-instances? all-instances-exited-similarly?) :bad-startup-command
                              (and has-failed-instances? (all-instances-flagged-with? :memory-limit-exceeded)) :not-enough-memory
+                             (and has-failed-instances? all-instances-exited-similarly?) :bad-startup-command
                              (and has-failed-instances? (all-instances-flagged-with? :ssl-exception)) :tls-error
                              (and has-failed-instances? (no-instances-flagged-with? :has-connected)) :cannot-connect
                              (and has-failed-instances? (no-instances-flagged-with? :has-responded)) (if (all-instances-flagged-with? :hangup-exception)

--- a/waiter/test/waiter/state/maintainer_test.clj
+++ b/waiter/test/waiter/state/maintainer_test.clj
@@ -648,6 +648,10 @@
                           :failed-instances [{:message "Memory limit exceeded:" :flags #{:memory-limit-exceeded}}
                                              {:message "Memory limit exceeded:" :flags #{:memory-limit-exceeded}}],
                           :expected :not-enough-memory}
+                         {:name "not-enough-memory-with-exit-code", :healthy-instances [], :unhealthy-instances [],
+                          :failed-instances [{:message "Memory limit exceeded:" :flags #{:memory-limit-exceeded} :exit-code 137}
+                                             {:message "Memory limit exceeded:" :flags #{:memory-limit-exceeded} :exit-code 137}],
+                          :expected :not-enough-memory}
                          {:name "invalid-health-check-response", :healthy-instances [], :unhealthy-instances [],
                           :failed-instances [{:message "Task was killed" :flags #{:has-connected :has-responded :never-passed-health-checks}}
                                              {:message nil :flags #{:has-connected :has-responded :never-passed-health-checks}}],


### PR DESCRIPTION
## Changes proposed in this PR

Currently, if a service gets OOM-killed as it's starting up, we end up returning the `bad-startup-command` deployment error due to the consistent exit codes. This is confusing. We should just be telling the users that their service is running out of memory.

## Why are we making these changes?

More specific error messages are better for users. This seems more accurate.