### PR TITLE
responds 2XX for waiter pings by wrapping descriptor errors in nested response

### DIFF
--- a/cli/waiter/action.py
+++ b/cli/waiter/action.py
@@ -33,10 +33,10 @@ def ping_on_cluster(cluster, timeout, wait_for_request, token_name, service_exis
             logging.debug(f'Response status code: {resp.status_code}')
             resp_json = resp.json()
             if resp.status_code == 200:
-                status = resp_json['service-state']['status']
+                status = resp_json.get('service-state', {}).get('status')
                 ping_response = resp_json['ping-response']
                 ping_response_result = ping_response['result']
-                if ping_response_result == 'received-response':
+                if ping_response_result in ['descriptor-error', 'received-response']:
                     ping_response_status = ping_response['status']
                     if ping_response_status == 200:
                         print(terminal.success('Ping successful.'))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1577,10 +1577,10 @@
                                   [:routines make-inter-router-requests-async-fn]
                                   [:settings health-check-config]
                                   [:state fallback-state-atom router-id user-agent-version]
-                                  process-request-fn wrap-descriptor-fn wrap-secure-request-fn]
+                                  process-request-fn wrap-descriptor-for-ping-fn wrap-secure-request-fn]
                            (let [{{:keys [query-state-fn]} :maintainer} router-state-maintainer
                                  user-agent (str "waiter-ping/" user-agent-version)
-                                 handler (wrap-descriptor-fn
+                                 handler (wrap-descriptor-for-ping-fn
                                            (fn inner-ping-service-handler [request]
                                              (let [retrieve-service-status-label-fn #(:service-status-label (service/retrieve-service-status-and-deployment-error % (query-state-fn)))
                                                    service-state-fn (partial descriptor/extract-service-state router-id retrieve-service-status-label-fn fallback-state-atom make-inter-router-requests-async-fn)]
@@ -2019,7 +2019,12 @@
                                 [:state fallback-state-atom]]
                          (fn wrap-descriptor-fn [handler]
                            (descriptor/wrap-descriptor handler request->descriptor-fn service-invocation-authorized?-fn
-                                                       start-new-service-fn fallback-state-atom)))
+                                                       start-new-service-fn fallback-state-atom utils/exception->response)))
+   :wrap-descriptor-for-ping-fn (pc/fnk [[:routines request->descriptor-fn service-invocation-authorized?-fn start-new-service-fn]
+                                         [:state fallback-state-atom]]
+                                  (fn wrap-descriptor-for-ping-fn [handler]
+                                    (descriptor/wrap-descriptor handler request->descriptor-fn service-invocation-authorized?-fn
+                                                                start-new-service-fn fallback-state-atom pr/exception->ping-response)))
    :wrap-router-auth-fn (pc/fnk [[:state passwords router-id]]
                           (fn wrap-router-auth-fn [handler]
                             (fn [request]

--- a/waiter/src/waiter/descriptor.clj
+++ b/waiter/src/waiter/descriptor.clj
@@ -69,7 +69,7 @@
 (defn wrap-descriptor
   "Adds the descriptor to the request/response.
   Redirects users in the case of missing user/run-as-requestor."
-  [handler request->descriptor-fn service-invocation-authorized?  start-new-service-fn fallback-state-atom]
+  [handler request->descriptor-fn service-invocation-authorized? start-new-service-fn fallback-state-atom exception->response-fn]
   (fn [request]
     (tl/try-let [request-descriptor (request->descriptor-fn request)]
       (let [{:keys [descriptor latest-descriptor]} request-descriptor
@@ -98,7 +98,7 @@
           (do
             ; For consistency with historical data, count errors looking up the descriptor as a "process error"
             (meters/mark! (metrics/waiter-meter "core" "process-errors"))
-            (utils/exception->response e request)))))))
+            (exception->response-fn e request)))))))
 
 (defn- log-service-changes
   "Logs changes to the tracker service ids."

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -1114,3 +1114,12 @@
               :status (if redirect-ping? (:status redirect-response) http-200-ok)))))
       (catch Exception ex
         (utils/exception->response ex request)))))
