### PR TITLE
fix /state/<service-id> scheduler-state lookup

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1472,7 +1472,7 @@
                      :interstitial-maintainer-state (:query-chan interstitial-maintainer)
                      :scheduler-broken-services-gc-state (:query-service-state-fn scheduler-broken-services-gc)
                      :scheduler-services-gc-state (:query-service-state-fn scheduler-services-gc)
-                     :scheduler-state (fn scheduler-state-fn [service-id]
+                     :scheduler-state (fn scheduler-state-fn [{:keys [service-id]}]
                                         (scheduler/service-id->state scheduler service-id))
                      :service-maintainer-state query-service-maintainer-chan
                      :transient-metrics-gc-state (:query-service-state-fn gc-for-transient-metrics)})


### PR DESCRIPTION
## Changes proposed in this PR

Fix `/state/<service-id>` endpoint's scheduler-state lookup.

## Why are we making these changes?

Wrong data structure being passed as service-id to lookup function, causing the lookup to fail and return no useful data.