### PR TITLE
Add GitHub Action to publish waiter cli package to pypi on new release tag pushed

### DIFF
--- a/.github/workflows/cd-waiter-cli.yml
+++ b/.github/workflows/cd-waiter-cli.yml
@@ -1,0 +1,36 @@
+name: Publish Waiter CLI to PyPI and TestPyPI
+
+on: push
+
+jobs:
+  build-n-publish:
+    name: Build and publish
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.6.x'
+    - name: Install pypa/build
+      run: |
+        python3 -m pip install --upgrade build
+    - name: Build a binary wheel and a source tarball
+      run: |
+        cd cli
+        python3 -m build
+    - name: Publish Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        packages_dir: cli/dist/
+        repository_url: https://test.pypi.org/legacy/
+        skip_existing: true
+    - name: Publish to PyPI
+      if: startsWith(github.ref, 'refs/tags/cli-v')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        packages_dir: cli/dist/


### PR DESCRIPTION
## Changes proposed in this PR

- adds CD workflow for building and uploading packages to PyPI and testpypi

## Why are we making these changes?

- this allows us to upload packages without having to manually run these commands ourselves and integrates nicely with our current tagging/release process.
- after this change, we will just need to make the release PR and push out the tag/create the release.
