### PR TITLE
updates dependency versions to avoid conflicts

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -83,11 +83,11 @@
                  [org.clojure/clojure "1.10.3"]
                  [org.clojure/core.async "1.5.648"
                   :exclusions [org.clojure/clojure org.clojure/tools.reader]]
-                 [org.clojure/core.memoize "1.0.236"
+                 [org.clojure/core.memoize "1.0.253"
                   :exclusions [org.clojure/clojure]]
                  [org.clojure/data.codec "0.1.1"]
                  [org.clojure/data.json "1.0.0"]
-                 [org.clojure/data.priority-map "1.0.0"]
+                 [org.clojure/data.priority-map "1.1.0"]
                  [org.clojure/data.zip "1.0.0"]
                  [org.clojure/tools.cli "1.0.194"]
                  [org.clojure/tools.logging "1.1.0"]


### PR DESCRIPTION
## Changes proposed in this PR

- updates dependency versions to avoid conflicts

## Why are we making these changes?

Ensures all dependencies can run on the same version of code as much as possible.

### Without these version changes we see the following dependency errors:
```
$ lein deps :tree
...
Possibly confusing dependencies found:
[org.clojure/core.memoize "1.0.236" :exclusions [org.clojure/clojure]]
 overrides
[org.clojure/core.async "1.5.648" :exclusions [org.clojure/clojure org.clojure/tools.reader]] -> [org.clojure/tools.analyzer.jvm "1.2.2"] -> [org.clojure/core.memoize "1.0.253"]

Consider using these exclusions:
[org.clojure/core.async "1.5.648" :exclusions [org.clojure/core.memoize org.clojure/clojure org.clojure/tools.reader]]

[org.clojure/data.priority-map "1.0.0"]
 overrides
[org.clojure/core.async "1.5.648" :exclusions [org.clojure/clojure org.clojure/tools.reader]] -> [org.clojure/tools.analyzer.jvm "1.2.2"] -> [org.clojure/core.memoize "1.0.253"] -> [org.clojure/core.cache "1.0.225"] -> [org.clojure/data.priority-map "1.1.0"]

Consider using these exclusions:
[org.clojure/core.async "1.5.648" :exclusions [org.clojure/clojure org.clojure/data.priority-map org.clojure/tools.reader]]

[org.clojure/core.memoize "1.0.236" :exclusions [org.clojure/clojure]] -> [org.clojure/core.cache "1.0.207"]
 overrides
[org.clojure/core.async "1.5.648" :exclusions [org.clojure/clojure org.clojure/tools.reader]] -> [org.clojure/tools.analyzer.jvm "1.2.2"] -> [org.clojure/core.memoize "1.0.253"] -> [org.clojure/core.cache "1.0.225"]

Consider using these exclusions:
[org.clojure/core.async "1.5.648" :exclusions [org.clojure/clojure org.clojure/tools.reader org.clojure/core.cache]]

...
```