### PR TITLE
avoids marking killed instances as failed instances by tracking kill candidates

### DIFF
--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -214,12 +214,15 @@
               "eject" instance-id "of" service-id "response:" (name response-code))
             (if successful?
               (do
+                (when (= "prepare-to-kill" reason)
+                  (scheduler/track-kill-candidate! instance-id :prepare-to-kill period-in-ms))
                 (when (= "killed" reason)
                   (let [instance (-> instance
                                      walk/keywordize-keys
                                      (update :started-at (fn [started-at]
                                                            (when started-at
                                                              (du/str-to-date started-at)))))]
+                    (scheduler/track-kill-candidate! instance-id :killed period-in-ms)
                     (notify-instance-killed-fn instance)))
                 (utils/clj->json-response {:instance-id instance-id
                                            :eject-period period-in-ms}))

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -862,7 +862,7 @@
     "Tracks which instances are being used as kill candidates for the provided duration."
     [instance-id reason duration-ms]
     (log/info "tracking instance as kill candidate" {:duration-sm duration-ms :id instance-id :reason reason})
-    (swap! kill-candidates-state-atom update instance-id update :tracked-states set/union #{reason})
+    (swap! kill-candidates-state-atom update-in [instance-id :tracked-states] set/union #{reason})
     (when (= :prepare-to-kill reason)
       (when (pos? duration-ms)
         (async/go

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -665,6 +665,51 @@
                         service
                         (assoc instances :active-instances active-instances))))))))
 
