### PR TITLE
adds support for periodically generating thread dumps

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -477,7 +477,7 @@
                                  ;; Configure the value to 0 to disable expiring instances and removing the duration constraint on pods
                                  ;; before they transition to the running state.
                                  :container-running-grace-secs 90
-                                 
+
                                  ;; The minimum age in seconds that a k8s object must be before events may be fetched
                                  :fetch-events-k8s-object-minimum-age-secs 30
 
@@ -1054,6 +1054,16 @@
  ;; Components which contain a :query-state entry that maps to a function which takes include-flags as an argument
  ;; can have their state queries and viewed at the /state/custom-component/<name> endpoint.
  :custom-components {:in-memory-kv-store {:factory-fn waiter.kv/new-local-kv-store}}
+
+ ;; Options for configuring debugging components
+ :debug-options {;; Configures daemon that logs a snapshot of all the threads in the current program.
+                 :thread-dump {;; Configures the interval, in seconds, at which thread dumps are logged.
+                               ;; A value of zero means the thread dump daemon is disabled.
+                               :interval-secs 0
+                               ;; Configures whether to dump all locked monitors, defaults to false.
+                               :show-locked-monitors false
+                               ;; Configures whether to dump all locked ownable synchronizers, defaults to false.
+                               :show-locked-synchronizers false}}
 
  ;; Certain messages that Waiter returns can be customized:
  :messages {:backend-request-failed "Request to service backend failed"

--- a/waiter/resources/log4j.properties
+++ b/waiter/resources/log4j.properties
@@ -48,3 +48,14 @@ log4j.appender.InstanceAppender.File=log/${waiter.logFilePrefix}instance.log
 log4j.appender.InstanceAppender.DatePattern='.'yyyy-MM-dd-HH
 log4j.appender.InstanceAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.InstanceAppender.layout.ConversionPattern=%m%n
+
+log4j.category.ThreadDump=INFO, ThreadDumpAppender
+log4j.additivity.ThreadDump=false
+
+log4j.appender.ThreadDumpAppender=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.ThreadDumpAppender.Threshold=DEBUG
+log4j.appender.ThreadDumpAppender.File=log/${waiter.logFilePrefix}thread-dump.log
+log4j.appender.ThreadDumpAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.ThreadDumpAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.ThreadDumpAppender.layout.ConversionPattern=%d{ISO8601} %-5p %c [%t] - [CID] %m%n
+

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -73,6 +73,7 @@
             [waiter.util.http-utils :as hu]
             [waiter.util.ring-utils :as ru]
             [waiter.util.semaphore :as semaphore]
+            [waiter.util.thread-dump :as thread-dump]
             [waiter.util.utils :as utils]
             [waiter.websocket :as ws]
             [waiter.work-stealing :as work-stealing])
@@ -363,8 +364,6 @@
           response))
       (catch Exception e
         (utils/exception->response e request)))))
-
-
 
 (defn- make-eject-request
   [make-inter-router-requests-fn eject-period-ms dest-router-id dest-endpoint {:keys [id] :as instance} reason]
@@ -1502,6 +1501,8 @@
                      {{:keys [query-state-fn]} :maintainer} router-state-maintainer]
                  (statsd/start-service-instance-metrics-publisher
                    service-id->service-description-fn query-state-fn sync-instances-interval-ms))))
