### PR TITLE
reverts websocket backpressure support

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -45,7 +45,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20220331_163431-g5c2743a"
+                 [twosigma/jet "0.7.10-20220407_144841-gd100014"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]


### PR DESCRIPTION
## Changes proposed in this PR

- reverts websocket backpressure support

## Why are we making these changes?

We are seeing WebSocket ping frames reporting timeouts and not receiving pongs. This results in the backend instances closing connections as errors.


