### PR TITLE
Add deployment errors to services when k8s events indicate an inabili…

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -612,12 +612,13 @@
   [{:keys [instances k8s/events k8s/namespace task-stats]}]
   (let [{:keys [message reason]} (last events)
         running-count (:running task-stats)]
-    (when (and (pos? instances)
+    (when (and (number? instances)
+               (pos? instances)
                (= 0 running-count)
                (= reason "FailedCreate"))
       (prettify-quota-error message namespace))))
 
-(defn- get-services
+(defn get-services
   "Get all Waiter Services (reified as ReplicaSets) running in this Kubernetes cluster."
   [{:keys [service-id->deployment-error-cache watch-state]}]
   (let [service-id->service (-> watch-state deref :service-id->service)

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -596,6 +596,17 @@
   [{:keys [service-id->service-description-fn]} service-id]
   (service-id->service-description-fn service-id))
 
+(defn- get-k8s-event-deployment-error
+  "Extract a deployment error if the given service includes a k8s event that is preventing
+   deployment."
+  [{:keys [instances k8s/events task-stats]}]
+  (let [{:keys [message reason]} (last events)
+        running-count (:running task-stats)]
+    (when (and (pos? instances)
+               (= 0 running-count)
+               (= reason "FailedCreate"))
+      message)))
+
 (defn- get-services
   "Get all Waiter Services (reified as ReplicaSets) running in this Kubernetes cluster."
   [{:keys [service-id->deployment-error-cache watch-state]}]
@@ -605,8 +616,10 @@
     (map
       (fn [service-id]
         (let [deployment-error (get-in service-id->deployment-error [service-id :data])
-              service (or (get service-id->service service-id) (create-empty-service service-id))]
+              service (or (get service-id->service service-id) (create-empty-service service-id))
+              k8s-event-deployment-error (get-k8s-event-deployment-error service)]
           (cond-> service
+            k8s-event-deployment-error (assoc :deployment-error k8s-event-deployment-error)
             deployment-error (assoc :deployment-error deployment-error))))
       service-ids)))
 


### PR DESCRIPTION
## Changes proposed in this PR

- When a service has no running pods and k8s events show an inability to create pods, add a deployment error to the service map.

## Why are we making these changes?

Certain k8s events, like `FailedCreate`, indicate that a pod cannot be created. When no pods are running, this should be reflected as an error that is visible to the user.