### PR TITLE
emits RFC3399 compliant dates in logs

### DIFF
--- a/waiter/resources/log4j-console.properties
+++ b/waiter/resources/log4j-console.properties
@@ -3,7 +3,7 @@ log4j.rootLogger=DEBUG, stdout, file
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{4} - %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'}{GMT+0} %-5p %c{4} - %m%n
 log4j.appender.stdout.Threshold=INFO
 
 log4j.appender.file=org.apache.log4j.FileAppender
@@ -11,7 +11,7 @@ log4j.appender.file.File=log/waiter-tests.log
 log4j.appender.file.ImmediateFlush=true
 log4j.appender.file.Append=true
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{4} - %m%n
+log4j.appender.file.layout.conversionPattern=%d{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'}{GMT+0} %-5p [%t] %c{4} - %m%n
 log4j.appender.file.Threshold=DEBUG
 
 # DEBUG is way too noisy for some categories

--- a/waiter/resources/log4j-repl.properties
+++ b/waiter/resources/log4j-repl.properties
@@ -3,7 +3,7 @@ log4j.rootLogger=DEBUG, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{4} - %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'}{GMT+0} %-5p %c{4} - %m%n
 log4j.appender.stdout.Threshold=DEBUG
 
 # DEBUG is way too noisy for some categories

--- a/waiter/resources/log4j-test.properties
+++ b/waiter/resources/log4j-test.properties
@@ -5,7 +5,7 @@ log4j.appender.file.File=log/waiter-tests.log
 log4j.appender.file.ImmediateFlush=true
 log4j.appender.file.Append=true
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{4} - %m%n
+log4j.appender.file.layout.conversionPattern=%d{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'}{GMT+0} %-5p [%t] %c{4} - %m%n
 log4j.appender.file.Threshold=DEBUG
 
 # DEBUG is way too noisy for some categories

--- a/waiter/resources/log4j.properties
+++ b/waiter/resources/log4j.properties
@@ -9,7 +9,7 @@ log4j.appender.InfoAppender.File=log/${waiter.logFilePrefix}waiter.log
 log4j.appender.InfoAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.InfoAppender.layout=org.apache.log4j.PatternLayout
 # CID will be replaced by the custom pattern layout configured in waiter.correlation-id/replace-pattern-layout-in-log4j-appenders
-log4j.appender.InfoAppender.layout.ConversionPattern=%d{ISO8601} %-5p %c [%t] - [CID] %m%n
+log4j.appender.InfoAppender.layout.ConversionPattern=%d{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'}{GMT+0} %-5p %c [%t] - [CID] %m%n
 
 log4j.appender.ErrorAppender=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.ErrorAppender.Threshold=ERROR
@@ -17,7 +17,7 @@ log4j.appender.ErrorAppender.File=log/${waiter.logFilePrefix}waiter-error.log
 log4j.appender.ErrorAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.ErrorAppender.layout=org.apache.log4j.PatternLayout
 # CID will be replaced by the custom pattern layout configured in waiter.correlation-id/replace-pattern-layout-in-log4j-appenders
-log4j.appender.ErrorAppender.layout.ConversionPattern=%d{ISO8601} %-5p %c [%t] - [CID] %m%n
+log4j.appender.ErrorAppender.layout.ConversionPattern=%d{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'}{GMT+0} %-5p %c [%t] - [CID] %m%n
 
 log4j.category.RequestLog=INFO, RequestLogAppender
 log4j.additivity.RequestLog=false
@@ -37,7 +37,7 @@ log4j.appender.SchedulerAppender.Threshold=DEBUG
 log4j.appender.SchedulerAppender.File=log/${waiter.logFilePrefix}scheduler.log
 log4j.appender.SchedulerAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.SchedulerAppender.layout=org.apache.log4j.PatternLayout
-log4j.appender.SchedulerAppender.layout.ConversionPattern=%d{ISO8601} %-5p %c [%t] - [CID] %m%n
+log4j.appender.SchedulerAppender.layout.ConversionPattern=%d{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'}{GMT+0} %-5p %c [%t] - [CID] %m%n
 
 log4j.category.InstanceTracker=INFO, InstanceAppender
 log4j.additivity.InstanceTracker=false


### PR DESCRIPTION
## Changes proposed in this PR

- emits RFC3399 compliant dates in logs

## Why are we making these changes?

Some log ingestion tools expect the date string to be RFC3399 compliant and emitting dates in UTC timezone.
