### PR TITLE
retrieves instance start time from main container status

### DIFF
--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -2770,9 +2770,6 @@
       (is (= expected-pod-names (set @killed-pods))))))
 
 (deftest test-pod->ServiceInstance
-  ;; TODO SHAMS
-  ;; TODO Add test-cases and then remove comment
-  ;; TODO SHAMS
   (let [api-server-url "https://k8s-api.example/"
         service-id "test-app-1234"
         revision-timestamp-0 "2020-09-22T20:00:00.000Z"
@@ -2830,6 +2827,46 @@
         expired-instance-map (assoc instance-map :flags #{:expired})
         expired-unhealthy-instance-map (assoc expired-instance-map :healthy? false :status "Unhealthy")
         rs-revision-timestamp-path [:service-id->service service-id :k8s/replicaset-annotations :waiter/revision-timestamp]]
+
+    (testing "pod start time from main container status"
+      (let [dummy-scheduler (assoc base-scheduler :restart-expiry-threshold 10)
+            container-start-time (t/minus (t/now) (t/seconds 30))
+            container-start-time-k8s-str (du/date-to-str container-start-time k8s-timestamp-format)
+            container-last-finish-time (t/minus (t/now) (t/seconds 32))
+            container-last-finish-time-k8s-str (du/date-to-str container-last-finish-time k8s-timestamp-format)]
+        (let [pod' (-> pod
+                       (assoc-in [:status :containerStatuses 0 :lastState] {:terminated {:finishedAt container-last-finish-time-k8s-str}})
+                       (assoc-in [:status :containerStatuses 0 :state] {:running {:startedAt container-start-time-k8s-str}}))
+              instance (pod->ServiceInstance dummy-scheduler pod')
+              expected-instance-map (assoc instance-map
+                                      :k8s/container-statuses [{:name waiter-primary-container-name
+                                                                :ready true
+                                                                :restart-count 9
+                                                                :state :running
+                                                                :type :app}]
+                                      :started-at (timestamp-str->datetime container-start-time-k8s-str))]
+          (is (= (scheduler/make-ServiceInstance expected-instance-map) instance)))
+        (let [pod' (-> pod
+                       (assoc-in [:status :containerStatuses 0 :state] {:running {:startedAt container-start-time-k8s-str}}))
+              instance (pod->ServiceInstance dummy-scheduler pod')
+              expected-instance-map (assoc instance-map
+                                      :k8s/container-statuses [{:name waiter-primary-container-name
+                                                                :ready true
+                                                                :restart-count 9
+                                                                :state :running
+                                                                :type :app}]
+                                      :started-at (timestamp-str->datetime container-start-time-k8s-str))]
+          (is (= (scheduler/make-ServiceInstance expected-instance-map) instance)))
+        (let [pod' (-> pod
+                       (assoc-in [:status :containerStatuses 0 :lastState] {:terminated {:finishedAt container-last-finish-time-k8s-str}}))
+              instance (pod->ServiceInstance dummy-scheduler pod')
+              expected-instance-map (assoc instance-map
+                                      :k8s/container-statuses [{:name waiter-primary-container-name
+                                                                :ready true
+                                                                :restart-count 9
+                                                                :type :app}]
+                                      :started-at (timestamp-str->datetime container-last-finish-time-k8s-str))]
+          (is (= (scheduler/make-ServiceInstance expected-instance-map) instance)))))
 
     (testing "pod init containers"
       (testing "succeeding"


### PR DESCRIPTION
## Changes proposed in this PR

- retrieves instance start time from main container status

## Why are we making these changes?

Reporting incorrect instance start time is confusing when the application container on a pod restarts.

