### PR TITLE
Expose router details, including fqdn and ssl port

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -163,6 +163,9 @@
                   ;; However, larger headers will also consume more memory.
                   :response-header-size 8192
 
+                  ;; The fully qualified domain name for this router
+                  :router-fqdn "route1.waiter.example.com"
+
                   ;; Whether to send the Date header in responses
                   :send-date-header? false
 

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -107,9 +107,15 @@
 
  ; ---------- Node ----------
 
+ ; The fully qualified domain name for this router
+ :router-fqdn "route1.waiter.example.com"
+
  ; Use a descriptive name for this router; this is useful in multi-router
  ; scenarios for identifying which router handled a request:
  :router-id-prefix "router-1"
+
+ ; The ssl port configured with certs for the name given by :router-fqdn
+ :router-ssl-port 12323
 
  ; ---------- Network ----------
 
@@ -162,9 +168,6 @@
                   ;; Larger headers will allow for more and/or larger cookies and longer HTTP headers (eg for redirection).
                   ;; However, larger headers will also consume more memory.
                   :response-header-size 8192
-
-                  ;; The fully qualified domain name for this router
-                  :router-fqdn "route1.waiter.example.com"
 
                   ;; Whether to send the Date header in responses
                   :send-date-header? false

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -107,15 +107,9 @@
 
  ; ---------- Node ----------
 
- ; The fully qualified domain name for this router
- :router-fqdn "route1.waiter.example.com"
-
  ; Use a descriptive name for this router; this is useful in multi-router
  ; scenarios for identifying which router handled a request:
  :router-id-prefix "router-1"
-
- ; The ssl port configured with certs for the name given by :router-fqdn
- :router-ssl-port 12323
 
  ; ---------- Network ----------
 
@@ -1034,6 +1028,14 @@
 
                     ; total number of token metrics events that can be buffered before old events are overwritten
                     :token-metric-chan-buffer-size 4096}
+
+ ; ---------- Router Config ----------
+
+ :router-config {; The fully qualified domain name for this router
+                 :router-fqdn "route1.waiter.example.com"
+
+                 ; The ssl port configured with certs for the name given by :router-fqdn
+                 :router-ssl-port 12323}
 
  ; ---------- Miscellaneous ----------
 

--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -1651,3 +1651,16 @@
             ; cleanup in case a service was created
             (when service-id
               (delete-service waiter-url service-id))))))))
+
+(deftest ^:parallel ^:integration-fast test-state-maintainer-router-details
+  (testing-using-waiter-url
+   (testing "state includes router details"
+     (doseq [[_ details] (router-details waiter-url)]
+       (is (contains? details "address"))
+       (is (contains? details "custom-details"))
+       (let [custom-details (get details "custom-details")]
+         (is (contains? custom-details "router-fqdn"))
+         (is (contains? custom-details "router-ssl-port")))
+       (is (contains? details "id"))
+       (is (contains? details "name"))
+       (is (contains? details "port"))))))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -647,12 +647,12 @@
    :discovery (pc/fnk [[:curator curator]
                        [:settings
                         [:cluster-config name]
-                        [:server-options router-fqdn ssl-port]
                         [:zookeeper base-path discovery-relative-path]
-                        host port]
+                        host port server-options]
                        router-id]
