### PR TITLE
removes waiter auth cookies from backend response

### DIFF
--- a/waiter/src/waiter/auth/authentication.clj
+++ b/waiter/src/waiter/auth/authentication.clj
@@ -165,7 +165,13 @@
   [cookie-string]
   (when cookie-string
     (->> [AUTH-COOKIE-EXPIRES-AT-ENTRY-PREFIX AUTH-COOKIE-NAME-ENTRY-PREFIX OIDC-CHALLENGE-COOKIE-PREFIX]
-      (cookie-support/remove-cookies cookie-string))))
+         (cookie-support/remove-cookies cookie-string))))
+
+(defn remove-auth-set-cookie
+  "Removes the auth cookies from response headers."
+  [headers]
+  (->> [AUTH-COOKIE-EXPIRES-AT-ENTRY-PREFIX AUTH-COOKIE-NAME-ENTRY-PREFIX OIDC-CHALLENGE-COOKIE-PREFIX]
+       (headers/remove-header-entries headers "set-cookie")))
 
 (defn select-auth-header
   "Filters and return the first authorization header that passes the predicate."

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -14,10 +14,8 @@
 ;; limitations under the License.
 ;;
 (ns waiter.process-request
-  (:require [clj-time.core :as t]
-            [clojure.core.async :as async]
+  (:require [clojure.core.async :as async]
             [clojure.core.async.impl.protocols :as protocols]
-            [clojure.set :as set]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [full.async :as fa]
@@ -908,6 +906,7 @@
                             (async/close! request-state-chan)
                             (handle-process-exception e request)))
                       (update :headers headers/dissoc-hop-by-hop-headers proto-version)
+                      (update :headers auth/remove-auth-set-cookie)
                       (assoc :get-instance-latency-ns instance-elapsed
                              :instance instance
                              :instance-proto request-proto

--- a/waiter/test/waiter/auth/authenticator_test.clj
+++ b/waiter/test/waiter/auth/authenticator_test.clj
@@ -499,3 +499,14 @@
            {:cookie-string "a=b; x-auth-expires-at-c=1234" :expected "a=b; x-auth-expires-at-c=1234"}
            {:cookie-string "x-waiter-oidc-challenge-a1b2c3=123; x-waiter-oidc-challenge-3cb2a1=321; a=b" :expected "a=b"}]]
     (is (= expected (remove-auth-cookie cookie-string)) (str test-case))))
+
+(deftest test-remove-auth-set-cookie
+  (let [headers {"fee" "fie"
+                 "lorem" "ipsum"
+                 "set-cookie" ["foo=bar"
+                               (str AUTH-COOKIE-EXPIRES-AT-ENTRY-PREFIX "123456")
+                               (str AUTH-COOKIE-NAME-ENTRY-PREFIX "a1b2c3d4e5f6")
+                               (str OIDC-CHALLENGE-COOKIE-PREFIX "1234=5678")
+                               "xyz=321"]}]
+    (is (= (assoc headers "set-cookie" ["foo=bar" "xyz=321"])
+           (remove-auth-set-cookie headers)))))

--- a/waiter/test/waiter/headers_test.clj
+++ b/waiter/test/waiter/headers_test.clj
@@ -190,3 +190,42 @@
             "proxy-connection" "keep-alive"
             "referer" "http://www.test-referer.com"}
            (dissoc-hop-by-hop-headers headers "HTTP/1.0")))))
+
+(deftest test-remove-header-entries
+  (let [headers {"fee" "fie"
+                 "foe" "fum"
+                 "foo" "bar"}]
+    (is (= headers
+           (remove-header-entries headers "lorem" ["ipsum="]))))
+  (let [headers {"h1" ["fee=fie" "foe=fum" "foo=bar"]
+                 "h2" "lorem=ipsum"}]
+    (is (= headers
+           (remove-header-entries headers "lorem" ["ipsum="]))))
+  (let [headers {"h1" ["fee=fie" "foe=fum" "foo=bar"]
+                 "h2" "lorem=ipsum"}]
+    (is (= headers
+           (remove-header-entries headers "lorem" "ipsum="))))
+  (let [headers {"h1" ["fee=fie" "foe=fum" "foo=bar"]
+                 "h2" "lorem=ipsum"}]
+    (is (= (assoc headers "h1" ["foe=fum" "foo=bar"])
+           (remove-header-entries headers "h1" ["fee="]))))
+  (let [headers {"h1" ["fee=fie" "foe=fum" "foo=bar"]
+                 "h2" "lorem=ipsum"}]
+    (is (= (assoc headers "h1" ["fee=fie" "foo=bar"])
+           (remove-header-entries headers "h1" ["foe="]))))
+  (let [headers {"h1" ["fee=fie" "foe=fum" "foo=bar"]
+                 "h2" "lorem=ipsum"}]
+    (is (= (assoc headers "h1" ["fee=fie" "foe=fum"])
+           (remove-header-entries headers "h1" ["foo="]))))
+  (let [headers {"h1" ["fee=fie" "foe=fum" "foo=bar"]
+                 "h2" "lorem=ipsum"}]
+    (is (= (assoc headers "h1" ["foe=fum"])
+           (remove-header-entries headers "h1" ["fee=" "foo="]))))
+  (let [headers {"h1" ["fee=fie" "foe=fum" "foo=bar"]
+                 "h2" "lorem=ipsum"}]
+    (is (= (dissoc headers "h1")
+           (remove-header-entries headers "h1" ["fee=" "foe=" "foo="]))))
+  (let [headers {"h1" ["fee=fie" "foe=fum" "foo=bar"]
+                 "h2" "lorem=ipsum"}]
+    (is (= (dissoc headers "h2")
+           (remove-header-entries headers "h2" ["lorem="])))))


### PR DESCRIPTION
## Changes proposed in this PR

- removes waiter auth cookies from backend response

## Why are we making these changes?

Currently, Waiter forwards all cookies it receives from the backend in its response to the client. This can lead to a security leak where the backend includes an `x-waiter-auth cookie` and causes the client to gain new credentials! We should disallow sending `x-waiter-auth` and other auth cookies from the backend to the client, only Waiter generated auth cookies should make its way to the client.