+
+(defn exception->ping-response
+  "Renders a ping response when there is an error in determining the descriptor for the request."
+  [^Exception ex request]
+  (utils/clj->json-response
+    {:ping-response (-> (utils/exception->response ex request)
+                      (select-keys [:body :headers :status])
+                      (assoc :result :descriptor-error))}
+    :status http-200-ok))

--- a/waiter/test/waiter/descriptor_test.clj
+++ b/waiter/test/waiter/descriptor_test.clj
@@ -27,7 +27,8 @@
             [waiter.service-description :as sd]
             [waiter.status-codes :refer :all]
             [waiter.token :as token]
-            [waiter.util.async-utils :as au])
+            [waiter.util.async-utils :as au]
+            [waiter.util.utils :as utils])
   (:import (clojure.lang ExceptionInfo)
            (org.joda.time DateTime)))
 
@@ -56,7 +57,8 @@
                                    (throw (UnsupportedOperationException. "Not expecting call in test")))
             service-invocation-authorized? (make-service-invocation-authorized? true)
             fallback-state-atom (atom {:available-service-ids #{} :healthy-service-ids #{}})
-            handler (wrap-descriptor default-handler request->descriptor-fn service-invocation-authorized? start-new-service-fn fallback-state-atom)
+            handler (wrap-descriptor default-handler request->descriptor-fn service-invocation-authorized?
+                                     start-new-service-fn fallback-state-atom utils/exception->response)
             response (handler request)]
         (is (= {:descriptor descriptor :latest-service-id latest-service-id :status http-200-ok} response))
         (is (= :no-service (deref started-service-id-promise 0 :no-service)))))
@@ -75,7 +77,8 @@
                                    (throw (UnsupportedOperationException. "Not expecting call in test")))
             service-invocation-authorized? (make-service-invocation-authorized? true)
             fallback-state-atom (atom {:available-service-ids #{latest-service-id} :healthy-service-ids #{}})
-            handler (wrap-descriptor default-handler request->descriptor-fn service-invocation-authorized? start-new-service-fn fallback-state-atom)
+            handler (wrap-descriptor default-handler request->descriptor-fn service-invocation-authorized?
+                                     start-new-service-fn fallback-state-atom utils/exception->response)
             response (handler request)]
         (is (= {:descriptor descriptor :latest-service-id latest-service-id :status http-200-ok} response))
         (is (= :no-service (deref started-service-id-promise 0 :no-service)))))
@@ -95,7 +98,8 @@
                                        (deliver started-service-id-promise (:service-id in-descriptor)))
                 service-invocation-authorized? (make-service-invocation-authorized? true)
                 fallback-state-atom (atom {:available-service-ids #{} :healthy-service-ids #{}})
-                handler (wrap-descriptor default-handler request->descriptor-fn service-invocation-authorized? start-new-service-fn fallback-state-atom)
+                handler (wrap-descriptor default-handler request->descriptor-fn service-invocation-authorized?
+                                         start-new-service-fn fallback-state-atom utils/exception->response)
                 response (handler request)]
             (is (= {:descriptor descriptor :latest-service-id latest-service-id :status http-200-ok} response))
             (is (= latest-service-id (deref started-service-id-promise 0 :no-service)))))
@@ -107,7 +111,8 @@
                                        (deliver started-service-id-promise (:service-id in-descriptor)))
                 service-invocation-authorized? (make-service-invocation-authorized? false)
                 fallback-state-atom (atom {:available-service-ids #{} :healthy-service-ids #{}})
-                handler (wrap-descriptor default-handler request->descriptor-fn service-invocation-authorized? start-new-service-fn fallback-state-atom)
+                handler (wrap-descriptor default-handler request->descriptor-fn service-invocation-authorized?
+                                         start-new-service-fn fallback-state-atom utils/exception->response)
                 response (handler request)]
             (is (= {:descriptor descriptor :latest-service-id latest-service-id :status http-200-ok} response))
             (is (= :no-service (deref started-service-id-promise 0 :no-service)))))))))

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -28,7 +28,8 @@
             [waiter.process-request :refer :all]
             [waiter.statsd :as statsd]
             [waiter.status-codes :refer :all]