-                (discovery/register router-id curator name (str base-path "/" discovery-relative-path)
-                                    {:host host :port (primary-port port) :router-fqdn router-fqdn :ssl-port ssl-port}))
+                (let [{:keys [router-fqdn ssl-port]} server-options] 
+                  (discovery/register router-id curator name (str base-path "/" discovery-relative-path)
+                                      {:host host :port (primary-port port) :router-fqdn router-fqdn :ssl-port ssl-port})))
    :ejection-expiry-tracker (pc/fnk [[:settings [:ejection-config expiry-threshold]]]
                               (let [service-id->instance-ids-atom (atom {})]
                                 (ejection-expiry/->EjectionExpiryTracker expiry-threshold service-id->instance-ids-atom)))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -645,10 +645,14 @@
                                 (resolved-factory-fn (merge context component-config))))
                             custom-components)))
    :discovery (pc/fnk [[:curator curator]
-                       [:settings [:cluster-config name] [:zookeeper base-path discovery-relative-path] host port]
+                       [:settings
+                        [:cluster-config name]
+                        [:server-options router-fqdn ssl-port]
+                        [:zookeeper base-path discovery-relative-path]
+                        host port]
                        router-id]
                 (discovery/register router-id curator name (str base-path "/" discovery-relative-path)
-                                    {:host host :port (primary-port port)}))
+                                    {:host host :port (primary-port port) :router-fqdn router-fqdn :ssl-port ssl-port}))
    :ejection-expiry-tracker (pc/fnk [[:settings [:ejection-config expiry-threshold]]]
                               (let [service-id->instance-ids-atom (atom {})]
                                 (ejection-expiry/->EjectionExpiryTracker expiry-threshold service-id->instance-ids-atom)))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -648,10 +648,11 @@
                        [:settings
                         [:cluster-config name]
                         [:zookeeper base-path discovery-relative-path]
-                        host port {router-fqdn nil} {router-ssl-port nil}]
+                        host port {router-config {}}]
                        router-id]
-                (discovery/register router-id curator name (str base-path "/" discovery-relative-path)
-                                    {:host host :port (primary-port port) :router-fqdn router-fqdn :router-ssl-port router-ssl-port}))
+                (let [{:keys [router-fqdn router-ssl-port]} router-config]
+                  (discovery/register router-id curator name (str base-path "/" discovery-relative-path)
+                                      {:host host :port (primary-port port) :router-fqdn router-fqdn :router-ssl-port router-ssl-port})))
    :ejection-expiry-tracker (pc/fnk [[:settings [:ejection-config expiry-threshold]]]
                               (let [service-id->instance-ids-atom (atom {})]
                                 (ejection-expiry/->EjectionExpiryTracker expiry-threshold service-id->instance-ids-atom)))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -648,11 +648,10 @@
                        [:settings
                         [:cluster-config name]
                         [:zookeeper base-path discovery-relative-path]
-                        host port server-options]
+                        host port {router-fqdn nil} {router-ssl-port nil}]
                        router-id]
-                (let [{:keys [router-fqdn ssl-port]} server-options] 
-                  (discovery/register router-id curator name (str base-path "/" discovery-relative-path)
-                                      {:host host :port (primary-port port) :router-fqdn router-fqdn :ssl-port ssl-port})))
+                (discovery/register router-id curator name (str base-path "/" discovery-relative-path)
+                                    {:host host :port (primary-port port) :router-fqdn router-fqdn :router-ssl-port router-ssl-port}))
    :ejection-expiry-tracker (pc/fnk [[:settings [:ejection-config expiry-threshold]]]
                               (let [service-id->instance-ids-atom (atom {})]
                                 (ejection-expiry/->EjectionExpiryTracker expiry-threshold service-id->instance-ids-atom)))

