### PR TITLE
record timeout exceptions for deployment errors

### DIFF
--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -625,6 +625,9 @@
                                                         (= error :ssl-exception)
                                                         (conj :ssl-exception)
 
+                                                        (= error :timeout-exception)
+                                                        (conj :timeout-exception)
+
                                                         (and (not= error :unknown-authority)
                                                              (not= error :ssl-exception)
                                                              (not= error :connect-exception))

--- a/waiter/src/waiter/state/maintainer.clj
+++ b/waiter/src/waiter/state/maintainer.clj
@@ -492,9 +492,9 @@
                              (and has-failed-instances? all-instances-exited-similarly?) :bad-startup-command
                              (and has-failed-instances? (all-instances-flagged-with? :ssl-exception)) :tls-error
                              (and has-failed-instances? (no-instances-flagged-with? :has-connected)) :cannot-connect
-                             (and has-failed-instances? (no-instances-flagged-with? :has-responded)) (if (all-instances-flagged-with? :hangup-exception)
-                                                                                                       :bad-socket
-                                                                                                       :health-check-timed-out)
+                             (and has-failed-instances? (no-instances-flagged-with? :has-responded)) (if (all-instances-flagged-with? :timeout-exception)
+                                                                                                       :health-check-timed-out
+                                                                                                       :bad-socket)
                              (and has-failed-instances? (all-instances-flagged-with? :never-passed-health-checks)) :invalid-health-check-response
                              (and has-unhealthy-instances? (= first-unhealthy-status http-401-unauthorized)) :health-check-requires-authentication)]
       (when deployment-error

--- a/waiter/test/waiter/state/maintainer_test.clj
+++ b/waiter/test/waiter/state/maintainer_test.clj
@@ -656,9 +656,13 @@
                           :failed-instances [{:message "Task was killed" :flags #{:has-connected :has-responded :never-passed-health-checks}}
                                              {:message nil :flags #{:has-connected :has-responded :never-passed-health-checks}}],
                           :expected :invalid-health-check-response}
-                         {:name "health-check-timed-out", :healthy-instances [], :unhealthy-instances [],
+                         {:name "bad-socket", :healthy-instances [], :unhealthy-instances [],
                           :failed-instances [{:message "Task was killed" :flags #{:has-connected :never-passed-health-checks}}
                                              {:message nil :flags #{:has-connected :never-passed-health-checks}}],
+                          :expected :bad-socket}
+                         {:name "health-check-timed-out", :healthy-instances [], :unhealthy-instances [],
+                          :failed-instances [{:message "Task was killed" :flags #{:has-connected :timeout-exception}}
+                                             {:message nil :flags #{:has-connected :never-passed-health-checks :timeout-exception}}],
                           :expected :health-check-timed-out}
                          {:name "cannot-connect", :healthy-instances [], :unhealthy-instances [],
                           :failed-instances [{:message "Task was killed" :flags #{:never-passed-health-checks}}


### PR DESCRIPTION
## Changes proposed in this PR

record timeout exceptions for deployment errors

## Why are we making these changes?

better distinguish timeouts vs socket connection errors (wrong proto)