### PR TITLE
reduces failures in current unit tests when run concurrently on the same host

### DIFF
--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -2475,7 +2475,7 @@
         pods-watch-stream (make-watch-stream pods-watch-updates watch-update-signals)
         pods-watch-query-fn (fn pods-watch-query-fn [scheduler resource-name watch-url request-options]
                               (is (= "Pods" resource-name))
-                              (is (empty? request-options))
+                              (is (= {:insecure? nil} request-options))
                               (swap! pods-watch-query-count inc)
                               (let [last-resource-version (->> watch-url
                                                                (re-find #"(?<=[&?]resourceVersion=)\d+")


### PR DESCRIPTION

## Changes proposed in this PR

- reduces failures in current unit tests when run concurrently on the same host

## Why are we making these changes?

We would like to avoid flaky tests and spurious failures.


