### PR TITLE
upgrades core.async from 1.2.603 to 1.5.648

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -81,7 +81,7 @@
                  [org.apache.curator/curator-x-discovery "2.11.0"
                   :exclusions [io.netty/netty org.slf4j/slf4j-api]]
                  [org.clojure/clojure "1.10.3"]
-                 [org.clojure/core.async "1.2.603"
+                 [org.clojure/core.async "1.5.648"
                   :exclusions [org.clojure/clojure org.clojure/tools.reader]]
                  [org.clojure/core.memoize "1.0.236"
                   :exclusions [org.clojure/clojure]]


### PR DESCRIPTION
## Changes proposed in this PR

- upgrades core.async from 1.2.603 to 1.5.648

## Why are we making these changes?

Benefit from any bug fixes and improvements from core.async library upgrade. In particular, it helps resolve a memory leak with the use of timeout channels ([gist](https://gist.github.com/shamsimam/2d0b924ecbafff4904fa7c14984e96ba?permalink_comment_id=4115150#gistcomment-4115150)).

