### PR TITLE
return 404 for token not found error

### DIFF
--- a/waiter/integration/waiter/health_check_test.clj
+++ b/waiter/integration/waiter/health_check_test.clj
@@ -87,7 +87,7 @@
           {:keys [result]} ping-response]
       (assert-response-status response http-200-ok)
       (assert-waiter-response response)
-      (assert-response-status ping-response http-400-bad-request)
+      (assert-response-status ping-response http-404-not-found)
       (is (= "descriptor-error" result))
       (is (str/includes? (str ping-response) "Token not found")))))
 

--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1072,27 +1072,27 @@
     (testing "can't use invalid token that's valid for zookeeper"
       (let [response (make-request waiter-url "/pathabc" :headers {"x-waiter-token" "bad#token"})]
         (is (str/includes? (:body response) "Token not found: bad#token"))
-        (assert-response-status response http-400-bad-request)))
+        (assert-response-status response http-404-not-found)))
 
     (testing "can't use invalid token"
       (let [response (make-request waiter-url "/pathabc" :headers {"x-waiter-token" "bad/token"})]
         (is (str/includes? (:body response) "Token not found: bad/token"))
-        (assert-response-status response http-400-bad-request)))
+        (assert-response-status response http-404-not-found)))
 
     (testing "can't use invalid token with host set"
       (let [response (make-request waiter-url "/pathabc" :headers {"host" "missing_token" "x-waiter-token" "bad/token"})]
         (is (str/includes? (:body response) "Token not found: bad/token"))
-        (assert-response-status response http-400-bad-request)))
+        (assert-response-status response http-404-not-found)))
 
     (testing "can't use missing token with host set"
       (let [response (make-request waiter-url "/pathabc" :headers {"host" "missing_token" "x-waiter-token" "missing_token"})]
         (is (str/includes? (:body response) "Token not found: missing_token"))
-        (assert-response-status response http-400-bad-request)))
+        (assert-response-status response http-404-not-found)))
 
     (testing "can't use missing token"
       (let [response (make-request waiter-url "/pathabc" :headers {"x-waiter-token" "missing_token"})]
         (is (str/includes? (:body response) "Token not found: missing_token"))
-        (assert-response-status response http-400-bad-request)))
+        (assert-response-status response http-404-not-found)))
 
 
     (testing "can't create bad token (invalid char)"

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -994,14 +994,14 @@
               (if error-on-missing
                 (do
                   (log/info e "Error in kv-store fetch")
-                  (throw (ex-info (str "Token not found: " token) {:status http-400-bad-request :log-level :warn} e)))
+                  (throw (ex-info (str "Token not found: " token) {:status http-404-not-found :log-level :warn} e)))
                 (log/info e "Ignoring kv-store fetch exception")))))
         token-data (when (seq token-data) ; populate token owner for backwards compatibility
                      (-> token-data
                          (utils/assoc-if-absent "owner" run-as-user)
                          (utils/assoc-if-absent "previous" {})))]
     (when (and error-on-missing (not token-data))
-      (throw (ex-info (str "Token not found: " token) {:status http-400-bad-request :log-level :warn})))
+      (throw (ex-info (str "Token not found: " token) {:status http-404-not-found :log-level :warn})))
     (log/debug "Extracted data for" token "is" token-data)
     (when (or (not deleted) include-deleted)
       (select-keys token-data allowed-keys))))


### PR DESCRIPTION
## Changes proposed in this PR

return 404 for token not found error

## Why are we making these changes?

404 is a better semantic match than 400
