### PR TITLE
CLI cluster matching works with cluster name alias

### DIFF
--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -819,7 +819,6 @@ class WaiterCliTest(util.WaiterTest):
                 self.assertEqual(0, cp.returncode, cp.stderr)
                 self.assertIn('Pinging token', cli.stdout(cp))
                 self.assertIn('successful', cli.stdout(cp))
-                self.assertIn(alias_cluster_name, cli.stdout(cp))
                 self.assertIn('Service is currently', cli.stdout(cp))
                 self.assertTrue(any(s in cli.stdout(cp) for s in ['Running', 'Starting']))
                 util.wait_until_services_for_token(self.waiter_url, token_name, 1)

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -803,6 +803,28 @@ class WaiterCliTest(util.WaiterTest):
             self.assertEqual(1, len(util.services_for_token(self.waiter_url, token_name)))
         finally:
             util.delete_token(self.waiter_url, token_name, kill_services=True)
+    
+    def test_ping_alias(self):
+        alias_cluster_name = 'weird-cluster'
+        # config uses alias cluster name as the locally configured name
+        config = {'clusters': [{'name': alias_cluster_name,
+                                'url': self.waiter_url,
+                                'default-for-create': True}]}
+        token_name = self.token_name()
+        util.post_token(self.waiter_url, token_name, util.minimal_service_description(cluster=alias_cluster_name))
+        try:
+            with cli.temp_config_file(config) as path:
+                self.assertEqual(0, len(util.services_for_token(self.waiter_url, token_name)))
+                cp = cli.ping(self.waiter_url, token_name, flags=f'--config {path}')
+                self.assertEqual(0, cp.returncode, cp.stderr)
+                self.assertIn('Pinging token', cli.stdout(cp))
+                self.assertIn('successful', cli.stdout(cp))
+                self.assertIn(alias_cluster_name, cli.stdout(cp))
+                self.assertIn('Service is currently', cli.stdout(cp))
+                self.assertTrue(any(s in cli.stdout(cp) for s in ['Running', 'Starting']))
+                util.wait_until_services_for_token(self.waiter_url, token_name, 1)
+        finally:
+            util.delete_token(self.waiter_url, token_name, kill_services=True)
 
     def test_create_does_not_patch(self):
         token_name = self.token_name()

--- a/cli/integration/tests/waiter/test_cli_multi_cluster.py
+++ b/cli/integration/tests/waiter/test_cli_multi_cluster.py
@@ -546,7 +546,7 @@ class MultiWaiterCliTest(util.WaiterTest):
                                  'url': self.waiter_url_2,
                                  'token-to-create': util.minimal_service_description(cluster=alias_cluster_name),
                                  'sync-group': sync_group_name}]
-        self._test_choose_latest_configured_cluster(cluster_test_configs, 0)
+        self._test_choose_latest_configured_cluster(cluster_test_configs, 1)
 
 
     def test_update_token_latest_configured_to_missing_cluster(self):
@@ -574,6 +574,7 @@ class MultiWaiterCliTest(util.WaiterTest):
         finally:
             util.delete_token(self.waiter_url_1, token_name)
             util.delete_token(self.waiter_url_2, token_name)
+
 
     def _test_update_token_multiple_sync_groups(self, config):
         token_name = self.token_name()

--- a/cli/integration/tests/waiter/test_cli_multi_cluster.py
+++ b/cli/integration/tests/waiter/test_cli_multi_cluster.py
@@ -553,9 +553,9 @@ class MultiWaiterCliTest(util.WaiterTest):
                 cp = cli.update(token_name=token_name, flags=f'--config {path}', update_flags=f'--version {version}')
                 self.assertEqual(1, cp.returncode, cp.stderr)
                 self.assertIn('The token is configured in cluster', cli.stderr(cp))
-                self.assertIn(unlisted_cluster_name, cli.stderr(cp))
-                self.assertIn(self.waiter_1_cluster, cli.stderr(cp))
-                self.assertIn(self.waiter_2_cluster, cli.stderr(cp))
+                self.assertIn(unlisted_cluster_name.upper(), cli.stderr(cp))
+                self.assertIn(self.waiter_1_cluster.upper(), cli.stderr(cp))
+                self.assertIn(self.waiter_2_cluster.upper(), cli.stderr(cp))
         finally:
             util.delete_token(self.waiter_url_1, token_name)
             util.delete_token(self.waiter_url_2, token_name)

--- a/cli/integration/tests/waiter/test_cli_multi_cluster.py
+++ b/cli/integration/tests/waiter/test_cli_multi_cluster.py
@@ -534,6 +534,21 @@ class MultiWaiterCliTest(util.WaiterTest):
                                  'sync-group': sync_group_name}]
         self._test_choose_latest_configured_cluster(cluster_test_configs, 0)
 
+    def test_update_token_latest_configured_to_alias_cluster(self):
+        alias_cluster_name = 'weird-cluster'
+        sync_group_name = 'group_name'
+        cluster_test_configs = [{'name': 'waiter1',
+                                 'url': self.waiter_url_1,
+                                 'token-to-create': util.minimal_service_description(cluster=self.waiter_1_cluster),
+                                 'default-for-create': True,
+                                 'sync-group': sync_group_name},
+                                {'name': alias_cluster_name,
+                                 'url': self.waiter_url_2,
+                                 'token-to-create': util.minimal_service_description(cluster=alias_cluster_name),
+                                 'sync-group': sync_group_name}]
+        self._test_choose_latest_configured_cluster(cluster_test_configs, 0)
+
+
     def test_update_token_latest_configured_to_missing_cluster(self):
         sync_group_1 = "sync-group-1"
         unlisted_cluster_name = "unlisted_cluster"

