### PR TITLE
retrieves instance start time from main container status

### DIFF
--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -424,6 +424,10 @@
                               (reduce max (map :restartCount unready-init-containers-statuses))
                               primary-container-restart-count)
           pod-started-at (-> pod (get-in [:status :startTime]) timestamp-str->datetime)
+          main-container-started-at (some-> (filter #(= (get % :name) waiter-primary-container-name) app-container-statuses)
+                                      (first)
+                                      (get-in [:state :running :startedAt])
+                                      (timestamp-str->datetime))
           {:keys [waiter/revision-timestamp waiter/revision-version]} (get-in pod [:metadata :annotations])
           pod-name (k8s-object->id pod)
           primary-container-ready (true? (get primary-container-status :ready))
@@ -469,7 +473,7 @@
                               :log-directory (log-dir-path run-as-user primary-container-restart-count)
                               :port port0
                               :service-id service-id
-                              :started-at pod-started-at
+                              :started-at (or main-container-started-at pod-started-at)
                               :status status-message}
                        kube-context (assoc :k8s/context kube-context)
                        node-name (assoc :k8s/node-name node-name)


### PR DESCRIPTION
## Changes proposed in this PR

- retrieves instance start time from main container status

## Why are we making these changes?

Reporting incorrect instance start time is confusing when the application container on a pod restarts.


