### PR TITLE
Fix: token-watch integration test for filtering stream

### DIFF
--- a/waiter/integration/waiter/token_watch_integration_test.clj
+++ b/waiter/integration/waiter/token_watch_integration_test.clj
@@ -380,9 +380,9 @@
                                                              "maintenance" true})
               (post-token waiter-url (assoc (kitchen-params) :token token-1 :maintenance {:message "maintenance message"}))
               (post-token waiter-url (assoc (kitchen-params) :token token-2))
-              (assert-watch-token-index-entry-does-not-change watch token-1 {"token" token-1
-                                                                             "owner" (retrieve-username)
-                                                                             "maintenance" true})
+              (assert-watch-token-index-entry watch token-1 {"token" token-1
+                                                             "owner" (retrieve-username)
+                                                             "maintenance" true})
               (assert-watch-token-index-entry-does-not-change watch token-2 {"token" token-2
                                                                              "owner" (retrieve-username)
                                                                              "maintenance" true})

--- a/waiter/integration/waiter/token_watch_integration_test.clj
+++ b/waiter/integration/waiter/token_watch_integration_test.clj
@@ -1,12 +1,12 @@
 (ns waiter.token-watch-integration-test
   (:require [clojure.core.async :as async]
+            [clojure.data :as data]
             [clojure.set :as set]
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [waiter.status-codes :refer :all]
             [waiter.util.client-tools :refer :all]
-            [waiter.util.utils :as utils]
-            [clojure.data :as data]))
+            [waiter.util.utils :as utils]))
 
 (defn- await-goal-response-for-all-routers
   "Returns true if the goal-response-fn was satisfied with the response from request-fn for all routers before

--- a/waiter/integration/waiter/token_watch_integration_test.clj
+++ b/waiter/integration/waiter/token_watch_integration_test.clj
@@ -130,9 +130,9 @@
           (try
             (doseq [msg json-objects
                     :when (some? msg)]
-              (log/info "received msg from token watch" {:msg msg
-                                                         :watch-cid x-cid
-                                                         :current-token->index @token->index-atom})
+              (log/info "received msg from token watch" {:current-token->index @token->index-atom
+                                                         :msg msg
+                                                         :watch-cid x-cid})
               (reset!
                 token->index-atom
                 (let [{:strs [object type]} msg


### PR DESCRIPTION
## Changes proposed in this PR

- there is a race condition with `assert-watch-token-index-entry-does-not-change` where the token1 index is nil for some time until the watch receives the message to update the map. This assertion isn't the correct assertion to make.
- this is also why we don't witness the race condition when integration tests were run remotely because the time waiting to "post-token" was greater than the time it took to receive and process the token event.

## Why are we making these changes?


