### PR TITLE
inter-pod anti-affinity for waiter services

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -447,7 +447,13 @@
                                                            :default-namespace "waiter"
                                                            ;; Map of image aliases. One of these aliases can be specified in the `image` field and the
                                                            ;; resolved image will be used.
-                                                           :image-aliases {"alias/sample-alias" "real/image"}}
+                                                           :image-aliases {"alias/sample-alias" "real/image"}
+                                                           ;; Optionally apply a pod anti-affinity strategy to prevent replicas of the same Waiter service
+                                                           ;; from being scheduled on the same Kubernetes node. This is helpful to avoid losing multiple
+                                                           ;; replicas when a node crashes or goes down for maintenance.
+                                                           ;; Valid values are :preferred, :required, or nil (default).
+                                                           ;; https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+                                                           :pod-anti-affinity :preferred}
 
                                  ;; The authorizer is used by the scheduler to verify that a user has the proper permissions
                                  ;; to create services on the underlying scheduler platform.


### PR DESCRIPTION
## Changes proposed in this PR

Add support for inter-pod anti-affinity for waiter services.

## Why are we making these changes?

Waiter should spread out replicas (pods) for a given Waiter service across multiple nodes when possible. If all of the replicas are on the same node, then if that node goes down, the whole service goes down. In other words, scheduling multiple pods for a given Waiter service on the same node negates one of the key benefits of having multiple replicas: higher availability.

https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity