### PR TITLE
adds kv-store-factory to the token-validator context

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -795,10 +795,11 @@
                                  cluster-calculator :context {:default-cluster name}))
    :token-root (pc/fnk [[:settings [:cluster-config name]]] name)
    :token-validator (pc/fnk [[:settings [:token-config validator]]
-                             entitlement-manager kv-store]
+                             entitlement-manager kv-store kv-store-factory]
                       (utils/create-component
                         validator :context {:entitlement-manager entitlement-manager
-                                            :kv-store kv-store}))
+                                            :kv-store kv-store
+                                            :kv-store-factory kv-store-factory}))
    :user-agent-version (pc/fnk [[:settings git-version]] (str/join (take 7 git-version)))
    :waiter-hostnames (pc/fnk [[:settings hostname]]
                        (set (if (sequential? hostname)


### PR DESCRIPTION
## Changes proposed in this PR

- adds kv-store-factory to the token-validator context

## Why are we making these changes?

We would like to allow token validators the capability to store their state in a custom Key-Value store.


