### PR TITLE
allow for other proxies in the `via` header test

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -242,8 +242,8 @@
               _ (assert-response-status response http-200-ok)
               body-json (try-parse-json (str body))
               expected-via-prefix "HTTP/1.1 waiter/"]
-          (is (str/starts-with? (str (get-in body-json ["headers" "via"])) expected-via-prefix) (str body))
-          (is (str/starts-with? (str (get headers "via")) expected-via-prefix) (str headers))))
+          (is (str/includes? (str (get-in body-json ["headers" "via"])) expected-via-prefix) (str body))
+          (is (str/includes? (str (get headers "via")) expected-via-prefix) (str headers))))
 
       (testing "query-string with special characters"
         (log/info "Basic test for query-string with special characters")


### PR DESCRIPTION
## Changes proposed in this PR

allow for other proxies in the `via` header test

## Why are we making these changes?

the waiter server entry might not be the first proxy in the `via` header list