### PR TITLE
default to consistent ssl-validation on k8s api requests

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -575,7 +575,11 @@
 
                                  ;; Defines, in milliseconds, the maximum period of inactivity between two consecutive data packets on watch connections.
                                  ;; Defaults to 15 minutes.
-                                 :watch-socket-timeout-ms 900000}
+                                 :watch-socket-timeout-ms 900000
+
+                                 ;; Whether to validate the SSL certificate of the API server on the k8s watch connections.
+                                 ;; Defaults to false (same as our the http client used for all other k8s api calls).
+                                 :watch-validate-ssl false}
 
                     ;; :kind :marathon uses Marathon (https://mesosphere.github.io/marathon/) for scheduling instances:
                     ;:kind :marathon


### PR DESCRIPTION
## Changes proposed in this PR

insecure ssl connection by default on k8s watch connections

## Why are we making these changes?

default to consistent ssl-validation behavior with the rest of our k8s api requests
(we're not validating certs by default with the other http client)