+   :thread-dump (pc/fnk [[:settings [:debug-options thread-dump]]]
+                  (thread-dump/start-thread-dump-daemon thread-dump))
    :token-watch-maintainer (pc/fnk
                              [[:settings
                                [:watch-config

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -30,9 +30,6 @@
                                              :kind s/Keyword
                                              s/Keyword schema/require-symbol-factory-fn}
                                             schema/contains-kind-sub-map?)
-   (s/required-key :ejection-config) {(s/required-key :eject-backoff-base-time-ms) schema/positive-int
-                                      (s/required-key :expiry-threshold) schema/positive-int
-                                      (s/required-key :max-eject-time-ms) schema/positive-int}
    (s/required-key :cors-config) (s/constrained
                                    {:kind s/Keyword
                                     (s/optional-key :exposed-headers) [schema/non-empty-string]
@@ -45,8 +42,14 @@
                                      (s/required-key :service-prefix) schema/non-empty-string}
    (s/required-key :consent-expiry-days) schema/positive-int
    (s/required-key :custom-components) {s/Keyword schema/require-symbol-factory-fn}
+   (s/required-key :debug-options) {(s/required-key :thread-dump) {(s/required-key :interval-secs) schema/non-negative-int
+                                                                   (s/required-key :show-locked-monitors) s/Bool
+                                                                   (s/required-key :show-locked-synchronizers) s/Bool}}
    (s/required-key :deployment-error-config) {(s/required-key :min-failed-instances) schema/positive-int
                                               (s/required-key :min-hosts) schema/positive-int}
+   (s/required-key :ejection-config) {(s/required-key :eject-backoff-base-time-ms) schema/positive-int
+                                      (s/required-key :expiry-threshold) schema/positive-int
+                                      (s/required-key :max-eject-time-ms) schema/positive-int}
    (s/required-key :entitlement-config) (s/constrained
                                           {:kind s/Keyword
                                            (s/optional-key :cache) {(s/required-key :threshold) schema/positive-int
@@ -301,6 +304,9 @@
                  :exposed-headers ["etag", "x-cid"]
                  :max-age 3600
                  :token-parameter {:factory-fn 'waiter.cors/token-parameter-based-validator}}
+   :debug-options {:thread-dump {:interval-secs 0
+                                 :show-locked-monitors false
+                                 :show-locked-synchronizers false}}
    :ejection-config {:eject-backoff-base-time-ms 10000
                      :expiry-threshold 5
                      :max-eject-time-ms 300000}

--- a/waiter/src/waiter/util/thread_dump.clj
+++ b/waiter/src/waiter/util/thread_dump.clj
@@ -1,0 +1,60 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns waiter.util.thread-dump
+  (:require [clj-time.core :as t]
+            [clojure.tools.logging :as log]
+            [waiter.util.date-utils :as du])
+  (:import (java.lang.management ManagementFactory ThreadInfo)))
+
+(defn generate-and-log-thread-dump
+  "Generates and logs the thread dump."
+  [show-locked-monitors show-locked-synchronizers]
+  (let [thread-bean (ManagementFactory/getThreadMXBean)
+        str-builder (StringBuilder.)
+        new-line (System/getProperty "line.separator")
+        dumped-thread-info (.dumpAllThreads thread-bean show-locked-monitors show-locked-synchronizers)]
+    (.append str-builder (str "Thread dump at " (du/date-to-str (t/now))))
+    (.append str-builder new-line)
+    (.append str-builder (str "Total number of peak threads: " (.getPeakThreadCount thread-bean)))
+    (.append str-builder new-line)
+    (.append str-builder (str "Total number of threads created and started: " (.getTotalStartedThreadCount thread-bean)))
+    (.append str-builder new-line)
+    (.append str-builder (str "Total number of live daemon threads: " (.getDaemonThreadCount thread-bean)))
+    (.append str-builder new-line)
+    (.append str-builder (str "Total number of live total threads: " (.getThreadCount thread-bean)))
+    (.append str-builder new-line)
+    (doseq [thread-info (sort-by (fn [^ThreadInfo ti] (.getThreadName ti)) dumped-thread-info)]
+      (.append str-builder new-line)
+      (.append str-builder (str thread-info)))
+    (log/log "ThreadDump" :info nil (str str-builder))))
+
+(defn start-thread-dump-daemon
+  "Launches daemon that logs a thread dump that provides a snapshot of all the threads in the current program.
+   The state of each thread is followed by a stack trace containing the information about the thread activity."
+  [{:keys [interval-secs show-locked-monitors show-locked-synchronizers]}]
+  (if (pos? interval-secs)
+    (let [interval-ms (-> interval-secs (t/seconds) (t/in-millis))]
+      (log/info "thread dump daemon will run every" interval-secs "secs")
+      (du/start-timer-task
+        (t/millis interval-ms)
+        (fn run-thread-dump-daemon-task []
+          (try
+            (log/info "generating thread dump")
+            (generate-and-log-thread-dump show-locked-monitors show-locked-synchronizers)
+            (catch Exception ex
+              (log/error ex "error logging thread dump"))))
+        :delay-ms interval-ms))
+    (log/info "thread dump daemon has been disabled")))


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for periodically generating thread dumps

## Why are we making these changes?

Having access to the thread dumps helps with debugging.

### Sample thread dump:
```
2022-07-01 11:22:26,671 INFO  ThreadDump [async-dispatch-25] - [CID] Thread dump at 2022-07-01T16:22:26.629Z
Total number of peak threads: 190
Total number of threads created and started: 192
Total number of live daemon threads: 88
Total number of live total threads: 190
"Common-Cleaner" daemon prio=8 Id=13 TIMED_WAITING on java.lang.ref.ReferenceQueue$Lock@2944d3c7
	at java.base@17.0.1/java.lang.Object.wait(Native Method)
	-  waiting on java.lang.ref.ReferenceQueue$Lock@2944d3c7
	at java.base@17.0.1/java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:155)
	at java.base@17.0.1/jdk.internal.ref.CleanerImpl.run(CleanerImpl.java:140)
	at java.base@17.0.1/java.lang.Thread.run(Thread.java:833)
	at java.base@17.0.1/jdk.internal.misc.InnocuousThread.run(InnocuousThread.java:162)


"Curator-ConnectionStateManager-0" daemon prio=5 Id=23 WAITING on java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@1e439bba
	at java.base@17.0.1/jdk.internal.misc.Unsafe.park(Native Method)
	-  waiting on java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@1e439bba
	at java.base@17.0.1/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
	at java.base@17.0.1/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
	at java.base@17.0.1/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3463)
	at java.base@17.0.1/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3434)
	at java.base@17.0.1/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1623)
	at java.base@17.0.1/java.util.concurrent.ArrayBlockingQueue.take(ArrayBlockingQueue.java:420)
	at app//org.apache.curator.framework.state.ConnectionStateManager.processEvents(ConnectionStateManager.java:245)
	...
```