--- a/waiter/src/waiter/discovery.clj
+++ b/waiter/src/waiter/discovery.clj
@@ -23,10 +23,10 @@
            (org.apache.curator.x.discovery.details JsonInstanceSerializer)))
 
 (defn- ->service-instance
-  [id service-name {:keys [host port router-fqdn ssl-port]}]
+  [id service-name {:keys [host port router-fqdn router-ssl-port]}]
   (let [payload (doto (HashMap.)
                   (.put "router-fqdn" router-fqdn)
-                  (.put "ssl-port" ssl-port))
+                  (.put "router-ssl-port" router-ssl-port))
         builder (-> (ServiceInstance/builder)
                     (.id id)
                     (.name service-name)
@@ -122,8 +122,8 @@
   (count (routers discovery #{})))
 
 (defn register
-  [router-id curator service-name discovery-path {:keys [host port router-fqdn ssl-port]}]
-  (let [instance (->service-instance router-id service-name {:host host :port port :router-fqdn router-fqdn :ssl-port ssl-port})
+  [router-id curator service-name discovery-path {:keys [host port router-fqdn router-ssl-port]}]
+  (let [instance (->service-instance router-id service-name {:host host :port port :router-fqdn router-fqdn :router-ssl-port router-ssl-port})
         discovery (->service-discovery curator discovery-path instance)
         cache (->service-cache discovery service-name)]
     (log/info "Using service name:" service-name "for router id:" router-id)

--- a/waiter/src/waiter/discovery.clj
+++ b/waiter/src/waiter/discovery.clj
@@ -24,6 +24,11 @@
 
 (defn- ->service-instance
   [id service-name {:keys [host port router-fqdn router-ssl-port]}]
+  ;; The payload type must be consistent for a given ZK discovery-path.
+  ;; If the payload type changes here, then there is a runtime risk that existing
+  ;; services in ZK will no longer be deserializable. This will prevent Waiter from
+  ;; starting and impact releases/rollbacks. If you must change the payload type,
+  ;; then you MUST pair the change with an updated discovery-path.
   (let [payload (doto (HashMap.)
                   (.put "router-fqdn" router-fqdn)
                   (.put "router-ssl-port" router-ssl-port))

--- a/waiter/src/waiter/metrics_sync.clj
+++ b/waiter/src/waiter/metrics_sync.clj
@@ -354,14 +354,14 @@
             (log/info "exiting router-syncer"))
 
           router-state-chan
-          (let [router-id->http-endpoint data]
-            (when (seq router-id->http-endpoint)
+          (let [{:keys [router-id->endpoint-url]} data]
+            (when (seq router-id->endpoint-url)
               (let [connect-options {:async-write-timeout metrics-sync-interval-ms
                                      :in au/latest-chan
                                      :max-idle-timeout inter-router-metrics-idle-timeout-ms
                                      :middleware (fn router-syncer-middleware [_ request] (attach-auth-cookie! request))
                                      :out au/latest-chan}]
-                (send router-metrics-agent update-metrics-router-state websocket-client router-id->http-endpoint
+                (send router-metrics-agent update-metrics-router-state websocket-client router-id->endpoint-url
                       encrypt connect-options router-metrics-agent)))
             (recur (inc iteration) timeouts (async/timeout router-update-interval-ms)))
 

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -134,6 +134,7 @@
                                      (s/optional-key :max-threads) schema/positive-int
                                      (s/optional-key :request-header-size) schema/positive-int
                                      (s/optional-key :response-header-size) schema/positive-int
+                                     (s/optional-key :router-fqdn) schema/non-empty-string
                                      (s/optional-key :send-date-header?) s/Bool
                                      (s/optional-key :ssl-port) schema/positive-int
                                      (s/optional-key :truststore) schema/non-empty-string

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -105,7 +105,9 @@
    (s/required-key :profile-config) {schema/non-empty-string schema/profile-definition}
    (s/optional-key :request-log) {(s/optional-key :request-headers) #{schema/non-empty-string}
                                   (s/optional-key :response-headers) #{schema/non-empty-string}}
+   (s/optional-key :router-fqdn) schema/non-empty-string
    (s/required-key :router-id-prefix) s/Str
+   (s/optional-key :router-ssl-port) schema/positive-int
    (s/required-key :router-syncer) {(s/required-key :delay-ms) schema/positive-int
                                     (s/required-key :interval-ms) schema/positive-int}
    (s/required-key :scaling) {(s/required-key :autoscaler-interval-ms) schema/positive-int
@@ -134,7 +136,6 @@
                                      (s/optional-key :max-threads) schema/positive-int
                                      (s/optional-key :request-header-size) schema/positive-int
                                      (s/optional-key :response-header-size) schema/positive-int
-                                     (s/optional-key :router-fqdn) schema/non-empty-string
                                      (s/optional-key :send-date-header?) s/Bool
                                      (s/optional-key :ssl-port) schema/positive-int
                                      (s/optional-key :truststore) schema/non-empty-string

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -105,9 +105,9 @@
    (s/required-key :profile-config) {schema/non-empty-string schema/profile-definition}
    (s/optional-key :request-log) {(s/optional-key :request-headers) #{schema/non-empty-string}
                                   (s/optional-key :response-headers) #{schema/non-empty-string}}
-   (s/optional-key :router-fqdn) schema/non-empty-string
+   (s/optional-key :router-config) {(s/optional-key :router-fqdn) schema/non-empty-string
+                                    (s/optional-key :router-ssl-port) schema/positive-int}
    (s/required-key :router-id-prefix) s/Str
-   (s/optional-key :router-ssl-port) schema/positive-int
    (s/required-key :router-syncer) {(s/required-key :delay-ms) schema/positive-int
                                     (s/required-key :interval-ms) schema/positive-int}
    (s/required-key :scaling) {(s/required-key :autoscaler-interval-ms) schema/positive-int
@@ -381,6 +381,7 @@
    :profile-config {}
    :request-log {:request-headers #{}
                  :response-headers #{}}
+   :router-config {}
    :router-id-prefix ""
    :router-syncer {:delay-ms 750
                    :interval-ms 1500}

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -530,7 +530,7 @@
                :curator-retry-policy {:base-sleep-time-ms 100
                                       :max-retries 10
                                       :max-sleep-time-ms 120000}
-               :discovery-relative-path "discovery"
+               :discovery-relative-path "discovery-v2"
                :gc-relative-path "gc-state"
                :leader-latch-relative-path "leader-latch"
                :mutex-timeout-ms 1000}})

--- a/waiter/src/waiter/state/maintainer.clj
+++ b/waiter/src/waiter/state/maintainer.clj
@@ -541,6 +541,7 @@
     (let [state-atom (atom {:all-available-service-ids #{}
                             :iteration 0
                             :routers []
+                            :router-details []
                             :service-id->deployment-error {}
                             :service-id->expired-instances {}
                             :service-id->failed-instances {}
@@ -742,10 +743,10 @@
 
                         router-chan
                         ([data]
-                         (let [router-id->endpoint-url data
+                         (let [{:keys [router-id->details router-id->endpoint-url]} data
                                new-state
                                (if (not= routers router-id->endpoint-url)
-                                 (let [candidate-state (assoc current-state :routers router-id->endpoint-url)
+                                 (let [candidate-state (assoc current-state :router-details router-id->details :routers router-id->endpoint-url)
                                        current-routers (-> current-state :routers keys vec sort)
                                        new-routers (-> router-id->endpoint-url keys vec sort)]
                                    (log/info "peer router info changed from" current-routers "to" new-routers)

--- a/waiter/src/waiter/state/router.clj
+++ b/waiter/src/waiter/state/router.clj
@@ -25,7 +25,11 @@
   "Query `discovery` for the list of currently running routers and populates it into `router-chan`."
   [discovery router-chan]
   (log/trace "querying discovery for routers")
-  (async/>!! router-chan (discovery/router-id->endpoint-url discovery "http" "")))
+  (let [router-id->endpoint-url (discovery/router-id->endpoint-url discovery "http" "")
+        router-id->details (discovery/router-id->details discovery)
+        router-info {:router-id->details router-id->details
+                     :router-id->endpoint-url router-id->endpoint-url}]
+    (async/>!! router-chan router-info)))
 
 (defn start-router-syncer
   "Starts loop to query discovery service for the list of currently running routers and

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -697,6 +697,14 @@
                      (str/starts-with? router-url HTTP-SCHEME) (str/replace HTTP-SCHEME "")))
                  routers-raw)))
 
+(defn router-details
+  "Fetches and returns router details from the maintainer state."
+  [waiter-url]
+  (let [state-json (maintainer-state waiter-url)
+        router-details-raw (get-in state-json ["state" "router-details"] {})]
+    (log/debug "router details retrieved from /state:" router-details-raw)
+    router-details-raw))
+
 (defn router-endpoint
   [waiter-url router-id]
   (let [routers (routers waiter-url)]

--- a/waiter/test/waiter/discovery_test.clj
+++ b/waiter/test/waiter/discovery_test.clj
@@ -14,7 +14,8 @@
 ;; limitations under the License.
 ;;
 (ns waiter.discovery-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
             [clojure.walk :as walk]
             [waiter.curator :as curator]
             [waiter.discovery :refer :all])
@@ -87,6 +88,10 @@
           "r3" (prepare-router-details "waiter" "r3")}
          (router-id->details (prepare-discovery "waiter" ["r1" "r2" "r3"]) :exclude-set #{}))))
 
+(deftest test-versioned-discovery-path
+  (is (str/ends-with? (versioned-discovery-path "/base") "-v2")
+      "unexpected discovery path suffix - see discovery/->service-instance for a note on discovery paths and payload types"))
+
 (deftest test-service-discover-payload-type
   (testing "service instances should include expected HashMap payload"
       (let [zk (curator/start-in-process-zookeeper)
@@ -95,7 +100,7 @@
         (try
           (.start curator)
           (let [{:keys [service-instance] :as discovery}
-                (register "r1" curator "waiter" "discovery" {:host "waiter.com" :port 1234 :router-fqdn "r1.waiter.com" :router-ssl-port 12345})
+                (register "r1" curator "waiter" "/base/discovery" {:host "waiter.com" :port 1234 :router-fqdn "r1.waiter.com" :router-ssl-port 12345})
                 payload (.getPayload service-instance)
                 expected-payload {"router-fqdn" "r1.waiter.com" "router-ssl-port" 12345}]
             (is (= HashMap (type payload)) "unexpected payload type - see discovery/->service-instance for a note on changes to payload types")

--- a/waiter/test/waiter/metrics_sync_test.clj
+++ b/waiter/test/waiter/metrics_sync_test.clj
@@ -406,19 +406,26 @@
                                    (let [response-chan (async/promise-chan)]
                                      (async/>!! query-chan {:response-chan response-chan})
                                      (async/<!! response-chan)))
-            router-state {"router-1" "http://www.router-1.com/"
-                          "router-2" "http://www.router-2.com/"
-                          "router-3" "http://www.router-3.com/"}]
+            router-id->endpoint-url {"router-1" "http://www.router-1.com/"
+                                     "router-2" "http://www.router-2.com/"
+                                     "router-3" "http://www.router-3.com/"}
+            router-state {:router-id->details {}
+                          :router-id->endpoint-url router-id->endpoint-url}]
+        (println router-state)
         (async/>!! router-state-chan router-state)
         (query-go-block-state) ; ensure router-state was read
         (let [out-router-metrics-state (retrieve-agent-state router-metrics-agent)]
-          (is (= {:router-id "router-0", :routers router-state, :source "update-1"} out-router-metrics-state)))
+          (is (= {:router-id "router-0", :routers router-id->endpoint-url, :source "update-1"} out-router-metrics-state)))
+        (println "check 1 pass")
+        (println router-state)
         (let [response-chan (async/promise-chan)]
-          (async/>!! router-state-chan (assoc router-state :response-chan response-chan))
+          (async/>!! router-state-chan (assoc-in router-state [:router-id->endpoint-url :response-chan] response-chan))
           (async/<!! response-chan))
         (is (pos? (:timeouts (query-go-block-state))))
         (let [out-router-metrics-state (retrieve-agent-state router-metrics-agent)]
-          (is (= {:router-id "router-0", :routers router-state, :source "update-2"} out-router-metrics-state)))
+          (is (= {:router-id "router-0", :routers router-id->endpoint-url, :source "update-2"} out-router-metrics-state)))
+        (println "check 2 pass")
+        (println router-state)
         (async/>!! exit-chan :exit)))))
 
 (deftest test-setup-metrics-syncer

--- a/waiter/test/waiter/metrics_sync_test.clj
+++ b/waiter/test/waiter/metrics_sync_test.clj
@@ -409,23 +409,17 @@
             router-id->endpoint-url {"router-1" "http://www.router-1.com/"
                                      "router-2" "http://www.router-2.com/"
                                      "router-3" "http://www.router-3.com/"}
-            router-state {:router-id->details {}
-                          :router-id->endpoint-url router-id->endpoint-url}]
-        (println router-state)
+            router-state {:router-id->endpoint-url router-id->endpoint-url}]
         (async/>!! router-state-chan router-state)
         (query-go-block-state) ; ensure router-state was read
         (let [out-router-metrics-state (retrieve-agent-state router-metrics-agent)]
           (is (= {:router-id "router-0", :routers router-id->endpoint-url, :source "update-1"} out-router-metrics-state)))
-        (println "check 1 pass")
-        (println router-state)
         (let [response-chan (async/promise-chan)]
           (async/>!! router-state-chan (assoc-in router-state [:router-id->endpoint-url :response-chan] response-chan))
           (async/<!! response-chan))
         (is (pos? (:timeouts (query-go-block-state))))
         (let [out-router-metrics-state (retrieve-agent-state router-metrics-agent)]
           (is (= {:router-id "router-0", :routers router-id->endpoint-url, :source "update-2"} out-router-metrics-state)))
-        (println "check 2 pass")
-        (println router-state)
         (async/>!! exit-chan :exit)))))
 
 (deftest test-setup-metrics-syncer

--- a/waiter/test/waiter/state/router_test.clj
+++ b/waiter/test/waiter/state/router_test.clj
@@ -21,11 +21,15 @@
 
 (deftest test-retrieve-peer-routers
   (testing "successful-retrieval-from-discovery"
-    (with-redefs [discovery/router-id->endpoint-url (constantly {"router-1" "url-1", "router-2" "url-2"})]
-      (let [discovery (Object.)
-            router-chan (async/chan 1)]
-        (retrieve-peer-routers discovery router-chan)
-        (is (= {"router-1" "url-1", "router-2" "url-2"} (async/<!! router-chan))))))
+    (let [router-id->details {"router-1" {}, "router-2" {}}
+          router-id->endpoint-url {"router-1" "url-1", "router-2" "url-2"}]
+      (with-redefs [discovery/router-id->details (constantly router-id->details)
+                    discovery/router-id->endpoint-url (constantly router-id->endpoint-url)]
+        (let [discovery (Object.)
+              router-chan (async/chan 1)]
+          (retrieve-peer-routers discovery router-chan)
+          (is (= {:router-id->details router-id->details :router-id->endpoint-url router-id->endpoint-url}
+                 (async/<!! router-chan)))))))
   (testing "exception-on-retrieval-from-discovery"
     (with-redefs [discovery/router-id->endpoint-url (fn [_ _ _]
                                                       (throw (RuntimeException. "Expected exception thrown from test")))]

--- a/waiter/test/waiter/state/router_test.clj
+++ b/waiter/test/waiter/state/router_test.clj
@@ -21,7 +21,8 @@
 
 (deftest test-retrieve-peer-routers
   (testing "successful-retrieval-from-discovery"
-    (let [router-id->details {"router-1" {}, "router-2" {}}
+    (let [router-id->details {"router-1" {:id "1" :custom-details {:router-fqdn "r1.waiter.com" :router-ssl-port 1234}}
+                              "router-2" {:id "2" :custom-details {:router-fqdn "r2.waiter.com" :router-ssl-port 1234}}}
           router-id->endpoint-url {"router-1" "url-1", "router-2" "url-2"}]
       (with-redefs [discovery/router-id->details (constantly router-id->details)
                     discovery/router-id->endpoint-url (constantly router-id->endpoint-url)]


### PR DESCRIPTION
## Changes proposed in this PR

- Introduce a dedicated setting for a router's fqdn
- Include fqdn and ssl-port in service instances exposed for service discovery
- Include router details, including fqdn and ssl-port, in visible state

## Why are we making these changes?

By exposing each router's fqdn and ssl port, direct requests to routers can be issued securely.
