### PR TITLE
Waiter ssh to use --context instead of --server when possible

### DIFF
--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -373,10 +373,10 @@ def get_ssh_command(instance, is_kubernetes_enabled, container_name=None, comman
     if is_kubernetes_enabled:
         container_name = container_name or 'waiter-app'
         command_to_run = command_to_run or 'exec /bin/bash'
-        api_server = instance['k8s/api-server-url']
+        context = instance['k8s/context']
         namespace = instance['k8s/namespace']
         pod_name = instance['k8s/pod-name']
-        return f'--server {api_server} --namespace {namespace} exec -it {pod_name} -c '\
+        return f'--context {context} --namespace {namespace} exec -it {pod_name} -c '\
                f"{container_name} -- /bin/bash -c cd {log_directory}; "\
                f"{command_to_run}"
     else:

--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -373,10 +373,13 @@ def get_ssh_command(instance, is_kubernetes_enabled, container_name=None, comman
     if is_kubernetes_enabled:
         container_name = container_name or 'waiter-app'
         command_to_run = command_to_run or 'exec /bin/bash'
-        context = instance['k8s/context']
+        context = instance.get('k8s/context')
+        context_flag = f'--context {context}'
+        api_server = instance['k8s/api-server-url']
+        api_server_flag = f'--server {api_server}'
         namespace = instance['k8s/namespace']
         pod_name = instance['k8s/pod-name']
-        return f'--context {context} --namespace {namespace} exec -it {pod_name} -c '\
+        return f'{context_flag if context is not None else api_server_flag} --namespace {namespace} exec -it {pod_name} -c '\
                f"{container_name} -- /bin/bash -c cd {log_directory}; "\
                f"{command_to_run}"
     else:

--- a/cli/waiter/subcommands/ssh.py
+++ b/cli/waiter/subcommands/ssh.py
@@ -40,9 +40,9 @@ def get_instances_from_service_id(clusters, service_id, include_active_instances
     return instances
 
 
-def kubectl_exec_to_instance(kubectl_cmd, api_server, namespace, pod_name, container_name, log_directory,
+def kubectl_exec_to_instance(kubectl_cmd, context, namespace, pod_name, container_name, log_directory,
                              command_to_run=None):
-    args = ['--server', api_server,
+    args = ['--context', context,
             '--namespace', namespace,
             'exec',
             '-it', pod_name,
@@ -57,13 +57,13 @@ def ssh_instance(instance, container_name, command_to_run=None):
     log_directory = instance['log-directory']
     k8s_pod_name = instance.get('k8s/pod-name', False)
     if k8s_pod_name:
-        k8s_api_server = instance['k8s/api-server-url']
+        context = instance['k8s/context']
         kubectl_cmd = os.getenv('WAITER_KUBECTL', plugins.get_fn('get-kubectl-cmd', lambda: 'kubectl')())
         k8s_namespace = instance['k8s/namespace']
         print_info(f'Executing ssh to k8s pod {terminal.bold(k8s_pod_name)}')
         logging.debug(f'Executing ssh to k8s pod {terminal.bold(k8s_pod_name)} '
-                      f'using namespace={k8s_namespace} api_server={k8s_api_server}')
-        kubectl_exec_to_instance(kubectl_cmd, k8s_api_server, k8s_namespace, k8s_pod_name, container_name,
+                      f'using namespace={k8s_namespace} context={context}')
+        kubectl_exec_to_instance(kubectl_cmd, context, k8s_namespace, k8s_pod_name, container_name,
                                  log_directory, command_to_run)
     else:
         hostname = instance['host']

--- a/cli/waiter/subcommands/ssh.py
+++ b/cli/waiter/subcommands/ssh.py
@@ -40,9 +40,13 @@ def get_instances_from_service_id(clusters, service_id, include_active_instances
     return instances
 
 
-def kubectl_exec_to_instance(kubectl_cmd, context, namespace, pod_name, container_name, log_directory,
-                             command_to_run=None):
-    args = ['--context', context,
+def kubectl_exec_to_instance(kubectl_cmd, namespace, pod_name, container_name, log_directory,
+                             command_to_run=None, api_server=None, context=None):
+    if context is not None:
+        args = ['--context', context]
+    elif api_server is not None:
+        args = ['--server', api_server]
+    args = [*args,
             '--namespace', namespace,
             'exec',
             '-it', pod_name,
@@ -57,14 +61,15 @@ def ssh_instance(instance, container_name, command_to_run=None):
     log_directory = instance['log-directory']
     k8s_pod_name = instance.get('k8s/pod-name', False)
     if k8s_pod_name:
-        context = instance['k8s/context']
+        context = instance.get('k8s/context')
+        k8s_api_server = instance['k8s/api-server-url']
         kubectl_cmd = os.getenv('WAITER_KUBECTL', plugins.get_fn('get-kubectl-cmd', lambda: 'kubectl')())
         k8s_namespace = instance['k8s/namespace']
         print_info(f'Executing ssh to k8s pod {terminal.bold(k8s_pod_name)}')
         logging.debug(f'Executing ssh to k8s pod {terminal.bold(k8s_pod_name)} '
-                      f'using namespace={k8s_namespace} context={context}')
-        kubectl_exec_to_instance(kubectl_cmd, context, k8s_namespace, k8s_pod_name, container_name,
-                                 log_directory, command_to_run)
+                      f'using namespace={k8s_namespace} api_server={k8s_api_server}')
+        kubectl_exec_to_instance(kubectl_cmd, k8s_namespace, k8s_pod_name, container_name,
+                                 log_directory, command_to_run, api_server=k8s_api_server, context=context)
     else:
         hostname = instance['host']
         command_to_run = command_to_run or [BASH_PATH]


### PR DESCRIPTION
## Changes proposed in this PR

- context has higher priority than server when constructing kubectl command

## Why are we making these changes?

