### PR TITLE
requires owner to be able to run as run-as-user

### DIFF
--- a/waiter/src/waiter/authorization.clj
+++ b/waiter/src/waiter/authorization.clj
@@ -67,6 +67,12 @@
   (and auth-user run-as-user
        (authorized? entitlement-manager auth-user :run-as {:resource-type :credential, :user run-as-user})))
 
+(defn own?
+  "Helper function that checks the whether the owner has privileges to own something running as the run-as-user."
+  [entitlement-manager owner run-as-user]
+  (and owner run-as-user
+       (authorized? entitlement-manager owner :own {:resource-type :credential, :user run-as-user})))
+
 (defn admin-user?
   "Helper function that checks the whether the auth-user has admin privileges."
   [entitlement-manager auth-user]

--- a/waiter/src/waiter/token_validator.clj
+++ b/waiter/src/waiter/token_validator.clj
@@ -144,6 +144,15 @@
               (throw (ex-info (str "Cannot modify " parameter-name " token metadata")
                               {:status http-400-bad-request
                                :token-metadata new-token-metadata
+                               :log-level :warn}))))
+          ;; owner must be able to run as run-as-user
+          (when (and run-as-user (not= "*" run-as-user))
+            (when-not (authz/own? entitlement-manager owner run-as-user)
+              (throw (ex-info (str "Owner: " owner " cannot run as user: " run-as-user)
+                              {:authenticated-user authenticated-user
+                               :owner owner
+                               :run-as-user run-as-user
+                               :status http-403-forbidden
                                :log-level :warn})))))
 
         (throw (ex-info (str "Invalid update-mode: " update-mode)


### PR DESCRIPTION
## Changes proposed in this PR

- requires owner to be able to run as run-as-user

## Why are we making these changes?

We would like to check that the `owner` is able to own tokens configured to run as `run-as-user`.
