### PR TITLE
use waiter labels for pod anti-affinities

### DIFF
--- a/waiter/config-k8s.edn
+++ b/waiter/config-k8s.edn
@@ -57,7 +57,8 @@
                                  :pod-sigkill-delay-secs 1
                                  :replicaset-spec-builder {:default-container-image "twosigma/waiter-test-apps"
                                                            :default-namespace "waiter"
-                                                           :image-aliases {"alias/integration" "twosigma/integration"}}
+                                                           :image-aliases {"alias/integration" "twosigma/integration"}
+                                                           :pod-anti-affinity :preferred}
                                  :restart-expiry-threshold 2
                                  :restart-kill-threshold 8
                                  :raven-sidecar {:cmd ["/opt/waiter/raven/bin/raven-start"]

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -1487,9 +1487,9 @@
                                       :preferred :preferredDuringSchedulingIgnoredDuringExecution
                                       :required :requiredDuringSchedulingIgnoredDuringExecution
                                       (throw (ex-info "misconfigured pod-anti-affinity" {:context context})))]
-                  {affinity-type [{:podAffinityTerm {:labelSelector {:matchExpressions [{:key "app"
-                                                                                         :operator "In"
-                                                                                         :values [k8s-name]}]}
+                  {affinity-type [{:podAffinityTerm {:labelSelector
+                                                     {:matchLabels {"waiter/cluster" cluster-name
+                                                                    "waiter/service-hash" service-hash}}
                                                      :topologyKey "kubernetes.io/hostname"}
                                    :weight 50}]}))
       ;; enable liveness only if positive grace-period-secs is specified


### PR DESCRIPTION
## Changes proposed in this PR

Use `waiter/...` labels for the pod anti-affinity selectors.

## Why are we making these changes?

The `app` label isn't really something we use in other parts of the api. We actually clobber it with a different value internally. It's better to use the `waiter/cluster` and `waiter/service-hash` fields since they're more likely to be unique and very unlikely to be overwritten in other code.