### PR TITLE
Waiter health checks include an "x-waiter-request-type: health-check" header

### DIFF
--- a/waiter/src/waiter/headers.clj
+++ b/waiter/src/waiter/headers.clj
@@ -32,6 +32,11 @@
 
 (def ^:const waiter-headers-with-str-value (set (map #(str waiter-header-prefix %) params-with-str-value)))
 
+; These headers should only be used for health checks that originate from Waiter or another system that would not
+; want the request to be counted by an external metrics provider, where last-request-time will not account for these
+; health check requests (used for GC).
+(def ^:const waiter-health-check-headers {"x-waiter-request-type" "health-check"})
+
 (defn get-waiter-header
   "Retrieves the waiter header value."
   ([waiter-headers name] (get waiter-headers (str waiter-header-prefix name)))

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -373,7 +373,8 @@
               authenticate-health-check? (use-authenticated-health-checks? scheduler service-id)
               request-headers (cond-> {"host" host
                                        "user-agent" (some-> http-client .getUserAgentField .getValue)
-                                       "x-cid" correlation-id}
+                                       "x-cid" correlation-id
+                                       "x-waiter-request-type" "health-check"}
                                 authenticate-health-check?
                                 (merge-auth-headers service-id->password-fn service-id))
               health-check-response-chan (http/get http-client instance-health-check-url

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -371,10 +371,10 @@
               request-time-ns (System/nanoTime)
               correlation-id (str "waiter-health-check-" (utils/unique-identifier))
               authenticate-health-check? (use-authenticated-health-checks? scheduler service-id)
-              request-headers (cond-> {"host" host
-                                       "user-agent" (some-> http-client .getUserAgentField .getValue)
-                                       "x-cid" correlation-id
-                                       "x-waiter-request-type" "health-check"}
+              request-headers (cond-> (merge headers/waiter-health-check-headers
+                                             {"host" host
+                                              "user-agent" (some-> http-client .getUserAgentField .getValue)
+                                              "x-cid" correlation-id})
                                 authenticate-health-check?
                                 (merge-auth-headers service-id->password-fn service-id))
               health-check-response-chan (http/get http-client instance-health-check-url

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -33,6 +33,7 @@
             [slingshot.slingshot :as ss]
             [waiter.authorization :as authz]
             [waiter.config :as config]
+            [waiter.headers :as headers]
             [waiter.metrics :as metrics]
             [waiter.scheduler :as scheduler]
             [waiter.schema :as schema]
@@ -42,8 +43,7 @@
             [waiter.util.cache-utils :as cu]
             [waiter.util.date-utils :as du]
             [waiter.util.http-utils :as hu]
-            [waiter.util.utils :as utils]
-            [waiter.headers :as headers])
+            [waiter.util.utils :as utils])
   (:import (java.io InputStreamReader)
            (java.util.concurrent Executors)
            (org.joda.time.format DateTimeFormat)))
@@ -1396,8 +1396,7 @@
                                                                     readiness-scheme health-check-url
                                                                     (+ service-port health-check-port-index)
                                                                     health-check-interval-secs)
-                                                                (assoc
-                                                                  :failureThreshold 1))
+                                                                (assoc :failureThreshold 1))
                                               :resources {:limits {:memory memory}
                                                           :requests {:cpu cpus
                                                                      :memory memory}}

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -1103,7 +1103,7 @@
               (assoc :httpHeaders
                      (->> (scheduler/retrieve-auth-headers service-id->password-fn service-id)
                        (map (fn [[k v]] {:name k :value v}))
-                       (conj {:name "x-waiter-request-type" :value "health-check"}))))
+                       (concat [{:name "x-waiter-request-type" :value "health-check"}]))))
    :periodSeconds health-check-interval-secs
    :timeoutSeconds 1})
 

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -1096,14 +1096,14 @@
   "Returns the configuration for a basic health check probe."
   [service-id->password-fn service-id authenticate-health-check?
    health-check-scheme health-check-url health-check-port health-check-interval-secs]
-  {:httpGet (cond-> {:path health-check-url
-                     :port health-check-port
-                     :scheme health-check-scheme}
-              authenticate-health-check?
-              (assoc :httpHeaders
-                     (->> (scheduler/retrieve-auth-headers service-id->password-fn service-id)
-                       (map (fn [[k v]] {:name k :value v}))
-                       (concat [{:name "x-waiter-request-type" :value "health-check"}]))))
+  {:httpGet
+   {:httpHeaders (cond-> [{:name "x-waiter-request-type" :value "health-check"}]
+                   authenticate-health-check?
+                   (concat (->> (scheduler/retrieve-auth-headers service-id->password-fn service-id)
+                                (map (fn [[k v]] {:name k :value v})))))
+    :path health-check-url
+    :port health-check-port
+    :scheme health-check-scheme}
    :periodSeconds health-check-interval-secs
    :timeoutSeconds 1})
 

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -42,7 +42,8 @@
             [waiter.util.cache-utils :as cu]
             [waiter.util.date-utils :as du]
             [waiter.util.http-utils :as hu]
