### PR TITLE
skips cors check for health checks from ping requests

### DIFF
--- a/waiter/src/waiter/cors.clj
+++ b/waiter/src/waiter/cors.clj
@@ -110,12 +110,12 @@
   (let [exposed-headers-str (when (seq exposed-headers)
                               (str/join ", " exposed-headers))]
     (fn wrap-cors-fn [request]
-      (let [{:keys [headers request-method]} request
+      (let [{:keys [headers request-method waiter/skip-cors-check?]} request
             {:strs [origin]} headers
             {:keys [allowed? summary]} (if origin
                                          (request-check cors-validator request)
                                          {:allowed? false :summary {:wrap-cors-request [:origin-absent]}})]
-        (if (not origin)
+        (if (or (true? skip-cors-check?) (not origin))
           (handler request)
           (do
             (when-not allowed?

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -1042,7 +1042,9 @@
                                  ;; override the protocol and port used while talking to the backend
                                  :instance-request-overrides {:port-index health-check-port-index}
                                  :request-method :get
-                                 :uri health-check-url))
+                                 :uri health-check-url
+                                 ;; skip any CORS checks
+                                 :waiter/skip-cors-check? true))
             pr-response (process-request-handler-fn new-request)
             timeout-ch (async/timeout idle-timeout-ms)
             [response source-ch] (if (au/chan? pr-response)


### PR DESCRIPTION
## Changes proposed in this PR

- skips cors check for health checks from ping requests

## Why are we making these changes?

We should avoid CORS handling on internally generated requests, e.g. health checks on pings. The CORS check should already be performed on the incoming API requests that is generating the internal ping.

