### PR TITLE
upgrades to jetty version 9.4.46.v20220331

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -45,7 +45,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20220407_144841-gd100014"
+                 [twosigma/jet "0.7.10-20220407_171401-gf630ee5"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]


### PR DESCRIPTION
## Changes proposed in this PR

- upgrades to jetty version 9.4.46.v20220331

### jet MR

[upgrades to jetty version 9.4.46.v20220331](https://github.com/twosigma/jet/pull/58)

## Why are we making these changes?


