### PR TITLE
accept kube-context scheduler field in builder fn context arg

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -1960,7 +1960,7 @@
   "Returns a new KubernetesScheduler with the provided configuration. Validates the
    configuration against kubernetes-scheduler-schema and throws if it's not valid."
   [{:keys [authenticate-health-checks? authentication authorizer cluster-name container-running-grace-secs custom-options 
-           fetch-events-k8s-object-minimum-age-secs http-options determine-replicaset-namespace-fn leader?-fn log-bucket-sync-secs
+           fetch-events-k8s-object-minimum-age-secs http-options determine-replicaset-namespace-fn kube-context leader?-fn log-bucket-sync-secs
            log-bucket-url max-patch-retries max-name-length namespace pdb-api-version pdb-spec-builder pod-base-port pod-sigkill-delay-secs
            pod-suffix-length replicaset-api-version response->deployment-error-msg-fn restart-expiry-threshold restart-kill-threshold
            raven-sidecar scheduler-name scheduler-state-chan scheduler-syncer-interval-secs service-id->service-description-fn
@@ -2118,6 +2118,7 @@
                             :fileserver fileserver
                             :http-client http-client
                             :k8s-object-key->event-cache k8s-object-key->event-cache
+                            :kube-context kube-context
                             :leader?-fn leader?-fn
                             :log-bucket-url log-bucket-url
                             :max-patch-retries max-patch-retries

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -1860,6 +1860,7 @@
                                    :socket-timeout 10000}
                     :k8s-object-key->event-cache {:threshold 5000
                                                   :ttl 60}
+                    :kube-context "test-kube-ctx"
                     :log-bucket-sync-secs 60
                     :log-bucket-url nil
                     :max-patch-retries 5
@@ -2009,6 +2010,9 @@
 
         (testing "should retain custom plugin options"
           (is (= custom-options (-> base-config kubernetes-scheduler :custom-options))))
+
+        (testing "should retain kube-context option"
+          (is (= "test-kube-ctx" (-> base-config kubernetes-scheduler :kube-context))))
 
         (testing "periodic auth-refresh task"
           (let [kill-task-fn (atom (constantly nil))


### PR DESCRIPTION
## Changes proposed in this PR

Accept `:kube-context` scheduler field value in the `kubernetes-scheduler` builder function's `context` parameter.

## Why are we making these changes?

Fixes a bug in #1549.

Since the partial `scheduler-promise` payload is passed into the `get-service->instances` function (rather than the final, full scheduler object), the `:kube-context` field must be set here (before the promise is fulfilled) rather than in the caller, otherwise the k8s cluster context value isn't available to the `pod->ServiceInstance` function.