+;;
+;; Support for tracking killed instance candidates
+;;
+(let [kill-candidate-id->state-atom (atom {})]
+
+  (defn- cleanup-kill-candidate
+    "Cleans up entries for instance-id from the state atom."
+    [instance-id kill-identifier]
+    (swap! kill-candidate-id->state-atom
+           (fn cleanup-kill-candidate-helper [kill-candidate-id->state]
+             (let [{:keys [identifier reasons]} (get kill-candidate-id->state instance-id)]
+               (if (= kill-identifier identifier)
+                 (do
+                   (log/info "end tracking instance as kill candidate"
+                             {:id instance-id :kill-identifier identifier :reasons reasons})
+                   (dissoc kill-candidate-id->state instance-id))
+                 (do
+                   (log/info "ignoring kill candidate cleanup as identifier has changed"
+                             {:id instance-id :cleanup-identifier kill-identifier :current-identifier identifier})
+                   kill-candidate-id->state))))))
+
+  (defn track-kill-candidate!
+    "Tracks which instances are being used as kill candidates for the provided duration.
+     When reason is :prepare-to-kill, attaches a unique identifier to the state.
+     This allows multiple invocations with the same instance-id where only the last call triggers state cleanup."
+    [instance-id reason duration-ms]
+    (let [kill-identifier (utils/unique-identifier)]
+      (log/info "tracking instance as kill candidate"
+                (cond-> {:id instance-id :reason reason}
+                  (= :prepare-to-kill reason) (assoc :identifier kill-identifier)))
+      (swap! kill-candidate-id->state-atom update instance-id
+             (fn update-kill-candidate-state [candidate-state]
+               (cond-> (update candidate-state :reasons (fnil conj #{}) reason)
+                 (= :prepare-to-kill reason) (assoc :identifier kill-identifier))))
+      (when (and (= :prepare-to-kill reason)
+                 (pos? duration-ms))
+        (async/go
+          (async/<! (async/timeout duration-ms))
+          (cleanup-kill-candidate instance-id kill-identifier)))))
+
+  (defn is-kill-candidate?
+    "Returns true if the queried instance is currently being tracked as a kill candidate."
+    [instance-id]
+    (contains? @kill-candidate-id->state-atom instance-id)))
+
 (defn- update-scheduler-state
   "Queries given scheduler, sends data on service and instance statuses to router state maintainer, and returns scheduler state"
   [scheduler-name get-service->instances-fn service-id->service-description-fn available? failed-check-threshold service-id->health-check-context]
@@ -701,13 +746,21 @@
                   (get service-id->health-check-context service-id)
                   {:keys [healthy-instances unhealthy-instances] :as service-instance-info}
                   (retrieve-instances-for-service service-id active-instances)
+                  ;; track instances that have gone missing with state updates as failed instances
                   instance-id->tracked-failed-instance'
                   ((fnil into {}) instance-id->tracked-failed-instance
-                    (keep (fn [[instance-id unhealthy-instance]]
-                            (when (and (not (contains? active-instance-ids instance-id))
-                                       (>= (or (get instance-id->failed-health-check-count instance-id) 0) failed-check-threshold))
-                              [instance-id (update-in unhealthy-instance [:flags] conj :never-passed-health-checks)]))
-                          instance-id->unhealthy-instance))
+                   (keep (fn [[instance-id unhealthy-instance]]
+                           (when (and (not (contains? active-instance-ids instance-id))
+                                      (>= (or (get instance-id->failed-health-check-count instance-id) 0) failed-check-threshold))
+                             ;; treat any pod that went missing and was a kill candidate as not a failed instance
+                             (if-not (is-kill-candidate? instance-id)
+                               (do
+                                 (log/info "tracking missing instance as a failed instance" {:instance-id instance-id})
+                                 [instance-id (update-in unhealthy-instance [:flags] conj :never-passed-health-checks)])
+                               (do
+                                 (log/info "not tracking missing instance as a failed instance" {:instance-id instance-id})
+                                 nil))))
+                         instance-id->unhealthy-instance))
                   all-failed-instances
                   (-> (fn [failed-instance tracked-instance]
                         (-> failed-instance
@@ -842,54 +895,8 @@
                                  ([service-id] (retrieve-syncer-state @syncer-state-atom service-id)))}))
 
 ;;
-;; Support for tracking killed instance candidates
+;; Support for tracking killed and failed instances
 ;;
-(defn- cleanup-kill-candidate
-  "Cleans up state for a kill candidate.
-   If candidate was not killed but still failed, we trigger the failed instance callback."
-  [kill-candidates-state instance-id]
-  (let [{:keys [track-failed-instance tracked-states]} (get kill-candidates-state instance-id)]
-    (when (and track-failed-instance
-               (contains? tracked-states :failed)
-               (not (contains? tracked-states :killed)))
-      (log/info "tracking kill candidate as failed instance" {:id instance-id})
-      (track-failed-instance))
-    (dissoc kill-candidates-state instance-id)))
-
-(let [kill-candidates-state-atom (atom {})]
-
-  (defn track-kill-candidate!
-    "Tracks which instances are being used as kill candidates for the provided duration."
-    [instance-id reason duration-ms]
-    (log/info "tracking instance as kill candidate" {:duration-sm duration-ms :id instance-id :reason reason})
-    (swap! kill-candidates-state-atom update-in [instance-id :tracked-states] set/union #{reason})
-    (when (= :prepare-to-kill reason)
-      (when (pos? duration-ms)
-        (async/go
-          (async/<! (async/timeout duration-ms))
-          (log/info "end tracking instance as kill candidate" {:id instance-id})
-          (swap! kill-candidates-state-atom cleanup-kill-candidate instance-id)))))
-
-  (defn track-failed-kill-candidate!
-    "Tags a kill candidate as a failed instance for processing during cleanup."
-    [instance-id track-failed-instance-callback]
-    (let [kill-candidate?-atom (atom false)]
-      (swap! kill-candidates-state-atom
-             (fn update-failed-kill-candidate-state-1 [kill-candidates-state]
-               (cond-> kill-candidates-state
-                 (contains? kill-candidates-state instance-id)
-                 (update instance-id (fn update-failed-kill-candidate-state-2 [state]
-                                       (reset! kill-candidate?-atom true)
-                                       (-> state
-                                         (update :tracked-states set/union #{:failed})
-                                         (assoc :track-failed-instance track-failed-instance-callback)))))))
-      (when @kill-candidate?-atom
-        (log/info "kill candidate marked as follow-up for failed instance" {:id instance-id}))))
-
-  (defn is-kill-candidate?
-    "Returns true if the queried instance is currently being tracked as a kill candidate."
-    [instance-id]
-    (contains? @kill-candidates-state-atom instance-id)))
 
 (defn add-instance-to-buffered-collection!
   "Helper function to add/remove entries into the transient store"
@@ -902,16 +909,10 @@
                          true (conj instance-entry))))))
 
 (defn add-to-store-and-track-failed-instance!
-  [transient-store max-instances-to-keep service-id {:keys [id] :as instance}]
-  (let [track-failed-instance-helper
-        (fn track-failed-instance-helper []
-          (do
-            (log-service-instance instance :fail :info)
-            (add-instance-to-buffered-collection! transient-store max-instances-to-keep service-id instance
-                                                  (fn [] #{}) (fn [instances] (-> (sort-instances instances) (rest) (set))))))]
-    (if (is-kill-candidate? id)
-      (track-failed-kill-candidate! id track-failed-instance-helper)
-      (track-failed-instance-helper))))
+  [transient-store max-instances-to-keep service-id instance]
+  (log-service-instance instance :fail :info)
+  (add-instance-to-buffered-collection! transient-store max-instances-to-keep service-id instance
+                                        (fn [] #{}) (fn [instances] (-> (sort-instances instances) (rest) (set)))))
 
 (defn environment
   "Returns a new environment variable map with some basic variables added in"

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -585,7 +585,7 @@
 
 (defn- get-service-instances!
   "Get all active Waiter Service Instances associated with the given Waiter Service.
-   Also updates the service-id->failed-instances-transient-store as a side-effect.
+   Also updates the service-id->failed-instances-transient-store as a side effect.
    Pods reporting Failed phase status are treated as failed instances and are excluded from the return value."
   [{:keys [service-id->failed-instances-transient-store] :as scheduler} basic-service-info]
   (let [all-instances (for [pod (get-replicaset-pods scheduler basic-service-info)

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -281,8 +281,8 @@
 
 (deftest test-scheduler-syncer
   (let [clock t/now
-        scheduler-state-chan (async/chan 1)
-        timeout-chan (async/chan 1)
+        scheduler-state-chan (au/latest-chan)
+        trigger-chan (async/chan 1)
         service-id->service-description-fn (fn [id] {"backend-proto" "http"
                                                      "health-check-authentication" "standard"
                                                      "health-check-proto" "https"
@@ -292,9 +292,15 @@
         instance1 (->ServiceInstance "s1.i1" "s1" started-at nil nil #{} nil "host" 123 [] "/log" "test" "Unhealthy")
         instance2 (->ServiceInstance "s1.i2" "s1" started-at true nil #{} nil "host" 123 [] "/log" "test" "Healthy")
         instance3 (->ServiceInstance "s1.i3" "s1" started-at nil nil #{} nil "host" 123 [] "/log" "test" "Unhealthy")
-        get-service->instances (constantly
-                                 {(->Service "s1" {} {} {}) {:active-instances [instance1 instance2 instance3]
-                                                             :failed-instances []}
+        instance4 (->ServiceInstance "s1.i4" "s1" started-at nil nil #{} nil "host" 123 [] "/log" "test" "Unhealthy")
+        instance5 (->ServiceInstance "s1.i5" "s1" started-at nil nil #{} nil "host" 123 [] "/log" "test" "Unhealthy")
+        instance6 (->ServiceInstance "s1.i6" "s1" started-at nil nil #{} nil "host" 123 [] "/log" "test" "Unhealthy")
+        get-service->instances-invocation-count (atom 0)
+        get-service->instances (fn []
+                                 (swap! get-service->instances-invocation-count inc)
+                                 {(->Service "s1" {} {} {}) {:active-instances (cond-> [instance1 instance2 instance3]
+                                                                                 (= 1 @get-service->instances-invocation-count) (conj instance4 instance6))
+                                                             :failed-instances [instance5]}
                                   (->Service "s2" {} {} {}) {:active-instances []
                                                              :failed-instances []}})
         available? (fn [_ {:keys [id]} {:strs [backend-proto health-check-authentication health-check-proto
@@ -309,64 +315,109 @@
                                  :else
                                  {:healthy? false, :status http-400-bad-request})))
         start-time-ms (.getMillis (clock))
-        failed-check-threshold 5
-        scheduler-name "test-scheduler"
-        {:keys [exit-chan query-chan retrieve-syncer-state-fn]}
-        (start-scheduler-syncer clock timeout-chan service-id->service-description-fn available?
-                                failed-check-threshold scheduler-name get-service->instances scheduler-state-chan)
-        instance3-unhealthy (assoc instance3
-                              :flags #{:has-connected :has-responded}
-                              :healthy? false
-                              :health-check-status http-400-bad-request)]
-    (let [response-chan (async/promise-chan)]
-      (async/>!! query-chan {:response-chan response-chan :service-id "s0"})
-      (is (= {:last-update-time nil} (async/<!! response-chan)))
-      (is (= {} (retrieve-syncer-state-fn))))
-    (async/>!! timeout-chan :timeout)
-    (let [[[update-apps-msg update-apps] [update-instances-msg update-instances]] (async/<!! scheduler-state-chan)]
-      (is (= :update-available-services update-apps-msg))
-      (is (= #{"s1" "s2"} (:available-service-ids update-apps)))
-      (is (= #{"s1"} (:healthy-service-ids update-apps)))
-      (is (= :update-service-instances update-instances-msg))
-      (is (= [(assoc instance1 :healthy? true) instance2] (:healthy-instances update-instances)))
-      (is (= [instance3-unhealthy] (:unhealthy-instances update-instances)))
-      (is (= "s1" (:service-id update-instances))))
-    ;; Retrieves scheduler state without service-id
-    (let [response-chan (async/promise-chan)
-          _ (async/>!! query-chan {:response-chan response-chan})
-          response (async/alt!!
-                     response-chan ([state] state)
-                     (async/timeout 10000) ([_] {:message "Request timed out!"}))]
-      (is (contains? response :service-id->health-check-context))
-      (is (= {"s1" {:instance-id->unhealthy-instance {"s1.i3" instance3-unhealthy},
-                    :instance-id->tracked-failed-instance {},
-                    :instance-id->failed-health-check-count {"s1.i3" 1}}
-              "s2" {:instance-id->failed-health-check-count {}
-                    :instance-id->tracked-failed-instance {}
-                    :instance-id->unhealthy-instance {}}}
-             (:service-id->health-check-context response)))
-      (is (= {"s1" {:instance-id->unhealthy-instance {"s1.i3" instance3-unhealthy},
-                    :instance-id->tracked-failed-instance {},
-                    :instance-id->failed-health-check-count {"s1.i3" 1}}
-              "s2" {:instance-id->failed-health-check-count {}
-                    :instance-id->tracked-failed-instance {}
-                    :instance-id->unhealthy-instance {}}}
-             (:service-id->health-check-context (retrieve-syncer-state-fn)))))
-    ;; Retrieves scheduler state with service-id
-    (let [response-chan (async/promise-chan)
-          _ (async/>!! query-chan {:response-chan response-chan :service-id "s1"})
-          response (async/alt!!
-                     response-chan ([state] state)
-                     (async/timeout 10000) ([_] {:message "Request timed out!"}))
-          end-time-ms (.getMillis (clock))]
-      (doseq [required-key [:instance-id->failed-health-check-count
-                            :instance-id->tracked-failed-instance
-                            :instance-id->unhealthy-instance
-                            :last-update-time]]
-        (is (contains? response required-key)))
-      (is (nil? (:service-id->health-check-context response)))
-      (is (<= start-time-ms (-> response :last-update-time .getMillis) end-time-ms)))
-    (async/>!! exit-chan :exit)))
+        failed-check-threshold 1
+        scheduler-name "test-scheduler"]
+    (with-redefs [is-kill-candidate? (fn [instance-id] (= instance-id (get instance6 :id)))]
+      (let [{:keys [exit-chan query-chan retrieve-syncer-state-fn]}
+            (start-scheduler-syncer clock trigger-chan service-id->service-description-fn available?
+                                    failed-check-threshold scheduler-name get-service->instances scheduler-state-chan)
+            make-unhealthy-instance (fn [instance]
+                                      (assoc instance
+                                        :flags #{:has-connected :has-responded}
+                                        :healthy? false
+                                        :health-check-status http-400-bad-request))
+            instance3-unhealthy (make-unhealthy-instance instance3)
+            instance4-unhealthy (make-unhealthy-instance instance4)
+            instance6-unhealthy (make-unhealthy-instance instance6)]
+        (let [response-chan (async/promise-chan)]
+          (async/>!! query-chan {:response-chan response-chan :service-id "s0"})
+          (is (= {:last-update-time nil} (async/<!! response-chan)))
+          (is (= {} (retrieve-syncer-state-fn))))
+        (async/>!! trigger-chan :trigger)
+        (let [[[update-apps-msg update-apps] [update-instances-msg update-instances]] (async/<!! scheduler-state-chan)]
+          (is (= :update-available-services update-apps-msg))
+          (is (= #{"s1" "s2"} (:available-service-ids update-apps)))
+          (is (= #{"s1"} (:healthy-service-ids update-apps)))
+          (is (= :update-service-instances update-instances-msg))
+          (is (= [(assoc instance1 :healthy? true) instance2] (:healthy-instances update-instances)))
+          (is (= [instance3-unhealthy instance4-unhealthy instance6-unhealthy] (:unhealthy-instances update-instances)))
+          (is (= "s1" (:service-id update-instances))))
+        ;; Retrieves scheduler state without service-id
+        (let [response-chan (async/promise-chan)
+              _ (async/>!! query-chan {:response-chan response-chan})
+              response (async/alt!!
+                         response-chan ([state] state)
+                         (async/timeout 10000) ([_] {:message "Request timed out!"}))]
+          (is (contains? response :service-id->health-check-context))
+          (is (= {"s1" {:instance-id->unhealthy-instance {"s1.i3" instance3-unhealthy
+                                                          "s1.i4" instance4-unhealthy
+                                                          "s1.i6" instance6-unhealthy},
+                        :instance-id->tracked-failed-instance {},
+                        :instance-id->failed-health-check-count {"s1.i3" 1
+                                                                 "s1.i4" 1
+                                                                 "s1.i6" 1}}
+                  "s2" {:instance-id->failed-health-check-count {}
+                        :instance-id->tracked-failed-instance {}
+                        :instance-id->unhealthy-instance {}}}
+                 (:service-id->health-check-context response)))
+          (is (= {"s1" {:instance-id->unhealthy-instance {"s1.i3" instance3-unhealthy
+                                                          "s1.i4" instance4-unhealthy
+                                                          "s1.i6" instance6-unhealthy},
+                        :instance-id->tracked-failed-instance {},
+                        :instance-id->failed-health-check-count {"s1.i3" 1
+                                                                 "s1.i4" 1
+                                                                 "s1.i6" 1}}
+                  "s2" {:instance-id->failed-health-check-count {}
+                        :instance-id->tracked-failed-instance {}
+                        :instance-id->unhealthy-instance {}}}
+                 (:service-id->health-check-context (retrieve-syncer-state-fn)))))
+        ;; Retrieves scheduler state with service-id
+        (let [response-chan (async/promise-chan)
+              _ (async/>!! query-chan {:response-chan response-chan :service-id "s1"})
+              response (async/alt!!
+                         response-chan ([state] state)
+                         (async/timeout 10000) ([_] {:message "Request timed out!"}))
+              end-time-ms (.getMillis (clock))]
+          (doseq [required-key [:instance-id->failed-health-check-count
+                                :instance-id->tracked-failed-instance
+                                :instance-id->unhealthy-instance
+                                :last-update-time]]
+            (is (contains? response required-key)))
+          (is (nil? (:service-id->health-check-context response)))
+          (is (<= start-time-ms (-> response :last-update-time .getMillis) end-time-ms)))
+        ;; instance4 and instance6 go missing, instance4 will be tracked as failed, instance6 skipped as a kill candidate
+        (async/>!! trigger-chan :trigger)
+        (let [[[update-apps-msg update-apps] [update-instances-msg update-instances]] (async/<!! scheduler-state-chan)]
+          (is (= :update-available-services update-apps-msg))
+          (is (= #{"s1" "s2"} (:available-service-ids update-apps)))
+          (is (= #{"s1"} (:healthy-service-ids update-apps)))
+          (is (= :update-service-instances update-instances-msg))
+          (is (= [(assoc instance1 :healthy? true) instance2] (:healthy-instances update-instances)))
+          (is (= [instance3-unhealthy] (:unhealthy-instances update-instances)))
+          (is (= "s1" (:service-id update-instances))))
+        ;; Retrieves scheduler state without service-id
+        (let [response-chan (async/promise-chan)
+              _ (async/>!! query-chan {:response-chan response-chan})
+              response (async/alt!!
+                         response-chan ([state] state)
+                         (async/timeout 10000) ([_] {:message "Request timed out!"}))
+              instance4-unhealthy (update instance4-unhealthy :flags conj :never-passed-health-checks)]
+          (is (contains? response :service-id->health-check-context))
+          (is (= {"s1" {:instance-id->unhealthy-instance {"s1.i3" instance3-unhealthy},
+                        :instance-id->tracked-failed-instance {"s1.i4" instance4-unhealthy},
+                        :instance-id->failed-health-check-count {"s1.i3" 2}}
+                  "s2" {:instance-id->failed-health-check-count {}
+                        :instance-id->tracked-failed-instance {}
+                        :instance-id->unhealthy-instance {}}}
+                 (:service-id->health-check-context response)))
+          (is (= {"s1" {:instance-id->unhealthy-instance {"s1.i3" instance3-unhealthy},
+                        :instance-id->tracked-failed-instance {"s1.i4" instance4-unhealthy},
+                        :instance-id->failed-health-check-count {"s1.i3" 2}}
+                  "s2" {:instance-id->failed-health-check-count {}
+                        :instance-id->tracked-failed-instance {}
+                        :instance-id->unhealthy-instance {}}}
+                 (:service-id->health-check-context (retrieve-syncer-state-fn)))))
+        (async/>!! exit-chan :exit)))))
 
 (deftest test-start-health-checks
   (let [available-instance "id1"
@@ -978,68 +1029,41 @@
           (is (= expected-state-2 actual-state-2)))))))
 
 (deftest test-track-kill-candidate!
-  (testing "basic cleanup"
-    (let [instance-id-1 (str "id-1-" (System/nanoTime))
-          instance-id-2 (str "id-1-" (System/nanoTime))
-          instance-id-3 (str "id-1-" (System/nanoTime))]
-      (track-kill-candidate! instance-id-1 :prepare-to-kill 200)
-      (track-kill-candidate! instance-id-2 :prepare-to-kill 400)
-      (is (is-kill-candidate? instance-id-1))
-      (is (is-kill-candidate? instance-id-2))
-      (is (not (is-kill-candidate? instance-id-3)))
-      (Thread/sleep 300)
-      (track-kill-candidate! instance-id-2 :killed 1000)
-      (is (not (is-kill-candidate? instance-id-1)))
-      (is (is-kill-candidate? instance-id-2))
-      (is (not (is-kill-candidate? instance-id-3)))
-      (Thread/sleep 200)
-      (is (not (is-kill-candidate? instance-id-1)))
-      (is (not (is-kill-candidate? instance-id-2)))
-      (is (not (is-kill-candidate? instance-id-3)))))
-
-  (testing "cleanup of failed but not killed instance"
-    (let [instance-id-1 (str "id-1-" (System/nanoTime))
-          instance-id-2 (str "id-1-" (System/nanoTime))
-          instance-id-3 (str "id-1-" (System/nanoTime))
-          failed-instance-tracker (atom #{})
-          failed-instance-callback-wrapper (fn [instance-id]
-                                             (fn []
-                                               (swap! failed-instance-tracker conj instance-id))) ]
-      (track-kill-candidate! instance-id-1 :prepare-to-kill 200)
-      (track-kill-candidate! instance-id-2 :prepare-to-kill 200)
-      (track-kill-candidate! instance-id-3 :prepare-to-kill 200)
-      (track-kill-candidate! instance-id-2 :killed 1000)
-      (track-failed-kill-candidate! instance-id-2 (failed-instance-callback-wrapper instance-id-2))
-      (track-failed-kill-candidate! instance-id-3 (failed-instance-callback-wrapper instance-id-3))
-      (Thread/sleep 300)
-      (is (not (is-kill-candidate? instance-id-1)))
-      (is (not (is-kill-candidate? instance-id-2)))
-      (is (not (is-kill-candidate? instance-id-3)))
-      (is (not (contains? @failed-instance-tracker instance-id-1)))
-      (is (not (contains? @failed-instance-tracker instance-id-2)))
-      (is (contains? @failed-instance-tracker instance-id-3)))))
+  (let [instance-id-1 (str "id-1-" (System/nanoTime))
+        instance-id-2 (str "id-2-" (System/nanoTime))
+        instance-id-3 (str "id-3-" (System/nanoTime))]
+    (track-kill-candidate! instance-id-1 :prepare-to-kill 200)
+    (track-kill-candidate! instance-id-2 :prepare-to-kill 200)
+    (track-kill-candidate! instance-id-3 :prepare-to-kill 200)
+    (track-kill-candidate! instance-id-1 :killed 1000)
+    (track-kill-candidate! instance-id-2 :killed 1000)
+    (Thread/sleep 100)
+    (is (is-kill-candidate? instance-id-1))
+    (is (is-kill-candidate? instance-id-2))
+    (is (is-kill-candidate? instance-id-3))
+    (track-kill-candidate! instance-id-2 :prepare-to-kill 200)
+    (Thread/sleep 150)
+    (is (not (is-kill-candidate? instance-id-1)))
+    (is (is-kill-candidate? instance-id-2))
+    (is (not (is-kill-candidate? instance-id-3)))
+    (Thread/sleep 100)
+    (is (not (is-kill-candidate? instance-id-1)))
+    (is (not (is-kill-candidate? instance-id-2)))
+    (is (not (is-kill-candidate? instance-id-3)))))
 
 (deftest test-add-to-store-and-track-failed-instance!
   (let [max-instances-to-keep 2
-        callback-atom (atom nil)]
-    (with-redefs [is-kill-candidate? (fn [instance-id] (= instance-id "i3"))
-                  track-failed-kill-candidate! (fn [instance-id callback]
-                                                 (is (= instance-id "i3"))
-                                                 (reset! callback-atom callback))]
-      (let [transient-store (atom {})
-            service-id "s1"
-            instance-1 {:id "i1" :service-id service-id :started-at "202204190010"}
-            instance-2 {:id "i2" :service-id service-id :started-at "202204190020"}
-            instance-3 {:id "i3" :service-id service-id :started-at "202204190030"}
-            instance-4 {:id "i4" :service-id service-id :started-at "202204190040"}]
-        (add-to-store-and-track-failed-instance! transient-store max-instances-to-keep service-id instance-1)
-        (is (= #{instance-1} (set (get @transient-store service-id))))
-        (add-to-store-and-track-failed-instance! transient-store max-instances-to-keep service-id instance-2)
-        (is (= #{instance-1 instance-2} (set (get @transient-store service-id))))
-        (add-to-store-and-track-failed-instance! transient-store max-instances-to-keep service-id instance-3)
-        (is (= #{instance-1 instance-2} (set (get @transient-store service-id))))
-        (add-to-store-and-track-failed-instance! transient-store max-instances-to-keep service-id instance-4)
-        (is (= #{instance-2 instance-4} (set (get @transient-store service-id))))
-        (is @callback-atom)
-        (@callback-atom)
-        (is (= #{instance-3 instance-4} (set (get @transient-store service-id))))))))
+        transient-store (atom {})
+        service-id "s1"
+        instance-1 {:id "i1" :service-id service-id :started-at "202204190010"}
+        instance-2 {:id "i2" :service-id service-id :started-at "202204190020"}
+        instance-3 {:id "i3" :service-id service-id :started-at "202204190030"}
+        instance-4 {:id "i4" :service-id service-id :started-at "202204190040"}]
+    (add-to-store-and-track-failed-instance! transient-store max-instances-to-keep service-id instance-1)
+    (is (= #{instance-1} (set (get @transient-store service-id))))
+    (add-to-store-and-track-failed-instance! transient-store max-instances-to-keep service-id instance-2)
+    (is (= #{instance-1 instance-2} (set (get @transient-store service-id))))
+    (add-to-store-and-track-failed-instance! transient-store max-instances-to-keep service-id instance-3)
+    (is (= #{instance-2 instance-3} (set (get @transient-store service-id))))
+    (add-to-store-and-track-failed-instance! transient-store max-instances-to-keep service-id instance-4)
+    (is (= #{instance-3 instance-4} (set (get @transient-store service-id))))))


### PR DESCRIPTION
## Changes proposed in this PR

- avoids marking killed instances as failed instances by tracking kill candidates

## Why are we making these changes?

The kubernetes scheduler, since it uses watches, encounters a race between treating deleted instances as killed or failed. By tracking kill candidates we can err on the side of caution and only track non-kill candidates as failed instances.

**Note**: A data race is still possible where our kill candidate actually fails and hence the subsequent but the kill operation returns success. 
