### PR TITLE
removes support for USE_BEARER_AUTH env variable

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -234,7 +234,6 @@
                               ;; When not configured, the value is assumed to be true.
                               :allow-bearer-auth-api? true
                               ;; Whether JWT authentication is the allowed for service (proxy) requests.
-                              ;; The value of USE_BEARER_AUTH environment variable of the service overrides this value.
                               ;; When not configured, the value is assumed to be false.
                               :allow-bearer-auth-services? false
                               ;; Whether OIDC+PKCE authentication is allowed for Waiter API requests.

--- a/waiter/integration/waiter/authentication_test.clj
+++ b/waiter/integration/waiter/authentication_test.clj
@@ -596,7 +596,7 @@
       (log/info "OIDC+PKCE authentication is disabled"))))
 
 (deftest ^:parallel ^:integration-fast test-spnego-authentication-disabled
-  (if (and use-spnego)
+  (if use-spnego
     (testing-using-waiter-url
       (if (jwt-auth-enabled-services? waiter-url)
         (let [{:keys [cookies] :as auth-response} (make-request waiter-url "/waiter-auth")

--- a/waiter/integration/waiter/authentication_test.clj
+++ b/waiter/integration/waiter/authentication_test.clj
@@ -244,11 +244,10 @@
 
 (deftest ^:parallel ^:integration-fast test-jwt-authentication-token-realm
   (testing-using-waiter-url
-    (if (jwt-auth-enabled? waiter-url)
+    (if (jwt-auth-enabled-services? waiter-url)
       (let [waiter-host (-> waiter-url sanitize-waiter-url utils/authority->host)
             host (create-token-name waiter-url ":")
             service-parameters (assoc (kitchen-params)
-                                 :env {"USE_BEARER_AUTH" "true"}
                                  :name (rand-name))
             token-response (post-token waiter-url (assoc service-parameters
                                                     :run-as-user (retrieve-username)
@@ -280,7 +279,7 @@
                   (validate-response service-id access-token "jwt")))))
           (finally
             (delete-token-and-assert waiter-url host))))
-      (log/info "JWT authentication is disabled"))))
+      (log/info "JWT authentication is disabled for services"))))
 
 (deftest ^:parallel ^:integration-fast test-fallback-to-alternate-auth-on-invalid-jwt-token-token-realm
   (testing-using-waiter-url
@@ -288,7 +287,6 @@
       (let [waiter-host (-> waiter-url sanitize-waiter-url utils/authority->host)
             host (create-token-name waiter-url ":")
             service-parameters (assoc (kitchen-params)
-                                 :env {"USE_BEARER_AUTH" "true"}
                                  :name (rand-name))
             token-response (post-token waiter-url (assoc service-parameters
                                                     :run-as-user (retrieve-username)
@@ -598,39 +596,40 @@
       (log/info "OIDC+PKCE authentication is disabled"))))
 
 (deftest ^:parallel ^:integration-fast test-spnego-authentication-disabled
-  (if use-spnego
+  (if (and use-spnego)
     (testing-using-waiter-url
-      (let [{:keys [cookies] :as auth-response} (make-request waiter-url "/waiter-auth")
-            token-name (create-token-name waiter-url ":")]
-        (is (seq cookies) (str auth-response))
-        (try
-          (let [service-parameters (assoc (kitchen-params)
-                                     :authentication "standard"
-                                     :env {"USE_BEARER_AUTH" "true"
-                                           "USE_SPNEGO_AUTH" "false"}
-                                     :name (rand-name)
-                                     :run-as-user (retrieve-username))
-                token-response (post-token waiter-url (assoc service-parameters "token" token-name))
-                _ (assert-response-status token-response http-200-ok)
-                {:keys [service-id] :as canary-response}
-                (make-request-with-debug-info
-                  {:x-waiter-token token-name}
-                  #(make-kitchen-request waiter-url % :cookies cookies :path "/request-info"))]
-            (with-service-cleanup
-              service-id
-              (assert-response-status canary-response http-200-ok)
-              (assert-backend-response canary-response)
-              (is (= "cookie" (get-in canary-response [:headers "x-waiter-auth-method"])) (str canary-response))
-              (is (= (retrieve-username) (get-in canary-response [:headers "x-waiter-auth-user"])) (str canary-response))
-              (let [response (make-request-with-debug-info
-                               {:x-waiter-token token-name}
-                               #(make-kitchen-request waiter-url % :path "/request-info"))]
-                (assert-response-status response http-401-unauthorized)
-                (assert-waiter-response response)
-                (let [www-authenticate-header (get-in response [:headers "www-authenticate"])]
-                  (is www-authenticate-header (str response))
-                  (is (not (str/includes? (str www-authenticate-header) "Negotiate")) (str response))
-                  (is (str/includes? (str www-authenticate-header) "Bearer") (str response))))))
-          (finally
-            (delete-token-and-assert waiter-url token-name)))))
+      (if (jwt-auth-enabled-services? waiter-url)
+        (let [{:keys [cookies] :as auth-response} (make-request waiter-url "/waiter-auth")
+              token-name (create-token-name waiter-url ":")]
+          (is (seq cookies) (str auth-response))
+          (try
+            (let [service-parameters (assoc (kitchen-params)
+                                       :authentication "standard"
+                                       :env {"USE_SPNEGO_AUTH" "false"}
+                                       :name (rand-name)
+                                       :run-as-user (retrieve-username))
+                  token-response (post-token waiter-url (assoc service-parameters "token" token-name))
+                  _ (assert-response-status token-response http-200-ok)
+                  {:keys [service-id] :as canary-response}
+                  (make-request-with-debug-info
+                    {:x-waiter-token token-name}
+                    #(make-kitchen-request waiter-url % :cookies cookies :path "/request-info"))]
+              (with-service-cleanup
+                service-id
+                (assert-response-status canary-response http-200-ok)
+                (assert-backend-response canary-response)
+                (is (= "cookie" (get-in canary-response [:headers "x-waiter-auth-method"])) (str canary-response))
+                (is (= (retrieve-username) (get-in canary-response [:headers "x-waiter-auth-user"])) (str canary-response))
+                (let [response (make-request-with-debug-info
+                                 {:x-waiter-token token-name}
+                                 #(make-kitchen-request waiter-url % :path "/request-info"))]
+                  (assert-response-status response http-401-unauthorized)
+                  (assert-waiter-response response)
+                  (let [www-authenticate-header (get-in response [:headers "www-authenticate"])]
+                    (is www-authenticate-header (str response))
+                    (is (not (str/includes? (str www-authenticate-header) "Negotiate")) (str response))
+                    (is (str/includes? (str www-authenticate-header) "Bearer") (str response))))))
+            (finally
+              (delete-token-and-assert waiter-url token-name))))
+        (log/info "Skipping test as Bearer authentication is disabled for services")))
     (log/info "Skipping test as spnego authentication is not available")))

--- a/waiter/src/waiter/auth/jwt.clj
+++ b/waiter/src/waiter/auth/jwt.clj
@@ -517,10 +517,9 @@
    request-handler]
   (fn jwt-auth-handler [{:keys [waiter-api-call?] :as request}]
     (let [use-jwt-auth? (or
-                          ;; service requests will enable JWT auth based on env variable or when absent, the allow-bearer-auth-services?
+                          ;; service requests will enable JWT auth based on allow-bearer-auth-services?
                           (and (not waiter-api-call?)
-                               (= "true" (get-in request [:waiter-discovery :service-description-template "env" "USE_BEARER_AUTH"]
-                                                 (str allow-bearer-auth-services?))))
+                               (= "true" (str allow-bearer-auth-services?)))
                           ;; waiter api requests will enable JWT auth based on allow-bearer-auth-api?
                           (and waiter-api-call? allow-bearer-auth-api?))]
       (cond

--- a/waiter/src/waiter/auth/jwt.clj
+++ b/waiter/src/waiter/auth/jwt.clj
@@ -518,8 +518,7 @@
   (fn jwt-auth-handler [{:keys [waiter-api-call?] :as request}]
     (let [use-jwt-auth? (or
                           ;; service requests will enable JWT auth based on allow-bearer-auth-services?
-                          (and (not waiter-api-call?)
-                               (= "true" (str allow-bearer-auth-services?)))
+                          (and (not waiter-api-call?) (true? allow-bearer-auth-services?))
                           ;; waiter api requests will enable JWT auth based on allow-bearer-auth-api?
                           (and waiter-api-call? allow-bearer-auth-api?))]
       (cond

--- a/waiter/src/waiter/auth/jwt.clj
+++ b/waiter/src/waiter/auth/jwt.clj
@@ -518,7 +518,7 @@
   (fn jwt-auth-handler [{:keys [waiter-api-call?] :as request}]
     (let [use-jwt-auth? (or
                           ;; service requests will enable JWT auth based on allow-bearer-auth-services?
-                          (and (not waiter-api-call?) (true? allow-bearer-auth-services?))
+                          (and (not waiter-api-call?) allow-bearer-auth-services?)
                           ;; waiter api requests will enable JWT auth based on allow-bearer-auth-api?
                           (and waiter-api-call? allow-bearer-auth-api?))]
       (cond

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -1323,6 +1323,14 @@
   [waiter-url]
   (not= "disabled" (setting waiter-url [:authenticator-config :jwt])))
 
+(defn jwt-auth-enabled-services?
+  "Returns true if JWT authentication is enabled for proxied requests."
+  [waiter-url]
+  (let [{:keys [jwt]} (setting waiter-url [:authenticator-config])]
+    (and (not= "disabled" jwt)
+         (map? jwt)
+         (get jwt :allow-bearer-auth-services?))))
+
 (defn oidc-auth-enabled?
   "Returns true if OIDC+PKCE authentication is enabled."
   [waiter-url]

--- a/waiter/test/waiter/auth/jwt_test.clj
+++ b/waiter/test/waiter/auth/jwt_test.clj
@@ -764,9 +764,6 @@
           (is (= {:body ::standard-request}
                  (jwt-handler {:headers {"authorization" "Bearer abcdef"}
                                :source ::standard-request})))
-          (is (= {:body ::standard-request}
-                 (jwt-handler {:headers {"authorization" "Bearer abcdef"}
-                               :source ::standard-request})))
           (is (= {:body ::jwt-auth}
                  (jwt-handler {:headers {"authorization" "Bearer ab.cd.ef"}
                                :source ::standard-request})))

--- a/waiter/test/waiter/auth/jwt_test.clj
+++ b/waiter/test/waiter/auth/jwt_test.clj
@@ -703,10 +703,9 @@
         max-expiry-duration-ms (-> 1 t/hours t/in-millis)
         subject-regex default-subject-regex
         issuer-constraints ["issuer"]
-        attach-bearer-auth-env
-        (fn attach-bearer-auth-env [request env-value]
-          (assoc-in request [:waiter-discovery :service-description-template "env" "USE_BEARER_AUTH"]
-                    (str env-value)))]
+        attach-bearer-auth-env (fn attach-bearer-auth-env [request env-value]
+                                 (assoc-in request [:waiter-discovery :service-description-template "env" "USE_BEARER_AUTH"]
+                                           (str env-value)))]
     (with-redefs [authenticate-request (fn [handler jwt-validator keys password request]
                                          (is (= "jwt+type" (:token-type jwt-validator)))
                                          (is (= issuer-constraints (:issuer-constraints jwt-validator)))
@@ -726,8 +725,10 @@
                (jwt-handler {:headers {}
                              :source ::standard-request})))
         (is (= {:body ::standard-request}
-               (jwt-handler {:headers {"authorization" "Negotiate abcd"}
-                             :source ::standard-request})))
+               (-> {:headers {"authorization" "Negotiate abcd"}
+                    :source ::standard-request}
+                 (attach-bearer-auth-env "true") ;; USE_BEARER_AUTH env variable ignored
+                 (jwt-handler))))
         (is (= {:body ::standard-request}
                (jwt-handler {:headers {"authorization" "Negotiate abcd,Negotiate wxyz"}
                              :source ::standard-request})))
@@ -751,98 +752,7 @@
                              :source ::standard-request})))
         (is (= {:body ::standard-request}
                (jwt-handler {:headers {"authorization" "Negotiate abcd,Bearer ab.cd.ef,Negotiate wxyz"}
-                             :source ::standard-request})))
-        (is (= {:body ::jwt-auth}
-               (jwt-handler
-                 (attach-bearer-auth-env
-                   {:headers {"authorization" "Bearer ab.cd.ef"}
-                    :source ::standard-request}
-                   true))))
-        (is (= {:body ::jwt-auth}
-               (jwt-handler
-                 (attach-bearer-auth-env
-                   {:headers {"authorization" "Bearer wxyz,Bearer ab.cd.ef"}
-                    :source ::standard-request}
-                   true))))
-        (is (= {:body ::jwt-auth}
-               (jwt-handler
-                 (attach-bearer-auth-env
-                   {:headers {"authorization" "Negotiate abcd,Bearer ab.cd.ef"}
-                    :source ::standard-request}
-                   true))))
-        (is (= {:body ::jwt-auth}
-               (jwt-handler
-                 (attach-bearer-auth-env
-                   {:headers {"authorization" "Bearer ab.cd.ef,Negotiate wxyz"}
-                    :source ::standard-request}
-                   true))))
-        (is (= {:body ::jwt-auth}
-               (jwt-handler
-                 (attach-bearer-auth-env
-                   {:headers {"authorization" "Negotiate abcd,Bearer ab.cd.ef,Negotiate wxyz"}
-                    :source ::standard-request}
-                   true))))
-
-        (is (= {:body ::standard-request}
-               (jwt-handler
-                 (attach-bearer-auth-env
-                   {:headers {"authorization" "Bearer wxyz,Bearer ab.cd.ef"}
-                    :source ::standard-request}
-                   false))))
-        (is (= {:body ::standard-request}
-               (jwt-handler
-                 (attach-bearer-auth-env
-                   {:headers {"authorization" "Negotiate abcd,Bearer ab.cd.ef"}
-                    :source ::standard-request}
-                   false))))
-        (is (= {:body ::standard-request}
-               (jwt-handler
-                 (attach-bearer-auth-env
-                   {:headers {"authorization" "Bearer ab.cd.ef,Negotiate wxyz"}
-                    :source ::standard-request}
-                   false))))
-        (is (= {:body ::standard-request}
-               (jwt-handler
-                 (attach-bearer-auth-env
-                   {:headers {"authorization" "Negotiate abcd,Bearer ab.cd.ef,Negotiate wxyz"}
-                    :source ::standard-request}
-                   false))))
-
-        (is (= {:body ::standard-request}
-               (jwt-handler
-                 {:authorization/principal "user@test.com"
-                  :authorization/user "user"
-                  :headers {"authorization" "Bearer abcd"}
-                  :source ::standard-request})))
-
-        (is (= {:body ::standard-request}
-               (jwt-handler
-                 (attach-bearer-auth-env
-                   {:headers {"authorization" "Bearer wxyz,Bearer ab.cd.ef"}
-                    :source ::standard-request
-                    :waiter-api-call? true}
-                   true))))
-        (is (= {:body ::standard-request}
-               (jwt-handler
-                 (attach-bearer-auth-env
-                   {:headers {"authorization" "Negotiate abcd,Bearer ab.cd.ef"}
-                    :source ::standard-request
-                    :waiter-api-call? true}
-                   true))))
-        (is (= {:body ::standard-request}
-               (jwt-handler
-                 (attach-bearer-auth-env
-                   {:headers {"authorization" "Bearer ab.cd.ef,Negotiate wxyz"}
-                    :source ::standard-request
-                    :waiter-api-call? true}
-                   true))))
-        (is (= {:body ::standard-request}
-               (jwt-handler
-                 (attach-bearer-auth-env
-                   {:headers {"authorization" "Negotiate abcd,Bearer ab.cd.ef,Negotiate wxyz"}
-                    :source ::standard-request
-                    :waiter-api-call? true}
-                   true)))))
+                             :source ::standard-request}))))
 
       (doseq [allow-bearer-auth-api? [true false]]
         (let [auth-server (make-jwt-auth-server :jwks-url "jwks-url" :keys-cache keys-cache)
@@ -851,6 +761,12 @@
               authenticator (->JwtAuthenticator
                               allow-bearer-auth-api? true false auth-server jwt-validator "password")
               jwt-handler (wrap-auth-handler authenticator handler)]
+          (is (= {:body ::standard-request}
+                 (jwt-handler {:headers {"authorization" "Bearer abcdef"}
+                               :source ::standard-request})))
+          (is (= {:body ::standard-request}
+                 (jwt-handler {:headers {"authorization" "Bearer abcdef"}
+                               :source ::standard-request})))
           (is (= {:body ::jwt-auth}
                  (jwt-handler {:headers {"authorization" "Bearer ab.cd.ef"}
                                :source ::standard-request})))
@@ -865,32 +781,7 @@
                                :source ::standard-request})))
           (is (= {:body ::jwt-auth}
                  (jwt-handler {:headers {"authorization" "Negotiate abcd,Bearer ab.cd.ef,Negotiate wxyz"}
-                               :source ::standard-request})))
-
-          (is (= {:body ::standard-request}
-                 (jwt-handler
-                   (attach-bearer-auth-env
-                     {:headers {"authorization" "Bearer wxyz,Bearer ab.cd.ef"}
-                      :source ::standard-request}
-                     false))))
-          (is (= {:body ::standard-request}
-                 (jwt-handler
-                   (attach-bearer-auth-env
-                     {:headers {"authorization" "Negotiate abcd,Bearer ab.cd.ef"}
-                      :source ::standard-request}
-                     false))))
-          (is (= {:body ::standard-request}
-                 (jwt-handler
-                   (attach-bearer-auth-env
-                     {:headers {"authorization" "Bearer ab.cd.ef,Negotiate wxyz"}
-                      :source ::standard-request}
-                     false))))
-          (is (= {:body ::standard-request}
-                 (jwt-handler
-                   (attach-bearer-auth-env
-                     {:headers {"authorization" "Negotiate abcd,Bearer ab.cd.ef,Negotiate wxyz"}
-                      :source ::standard-request}
-                     false))))))
+                               :source ::standard-request})))))
 
       (doseq [allow-bearer-auth-services? [true false]]
         (let [auth-server (make-jwt-auth-server :jwks-url "jwks-url" :keys-cache keys-cache)
@@ -899,34 +790,36 @@
               authenticator (->JwtAuthenticator
                               true allow-bearer-auth-services? false auth-server jwt-validator "password")
               jwt-handler (wrap-auth-handler authenticator handler)]
+          (is (= {:body (if allow-bearer-auth-services? ::jwt-auth ::standard-request)}
+                 (-> {:headers {"authorization" "Bearer wxyz,Bearer ab.cd.ef"}
+                      :source ::standard-request}
+                   (attach-bearer-auth-env "true") ;; USE_BEARER_AUTH env variable ignored
+                   (jwt-handler))))
+          (is (= {:body (if allow-bearer-auth-services? ::jwt-auth ::standard-request)}
+                 (-> {:headers {"authorization" "Bearer wxyz,Bearer ab.cd.ef"}
+                      :source ::standard-request}
+                   (attach-bearer-auth-env "false") ;; USE_BEARER_AUTH env variable ignored
+                   (jwt-handler))))
           (is (= {:body ::jwt-auth}
                  (jwt-handler
-                   (attach-bearer-auth-env
-                     {:headers {"authorization" "Bearer wxyz,Bearer ab.cd.ef"}
-                      :source ::standard-request
-                      :waiter-api-call? true}
-                     false))))
+                   {:headers {"authorization" "Bearer wxyz,Bearer ab.cd.ef"}
+                    :source ::standard-request
+                    :waiter-api-call? true})))
           (is (= {:body ::jwt-auth}
                  (jwt-handler
-                   (attach-bearer-auth-env
-                     {:headers {"authorization" "Negotiate abcd,Bearer ab.cd.ef"}
-                      :source ::standard-request
-                      :waiter-api-call? true}
-                     false))))
+                   {:headers {"authorization" "Negotiate abcd,Bearer ab.cd.ef"}
+                    :source ::standard-request
+                    :waiter-api-call? true})))
           (is (= {:body ::jwt-auth}
                  (jwt-handler
-                   (attach-bearer-auth-env
-                     {:headers {"authorization" "Bearer ab.cd.ef,Negotiate wxyz"}
-                      :source ::standard-request
-                      :waiter-api-call? true}
-                     false))))
+                   {:headers {"authorization" "Bearer ab.cd.ef,Negotiate wxyz"}
+                    :source ::standard-request
+                    :waiter-api-call? true})))
           (is (= {:body ::jwt-auth}
                  (jwt-handler
-                   (attach-bearer-auth-env
-                     {:headers {"authorization" "Negotiate abcd,Bearer ab.cd.ef,Negotiate wxyz"}
-                      :source ::standard-request
-                      :waiter-api-call? true}
-                     false)))))))))
+                   {:headers {"authorization" "Negotiate abcd,Bearer ab.cd.ef,Negotiate wxyz"}
+                    :source ::standard-request
+                    :waiter-api-call? true}))))))))
 
 (deftest test-request-access-token
   (let [access-code "access-code"


### PR DESCRIPTION
## Changes proposed in this PR

- removes support for USE_BEARER_AUTH env variable

## Why are we making these changes?

We wish to no longer allow services to disable Bearer auth.