--- a/cli/waiter/action.py
+++ b/cli/waiter/action.py
@@ -240,10 +240,15 @@ def process_kill_request(clusters, token_name_or_service_id, is_service_id, forc
 
 
 def token_explicitly_created_on_cluster(cluster, token_cluster_name):
-    """Returns true if the given token cluster matches the configured cluster name of the given cluster"""
+    """Returns true if the given token cluster matches the configured cluster name of the given cluster
+    or if the token cluster matches the configured cluster name in the .waiter.json file"""
     cluster_settings, _ = http_util.make_data_request(cluster, lambda: http_util.get(cluster, '/settings'))
     cluster_config_name = cluster_settings['cluster-config']['name'].upper()
-    created_on_this_cluster = token_cluster_name == cluster_config_name or token_cluster_name == cluster['name']
+    cluster_local_config_name = cluster['name'].upper()
+
+    # we consider the token having the same cluster value as the configured cluster in .waiter.json as an alias
+    # which makes it easier to change a Waiter cluster name without making breaking changes to the CLI client.
+    created_on_this_cluster = token_cluster_name == cluster_config_name or token_cluster_name == cluster_local_config_name
     return created_on_this_cluster
 
 

--- a/cli/waiter/action.py
+++ b/cli/waiter/action.py
@@ -243,7 +243,7 @@ def token_explicitly_created_on_cluster(cluster, token_cluster_name):
     """Returns true if the given token cluster matches the configured cluster name of the given cluster"""
     cluster_settings, _ = http_util.make_data_request(cluster, lambda: http_util.get(cluster, '/settings'))
     cluster_config_name = cluster_settings['cluster-config']['name'].upper()
-    created_on_this_cluster = token_cluster_name == cluster_config_name
+    created_on_this_cluster = token_cluster_name == cluster_config_name or token_cluster_name == cluster['name']
     return created_on_this_cluster
 
 

--- a/cli/waiter/action.py
+++ b/cli/waiter/action.py
@@ -248,7 +248,7 @@ def token_explicitly_created_on_cluster(cluster, token_cluster_name):
 
     # we consider the token having the same cluster value as the configured cluster in .waiter.json as an alias
     # which makes it easier to change a Waiter cluster name without making breaking changes to the CLI client.
-    created_on_this_cluster = token_cluster_name == cluster_config_name or token_cluster_name == cluster_local_config_name
+    created_on_this_cluster = token_cluster_name in [cluster_config_name, cluster_local_config_name]
     return created_on_this_cluster
 
 

--- a/cli/waiter/querying.py
+++ b/cli/waiter/querying.py
@@ -174,20 +174,21 @@ def _get_latest_cluster(clusters, query_result):
     :param clusters: list of local cluster configs from the configuration file
     :param query_result: value from query_token function
     :return: Finds latest token configuration from the query_result. Gets the cluster that is configured in the
-     token description and returns a local cluster who's serverside name matches the one specified in the token.
+     token description and returns a local cluster who's server side name matches the one specified in the token.
      If the token's cluster does not exist in one of the local cluster configurations then an Exception is raised.
     """
     token_descriptions = list(query_result['clusters'].values())
     token_result = max(token_descriptions, key=lambda token: token['token']['last-update-time'])
     if token_result['token'].get('deleted', False):
         return None
-    cluster_name_goal = token_result['token']['cluster']
-    provided_cluster_names = []
+    cluster_name_goal = token_result['token']['cluster'].upper()
+    provided_cluster_names = set()
     for c in clusters:
         cluster_settings, _ = http_util.make_data_request(c, lambda: http_util.get(c, '/settings'))
-        cluster_config_name = cluster_settings['cluster-config']['name']
-        provided_cluster_names.append(cluster_config_name)
-        if cluster_name_goal.upper() == cluster_config_name.upper():
+        cluster_config_name = cluster_settings['cluster-config']['name'].upper()
+        cluster_local_config_name = c['name'].upper()
+        provided_cluster_names.add(cluster_config_name)
+        if cluster_name_goal == cluster_config_name or cluster_name_goal == cluster_local_config_name:
             return c
     raise Exception(f'The token is configured in cluster {cluster_name_goal}, which is not provided.' +
                     f' The following clusters were provided: {", ".join(provided_cluster_names)}.')

--- a/cli/waiter/querying.py
+++ b/cli/waiter/querying.py
@@ -188,7 +188,7 @@ def _get_latest_cluster(clusters, query_result):
         cluster_config_name = cluster_settings['cluster-config']['name'].upper()
         cluster_local_config_name = c['name'].upper()
         provided_cluster_names.add(cluster_config_name)
-        if cluster_name_goal == cluster_config_name or cluster_name_goal == cluster_local_config_name:
+        if cluster_name_goal in [cluster_config_name, cluster_local_config_name]:
             return c
     raise Exception(f'The token is configured in cluster {cluster_name_goal}, which is not provided.' +
                     f' The following clusters were provided: {", ".join(provided_cluster_names)}.')


### PR DESCRIPTION
## Changes proposed in this PR

- We will be less strict with the cluster name matching
- Pinging tokens that's `cluster` field is the same as the local `.waiter.json` cluster config will also consider it to be in that cluster
- Same behavior for updating, creating, maintenance sub commands

## Why are we making these changes?

- This will make it easier to migrate a Waiter's cluster configuration as changing the cluster name will not break the CLI.