-            [waiter.util.utils :as utils])
+            [waiter.util.utils :as utils]
+            [waiter.headers :as headers])
   (:import (java.io InputStreamReader)
            (java.util.concurrent Executors)
            (org.joda.time.format DateTimeFormat)))
@@ -1097,10 +1098,11 @@
   [service-id->password-fn service-id authenticate-health-check?
    health-check-scheme health-check-url health-check-port health-check-interval-secs]
   {:httpGet
-   {:httpHeaders (cond-> [{:name "x-waiter-request-type" :value "health-check"}]
-                   authenticate-health-check?
-                   (concat (->> (scheduler/retrieve-auth-headers service-id->password-fn service-id)
-                                (map (fn [[k v]] {:name k :value v})))))
+   {:httpHeaders (cond->> headers/waiter-health-check-headers
+                          authenticate-health-check?
+                          (merge (scheduler/retrieve-auth-headers service-id->password-fn service-id))
+                          true
+                          (map (fn [[k v]] {:name k :value v})))
     :path health-check-url
     :port health-check-port
     :scheme health-check-scheme}

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -1102,7 +1102,8 @@
               authenticate-health-check?
               (assoc :httpHeaders
                      (->> (scheduler/retrieve-auth-headers service-id->password-fn service-id)
-                       (map (fn [[k v]] {:name k :value v})))))
+                       (map (fn [[k v]] {:name k :value v}))
+                       (conj {:name "x-waiter-request-type" :value "health-check"}))))
    :periodSeconds health-check-interval-secs
    :timeoutSeconds 1})
 
@@ -1393,7 +1394,8 @@
                                                                     readiness-scheme health-check-url
                                                                     (+ service-port health-check-port-index)
                                                                     health-check-interval-secs)
-                                                                (assoc :failureThreshold 1))
+                                                                (assoc
+                                                                  :failureThreshold 1))
                                               :resources {:limits {:memory memory}
                                                           :requests {:cpu cpus
                                                                      :memory memory}}

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -556,7 +556,10 @@
 
 (deftest test-replicaset-spec-liveness-and-readiness
   (let [basic-probe {:failureThreshold 1
-               :httpGet {:path "/status" :port 8330 :scheme "HTTP"}
+               :httpGet {:httpHeaders [{:name "x-waiter-request-type" :value "health-check"}]
+                         :path "/status"
+                         :port 8330
+                         :scheme "HTTP"}
                :periodSeconds 10
                :timeoutSeconds 1}]
     (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")
@@ -712,7 +715,8 @@
              (prepare-health-check-probe
                service-id->password-fn service-id true
                health-check-scheme health-check-url health-check-port health-check-interval-secs)))
-      (is (= {:httpGet {:path health-check-url
+      (is (= {:httpGet {:httpHeaders [{:name "x-waiter-request-type" :value "health-check"}]
+                        :path health-check-url
                         :port health-check-port
                         :scheme health-check-scheme}
               :periodSeconds health-check-interval-secs

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -702,7 +702,8 @@
           health-check-url "/status"
           health-check-port 80
           health-check-interval-secs 10]
-      (is (= {:httpGet {:httpHeaders [{:name "Authorization", :value "Basic foo:bar"}]
+      (is (= {:httpGet {:httpHeaders [{:name "x-waiter-request-type" :value "health-check"}
+                                      {:name "Authorization", :value "Basic foo:bar"}]
                         :path health-check-url
                         :port health-check-port
                         :scheme health-check-scheme}

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -705,8 +705,8 @@
           health-check-url "/status"
           health-check-port 80
           health-check-interval-secs 10]
-      (is (= {:httpGet {:httpHeaders [{:name "x-waiter-request-type" :value "health-check"}
-                                      {:name "Authorization", :value "Basic foo:bar"}]
+      (is (= {:httpGet {:httpHeaders [{:name "Authorization", :value "Basic foo:bar"}
+                                      {:name "x-waiter-request-type" :value "health-check"}]
                         :path health-check-url
                         :port health-check-port
                         :scheme health-check-scheme}

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -597,7 +597,8 @@
          waiter-principal# ~waiter-principal
          request-headers# ~request-headers
          expected-headers# (cond-> {"host" "www.example.com"
-                                    "user-agent" (some-> http-client# .getUserAgentField .getValue)}
+                                    "user-agent" (some-> http-client# .getUserAgentField .getValue)
+                                    "x-waiter-request-type" "health-check"}
                              (= "standard" health-check-authentication#)
                              (merge (headers/retrieve-basic-auth-headers "waiter" service-password# waiter-principal#)))]
      (is (contains? request-headers# "x-cid"))


### PR DESCRIPTION
## Changes proposed in this PR

- both kubernetes and waiter health checks now use "x-waiter-request-type: health-check" header when making health check requests to the backend

## Why are we making these changes?

- this header will help us differentiate request metrics of requests originating from users' clients from health check requests