-            [waiter.test-helpers :refer :all])
+            [waiter.test-helpers :refer :all]
+            [waiter.util.utils :as utils])
   (:import (java.io ByteArrayOutputStream IOException)
            (java.util.concurrent TimeoutException)
            (org.eclipse.jetty.client HttpClient)
@@ -523,8 +524,8 @@
         service-invocation-authorized? (constantly true)
         start-new-service-fn (constantly nil)
         fallback-state-atom (atom {})
-        handler (descriptor/wrap-descriptor (fn [_] {:status http-200-ok}) request->descriptor-fn
-                                            service-invocation-authorized? start-new-service-fn fallback-state-atom)]
+        handler (descriptor/wrap-descriptor (fn [_] {:status http-200-ok}) request->descriptor-fn service-invocation-authorized?
+                                            start-new-service-fn fallback-state-atom utils/exception->response)]
     (testing "with-query-params"
       (let [request {:headers {"host" "www.example.com:1234"}, :query-string "a=b&c=d", :uri "/path"}
             {:keys [headers status]} (handler request)]
@@ -548,8 +549,8 @@
         service-invocation-authorized? (constantly true)
         start-new-service-fn (constantly nil)
         fallback-state-atom (atom {})
-        handler (descriptor/wrap-descriptor (fn [_] {:status http-200-ok}) request->descriptor-fn
-                                            service-invocation-authorized? start-new-service-fn fallback-state-atom)
+        handler (descriptor/wrap-descriptor (fn [_] {:status http-200-ok}) request->descriptor-fn service-invocation-authorized?
+                                            start-new-service-fn fallback-state-atom utils/exception->response)
         request {}
         {:keys [body headers status]} (handler request)]
     (is (= http-500-internal-server-error status))
@@ -562,8 +563,8 @@
         service-invocation-authorized? (constantly true)
         start-new-service-fn (constantly nil)
         fallback-state-atom (atom {})
-        handler (descriptor/wrap-descriptor (fn [_] {:status http-200-ok}) request->descriptor-fn
-                                            service-invocation-authorized? start-new-service-fn fallback-state-atom)
+        handler (descriptor/wrap-descriptor (fn [_] {:status http-200-ok}) request->descriptor-fn service-invocation-authorized?
+                                            start-new-service-fn fallback-state-atom utils/exception->response)
         request {}
         {:keys [body headers status]} (handler request)]
     (is (= http-404-not-found status))


### PR DESCRIPTION

## Changes proposed in this PR

- responds 2XX for waiter pings by wrapping descriptor errors in nested response

## Why are we making these changes?

Ping invocations should not respond non-2XX on descriptor errors. Instead, it is 2XX response for ping, with the ping response reporting that the ping failed.

### Sample output

Before change:
```
$ curl -s -H'x-waiter-token: foo-bar' 'http://localhost:9091/waiter-ping' 

  Waiter Error 400
  ================
  
    Token not found: foo-bar
  
...
```

After change:
```
$ curl -s -H'x-waiter-token: foo' 'http://localhost:9091/waiter-ping' | jq -rS .                                                                   
{
  "ping-response": {
    "body": "\n  Waiter Error 400\n  ================\n  \n    Token not found: foo\n  \n  Request Info\n  ============\n  \n            Host: localhost:9091\n            Path: /waiter-pin
g\n    Query String: \n          Method: GET\n             CID: 297caea8382b0-69ce2b57f9f88ace\n            Time: 2022-04-21T18:07:03.331Z\n       Principal: shamsimam\n  \n  \n  Additiona
l Info\n  ===============\n  \n    {:status 400, :log-level :warn}\n    \n  Getting Help\n  ============\n  \n    Waiter on GitHub: http://github.com/twosigma/waiter \n  \n",
    "headers": {
      "content-type": "text/plain"
    },
    "result": "descriptor-error",
    "status": 400
  }
}
```

