### PR TITLE
Bumps CLI version for 1.5.2 release

### DIFF
--- a/cli/waiter/version.py
+++ b/cli/waiter/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.5.2-dev'
+VERSION = '1.5.2'

--- a/cli/waiter/version.py
+++ b/cli/waiter/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.5.2'
+VERSION = '1.5.3-dev0'


### PR DESCRIPTION
## Changes proposed in this PR
- change version to 1.5.2-dev0 to 1.5.2 to 1.5.3-dev0
## Why are we making these changes?
- planning on releasing the cli
