### PR TITLE
Scaling down in two phases for bypass services

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -815,13 +815,13 @@
  ; instances. Such instances are guaranteed not to be served up as an available instance until sufficient time has
  ; elapsed since their last use. This is referred to as ejecting an instance:
  :ejection-config {
-                   ;; The bypass instance cannot be killed during this period right after being ejected because the instance may still be
-                   ;; handling requests, and those request metrics will have some latency before waiter routers are up to date.
-                   :bypass-grace-buffer-ms 15000
-
                    ;; The minimum amount of time that needs to pass before the instance of a bypass service will be fully deleted after
                    ;; being marked as ejected.
-                   :bypass-max-eject-time-secs 120
+                   :bypass-force-kill-time-ms 120000
+
+                   ;; The bypass instance cannot be killed during this period right after being ejected because the instance may still be
+                   ;; handling requests, and those request metrics will have some latency before waiter routers are up to date.
+                   :bypass-grace-kill-time-ms 15000
 
                    ;; Erroneous instances are ejected using an exponential delay based on the number of successive
                    ;; failures and eject-backoff-base-time-ms (milliseconds):

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -526,15 +526,15 @@
                                  :pod-base-port 31000
 
                                  ;; Determines the interval the pod cleanup daemon should check for pods in phase 1 of safe scale down
-                                 ;; to phase 2 where the pod is deleted.
+                                 ;; and hard delete any killable pods.
                                  :pod-cleanup-interval-ms 5000
 
-                                 ;; The minimum amount of time that needs to pass before the pod cleanup daemon can considering deleting
+                                 ;; The minimum amount of time that needs to pass before the pod cleanup daemon can consider deleting
                                  ;; the pod. This allows for some lingering metrics from raven to be tracked by waiter routers, before knowing
                                  ;; if a pod is no longer serving any active requests.
                                  :pod-cleanup-grace-buffer-ms 15000
 
-                                 ;; The pod daemon will delete the pod after this timeout is reached even if it is still serving requests
+                                 ;; The pod daemon will delete the pod after this timeout is reached even if it is still serving requests.
                                  :pod-cleanup-scale-down-timeout-secs 120
 
                                  ;; The number of seconds between the SIGTERM and SIGKILL signals sent to a pod on shutdown.

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -525,18 +525,6 @@
                                  ;; e.g., if pod-base-port is 31000, and the random offset was 390, then $PORT0==31390 and $PORT9==31399:
                                  :pod-base-port 31000
 
-                                 ;; Determines the interval the pod cleanup daemon should check for pods in phase 1 of safe scale down
-                                 ;; and hard delete any killable pods.
-                                 :pod-cleanup-interval-ms 5000
-
-                                 ;; The minimum amount of time that needs to pass before the pod cleanup daemon can consider deleting
-                                 ;; the pod. This allows for some lingering metrics from raven to be tracked by waiter routers, before knowing
-                                 ;; if a pod is no longer serving any active requests.
-                                 :pod-cleanup-grace-buffer-ms 15000
-
-                                 ;; The pod daemon will delete the pod after this timeout is reached even if it is still serving requests.
-                                 :pod-cleanup-scale-down-timeout-secs 120
-
                                  ;; The number of seconds between the SIGTERM and SIGKILL signals sent to a pod on shutdown.
                                  ;; This value should be placed in the terminationGracePeriodSeconds field in the pod template.
                                  ;; Should be set between 0 and 300 seconds, inclusive.
@@ -827,6 +815,14 @@
  ; instances. Such instances are guaranteed not to be served up as an available instance until sufficient time has
  ; elapsed since their last use. This is referred to as ejecting an instance:
  :ejection-config {
+                   ;; The bypass instance cannot be killed during this period right after being ejected because the instance may still be
+                   ;; handling requests, and those request metrics will have some latency before waiter routers are up to date.
+                   :bypass-grace-buffer-ms 15000
+
+                   ;; The minimum amount of time that needs to pass before the instance of a bypass service will be fully deleted after
+                   ;; being marked as ejected.
+                   :bypass-max-eject-time-secs 120
+
                    ;; Erroneous instances are ejected using an exponential delay based on the number of successive
                    ;; failures and eject-backoff-base-time-ms (milliseconds):
                    :eject-backoff-base-time-ms 10000

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -525,6 +525,18 @@
                                  ;; e.g., if pod-base-port is 31000, and the random offset was 390, then $PORT0==31390 and $PORT9==31399:
                                  :pod-base-port 31000
 
+                                 ;; Determines the interval the pod cleanup daemon should check for pods in phase 1 of safe scale down
+                                 ;; to phase 2 where the pod is deleted.
+                                 :pod-cleanup-interval-ms 5000
+
+                                 ;; The minimum amount of time that needs to pass before the pod cleanup daemon can considering deleting
+                                 ;; the pod. This allows for some lingering metrics from raven to be tracked by waiter routers, before knowing
+                                 ;; if a pod is no longer serving any active requests.
+                                 :pod-cleanup-grace-buffer-ms 15000
+
+                                 ;; The pod daemon will delete the pod after this timeout is reached even if it is still serving requests
+                                 :pod-cleanup-scale-down-timeout-secs 120
+
                                  ;; The number of seconds between the SIGTERM and SIGKILL signals sent to a pod on shutdown.
                                  ;; This value should be placed in the terminationGracePeriodSeconds field in the pod template.
                                  ;; Should be set between 0 and 300 seconds, inclusive.

--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -630,9 +630,4 @@
                    ; pod should not be deleted before grace period
                    (is (t/before? (t/plus scale-down-time-at (t/millis pod-cleanup-grace-buffer-ms)) pod-deleted-at))
                    ; pod should be deleted after the timeout is reached
-                   (is (t/after? pod-deleted-at (t/plus scale-down-time-at (t/seconds pod-cleanup-scale-down-timeout-secs)))))))
-
-             (let [active-instances (active-instances waiter-url service-id)
-                   killed-instances (killed-instances waiter-url service-id)]
-               (is (= 1 (count active-instances)) (str "should only be one active instance:" active-instances))
-               (is (= 2 (count killed-instances)) (str "should only be two killed instances:" killed-instances))))))))))
+                   (is (t/after? pod-deleted-at (t/plus scale-down-time-at (t/seconds pod-cleanup-scale-down-timeout-secs))))))))))))))

--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -507,16 +507,6 @@
                             (and (contains? rs-spec "k8s/events")
                                  (contains? pod-spec "k8s/events"))))))))))))))
 
-(defn- wait-for-n-active-instances
-  "Waits for n instances to become active and then returns true. If timeout is reached nil is returned."
-  [waiter-url service-id n]
-  (wait-for
-   (fn two-instances-on-waiter? []
-     (let [instances (active-instances waiter-url service-id)]
-       (log/info "waiting for two instances total:" {:instances instances
-                                                     :service-id service-id})
-       (= n (count instances))))))
-
 (defmacro update-instance-metrics-active-requests-and-assert
   "Updates the instance metrics active-request-count for a single instance."
   [cluster-name waiter-url service-id instance-id active-requests]

--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -580,7 +580,7 @@
                   prepared-to-scale-down-at (some-> instance-preparing-to-scale-down :prepared-to-scale-down-at du/str-to-date)
                   flags (some-> instance-preparing-to-scale-down :flags)]
              (is (some? instance-preparing-to-scale-down))
-             (is (some? prepared-to-scale-down-at))
+             (is (some? prepared-to-scale-down-at) (str instance-preparing-to-scale-down))
              (is (t/before? prepared-to-scale-down-at (t/now)))
              (is (contains? (set flags) "ejected"))
 

--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -592,7 +592,7 @@
              (is (some? instance-preparing-to-scale-down))
              (is (some? prepared-to-scale-down-at))
              (is (t/before? prepared-to-scale-down-at (t/now)))
-             (is (contains? flags "ejected"))
+             (is (contains? (set flags) "ejected"))
 
              ; the pod should still exist and be tracked, but is currently draining
              (let [watch-state-json (get-k8s-watch-state waiter-url cookies)

--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -574,7 +574,7 @@
                                                                      :killed-instances killed-instances
                                                                      :service-id service-id})
                          (when (< 1 num-killed-instances)
-                           (throw (ex-info "There should only be one killed instance!" {:killed-instances killed-instances
+                           (throw (ex-info "There should only be one killed instance!" {:killed-instances (map :id killed-instances)
                                                                                         :service-id service-id})))
                          (and
                            ; none of the active instances should have the killed instance
@@ -600,14 +600,13 @@
                                                          :pod-spec pod-spec
                                                          :prepared-to-scale-down-at prepared-to-scale-down-at})
                  (is (some? pod-spec))
-                 (is (= app-label app-drain-label))
                  (is (some? prepared-to-scale-down-at))
 
                  ; prepared-to-scale-down-at should be set to when the waiter router determined to scale it down
                  ; which should be before the current time
                  (is (t/before? prepared-to-scale-down-at (t/now)))
 
-                 ; wait for the pod to be deleted on kuberenetes
+                 ; wait for the pod to be deleted on kubernetes
                  (is (wait-for
                       (fn pod-gced? []
                         (let [watch-state-json (get-k8s-watch-state waiter-url cookies)

--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -514,8 +514,6 @@
        (let [cluster-name (retrieve-cluster-name waiter-url)
              {:keys [pod-cleanup-grace-buffer-ms pod-cleanup-scale-down-timeout-secs]} (get-kubernetes-scheduler-settings waiter-url) 
              extra-headers {:content-type "application/json"
-                            ; this must be simple distribution because we rely on x-kitchen-delay-ms to cause queue build up
-                            :x-waiter-distribution-scheme "simple"
                             :x-waiter-concurrency-level 1
                             ; make sure raven doesn't send external metrics for these services
                             :x-waiter-env-raven_export_metrics "false"

--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -542,7 +542,7 @@
      (testing "service with bypass enabled puts instances in draining mode before deleting the pod when scaling down and waits until 'bypass-force-kill-time-ms'
                is up before attempting to fully kill the instance."
        (let [cluster-name (retrieve-cluster-name waiter-url)
-             {:keys [bypass-grace-buffer-ms bypass-force-kill-time-ms]} (setting waiter-url [:ejection-config])
+             {:keys [bypass-grace-kill-time-ms bypass-force-kill-time-ms]} (setting waiter-url [:ejection-config])
              extra-headers {:content-type "application/json"
                             :x-waiter-concurrency-level 1
                             ; make sure raven doesn't send external metrics for these services
@@ -633,7 +633,7 @@
                ; 'bypass-force-kill-time-ms'.
                (let [pod-deleted-at (t/now)]
                  ; pod should not be deleted before grace period
-                 (is (t/before? (t/plus prepared-to-scale-down-at (t/millis bypass-grace-buffer-ms)) pod-deleted-at))
+                 (is (t/before? (t/plus prepared-to-scale-down-at (t/millis bypass-grace-kill-time-ms)) pod-deleted-at))
                  ; pod should be deleted after the timeout is reached
                  (is (t/after? pod-deleted-at (t/plus prepared-to-scale-down-at (t/millis bypass-force-kill-time-ms)))))
 

--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -572,7 +572,7 @@
                                                                      :killed-instances killed-instances
                                                                      :service-id service-id})
                          (and
-                           ; non of the active instances should be preparing to scale down
+                           ; none of the active instances should be preparing to scale down
                            (every?
                              (fn is-not-prepared-to-scale-down [{:keys [k8s/prepared-to-scale-down-at]}]
                                (nil? prepared-to-scale-down-at))

--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -567,7 +567,7 @@
                                                                   :killed-instances killed-instances
                                                                   :instances-preparing-to-scale-down instances-preparing-to-scale-down
                                                                   :service-id service-id})
-                      (when (< 0 num-killed-instances)
+                      (when (pos? num-killed-instances)
                         (throw (ex-info "There should not be a killed instance when instance is marked for scale down"
                                         {:killed-instances (map :id killed-instances)
                                          :service-id service-id})))

--- a/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
+++ b/waiter/integration/waiter/kubernetes_scheduler_integration_test.clj
@@ -587,13 +587,13 @@
                       (first instances-preparing-to-scale-down)))
                   :interval 5
                   :timeout 30)
-                 prepared-to-scale-down-at (some-> instance-preparing-to-scale-down :prepared-to-scale-down-at du/str-to-date)]
+                  prepared-to-scale-down-at (some-> instance-preparing-to-scale-down :prepared-to-scale-down-at du/str-to-date)]
              (is (some? instance-preparing-to-scale-down))
              (is (some? prepared-to-scale-down-at))
              (is (t/before? prepared-to-scale-down-at (t/now)))
 
-               ; the pod should still exist, but is currently draining
-               ; check the annotation on the instance scaling down
+             ; the pod should still exist, but is currently draining
+             ; check the annotation on the instance scaling down
              (let [watch-state-json (get-k8s-watch-state waiter-url cookies)
                    pod-spec (get-in watch-state-json ["service-id->pod-id->pod" service-id pod-name])
                    k8s-prepared-to-scale-down-at (some-> pod-spec
@@ -606,7 +606,7 @@
                (is (some? k8s-prepared-to-scale-down-at))
                (is (t/equal? k8s-prepared-to-scale-down-at k8s-prepared-to-scale-down-at))
 
-                 ; wait for the pod to be deleted on kubernetes
+               ; wait for the pod to be deleted on kubernetes
                (is (wait-for
                     (fn pod-gced? []
                       (let [watch-state-json (get-k8s-watch-state waiter-url cookies)

--- a/waiter/src/waiter/scaling.clj
+++ b/waiter/src/waiter/scaling.clj
@@ -25,7 +25,6 @@
             [waiter.metrics :as metrics]
             [waiter.scheduler :as scheduler]
             [waiter.service :as service]
-            [waiter.service-description :as sd]
             [waiter.status-codes :refer :all]
             [waiter.util.async-utils :as au]
             [waiter.util.utils :as utils])

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -35,6 +35,7 @@
             [waiter.statsd :as statsd]
             [waiter.status-codes :refer :all]
             [waiter.util.async-utils :as au]
+            [waiter.util.cache-utils :as cu]
             [waiter.util.date-utils :as du]
             [waiter.util.http-utils :as hu]
             [waiter.util.utils :as utils])
@@ -53,6 +54,25 @@
   "The maximum number of kill instances tracked per service."
   ;; track more killed instances than failed instances
   (+ max-failed-instances-to-keep 2))
+
+(def ^:const service-scale-down-throttle-secs 20)
+
+(let [;; This cache is used for throttling services from scaling down instances to quickly that
+      ;; are in bypass. We have to do this because there is a race condtion with schedulers and
+      ;; the scheduler syncer updating the state of instances defining the :prepared-to-scale-down-at
+      ;; field. The cache is mapping service-id to throttle-expires-at
+      service-scale-down-throttle-cache (cu/cache-factory {:threshold 100000 :ttl (-> service-scale-down-throttle-secs t/seconds t/in-millis)})]
+  (defn can-bypass-service-scale-down?
+    "Checks if the service can scale down based on whether or not there was a scale down operation within the service-scale-down-throttle-secs."
+    [service-id]
+    (let [throttle-expires-at (cu/cache-get-or-load service-scale-down-throttle-cache service-id (constantly nil))]
+      (or (nil? throttle-expires-at)
+          (t/after? (t/now) throttle-expires-at))))
+
+  (defn set-bypass-service-scale-down
+    "Updates the cache with the service-id with the throttle-expires-at"
+    [service-id]
+    (cu/cache-put! service-scale-down-throttle-cache service-id (t/plus (t/now) (t/seconds service-scale-down-throttle-secs)))))
 
 (defmacro log
   "Log Scheduler-specific messages."

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -115,6 +115,7 @@
    exit-code
    ^String host
    port
+   prepared-to-scale-down-at
    extra-ports
    ^String log-directory
    ^String message

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -66,13 +66,17 @@
     "Checks if the service can scale down based on whether or not there was a scale down operation within the service-scale-down-throttle-secs."
     [service-id]
     (let [throttle-expires-at (cu/cache-get-or-load service-scale-down-throttle-cache service-id (constantly nil))]
+      (log/info "can-bypass-service-scale-down?" {:service-id service-id
+                                                  :throttle-expires-at throttle-expires-at})
       (or (nil? throttle-expires-at)
           (t/after? (t/now) throttle-expires-at))))
 
   (defn set-bypass-service-scale-down
     "Updates the cache with the service-id with the throttle-expires-at"
     [service-id]
-    (cu/cache-put! service-scale-down-throttle-cache service-id (t/plus (t/now) (t/seconds service-scale-down-throttle-secs)))))
+    (let [throttle-expires-at (t/plus (t/now) (t/seconds service-scale-down-throttle-secs))]
+      (log/info "set-bypass-service-scale-down" {:service-id service-id})
+      (cu/cache-put! service-scale-down-throttle-cache service-id throttle-expires-at))))
 
 (defmacro log
   "Log Scheduler-specific messages."

--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -35,7 +35,6 @@
             [waiter.statsd :as statsd]
             [waiter.status-codes :refer :all]
             [waiter.util.async-utils :as au]
-            [waiter.util.cache-utils :as cu]
             [waiter.util.date-utils :as du]
             [waiter.util.http-utils :as hu]
             [waiter.util.utils :as utils])

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -876,7 +876,8 @@
       (mark-pod-for-scale-down scheduler instance prepared-to-scale-down-at)
       (do
         (when two-phase-scale-down?
-          ; pod needs to be marked so that the calculation of pods scaling down is accurate
+          ; Pod needs to be marked so that kubernetes watches will receive event that the pod is moving in phase 2 of
+          ; scale down. This is important as each router will need to update their :instances field for the service.
           (mark-pod-with-delete-triggered scheduler instance))
 
         ; "soft" delete of the pod (i.e., simply transition the pod to "Terminating" state)

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -705,8 +705,8 @@
 
 (defn- get-replica-count
   "Query the current requested replica count for the given Kubernetes object."
-  [{:keys [watch-state]} service-id]
-  (-> watch-state deref :service-id->service (get service-id) :k8s/replicaset-replicas))
+  [{:keys [watch-state] :as scheduler} service-id]
+  (-> watch-state deref :service-id->service (get service-id) :instances))
 
 (defmacro k8s-patch-with-retries
   "Query the current replica count for the given Kubernetes object,

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -778,7 +778,7 @@
                 ;; New replica count needs to be the previous replcas + the scaling delta.
                 ;; We can't directly use :instances as the replicas because they are not the same.
                 ;; 'instances' omits pods that are scaling down, but replicas includes them.
-                replicas' (+ replicaset-replicas delta)]
+                replicas' (+ replicas delta)]
             (k8s-patch-with-retries
               (patch-object-replicas replicaset-url replicas replicas' scheduler)
               (<= attempt max-patch-retries)

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -730,7 +730,7 @@
   (-> watch-state deref :service-id->service (get service-id) :k8s/replicaset-replicas))
 
 (defn- get-instances-count
-  "Query the current requested instances count, which is the replcas minus the number of pods scaling down."
+  "Query the current requested instances count, which is the replicas minus the number of pods scaling down."
   [{:keys [watch-state]} service-id]
   (-> watch-state deref :service-id->service (get service-id) :instances))
 
@@ -760,7 +760,7 @@
 (defn- scale-service-up-to
   "Scale the number of instances for a given service to a specific number.
    Only used for upward scaling. No-op if it would result in downward scaling."
-  [{:keys [max-patch-retries watch-state] :as scheduler} {:keys [k8s/replicaset-replicas] service-id :id :as service} instances']
+  [{:keys [max-patch-retries] :as scheduler} {:keys [k8s/replicaset-replicas] service-id :id :as service} instances']
   (let [replicaset-url (build-replicaset-url scheduler service)]
     (loop [attempt 1
            replicas replicaset-replicas]

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -696,8 +696,6 @@
 (defn- patch-object-replicas
   "Update the replica count in the given Kubernetes object's spec."
   [k8s-object-uri replicas replicas' scheduler]
-  (log/info "KEVIN: patching replicas" {:replicas replicas
-                                        :replicas' replicas'})
   (patch-object-json k8s-object-uri
                      [{:op :test :path "/spec/replicas" :value replicas}
                       {:op :replace :path "/spec/replicas" :value replicas'}]

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -204,7 +204,9 @@
 (defn update-service-with-pods
   "Recalculates the instances count based on changes to the number of pods that are actively draining."
   [{:keys [k8s/replicaset-replicas] service-id :id :as service} service-id->pod-id->pod]
-  (let [num-pods-draining (get-num-pods-scaling-down service-id service-id->pod-id->pod)]
+  (let [num-pods-draining (get-num-pods-scaling-down service-id service-id->pod-id->pod)
+        ;; replicaset-replicas may be nil when service is empty
+        replicaset-replicas (or replicaset-replicas 0)]
     (assoc service :instances (- replicaset-replicas num-pods-draining))))
 
 (defn create-empty-service

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -669,12 +669,7 @@
                           (track-failed-instances! service-instance scheduler pod)
                           service-instance))
         {active-instances false failed-instances true}
-        (->> all-instances
-             (remove nil?)
-             ;; filter out instances that are prepared-to-scale-down-at, they should not be considered
-             ;; active-instances and thus should not have any requests routed to them
-             (remove :k8s/prepared-to-scale-down-at)
-             (group-by #(-> % :k8s/pod-phase (= "Failed")) ))]
+        (->> all-instances (remove nil?) (group-by #(-> % :k8s/pod-phase (= "Failed")) ))]
     ;; pods with Failed phase are treated as failed instances
     (doseq [{:keys [service-id] :as failed-instance} failed-instances]
       (->> (assoc failed-instance :healthy? false :status "Failed")

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -2113,6 +2113,9 @@
     "k8s-pod-cleaner"
     (retry-start-pod-cleaner
      (fn pod-cleaner-thunk []
+       (log/info "starting pod cleaner with configuration:" {:daemon-interval-ms daemon-interval-ms
+                                                             :grace-buffer-ms grace-buffer-ms
+                                                             :scale-down-timeout-secs scale-down-timeout-secs})
        (async/go
          (try
            (loop [iteration 0]

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -975,15 +975,10 @@
             first-phase? (and bypass-enabled? (nil? prepared-to-scale-down-at))
             second-phase? (and bypass-enabled? (some? prepared-to-scale-down-at))
             kill-result (cond first-phase?
-                              (if (scheduler/can-bypass-service-scale-down? service-id)
-                                (do
-                                  (scheduler/set-bypass-service-scale-down service-id)
-                                  (mark-pod-for-scale-down this instance)
-                                  {:message "Successfully annotated pod to be prepared for scale down"})
-                                (do
-                                  (log/info "throttled when trying to annotate the pod" {:instance-id id})
-                                  {:message "Throttled when trying to annotate the pod"
-                                   :status http-429-too-many-requests}))
+                              (do
+                                (mark-pod-for-scale-down this instance)
+                                {:marked-prepared-for-scale-down true
+                                 :message "Successfully annotated pod to be prepared for scale down"})
                               second-phase?
                               (do
                                 (kill-service-instance this instance service)

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -417,6 +417,9 @@
                                    :max-patch-retries 5
                                    :max-name-length 63
                                    :pod-base-port 31000
+                                   :pod-cleanup-grace-buffer-ms 15000
+                                   :pod-cleanup-interval-ms 5000
+                                   :pod-cleanup-scale-down-timeout-secs 120
                                    ; Marathon also defaults this value to 3 seconds:
                                    ; https://mesosphere.github.io/marathon/docs/health-checks.html#taskkillgraceperiodseconds
                                    :pod-sigkill-delay-secs 3

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -48,8 +48,8 @@
                                                                    (s/required-key :show-locked-synchronizers) s/Bool}}
    (s/required-key :deployment-error-config) {(s/required-key :min-failed-instances) schema/positive-int
                                               (s/required-key :min-hosts) schema/positive-int}
-   (s/required-key :ejection-config) {(s/required-key :bypass-grace-buffer-ms) schema/positive-int
-                                      (s/required-key :bypass-max-eject-time-secs) schema/positive-int
+   (s/required-key :ejection-config) {(s/required-key :bypass-force-kill-time-ms) schema/positive-int
+                                      (s/required-key :bypass-grace-buffer-ms) schema/positive-int
                                       (s/required-key :eject-backoff-base-time-ms) schema/positive-int
                                       (s/required-key :expiry-threshold) schema/positive-int
                                       (s/required-key :max-eject-time-ms) schema/positive-int}
@@ -307,8 +307,8 @@
    :debug-options {:thread-dump {:interval-secs 0
                                  :show-locked-monitors false
                                  :show-locked-synchronizers false}}
-   :ejection-config {:bypass-grace-buffer-ms 15000
-                     :bypass-max-eject-time-secs 120
+   :ejection-config {:bypass-force-kill-time-ms 120
+                     :bypass-grace-buffer-ms 15000
                      :eject-backoff-base-time-ms 10000
                      :expiry-threshold 5
                      :max-eject-time-ms 300000}

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -49,7 +49,7 @@
    (s/required-key :deployment-error-config) {(s/required-key :min-failed-instances) schema/positive-int
                                               (s/required-key :min-hosts) schema/positive-int}
    (s/required-key :ejection-config) {(s/required-key :bypass-force-kill-time-ms) schema/positive-int
-                                      (s/required-key :bypass-grace-buffer-ms) schema/positive-int
+                                      (s/required-key :bypass-grace-kill-time-ms) schema/positive-int
                                       (s/required-key :eject-backoff-base-time-ms) schema/positive-int
                                       (s/required-key :expiry-threshold) schema/positive-int
                                       (s/required-key :max-eject-time-ms) schema/positive-int}
@@ -308,7 +308,7 @@
                                  :show-locked-monitors false
                                  :show-locked-synchronizers false}}
    :ejection-config {:bypass-force-kill-time-ms 120
-                     :bypass-grace-buffer-ms 15000
+                     :bypass-grace-kill-time-ms 15000
                      :eject-backoff-base-time-ms 10000
                      :expiry-threshold 5
                      :max-eject-time-ms 300000}

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -48,7 +48,9 @@
                                                                    (s/required-key :show-locked-synchronizers) s/Bool}}
    (s/required-key :deployment-error-config) {(s/required-key :min-failed-instances) schema/positive-int
                                               (s/required-key :min-hosts) schema/positive-int}
-   (s/required-key :ejection-config) {(s/required-key :eject-backoff-base-time-ms) schema/positive-int
+   (s/required-key :ejection-config) {(s/required-key :bypass-grace-buffer-ms) schema/positive-int
+                                      (s/required-key :bypass-max-eject-time-secs) schema/positive-int
+                                      (s/required-key :eject-backoff-base-time-ms) schema/positive-int
                                       (s/required-key :expiry-threshold) schema/positive-int
                                       (s/required-key :max-eject-time-ms) schema/positive-int}
    (s/required-key :entitlement-config) (s/constrained
@@ -305,7 +307,9 @@
    :debug-options {:thread-dump {:interval-secs 0
                                  :show-locked-monitors false
                                  :show-locked-synchronizers false}}
-   :ejection-config {:eject-backoff-base-time-ms 10000
+   :ejection-config {:bypass-grace-buffer-ms 15000
+                     :bypass-max-eject-time-secs 120
+                     :eject-backoff-base-time-ms 10000
                      :expiry-threshold 5
                      :max-eject-time-ms 300000}
    ;; To be considered part of the same cluster, routers need to
@@ -417,9 +421,6 @@
                                    :max-patch-retries 5
                                    :max-name-length 63
                                    :pod-base-port 31000
-                                   :pod-cleanup-grace-buffer-ms 15000
-                                   :pod-cleanup-interval-ms 5000
-                                   :pod-cleanup-scale-down-timeout-secs 120
                                    ; Marathon also defaults this value to 3 seconds:
                                    ; https://mesosphere.github.io/marathon/docs/health-checks.html#taskkillgraceperiodseconds
                                    :pod-sigkill-delay-secs 3

--- a/waiter/src/waiter/state/maintainer.clj
+++ b/waiter/src/waiter/state/maintainer.clj
@@ -135,7 +135,7 @@
                    (timers/start-stop-time!
                      update-state-timer
                      (try
-                       (let [{:keys [service-id->my-instance->slots service-id->unhealthy-instances service-id->expired-instances
+                       (let [{:keys [service-id->healthy-instances service-id->my-instance->slots service-id->unhealthy-instances service-id->expired-instances
                                      service-id->starting-instances service-id->deployment-error service-id->instability-issue time]} router-state
                              incoming-service-ids (set (keys service-id->my-instance->slots))
                              known-service-ids (set (keys service-id->channel-map))
@@ -153,7 +153,8 @@
                          ;; Update state for responders
                          (doseq [service-id (keys service-id->channel-map'')]
                            (try
-                             (let [my-instance->slots (get service-id->my-instance->slots service-id)
+                             (let [all-healthy-instances (get service-id->healthy-instances service-id)
+                                   my-instance->slots (get service-id->my-instance->slots service-id)
                                    healthy-instances (keys my-instance->slots)
                                    unhealthy-instances (get service-id->unhealthy-instances service-id)
                                    expired-instances (get service-id->expired-instances service-id)
@@ -163,7 +164,8 @@
                                    update-state-chan (retrieve-channel (get service-id->channel-map'' service-id) :update-state)]
                                (if (or healthy-instances unhealthy-instances)
                                  (async/put! update-state-chan
-                                             (let [update-state {:healthy-instances healthy-instances
+                                             (let [update-state {:all-healthy-instances all-healthy-instances
+                                                                 :healthy-instances healthy-instances
                                                                  :unhealthy-instances unhealthy-instances
                                                                  :expired-instances expired-instances
                                                                  :starting-instances starting-instances

--- a/waiter/src/waiter/state/responder.clj
+++ b/waiter/src/waiter/state/responder.clj
@@ -140,11 +140,7 @@
                                     category-comparison))
         has-prepared-to-scale-down-instances (prepared-to-scale-down-at-instances? id->instance)
         has-expired-instances (expired-instances? instance-id->state)
-        has-starting-instances (starting-instances? instance-id->state)
-        print-identity (fn [temp]
-                         (log/info "kevin: instance" temp)
-                         temp)]
-    (log/info "kevin: has-prepared-to-scale-down-instances?" {:has-prepared-to-scale-down-instances has-prepared-to-scale-down-instances})
+        has-starting-instances (starting-instances? instance-id->state)]
     (some->> instance-id->state
       (filter (fn [[instance-id _]] (and (acceptable-instance-id? instance-id)
                                          (contains? id->instance instance-id))))
@@ -156,8 +152,7 @@
                              has-prepared-to-scale-down-instances has-expired-instances has-starting-instances state instance now))))
       (find-max instance-id-comparator)
       first ; extract the instance-id
-      id->instance
-             print-identity)))
+      id->instance)))
 
 (defn find-available-instance
   "For servicing requests, choose the _oldest_ live healthy instance with available slots.

--- a/waiter/src/waiter/state/responder.clj
+++ b/waiter/src/waiter/state/responder.clj
@@ -143,9 +143,11 @@
         has-starting-instances (starting-instances? instance-id->state)
         print-identity-fn (fn [res]
                             (log/info "kevin: find-killable-instance" {:instances-considered (keys instance-id->state)
-                                                                       :has-expired-instances has-expired-instances
+                                                                       :prepared-to-scale-down-at-instances? prepared-to-scale-down-at-instances?
                                                                        :return res})
                             res)]
+    (log/info "kevin: find-killable-instance called" {:instances-considered (keys instance-id->state)
+                                                      :prepared-to-scale-down-at-instances? prepared-to-scale-down-at-instances?})
     (some->> instance-id->state
       (filter (fn [[instance-id _]] (and (acceptable-instance-id? instance-id)
                                          (contains? id->instance instance-id))))

--- a/waiter/src/waiter/state/responder.clj
+++ b/waiter/src/waiter/state/responder.clj
@@ -140,7 +140,12 @@
                                     category-comparison))
         has-prepared-to-scale-down-instances (prepared-to-scale-down-at-instances? id->instance)
         has-expired-instances (expired-instances? instance-id->state)
-        has-starting-instances (starting-instances? instance-id->state)]
+        has-starting-instances (starting-instances? instance-id->state)
+        print-identity-fn (fn [res]
+                            (log/info "kevin: find-killable-instance" {:instances-considered (keys instance-id->state)
+                                                                       :has-expired-instances has-expired-instances
+                                                                       :return res})
+                            res)]
     (some->> instance-id->state
       (filter (fn [[instance-id _]] (and (acceptable-instance-id? instance-id)
                                          (contains? id->instance instance-id))))
@@ -152,7 +157,8 @@
                              has-prepared-to-scale-down-instances has-expired-instances has-starting-instances state instance now))))
       (find-max instance-id-comparator)
       first ; extract the instance-id
-      id->instance)))
+      id->instance
+             print-identity-fn)))
 
 (defn find-available-instance
   "For servicing requests, choose the _oldest_ live healthy instance with available slots.

--- a/waiter/src/waiter/state/responder.clj
+++ b/waiter/src/waiter/state/responder.clj
@@ -62,16 +62,16 @@
    - expired and idle or processing lingering requests.
    If there are expired instances, only choose healthy instances that are ejected or expired.
    If there are expired and starting instances, only kill unhealthy instances that are not starting."
-  [request-id->use-reason-map bypass-grace-buffer-ms bypass-max-eject-time-secs earliest-request-threshold-time
+  [request-id->use-reason-map bypass-grace-buffer-ms bypass-force-kill-time-ms earliest-request-threshold-time
    prepared-to-scale-down-instances? expired-instances? starting-instances? {:keys [slots-used status-tags] :as state}
    {:keys [prepared-to-scale-down-at]} now]
   (and (or (not prepared-to-scale-down-instances?)
            ;; If there are any bypass instances preparing to scale down then we should only attempt to kill those instances
-           ;; first. Bypass instances that are scaling down are only killable if the bypass-max-eject-time-secs is met.
+           ;; first. Bypass instances that are scaling down are only killable if the bypass-force-kill-time-ms is met.
            (and (some? prepared-to-scale-down-at)
                 (t/before? (t/plus prepared-to-scale-down-at (t/millis bypass-grace-buffer-ms)) now)
                 ; TODO: need to include outstanding requests check
-                (t/before? (t/plus prepared-to-scale-down-at (t/seconds bypass-max-eject-time-secs)) now)))
+                (t/before? (t/plus prepared-to-scale-down-at (t/millis bypass-force-kill-time-ms)) now)))
        (not-any? #(contains? status-tags %) [:killed :locked])
        (or (zero? slots-used)
            (and (expired? state)
@@ -113,7 +113,7 @@
    - choose amongst the idle ejected instances
    - choose amongst the idle youngest healthy instances."
   [id->all-healthy-instances id->instance instance-id->state acceptable-instance-id? instance-id->request-id->use-reason-map
-   load-balancing bypass-grace-buffer-ms bypass-max-eject-time-secs lingering-request-threshold-ms]
+   load-balancing bypass-grace-buffer-ms bypass-force-kill-time-ms lingering-request-threshold-ms]
   (let [earliest-request-threshold-time (t/minus (t/now) (t/millis lingering-request-threshold-ms))
         instance-id-state-pair->categorizer-vec (fn [[instance-id {:keys [slots-used status-tags] :as state}]]
                                                   ; most important goes first
@@ -152,7 +152,7 @@
                 (let [instance (get id->instance instance-id)
                       request-id->use-reason-map (instance-id->request-id->use-reason-map instance-id)
                       now (t/now)]
-                  (killable? request-id->use-reason-map bypass-grace-buffer-ms bypass-max-eject-time-secs earliest-request-threshold-time
+                  (killable? request-id->use-reason-map bypass-grace-buffer-ms bypass-force-kill-time-ms earliest-request-threshold-time
                              has-prepared-to-scale-down-instances has-expired-instances has-starting-instances state instance now))))
       (find-max instance-id-comparator)
       first ; extract the instance-id
@@ -414,12 +414,12 @@
 (defn handle-kill-instance-request
   "Handles a kill request."
   [{:keys [id->all-healthy-instances id->instance instance-id->request-id->use-reason-map instance-id->state load-balancing] :as current-state}
-   update-status-tag-fn bypass-grace-buffer-ms bypass-max-eject-time-secs lingering-request-threshold-ms
+   update-status-tag-fn bypass-grace-buffer-ms bypass-force-kill-time-ms lingering-request-threshold-ms
    [{:keys [request-id] :as reason-map} resp-chan exclude-ids-set _]]
   (let [acceptable-instance-id? #(not (contains? exclude-ids-set %))
         instance (find-killable-instance id->all-healthy-instances id->instance instance-id->state acceptable-instance-id?
                                          instance-id->request-id->use-reason-map load-balancing
-                                         bypass-grace-buffer-ms bypass-max-eject-time-secs
+                                         bypass-grace-buffer-ms bypass-force-kill-time-ms
                                          lingering-request-threshold-ms)]
     (if instance
       (let [instance-id (:id instance)]
@@ -485,7 +485,7 @@
 (defn handle-eject-request
   "Handle a request to eject an instance."
   [{:keys [id->all-healthy-instances id->instance instance-id->request-id->use-reason-map instance-id->state] :as current-state}
-   update-status-tag-fn update-state-by-ejecting-instance-fn bypass-grace-buffer-ms bypass-max-eject-time-secs
+   update-status-tag-fn update-state-by-ejecting-instance-fn bypass-grace-buffer-ms bypass-force-kill-time-ms
    lingering-request-threshold-ms [{:keys [instance-id eject-period-ms cid]} response-chan]]
   (cid/with-correlation-id
     cid
@@ -504,7 +504,7 @@
                                            instance (id->instance instance-id)
                                            now (t/now)]
                                        (not
-                                         (killable? request-id->use-reason-map bypass-grace-buffer-ms bypass-max-eject-time-secs earliest-request-threshold-time
+                                         (killable? request-id->use-reason-map bypass-grace-buffer-ms bypass-force-kill-time-ms earliest-request-threshold-time
                                                     has-prepared-to-scale-down-instances has-expired-instances has-starting-instances state instance now))))
           response-code (if instance-not-allowed? :in-use :ejected)]
       {:current-state' (if (= :ejected response-code)
@@ -599,7 +599,7 @@
   updated state is passed into the block through the update-state-chan,
   state queries are passed into the block through the query-state-chan."
   [ejection-expiry-tracker service-id trigger-uneject-process-fn
-   {:keys [bypass-grace-buffer-ms bypass-max-eject-time-secs eject-backoff-base-time-ms lingering-request-threshold-ms max-eject-time-ms]}
+   {:keys [bypass-grace-buffer-ms bypass-force-kill-time-ms eject-backoff-base-time-ms lingering-request-threshold-ms max-eject-time-ms]}
    {:keys [eject-instance-chan exit-chan kill-instance-chan query-state-chan release-instance-chan
            reserve-instance-chan scaling-state-chan uneject-instance-chan update-state-chan work-stealing-chan]}
    initial-state]
@@ -716,7 +716,7 @@
                          (let [{:keys [current-state' response-chan response]}
                                (timers/start-stop-time!
                                  responder-kill-timer
-                                 (handle-kill-instance-request current-state update-status-tag-fn bypass-grace-buffer-ms bypass-max-eject-time-secs 
+                                 (handle-kill-instance-request current-state update-status-tag-fn bypass-grace-buffer-ms bypass-force-kill-time-ms 
                                                                lingering-request-threshold-ms data))]
                            (async/>! response-chan response)
                            current-state')
@@ -764,7 +764,7 @@
                                  responder-eject-timer
                                  (handle-eject-request
                                    current-state update-status-tag-fn update-state-by-ejecting-instance-fn
-                                   bypass-grace-buffer-ms bypass-max-eject-time-secs lingering-request-threshold-ms data))]
+                                   bypass-grace-buffer-ms bypass-force-kill-time-ms lingering-request-threshold-ms data))]
                            (async/put! response-chan response)
                            current-state')
 
@@ -841,7 +841,7 @@
                      :update-state-chan (au/latest-chan)
                      :work-stealing-chan (async/chan 1024)
                      :exit-chan (async/chan 1)}]
-    (let [timeout-config (-> (select-keys ejection-config [:bypass-grace-buffer-ms :bypass-max-eject-time-secs 
+    (let [timeout-config (-> (select-keys ejection-config [:bypass-grace-buffer-ms :bypass-force-kill-time-ms 
                                                            :eject-backoff-base-time-ms :max-eject-time-ms])
                            (assoc :lingering-request-threshold-ms lingering-request-threshold-ms))
           {:strs [load-balancing]} service-description

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -1400,3 +1400,14 @@
   "Makes a request to the start-new-services-maintainer state endpoint."
   [waiter-url cookies]
   (make-request waiter-url "/state/start-new-services-maintainer" :cookies cookies))
+
+(defn wait-for-n-active-instances
+  "Waits for n instances to become active and then returns true. If timeout is reached nil is returned."
+  [waiter-url service-id n]
+  (wait-for
+   (fn n-instances-on-waiter? []
+     (let [instances (active-instances waiter-url service-id)]
+       (log/info "waiting for instances:" {:desired-num-instances n
+                                           :instances instances
+                                           :service-id service-id})
+       (= n (count instances))))))

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -735,6 +735,16 @@
       (log/info "cannot convert value to an int:" value)
       nil)))
 
+(defn parse-long
+  "Returns either the input as a long or nil if there was an error in parsing."
+  [value]
+  (try
+    (when value
+      (Long/parseLong (str value)))
+    (catch Exception e
+      (log/info "cannot convert value to a long:" value)
+      nil)))
+
 (defn parse-double
   "Returns either the input as an double or nil if there was an error in parsing."
   ([value]

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -735,16 +735,6 @@
       (log/info "cannot convert value to an int:" value)
       nil)))
 
-(defn parse-long
-  "Returns either the input as a long or nil if there was an error in parsing."
-  [value]
-  (try
-    (when value
-      (Long/parseLong (str value)))
-    (catch Exception e
-      (log/info "cannot convert value to a long:" value)
-      nil)))
-
 (defn parse-double
   "Returns either the input as an double or nil if there was an error in parsing."
   ([value]

--- a/waiter/test/waiter/instance_tracker_test.clj
+++ b/waiter/test/waiter/instance_tracker_test.clj
@@ -219,8 +219,8 @@
             router-state-chan (au/latest-chan)
             watch-chans (create-watch-chans 10)
             started-at (t/minus (clock) (t/hours 1))
-            inst-1-original (scheduler/->ServiceInstance "s1.i1" "s1" started-at nil nil #{} nil "host" 123 [] "/log" "test" nil)
-            inst-1-changed (scheduler/->ServiceInstance "s1.i1" "s1" started-at nil nil #{} nil "different-host" 123 [] "/log" "test" nil)
+            inst-1-original (scheduler/->ServiceInstance "s1.i1" "s1" started-at nil nil #{} nil "host" 123 nil [] "/log" "test" nil)
+            inst-1-changed (scheduler/->ServiceInstance "s1.i1" "s1" started-at nil nil #{} nil "different-host" nil 123 [] "/log" "test" nil)
             {:keys [exit-chan go-chan instance-watch-channels-update-chan]}
             (start-instance-tracker clock router-state-chan ev-handler)]
         (async/>!! router-state-chan {:service-id->failed-instances {}

--- a/waiter/test/waiter/scaling_test.clj
+++ b/waiter/test/waiter/scaling_test.clj
@@ -315,9 +315,9 @@
                                                     notify-instance-killed-fn notify-instance-killed-fn
                                                     peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn}}]
                                            (service-scaling-executor
-                                             notify-instance-killed-fn peers-acknowledged-eject-requests-fn delegate-instance-kill-request-fn
-                                             service-id->service-description-fn scheduler populate-maintainer-chan! quanta-constraints
-                                             timeout-config scale-service-thread-pool test-service-id))]
+                                            notify-instance-killed-fn peers-acknowledged-eject-requests-fn delegate-instance-kill-request-fn
+                                            service-id->service-description-fn scheduler populate-maintainer-chan! quanta-constraints
+                                            timeout-config scale-service-thread-pool test-service-id))]
         (testing "basic-equilibrium-with-no-scaling"
           (let [instance-rpc-chan (async/chan 1)
                 populate-maintainer-chan! (make-populate-maintainer-chan! instance-rpc-chan)
@@ -327,8 +327,8 @@
                 scale-service-thread-pool (Executors/newFixedThreadPool 2)
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                  scheduler populate-maintainer-chan! scale-service-thread-pool
-                  :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)]
+                 scheduler populate-maintainer-chan! scale-service-thread-pool
+                 :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)]
             (mock-reservation-system instance-rpc-chan [])
             (async/>!! executor-chan {:correlation-id (first *testing-contexts*) :service-id test-service-id, :scale-amount 0})
             (is (= equilibrium-state (retrieve-state-fn query-chan)))
@@ -344,8 +344,8 @@
                 scale-service-thread-pool (Executors/newFixedThreadPool 2)
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                  scheduler populate-maintainer-chan! scale-service-thread-pool
-                  :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)]
+                 scheduler populate-maintainer-chan! scale-service-thread-pool
+                 :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)]
             (mock-reservation-system instance-rpc-chan [])
             (async/>!! executor-chan (make-scaling-message test-service-id 10 30 25 30 nil))
             (is (= equilibrium-state (retrieve-state-fn query-chan)))
@@ -362,8 +362,8 @@
                 scale-service-thread-pool (Executors/newFixedThreadPool 2)
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                  scheduler populate-maintainer-chan! scale-service-thread-pool
-                  :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)]
+                 scheduler populate-maintainer-chan! scale-service-thread-pool
+                 :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)]
             (mock-reservation-system instance-rpc-chan [])
             (async/>!! executor-chan (make-scaling-message test-service-id 10 30 25 20 nil))
             (is (= equilibrium-state (retrieve-state-fn query-chan)))
@@ -380,8 +380,8 @@
                 scale-service-thread-pool (Executors/newFixedThreadPool 2)
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                  scheduler populate-maintainer-chan! scale-service-thread-pool
-                  :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)]
+                 scheduler populate-maintainer-chan! scale-service-thread-pool
+                 :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)]
             (mock-reservation-system instance-rpc-chan [])
             (async/>!! executor-chan (make-scaling-message test-service-id 4 24 22 20 nil))
             (is (= equilibrium-state (retrieve-state-fn query-chan)))
@@ -398,8 +398,8 @@
                 scale-service-thread-pool (Executors/newFixedThreadPool 2)
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                  scheduler populate-maintainer-chan! scale-service-thread-pool
-                  :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)]
+                 scheduler populate-maintainer-chan! scale-service-thread-pool
+                 :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)]
             (mock-reservation-system instance-rpc-chan [])
             (async/>!! executor-chan (make-scaling-message test-service-id -5 25 20 20 nil))
             (is (= equilibrium-state (retrieve-state-fn query-chan)))
@@ -421,13 +421,13 @@
                                                     false)
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                  scheduler populate-maintainer-chan! scale-service-thread-pool
-                  :delegate-instance-kill-request-fn delegate-instance-kill-request-fn)]
+                 scheduler populate-maintainer-chan! scale-service-thread-pool
+                 :delegate-instance-kill-request-fn delegate-instance-kill-request-fn)]
             (mock-reservation-system
-              instance-rpc-chan
-              [(fn [[{:keys [reason]} response-chan]]
-                 (is (= :kill-instance reason))
-                 (async/>!! response-chan :no-instance-available))])
+             instance-rpc-chan
+             [(fn [[{:keys [reason]} response-chan]]
+                (is (= :kill-instance reason))
+                (async/>!! response-chan :no-instance-available))])
             (async/>!! executor-chan (make-scaling-message test-service-id -1 30 31 31 response-chan))
             (.await latch)
             (is (= equilibrium-state (retrieve-state-fn query-chan)))
@@ -436,6 +436,8 @@
             (is (empty? @scheduler-operation-tracker-atom))
             (async/>!! exit-chan :exit)
             (.shutdown scale-service-thread-pool)))
+
+        ;; TODO:KEVIN add delegated-instance-kill test with service in bypass
 
         (testing "scale-down:delegated-instance-kill"
           (let [instance-rpc-chan (async/chan 1)
@@ -451,13 +453,13 @@
                                                     true)
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                  scheduler populate-maintainer-chan! scale-service-thread-pool
-                  :delegate-instance-kill-request-fn delegate-instance-kill-request-fn)]
+                 scheduler populate-maintainer-chan! scale-service-thread-pool
+                 :delegate-instance-kill-request-fn delegate-instance-kill-request-fn)]
             (mock-reservation-system
-              instance-rpc-chan
-              [(fn [[{:keys [reason]} response-chan]]
-                 (is (= :kill-instance reason))
-                 (async/>!! response-chan :no-instance-available))])
+             instance-rpc-chan
+             [(fn [[{:keys [reason]} response-chan]]
+                (is (= :kill-instance reason))
+                (async/>!! response-chan :no-instance-available))])
             (async/>!! executor-chan (make-scaling-message test-service-id -1 30 31 31 response-chan))
             (.await latch)
             (is (= (assoc equilibrium-state :last-scale-down-time current-time)
@@ -481,17 +483,17 @@
                 response-chan (async/promise-chan)
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                  scheduler populate-maintainer-chan! scale-service-thread-pool
-                  :notify-instance-killed-fn notify-instance-killed-fn)]
+                 scheduler populate-maintainer-chan! scale-service-thread-pool
+                 :notify-instance-killed-fn notify-instance-killed-fn)]
             (let [instance-1 {:id instance-id-1, :service-id test-service-id, :success-flag true}]
               (mock-reservation-system
-                instance-rpc-chan
-                [(fn [[{:keys [reason]} response-chan]]
-                   (is (= :kill-instance reason))
-                   (async/>!! response-chan instance-1))
-                 (fn [[instance result]]
-                   (is (= instance instance))
-                   (is (= :killed (:status result))))])
+               instance-rpc-chan
+               [(fn [[{:keys [reason]} response-chan]]
+                  (is (= :kill-instance reason))
+                  (async/>!! response-chan instance-1))
+                (fn [[instance result]]
+                  (is (= instance instance))
+                  (is (= :killed (:status result))))])
               (async/>!! executor-chan (make-scaling-message test-service-id -1 30 31 31 response-chan))
               (is (= {:instance-id (:id instance-1), :killed? true, :service-id test-service-id}
                      (async/<!! response-chan)))
@@ -520,23 +522,23 @@
                   false)
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                  scheduler populate-maintainer-chan! scale-service-thread-pool
-                  :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)
+                 scheduler populate-maintainer-chan! scale-service-thread-pool
+                 :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)
                 latch (CountDownLatch. 1)]
             (let [instance-1 {:id instance-id-1, :service-id test-service-id, :success-flag true}]
               (mock-reservation-system
-                instance-rpc-chan
-                [(fn [[{:keys [reason]} response-chan]]
-                   (is (= :kill-instance reason))
-                   (async/>!! response-chan instance-1))
-                 (fn [[instance result]]
-                   (is (= instance-1 instance))
-                   (is (= :not-killed (:status result))))
-                 (fn [[{:keys [reason]} response-chan exclude-ids-set]]
-                   (is (= :kill-instance reason))
-                   (is (= #{instance-id-1} exclude-ids-set))
-                   (.countDown latch)
-                   (async/>!! response-chan :no-matching-instance-found))])
+               instance-rpc-chan
+               [(fn [[{:keys [reason]} response-chan]]
+                  (is (= :kill-instance reason))
+                  (async/>!! response-chan instance-1))
+                (fn [[instance result]]
+                  (is (= instance-1 instance))
+                  (is (= :not-killed (:status result))))
+                (fn [[{:keys [reason]} response-chan exclude-ids-set]]
+                  (is (= :kill-instance reason))
+                  (is (= #{instance-id-1} exclude-ids-set))
+                  (.countDown latch)
+                  (async/>!! response-chan :no-matching-instance-found))])
               (async/>!! executor-chan (make-scaling-message test-service-id -2 30 32 32 response-chan))
               (.await latch)
               (is (= equilibrium-state (retrieve-state-fn query-chan)))
@@ -562,27 +564,27 @@
                 peers-acknowledged-eject-requests-fn (fn [{:keys [id]} _ _ _] (not= instance-id-1 id))
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                  scheduler populate-maintainer-chan! scale-service-thread-pool
-                  :notify-instance-killed-fn notify-instance-killed-fn
-                  :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)
+                 scheduler populate-maintainer-chan! scale-service-thread-pool
+                 :notify-instance-killed-fn notify-instance-killed-fn
+                 :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)
                 latch (CountDownLatch. 1)]
             (let [instance-1 {:id instance-id-1, :service-id test-service-id, :success-flag true}
                   instance-2 {:id instance-id-2, :service-id test-service-id, :success-flag true}]
               (mock-reservation-system
-                instance-rpc-chan
-                [(fn [[{:keys [reason]} response-chan]]
-                   (is (= :kill-instance reason))
-                   (async/>!! response-chan instance-1))
-                 (fn [[instance result]]
-                   (is (= instance-1 instance))
-                   (is (= :not-killed (:status result))))
-                 (fn [[{:keys [reason]} response-chan]]
-                   (is (= :kill-instance reason))
-                   (async/>!! response-chan instance-2))
-                 (fn [[instance result]]
-                   (is (= instance-2 instance))
-                   (is (= :killed (:status result)))
-                   (.countDown latch))])
+               instance-rpc-chan
+               [(fn [[{:keys [reason]} response-chan]]
+                  (is (= :kill-instance reason))
+                  (async/>!! response-chan instance-1))
+                (fn [[instance result]]
+                  (is (= instance-1 instance))
+                  (is (= :not-killed (:status result))))
+                (fn [[{:keys [reason]} response-chan]]
+                  (is (= :kill-instance reason))
+                  (async/>!! response-chan instance-2))
+                (fn [[instance result]]
+                  (is (= instance-2 instance))
+                  (is (= :killed (:status result)))
+                  (.countDown latch))])
               (async/>!! executor-chan (make-scaling-message test-service-id -2 30 32 32 response-chan))
               (.await latch)
               (is (= (assoc equilibrium-state :last-scale-down-time current-time)
@@ -608,28 +610,28 @@
                 peers-acknowledged-eject-requests-fn (fn [{:keys [id]} _ _ _] (not= instance-id-1 id))
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                  scheduler populate-maintainer-chan! scale-service-thread-pool
-                  :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)
+                 scheduler populate-maintainer-chan! scale-service-thread-pool
+                 :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)
                 latch (CountDownLatch. 1)]
             (let [instance-1 {:id instance-id-1, :service-id test-service-id, :success-flag true}
                   instance-2 {:id instance-id-2, :service-id test-service-id, :success-flag false}]
               (mock-reservation-system
-                instance-rpc-chan
-                [(fn [[{:keys [reason]} response-chan exclude-ids-set]]
-                   (is (= :kill-instance reason))
-                   (is (= #{} exclude-ids-set))
-                   (async/>!! response-chan instance-1))
-                 (fn [[instance result]]
-                   (is (= instance-1 instance))
-                   (is (= :not-killed (:status result))))
-                 (fn [[{:keys [reason]} response-chan exclude-ids-set]]
-                   (is (= :kill-instance reason))
-                   (is (= #{instance-id-1} exclude-ids-set))
-                   (async/>!! response-chan instance-2))
-                 (fn [[instance result]]
-                   (is (= instance-2 instance))
-                   (is (= :not-killed (:status result)))
-                   (.countDown latch))])
+               instance-rpc-chan
+               [(fn [[{:keys [reason]} response-chan exclude-ids-set]]
+                  (is (= :kill-instance reason))
+                  (is (= #{} exclude-ids-set))
+                  (async/>!! response-chan instance-1))
+                (fn [[instance result]]
+                  (is (= instance-1 instance))
+                  (is (= :not-killed (:status result))))
+                (fn [[{:keys [reason]} response-chan exclude-ids-set]]
+                  (is (= :kill-instance reason))
+                  (is (= #{instance-id-1} exclude-ids-set))
+                  (async/>!! response-chan instance-2))
+                (fn [[instance result]]
+                  (is (= instance-2 instance))
+                  (is (= :not-killed (:status result)))
+                  (.countDown latch))])
               (async/>!! executor-chan (make-scaling-message test-service-id -3 30 33 33 response-chan))
               (.await latch)
               (is (= {:instance-id (:id instance-2), :killed? false, :service-id test-service-id}
@@ -655,17 +657,17 @@
                                             (is (= test-service-id service-id)))
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                  scheduler populate-maintainer-chan! scale-service-thread-pool
-                  :notify-instance-killed-fn notify-instance-killed-fn)]
+                 scheduler populate-maintainer-chan! scale-service-thread-pool
+                 :notify-instance-killed-fn notify-instance-killed-fn)]
             (let [instance-1 {:id instance-id-1, :service-id test-service-id, :success-flag true}]
               (mock-reservation-system
-                instance-rpc-chan
-                [(fn [[{:keys [reason]} response-chan exclude-ids-set]]
-                   (is (= :kill-instance reason))
-                   (is (= #{} exclude-ids-set))
-                   (async/>!! response-chan instance-1))
-                 (fn [[instance result]] (is (= instance-1 instance))
-                   (is (= :killed (:status result))))])
+               instance-rpc-chan
+               [(fn [[{:keys [reason]} response-chan exclude-ids-set]]
+                  (is (= :kill-instance reason))
+                  (is (= #{} exclude-ids-set))
+                  (async/>!! response-chan instance-1))
+                (fn [[instance result]] (is (= instance-1 instance))
+                  (is (= :killed (:status result))))])
               (async/>!! executor-chan (make-scaling-message test-service-id -2 30 32 32 response-chan))
               (is (= {:instance-id (:id instance-1), :killed? true, :service-id test-service-id}
                      (async/<!! response-chan)))

--- a/waiter/test/waiter/scaling_test.clj
+++ b/waiter/test/waiter/scaling_test.clj
@@ -349,9 +349,9 @@
                                                     notify-instance-killed-fn notify-instance-killed-fn
                                                     peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn}}]
                                            (service-scaling-executor
-                                            notify-instance-killed-fn peers-acknowledged-eject-requests-fn delegate-instance-kill-request-fn
-                                            service-id->service-description-fn scheduler populate-maintainer-chan! quanta-constraints
-                                            timeout-config scale-service-thread-pool test-service-id))]
+                                             notify-instance-killed-fn peers-acknowledged-eject-requests-fn delegate-instance-kill-request-fn
+                                             service-id->service-description-fn scheduler populate-maintainer-chan! quanta-constraints
+                                             timeout-config scale-service-thread-pool test-service-id))]
         (testing "basic-equilibrium-with-no-scaling"
           (let [instance-rpc-chan (async/chan 1)
                 populate-maintainer-chan! (make-populate-maintainer-chan! instance-rpc-chan)
@@ -361,8 +361,8 @@
                 scale-service-thread-pool (Executors/newFixedThreadPool 2)
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                 scheduler populate-maintainer-chan! scale-service-thread-pool
-                 :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)]
+                  scheduler populate-maintainer-chan! scale-service-thread-pool
+                  :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)]
             (mock-reservation-system instance-rpc-chan [])
             (async/>!! executor-chan {:correlation-id (first *testing-contexts*) :service-id test-service-id, :scale-amount 0})
             (is (= equilibrium-state (retrieve-state-fn query-chan)))
@@ -378,8 +378,8 @@
                 scale-service-thread-pool (Executors/newFixedThreadPool 2)
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                 scheduler populate-maintainer-chan! scale-service-thread-pool
-                 :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)]
+                  scheduler populate-maintainer-chan! scale-service-thread-pool
+                  :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)]
             (mock-reservation-system instance-rpc-chan [])
             (async/>!! executor-chan (make-scaling-message test-service-id 10 30 25 30 nil))
             (is (= equilibrium-state (retrieve-state-fn query-chan)))
@@ -396,8 +396,8 @@
                 scale-service-thread-pool (Executors/newFixedThreadPool 2)
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                 scheduler populate-maintainer-chan! scale-service-thread-pool
-                 :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)]
+                  scheduler populate-maintainer-chan! scale-service-thread-pool
+                  :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)]
             (mock-reservation-system instance-rpc-chan [])
             (async/>!! executor-chan (make-scaling-message test-service-id 10 30 25 20 nil))
             (is (= equilibrium-state (retrieve-state-fn query-chan)))
@@ -414,8 +414,8 @@
                 scale-service-thread-pool (Executors/newFixedThreadPool 2)
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                 scheduler populate-maintainer-chan! scale-service-thread-pool
-                 :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)]
+                  scheduler populate-maintainer-chan! scale-service-thread-pool
+                  :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)]
             (mock-reservation-system instance-rpc-chan [])
             (async/>!! executor-chan (make-scaling-message test-service-id 4 24 22 20 nil))
             (is (= equilibrium-state (retrieve-state-fn query-chan)))
@@ -432,8 +432,8 @@
                 scale-service-thread-pool (Executors/newFixedThreadPool 2)
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                 scheduler populate-maintainer-chan! scale-service-thread-pool
-                 :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)]
+                  scheduler populate-maintainer-chan! scale-service-thread-pool
+                  :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)]
             (mock-reservation-system instance-rpc-chan [])
             (async/>!! executor-chan (make-scaling-message test-service-id -5 25 20 20 nil))
             (is (= equilibrium-state (retrieve-state-fn query-chan)))
@@ -455,13 +455,13 @@
                                                     false)
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                 scheduler populate-maintainer-chan! scale-service-thread-pool
-                 :delegate-instance-kill-request-fn delegate-instance-kill-request-fn)]
+                  scheduler populate-maintainer-chan! scale-service-thread-pool
+                  :delegate-instance-kill-request-fn delegate-instance-kill-request-fn)]
             (mock-reservation-system
-             instance-rpc-chan
-             [(fn [[{:keys [reason]} response-chan]]
-                (is (= :kill-instance reason))
-                (async/>!! response-chan :no-instance-available))])
+              instance-rpc-chan
+              [(fn [[{:keys [reason]} response-chan]]
+                 (is (= :kill-instance reason))
+                 (async/>!! response-chan :no-instance-available))])
             (async/>!! executor-chan (make-scaling-message test-service-id -1 30 31 31 response-chan))
             (.await latch)
             (is (= equilibrium-state (retrieve-state-fn query-chan)))
@@ -485,13 +485,13 @@
                                                     true)
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                 scheduler populate-maintainer-chan! scale-service-thread-pool
-                 :delegate-instance-kill-request-fn delegate-instance-kill-request-fn)]
+                  scheduler populate-maintainer-chan! scale-service-thread-pool
+                  :delegate-instance-kill-request-fn delegate-instance-kill-request-fn)]
             (mock-reservation-system
-             instance-rpc-chan
-             [(fn [[{:keys [reason]} response-chan]]
-                (is (= :kill-instance reason))
-                (async/>!! response-chan :no-instance-available))])
+              instance-rpc-chan
+              [(fn [[{:keys [reason]} response-chan]]
+                 (is (= :kill-instance reason))
+                 (async/>!! response-chan :no-instance-available))])
             (async/>!! executor-chan (make-scaling-message test-service-id -1 30 31 31 response-chan))
             (.await latch)
             (is (= (assoc equilibrium-state :last-scale-down-time current-time)
@@ -519,13 +519,13 @@
                  :notify-instance-killed-fn notify-instance-killed-fn)]
             (let [instance-1 {:id instance-id-1, :service-id test-service-id, :success-flag true}]
               (mock-reservation-system
-               instance-rpc-chan
-               [(fn [[{:keys [reason]} response-chan]]
-                  (is (= :kill-instance reason))
-                  (async/>!! response-chan instance-1))
-                (fn [[instance result]]
-                  (is (= instance instance))
-                  (is (= :killed (:status result))))])
+                instance-rpc-chan
+                [(fn [[{:keys [reason]} response-chan]]
+                   (is (= :kill-instance reason))
+                   (async/>!! response-chan instance-1))
+                 (fn [[instance result]]
+                   (is (= instance instance))
+                   (is (= :killed (:status result))))])
               (async/>!! executor-chan (make-scaling-message test-service-id -1 30 31 31 response-chan))
               (is (= {:instance-id (:id instance-1), :killed? true, :service-id test-service-id}
                      (async/<!! response-chan)))
@@ -554,23 +554,23 @@
                   false)
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                 scheduler populate-maintainer-chan! scale-service-thread-pool
-                 :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)
+                  scheduler populate-maintainer-chan! scale-service-thread-pool
+                  :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)
                 latch (CountDownLatch. 1)]
             (let [instance-1 {:id instance-id-1, :service-id test-service-id, :success-flag true}]
               (mock-reservation-system
-               instance-rpc-chan
-               [(fn [[{:keys [reason]} response-chan]]
-                  (is (= :kill-instance reason))
-                  (async/>!! response-chan instance-1))
-                (fn [[instance result]]
-                  (is (= instance-1 instance))
-                  (is (= :not-killed (:status result))))
-                (fn [[{:keys [reason]} response-chan exclude-ids-set]]
-                  (is (= :kill-instance reason))
-                  (is (= #{instance-id-1} exclude-ids-set))
-                  (.countDown latch)
-                  (async/>!! response-chan :no-matching-instance-found))])
+                instance-rpc-chan
+                [(fn [[{:keys [reason]} response-chan]]
+                   (is (= :kill-instance reason))
+                   (async/>!! response-chan instance-1))
+                 (fn [[instance result]]
+                   (is (= instance-1 instance))
+                   (is (= :not-killed (:status result))))
+                 (fn [[{:keys [reason]} response-chan exclude-ids-set]]
+                   (is (= :kill-instance reason))
+                   (is (= #{instance-id-1} exclude-ids-set))
+                   (.countDown latch)
+                   (async/>!! response-chan :no-matching-instance-found))])
               (async/>!! executor-chan (make-scaling-message test-service-id -2 30 32 32 response-chan))
               (.await latch)
               (is (= equilibrium-state (retrieve-state-fn query-chan)))
@@ -596,27 +596,27 @@
                 peers-acknowledged-eject-requests-fn (fn [{:keys [id]} _ _ _] (not= instance-id-1 id))
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                 scheduler populate-maintainer-chan! scale-service-thread-pool
-                 :notify-instance-killed-fn notify-instance-killed-fn
-                 :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)
+                  scheduler populate-maintainer-chan! scale-service-thread-pool
+                  :notify-instance-killed-fn notify-instance-killed-fn
+                  :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)
                 latch (CountDownLatch. 1)]
             (let [instance-1 {:id instance-id-1, :service-id test-service-id, :success-flag true}
                   instance-2 {:id instance-id-2, :service-id test-service-id, :success-flag true}]
               (mock-reservation-system
-               instance-rpc-chan
-               [(fn [[{:keys [reason]} response-chan]]
-                  (is (= :kill-instance reason))
-                  (async/>!! response-chan instance-1))
-                (fn [[instance result]]
-                  (is (= instance-1 instance))
-                  (is (= :not-killed (:status result))))
-                (fn [[{:keys [reason]} response-chan]]
-                  (is (= :kill-instance reason))
-                  (async/>!! response-chan instance-2))
-                (fn [[instance result]]
-                  (is (= instance-2 instance))
-                  (is (= :killed (:status result)))
-                  (.countDown latch))])
+                instance-rpc-chan
+                [(fn [[{:keys [reason]} response-chan]]
+                   (is (= :kill-instance reason))
+                   (async/>!! response-chan instance-1))
+                 (fn [[instance result]]
+                   (is (= instance-1 instance))
+                   (is (= :not-killed (:status result))))
+                 (fn [[{:keys [reason]} response-chan]]
+                   (is (= :kill-instance reason))
+                   (async/>!! response-chan instance-2))
+                 (fn [[instance result]]
+                   (is (= instance-2 instance))
+                   (is (= :killed (:status result)))
+                   (.countDown latch))])
               (async/>!! executor-chan (make-scaling-message test-service-id -2 30 32 32 response-chan))
               (.await latch)
               (is (= (assoc equilibrium-state :last-scale-down-time current-time)
@@ -642,28 +642,28 @@
                 peers-acknowledged-eject-requests-fn (fn [{:keys [id]} _ _ _] (not= instance-id-1 id))
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                 scheduler populate-maintainer-chan! scale-service-thread-pool
-                 :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)
+                  scheduler populate-maintainer-chan! scale-service-thread-pool
+                  :peers-acknowledged-eject-requests-fn peers-acknowledged-eject-requests-fn)
                 latch (CountDownLatch. 1)]
             (let [instance-1 {:id instance-id-1, :service-id test-service-id, :success-flag true}
                   instance-2 {:id instance-id-2, :service-id test-service-id, :success-flag false}]
               (mock-reservation-system
-               instance-rpc-chan
-               [(fn [[{:keys [reason]} response-chan exclude-ids-set]]
-                  (is (= :kill-instance reason))
-                  (is (= #{} exclude-ids-set))
-                  (async/>!! response-chan instance-1))
-                (fn [[instance result]]
-                  (is (= instance-1 instance))
-                  (is (= :not-killed (:status result))))
-                (fn [[{:keys [reason]} response-chan exclude-ids-set]]
-                  (is (= :kill-instance reason))
-                  (is (= #{instance-id-1} exclude-ids-set))
-                  (async/>!! response-chan instance-2))
-                (fn [[instance result]]
-                  (is (= instance-2 instance))
-                  (is (= :not-killed (:status result)))
-                  (.countDown latch))])
+                instance-rpc-chan
+                [(fn [[{:keys [reason]} response-chan exclude-ids-set]]
+                   (is (= :kill-instance reason))
+                   (is (= #{} exclude-ids-set))
+                   (async/>!! response-chan instance-1))
+                 (fn [[instance result]]
+                   (is (= instance-1 instance))
+                   (is (= :not-killed (:status result))))
+                 (fn [[{:keys [reason]} response-chan exclude-ids-set]]
+                   (is (= :kill-instance reason))
+                   (is (= #{instance-id-1} exclude-ids-set))
+                   (async/>!! response-chan instance-2))
+                 (fn [[instance result]]
+                   (is (= instance-2 instance))
+                   (is (= :not-killed (:status result)))
+                   (.countDown latch))])
               (async/>!! executor-chan (make-scaling-message test-service-id -3 30 33 33 response-chan))
               (.await latch)
               (is (= {:instance-id (:id instance-2), :killed? false, :service-id test-service-id}
@@ -689,17 +689,17 @@
                                             (is (= test-service-id service-id)))
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                 scheduler populate-maintainer-chan! scale-service-thread-pool
-                 :notify-instance-killed-fn notify-instance-killed-fn)]
+                  scheduler populate-maintainer-chan! scale-service-thread-pool
+                  :notify-instance-killed-fn notify-instance-killed-fn)]
             (let [instance-1 {:id instance-id-1, :service-id test-service-id, :success-flag true}]
               (mock-reservation-system
-               instance-rpc-chan
-               [(fn [[{:keys [reason]} response-chan exclude-ids-set]]
-                  (is (= :kill-instance reason))
-                  (is (= #{} exclude-ids-set))
-                  (async/>!! response-chan instance-1))
-                (fn [[instance result]] (is (= instance-1 instance))
-                  (is (= :killed (:status result))))])
+                instance-rpc-chan
+                [(fn [[{:keys [reason]} response-chan exclude-ids-set]]
+                   (is (= :kill-instance reason))
+                   (is (= #{} exclude-ids-set))
+                   (async/>!! response-chan instance-1))
+                 (fn [[instance result]] (is (= instance-1 instance))
+                   (is (= :killed (:status result))))])
               (async/>!! executor-chan (make-scaling-message test-service-id -2 30 32 32 response-chan))
               (is (= {:instance-id (:id instance-1), :killed? true, :service-id test-service-id}
                      (async/<!! response-chan)))

--- a/waiter/test/waiter/scaling_test.clj
+++ b/waiter/test/waiter/scaling_test.clj
@@ -515,8 +515,8 @@
                 response-chan (async/promise-chan)
                 {:keys [executor-chan exit-chan query-chan]}
                 (run-service-scaling-executor
-                 scheduler populate-maintainer-chan! scale-service-thread-pool
-                 :notify-instance-killed-fn notify-instance-killed-fn)]
+                  scheduler populate-maintainer-chan! scale-service-thread-pool
+                  :notify-instance-killed-fn notify-instance-killed-fn)]
             (let [instance-1 {:id instance-id-1, :service-id test-service-id, :success-flag true}]
               (mock-reservation-system
                 instance-rpc-chan

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -1642,7 +1642,7 @@
                         :message "Error while killing instance"
                         :status http-500-internal-server-error)
                  actual))))
-      (testing "succesful-delete: service is in bypass, instance is has not been annotated with 'prepared-to-scale-down-at'"
+      (testing "succesful-delete: service is in bypass, instance has not been annotated with 'prepared-to-scale-down-at'"
         (let [service-id->service-description-fn
               (constantly {"metadata" {"waiter-proxy-bypass-opt-in" "true"}})
               dummy-scheduler (assoc dummy-scheduler :service-id->service-description-fn service-id->service-description-fn)

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -1643,7 +1643,8 @@
                         :status http-200-ok)
                  actual))
           (is @pod-marked-for-scale-down?-atom)
-          (is (not @instances-killed?-fn)))))))
+          (is (not @instances-killed?-fn)
+              "Instance should not be killed fully, that is handled by the pod cleanup daemon separately."))))))
 
 (deftest test-scheduler-service-exists?
   (let [service-id "test-app-1234"

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -1665,7 +1665,7 @@
                         :message "Successfully annotated pod to be prepared for scale down"
                         :status http-200-ok)
                  actual))
-          (is (not @pod-marked-for-scale-down?-atom))
+          (is @pod-marked-for-scale-down?-atom)
           (is @set-bypass-service-scale-down-atom
               "Instance should update the cache with service-id as the pod is being marked for scale down.")
           (is (not @instances-killed?-fn)
@@ -1693,7 +1693,7 @@
                         :message "Throttled when trying to annotate the pod"
                         :status http-429-too-many-requests)
                  actual))
-          (is @pod-marked-for-scale-down?-atom)
+          (is (not @pod-marked-for-scale-down?-atom))
           (is (not @set-bypass-service-scale-down-atom)
               "Instance was throttled and should not reset the service value in cache!")
           (is (not @instances-killed?-fn)

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -918,7 +918,6 @@
                                     :k8s/replicaset-creation-timestamp "2019-08-01T00:00:00.000Z"
                                     :k8s/replicaset-annotations {}
                                     :k8s/replicaset-pod-annotations {}
-                                    :k8s/replicaset-replicas 2
                                     :task-count 2
                                     :task-stats {:running 2, :healthy 2, :unhealthy 0, :staged 0}})
            (scheduler/make-Service {:id "test-app-6789"
@@ -928,7 +927,6 @@
                                     :k8s/replicaset-creation-timestamp "2019-08-05T00:00:00.000Z"
                                     :k8s/replicaset-annotations {}
                                     :k8s/replicaset-pod-annotations {}
-                                    :k8s/replicaset-replicas 3
                                     :task-count 3
                                     :task-stats {:running 3 :healthy 1 :unhealthy 2 :staged 0}})]}
          {:api-server-response
@@ -980,7 +978,6 @@
                                     :k8s/replicaset-creation-timestamp "2019-09-07T00:00:00.000Z"
                                     :k8s/replicaset-annotations {}
                                     :k8s/replicaset-pod-annotations {}
-                                    :k8s/replicaset-replicas 2
                                     :task-count 2
                                     :task-stats {:running 2, :healthy 2, :unhealthy 0, :staged 0}})
            (scheduler/make-Service {:id "test-app-wxyz"
@@ -991,7 +988,6 @@
                                     :k8s/replicaset-creation-timestamp "2019-10-15T00:00:00.000Z"
                                     :k8s/replicaset-annotations {}
                                     :k8s/replicaset-pod-annotations {}
-                                    :k8s/replicaset-replicas 3
                                     :task-count 3
                                     :task-stats {:running 3 :healthy 1 :unhealthy 2 :staged 0}})]}
 
@@ -1030,7 +1026,6 @@
                                     :k8s/replicaset-creation-timestamp "2020-03-04T05:06:07.000Z"
                                     :k8s/replicaset-annotations {}
                                     :k8s/replicaset-pod-annotations {}
-                                    :k8s/replicaset-replicas 3
                                     :task-count 3
                                     :task-stats {:running 2 :healthy 1 :unhealthy 1 :staged 1}})]}
 
@@ -1064,7 +1059,6 @@
                                     :k8s/replicaset-creation-timestamp "2020-01-02T03:04:05.000Z"
                                     :k8s/replicaset-annotations {:waiter/revision-timestamp "2020-09-22T20:22:22.000Z"}
                                     :k8s/replicaset-pod-annotations {:waiter/revision-timestamp "2020-09-22T20:22:22.000Z"}
-                                    :k8s/replicaset-replicas 0
                                     :task-count 0
                                     :task-stats {:running 0, :healthy 0, :unhealthy 0, :staged 0}})]}
 
@@ -1102,7 +1096,6 @@
                                                                  :waiter/revision-version "3"}
                                     :k8s/replicaset-pod-annotations {:waiter/revision-timestamp "2020-09-22T20:22:22.000Z"
                                                                      :waiter/revision-version "3"}
-                                    :k8s/replicaset-replicas 0
                                     :task-count 0
                                     :task-stats {:running 0, :healthy 0, :unhealthy 0, :staged 0}})]}
 
@@ -1383,7 +1376,6 @@
                                            :k8s/replicaset-creation-timestamp "2020-01-02T03:04:05.000Z"
                                            :k8s/replicaset-annotations {:waiter/revision-timestamp "2020-09-22T20:33:33.000Z"}
                                            :k8s/replicaset-pod-annotations {:waiter/revision-timestamp "2020-09-22T20:33:33.000Z"}
-                                           :k8s/replicaset-replicas 2
                                            :task-count 2
                                            :task-stats {:running 2, :healthy 2, :unhealthy 0, :staged 0}})
                   {:active-instances
@@ -1469,7 +1461,6 @@
                                            :k8s/replicaset-creation-timestamp "2020-09-08T07:06:05.000Z"
                                            :k8s/replicaset-annotations {}
                                            :k8s/replicaset-pod-annotations {}
-                                           :k8s/replicaset-replicas 3
                                            :task-count 3
                                            :task-stats {:running 3 :healthy 1 :unhealthy 2 :staged 0}})
                   {:active-instances
@@ -1524,6 +1515,24 @@
                                                 :type :init}]
                       :log-directory "/home/myself/r0"
                       :port 8080
+                      :service-id "test-app-6789"
+                      :started-at (du/str-to-date "2014-09-13T00:24:48Z" k8s-timestamp-format)
+                      :status "Unhealthy"})
+                    (scheduler/make-ServiceInstance
+                     {:flags #{:expired}
+                      :healthy? false
+                      :host "10.141.141.16"
+                      :id "test-app-6789.test-app-6789-abcd5-0"
+                      :k8s/container-statuses [{:name waiter-primary-container-name
+                                                :restart-count 0
+                                                :type :app}
+                                               {:name "waiter-setup"
+                                                :ready false
+                                                :restart-count 200
+                                                :type :init}]
+                      :log-directory "/home/myself/r0"
+                      :port 8080
+                      :prepared-to-scale-down-at (du/str-to-date "2020-09-22T20:11:11.000Z")
                       :service-id "test-app-6789"
                       :started-at (du/str-to-date "2014-09-13T00:24:48Z" k8s-timestamp-format)
                       :status "Unhealthy"})]
@@ -1880,9 +1889,9 @@
 (deftest test-scale-service
   (let [instances' 4
         service-id "test-service-id"
-        service (scheduler/make-Service {:id service-id :instances 1 :k8s/app-name service-id :k8s/namespace "myself" :k8s/replicaset-replicas 1})
+        service (scheduler/make-Service {:id service-id :instances 1 :k8s/app-name service-id :k8s/namespace "myself"})
         service-id-with-scale-down "test-service-id-scale-down"
-        service-scale-down (scheduler/make-Service {:id service-id-with-scale-down :instances 1 :k8s/app-name service-id :k8s/namespace "myself" :k8s/replicaset-replicas 2})
+        service-scale-down (scheduler/make-Service {:id service-id-with-scale-down :instances 1 :k8s/app-name service-id :k8s/namespace "myself"})
         service-state (atom {:service-id->service {service-id service
                                                    service-id-with-scale-down service-scale-down}})
         dummy-scheduler (assoc (make-dummy-scheduler [service-id service-id-with-scale-down]) :watch-state service-state)]
@@ -3195,7 +3204,7 @@
               pod' (-> pod
                        (assoc-in [:metadata :annotations :waiter/prepared-to-scale-down-at] now-str))
               instance (pod->ServiceInstance base-scheduler pod')
-              expected-instance-map (assoc instance-map :k8s/prepared-to-scale-down-at now)]
+              expected-instance-map (assoc instance-map :prepared-to-scale-down-at now)]
           (is (= (scheduler/make-ServiceInstance expected-instance-map) instance))))
 
       (testing "annotation is NOT a valid ISO-8601 string so it is ignored"

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -1650,52 +1650,19 @@
               mark-pod-for-scale-down-mock (fn mark-pod-for-scale-down-fn [_ _]
                                              (reset! pod-marked-for-scale-down?-atom true))
               instances-killed?-fn (atom false)
-              set-bypass-service-scale-down-atom (atom false)
               hard-delete-service-instance-mock (fn hard-delete-service-instance-fn [_ _]
                                                   (reset! instances-killed?-fn true))
-              actual (with-redefs [scheduler/can-bypass-service-scale-down? (constantly true)
-                                   scheduler/set-bypass-service-scale-down (fn set-bypass-service-scale-down-fn [_]
-                                                                             (reset! set-bypass-service-scale-down-atom true))
-                                   api-request (constantly {:status "OK"})
+              actual (with-redefs [api-request (constantly {:status "OK"})
                                    mark-pod-for-scale-down mark-pod-for-scale-down-mock
                                    hard-delete-service-instance hard-delete-service-instance-mock]
                        (scheduler/kill-instance dummy-scheduler instance))]
           (is (= (assoc partial-expected
                         :killed? false
+                        :marked-prepared-for-scale-down true
                         :message "Successfully annotated pod to be prepared for scale down"
                         :status http-200-ok)
                  actual))
           (is @pod-marked-for-scale-down?-atom)
-          (is @set-bypass-service-scale-down-atom
-              "Instance should update the cache with service-id as the pod is being marked for scale down.")
-          (is (not @instances-killed?-fn)
-              "Instance should not be killed fully, that is handled by the pod cleanup daemon separately.")))
-      (testing "succesful-delete: service is in bypass, instance needs to be annotated with 'prepared-to-scale-down-at' but is throttled"
-        (let [service-id->service-description-fn
-              (constantly {"metadata" {"waiter-proxy-bypass-opt-in" "true"}})
-              dummy-scheduler (assoc dummy-scheduler :service-id->service-description-fn service-id->service-description-fn)
-              pod-marked-for-scale-down?-atom (atom false)
-              mark-pod-for-scale-down-mock (fn mark-pod-for-scale-down-fn [_ _]
-                                             (reset! pod-marked-for-scale-down?-atom true))
-              instances-killed?-fn (atom false)
-              set-bypass-service-scale-down-atom (atom false)
-              hard-delete-service-instance-mock (fn hard-delete-service-instance-fn [_ _]
-                                                  (reset! instances-killed?-fn true))
-              actual (with-redefs [scheduler/can-bypass-service-scale-down? (constantly false)
-                                   scheduler/set-bypass-service-scale-down (fn set-bypass-service-scale-down-fn [_]
-                                                                             (reset! set-bypass-service-scale-down-atom true))
-                                   api-request (constantly {:status "OK"})
-                                   mark-pod-for-scale-down mark-pod-for-scale-down-mock
-                                   hard-delete-service-instance hard-delete-service-instance-mock]
-                       (scheduler/kill-instance dummy-scheduler instance))]
-          (is (= (assoc partial-expected
-                        :killed? false
-                        :message "Throttled when trying to annotate the pod"
-                        :status http-429-too-many-requests)
-                 actual))
-          (is (not @pod-marked-for-scale-down?-atom))
-          (is (not @set-bypass-service-scale-down-atom)
-              "Instance was throttled and should not reset the service value in cache!")
           (is (not @instances-killed?-fn)
               "Instance should not be killed fully, that is handled by the pod cleanup daemon separately.")))
       (testing "succesful-delete: service is in bypass, instance already has 'prepared-to-scale-down-at' and needs to be fully scaled down"

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -1351,8 +1351,7 @@
                                                     :restartCount 200}]}}
                  {:metadata {:name "test-app-6789-abcd5"
                              :namespace "myself"
-                             :labels {:app app-drain-label
-                                      :waiter/cluster "waiter"
+                             :labels {:waiter/cluster "waiter"
                                       :waiter/user "myself"
                                       :waiter/service-hash "test-app-6789"}
                              :annotations {:waiter/prepared-to-scale-down-at (du/date-to-str (t/now))
@@ -3478,13 +3477,11 @@
 (defn create-killable-pod
   [id service-id now timeout-secs]
   (-> (create-generic-pod id service-id)
-      (assoc-in [:metadata :labels :app] app-drain-label)
       (assoc-in [:metadata :annotations :waiter/prepared-to-scale-down-at] (du/date-to-str (t/minus now (t/seconds (+ timeout-secs 1)))))))
 
 (defn create-scale-down-pod
   [id service-id now grace-buffer-ms]
   (-> (create-generic-pod id service-id)
-      (assoc-in [:metadata :labels :app] app-drain-label)
       (assoc-in [:metadata :annotations :waiter/prepared-to-scale-down-at] (du/date-to-str (t/minus now (t/millis (+ grace-buffer-ms 1)))))))
 
 (deftest test-cleanup-killable-pods

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -1756,7 +1756,7 @@
             (testing "removes previously created deployment error"
               (let [api-calls-atom (atom [])
                     actual (with-redefs [api-request (make-api-request api-calls-atom)
-                                         replicaset->Service identity]
+                                         replicaset->Service (fn get-first-arg-fn [rs-json & _] rs-json)]
                              (scheduler/create-service-if-new dummy-scheduler descriptor))
                     api-calls @api-calls-atom
                     services (scheduler/get-services dummy-scheduler)]
@@ -1771,7 +1771,7 @@
             (testing "without pod disruption budget"
               (let [api-calls-atom (atom [])
                     actual (with-redefs [api-request (make-api-request api-calls-atom)
-                                         replicaset->Service identity]
+                                         replicaset->Service (fn get-first-arg-fn [rs-json & _] rs-json)]
                              (scheduler/create-service-if-new dummy-scheduler descriptor))
                     api-calls @api-calls-atom]
                 (is (= 1 (count api-calls)))
@@ -1785,7 +1785,7 @@
                     api-calls-atom (atom [])
                     dummy-scheduler (make-dummy-scheduler [service-id] {:pdb-spec-builder-fn nil})
                     actual (with-redefs [api-request (make-api-request api-calls-atom)
-                                         replicaset->Service identity]
+                                         replicaset->Service (fn get-first-arg-fn [rs-json & _] rs-json)]
                              (scheduler/create-service-if-new dummy-scheduler descriptor))
                     api-calls @api-calls-atom]
                 (is (= 1 (count api-calls)))
@@ -1799,7 +1799,7 @@
               (let [descriptor (assoc-in descriptor [:service-description "min-instances"] 2)
                     api-calls-atom (atom [])
                     actual (with-redefs [api-request (make-api-request api-calls-atom)
-                                         replicaset->Service identity]
+                                         replicaset->Service (fn get-first-arg-fn [rs-json & _] rs-json)]
                              (scheduler/create-service-if-new dummy-scheduler descriptor))
                     api-calls @api-calls-atom]
                 (is (= 2 (count api-calls)))
@@ -1828,7 +1828,7 @@
                                             (-> (base-spec-builder-fn scheduler service-id service-description context)
                                                 (assoc-in [:metadata :annotations] {:waiter/x :waiter/y}))))))]
         (let [spec-json (with-redefs [api-request (fn [_ _ & {:keys [body]}] body)
-                                      replicaset->Service identity]
+                                      replicaset->Service (fn get-first-arg-fn [rs-json & _] rs-json)]
                           (create-service descriptor dummy-scheduler))]
           (is (str/includes? spec-json "\"annotations\":{\"waiter/x\":\"waiter/y\"}")))))))
 

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -70,6 +70,7 @@
 
 (deftest test-record-ServiceInstance
   (let [start-time (du/str-to-date "2014-09-13T00:24:46.959Z" du/formatter-iso8601)
+        prepared-to-scale-down-at (du/str-to-date "2014-09-13T00:24:47.959Z" du/formatter-iso8601)
         test-instance (->ServiceInstance
                         "instance-id"
                         "service-id"
@@ -80,6 +81,7 @@
                         nil
                         "www.scheduler-test.example.com"
                         1234
+                        prepared-to-scale-down-at
                         []
                         "log-dir"
                         "instance-message"
@@ -92,6 +94,7 @@
       (is (= http-200-ok (:health-check-status test-instance)))
       (is (= "www.scheduler-test.example.com" (:host test-instance)))
       (is (= 1234 (:port test-instance)))
+      (is (= prepared-to-scale-down-at (:prepared-to-scale-down-at test-instance)))
       (is (= "log-dir" (:log-directory test-instance)))
       (is (= "instance-message" (:message test-instance))))))
 
@@ -309,12 +312,12 @@
                                                      "health-check-port-index" 2
                                                      "health-check-url" (str "/" id)})
         started-at (t/minus (clock) (t/hours 1))
-        instance1 (->ServiceInstance "s1.i1" "s1" started-at nil nil #{} nil "host" 123 [] "/log" "test" "Unhealthy")
-        instance2 (->ServiceInstance "s1.i2" "s1" started-at true nil #{} nil "host" 123 [] "/log" "test" "Healthy")
-        instance3 (->ServiceInstance "s1.i3" "s1" started-at nil nil #{} nil "host" 123 [] "/log" "test" "Unhealthy")
-        instance4 (->ServiceInstance "s1.i4" "s1" started-at nil nil #{} nil "host" 123 [] "/log" "test" "Unhealthy")
-        instance5 (->ServiceInstance "s1.i5" "s1" started-at nil nil #{} nil "host" 123 [] "/log" "test" "Unhealthy")
-        instance6 (->ServiceInstance "s1.i6" "s1" started-at nil nil #{} nil "host" 123 [] "/log" "test" "Unhealthy")
+        instance1 (->ServiceInstance "s1.i1" "s1" started-at nil nil #{} nil "host" 123 nil [] "/log" "test" "Unhealthy")
+        instance2 (->ServiceInstance "s1.i2" "s1" started-at true nil #{} nil "host" 123 nil [] "/log" "test" "Healthy")
+        instance3 (->ServiceInstance "s1.i3" "s1" started-at nil nil #{} nil "host" 123 nil [] "/log" "test" "Unhealthy")
+        instance4 (->ServiceInstance "s1.i4" "s1" started-at nil nil #{} nil "host" 123 nil [] "/log" "test" "Unhealthy")
+        instance5 (->ServiceInstance "s1.i5" "s1" started-at nil nil #{} nil "host" 123 nil [] "/log" "test" "Unhealthy")
+        instance6 (->ServiceInstance "s1.i6" "s1" started-at nil nil #{} nil "host" 123 nil [] "/log" "test" "Unhealthy")
         get-service->instances-invocation-count (atom 0)
         get-service->instances (fn []
                                  (swap! get-service->instances-invocation-count inc)

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -53,28 +53,6 @@
     (locking lock
       (f))))
 
-(deftest test-service-scale-down-throttle-cache
-  (testing "can-bypass-service-scale-down? returns true initially for a service-id"
-    (is (can-bypass-service-scale-down? "test-throttle-s1"))
-    (is (can-bypass-service-scale-down? "test-throttle-s2"))
-    (is (can-bypass-service-scale-down? "test-throttle-s3")))
-  (testing "after the configured ttl is up can-bypass-service-scale-down? returns true"
-    (let [now (t/now)]
-      (with-redefs [t/now (constantly now)]
-        (set-bypass-service-scale-down "test-throttle-s1")
-        (is (not (can-bypass-service-scale-down? "test-throttle-s1"))))
-      ;; service still can't scale down right before throttle-secs is reached
-      (with-redefs [t/now (constantly (t/plus (t/now) (t/seconds (dec service-scale-down-throttle-secs))))]
-        (is (not (can-bypass-service-scale-down? "test-throttle-s1"))))
-      ;; t/now is now passed the throttle-secs; service should be able to scale down
-      (with-redefs [t/now (constantly (t/plus (t/now) (t/seconds service-scale-down-throttle-secs)))]
-        (is (can-bypass-service-scale-down? "test-throttle-s1")))
-      ;; wait until cache is expired
-      (utils/sleep (* service-scale-down-throttle-secs 1001))
-      ;; service should be able to scale down
-      (with-redefs [t/now now]
-        (is (can-bypass-service-scale-down? "test-throttle-s1"))))))
-
 (deftest test-record-Service
   (let [test-instance-1 (->Service "service1-id" 100 100 {:running 0, :healthy 0, :unhealthy 0, :staged 0})
         test-instance-2 (make-Service {:id "service2-id" :instances 200 :task-count 200})

--- a/waiter/test/waiter/state/maintainer_test.clj
+++ b/waiter/test/waiter/state/maintainer_test.clj
@@ -1530,6 +1530,7 @@
                                                           "service-3" {"service-3.A" 6, "service-3.B" 8}
                                                           "service-4" {"service-4.B" 3}
                                                           "service-5" {"service-5.A" 5}}
+                         :service-id->healthy-instances {}
                          :service-id->unhealthy-instances {}
                          :service-id->expired-instances {}
                          :service-id->starting-instances {}
@@ -1544,7 +1545,8 @@
                                      "service-5" {:channel-map-for "service-5"}}
            :last-state-update-time current-time})
 
-        (is (= [{:healthy-instances ["service-1.A" "service-1.B"]
+        (is (= [{:all-healthy-instances nil
+                 :healthy-instances ["service-1.A" "service-1.B"]
                  :expired-instances nil
                  :unhealthy-instances nil
                  :starting-instances nil
@@ -1553,7 +1555,8 @@
                  :instability-issue nil}
                 current-time]
                (async/<!! (retrieve-channel {:channel-map-for "service-1"} :update-state))))
-        (is (= [{:healthy-instances ["service-3.A" "service-3.B"]
+        (is (= [{:all-healthy-instances nil
+                 :healthy-instances ["service-3.A" "service-3.B"]
                  :expired-instances nil
                  :unhealthy-instances nil
                  :starting-instances nil
@@ -1562,7 +1565,8 @@
                  :instability-issue nil}
                 current-time]
                (async/<!! (retrieve-channel {:channel-map-for "service-3"} :update-state))))
-        (is (= [{:healthy-instances ["service-4.B"]
+        (is (= [{:all-healthy-instances nil
+                 :healthy-instances ["service-4.B"]
                  :expired-instances nil
                  :unhealthy-instances nil
                  :starting-instances nil
@@ -1571,7 +1575,8 @@
                  :instability-issue nil}
                 current-time]
                (async/<!! (retrieve-channel {:channel-map-for "service-4"} :update-state))))
-        (is (= [{:healthy-instances ["service-5.A"]
+        (is (= [{:all-healthy-instances nil
+                 :healthy-instances ["service-5.A"]
                  :expired-instances nil
                  :unhealthy-instances nil
                  :starting-instances nil

--- a/waiter/test/waiter/state/responder_test.clj
+++ b/waiter/test/waiter/state/responder_test.clj
@@ -129,7 +129,7 @@
                       :name "find-instance-to-offer:select-youngest-healthy-expired-instance"
                       :reason :serve-request
                       :instance-id->state (->> (instance-id->state-fn healthy-instance-ids [])
-                                               (pc/map-vals #(update % :status-tags conj :expired)))}
+                                            (pc/map-vals #(update % :status-tags conj :expired)))}
                      {:name "find-instance-to-offer:killing-with-no-instances"
                       :expected nil
                       :reason :kill-instance
@@ -309,7 +309,6 @@
                                             (update-in ["inst-2" :status-tags] conj :expired)
                                             (update-in ["inst-7" :status-tags] conj :killed)
                                             (update-in ["inst-2"] assoc :slots-used 1))}
- 
                      {:expected [instance-3]
                       :name "find-instance-to-offer:only-healthy-and-unknown-ejected-instance"
                       :reason :kill-instance

--- a/waiter/test/waiter/state/responder_test.clj
+++ b/waiter/test/waiter/state/responder_test.clj
@@ -58,279 +58,279 @@
         time-active (->> (- lingering-request-threshold-ms 1000) (t/millis) (t/minus current-time))
         time-linger (->> (+ lingering-request-threshold-ms 1000) (t/millis) (t/minus current-time))
         test-cases (list
-                    {:name "find-instance-to-offer:serving-with-no-healthy-instances"
-                     :expected nil
-                     :reason :serve-request
-                     :id->instance {}
-                     :instance-id->state (instance-id->state-fn [] [])}
-                    {:name "find-instance-to-offer:serving-healthy-instance-with-no-unhealthy-instances"
-                     :expected [instance-2]
-                     :reason :serve-request
-                     :instance-id->state (instance-id->state-fn healthy-instance-ids [])}
-                    {:name "find-instance-to-offer:serving-healthy-unejected-instance-with-no-unhealthy-instances"
-                     :expected [instance-3]
-                     :reason :serve-request
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                             (update-in ["inst-2" :status-tags] conj :ejected))}
-                    {:name "find-instance-to-offer:serving-healthy-unejected-instance-with-no-unhealthy-instances:limited-sorted-instance-ids"
-                     :expected [instance-5]
-                     :reason :serve-request
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                             (update-in ["inst-2" :status-tags] conj :ejected))
-                     :sorted-instance-ids (drop 3 all-sorted-instance-ids)}
-                    {:name "find-instance-to-offer:serving-healthy-unejected-instance-with-no-unhealthy-instances:limited-sorted-instance-ids-2"
-                     :expected [instance-6]
-                     :reason :serve-request
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                             (update-in ["inst-2" :status-tags] conj :ejected))
-                     :sorted-instance-ids (drop 5 all-sorted-instance-ids)}
-                    {:name "find-instance-to-offer:serving-healthy-instance-with-no-unhealthy-instances:exclude-ejected-locked-and-killed"
-                     :expected [instance-6]
-                     :reason :serve-request
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                             (update-in ["inst-2" :status-tags] conj :ejected)
-                                             (update-in ["inst-3" :status-tags] conj :killed)
-                                             (update-in ["inst-5" :status-tags] conj :locked))}
-                    {:name "find-instance-to-offer:serving-healthy-instance-with-no-unhealthy-instances-but-all-excluded"
-                     :expected nil
-                     :reason :serve-request
-                     :instance-id->state (instance-id->state-fn healthy-instance-ids [])
-                     :exclude-ids-set (set (concat healthy-instance-ids unhealthy-instance-ids))}
-                    (let [exclude-ids-set #{"inst-1" "inst-2" "inst-7" "inst-8"}]
-                      {:name "find-instance-to-offer:serving-healthy-instance-with-no-unhealthy-but-excluded-instances"
-                       :expected [instance-3]
-                       :reason :serve-request
-                       :instance-id->state (instance-id->state-fn healthy-instance-ids [])
-                       :exclude-ids-set exclude-ids-set})
-                    {:name "find-instance-to-offer:serving-healthy-instance-with-some-unhealthy-instances"
-                     :expected [instance-2]
-                     :reason :serve-request
-                     :instance-id->state (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)}
-                    (let [exclude-ids-set #{"inst-1" "inst-2" "inst-3" "inst-7" "inst-8"}]
-                      {:name "find-instance-to-offer:serving-healthy-instance-with-some-unhealthy-and-excluded-instances"
-                       :expected [instance-5]
-                       :reason :serve-request
-                       :instance-id->state (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
-                       :exclude-ids-set exclude-ids-set})
-                    (let [exclude-ids-set (set healthy-instance-ids)]
-                      {:name "find-instance-to-offer:exclude-all-healthy-instances"
-                       :expected [nil]
-                       :reason :serve-request
-                       :instance-id->state (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
-                       :exclude-ids-set exclude-ids-set})
-                    {:expected [instance-5]
-                     :name "find-instance-to-offer:select-oldest-healthy-live-instance"
-                     :reason :serve-request
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                             (update-in ["inst-2" :status-tags] conj :expired)
-                                             (update-in ["inst-3" :status-tags] conj :expired)
-                                             (update-in ["inst-8" :status-tags] conj :expired))}
-                    {:expected [instance-8]
-                     :name "find-instance-to-offer:select-youngest-healthy-expired-instance"
-                     :reason :serve-request
-                     :instance-id->state (->> (instance-id->state-fn healthy-instance-ids [])
-                                              (pc/map-vals #(update % :status-tags conj :expired)))}
-                    {:name "find-instance-to-offer:killing-with-no-instances"
-                     :expected nil
-                     :reason :kill-instance
-                     :id->instance {}
-                     :instance-id->state (instance-id->state-fn [] [])}
-                    {:name "find-instance-to-offer:killing-youngest-healthy-instance-with-no-unhealthy-instances"
-                     :expected [instance-8]
-                     :reason :kill-instance
-                     :instance-id->state (instance-id->state-fn healthy-instance-ids [])}
-                    {:name "find-instance-to-offer:killing-oldest-healthy-instance-with-no-unhealthy-instances"
-                     :expected [instance-2]
-                     :load-balancing :youngest
-                     :reason :kill-instance
-                     :instance-id->state (instance-id->state-fn healthy-instance-ids [])}
-                    {:name "find-instance-to-offer:killing-oldest-healthy-instance-with-no-unhealthy-but-excluded-instances"
-                     :expected [instance-6]
-                     :reason :kill-instance
-                     :instance-id->state (instance-id->state-fn healthy-instance-ids [])
-                     :exclude-ids-set #{"inst-1" "inst-2" "inst-7" "inst-8"}}
-                    {:name "find-instance-to-offer:killing-youngest-healthy-instance-with-no-unhealthy-but-excluded-instances"
-                     :expected [instance-3]
-                     :load-balancing :youngest
-                     :reason :kill-instance
-                     :instance-id->state (instance-id->state-fn healthy-instance-ids [])
-                     :exclude-ids-set #{"inst-1" "inst-2" "inst-7" "inst-8"}}
-                    {:name "find-instance-to-offer:killing-healthy-instance-with-no-unhealthy-but-excluded-instances:exclude-busy"
-                     :expected [instance-5]
-                     :reason :kill-instance
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                             (update-in ["inst-6"]
-                                                        assoc :slots-assigned 2 :slots-used 1))
-                     :exclude-ids-set #{"inst-1" "inst-2" "inst-7" "inst-8"}}
-                    {:name "find-instance-to-offer:killing-unhealthy-instance-with-some-unhealthy-instances"
-                     :expected [instance-7]
-                     :reason :kill-instance
-                     :instance-id->state (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)}
-                    {:name "find-instance-to-offer:killing-unhealthy-instance-with-some-unhealthy-instances:exclude-busy"
-                     :expected [instance-4]
-                     :reason :kill-instance
-                     :id->instance all-id->instance
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
-                                             (update-in ["inst-7"]
-                                                        assoc :slots-assigned 0 :slots-used 1))}
-                    {:name "find-instance-to-offer:killing-unhealthy-instance-with-some-unhealthy-instances:exclude-killed"
-                     :expected [instance-4]
-                     :reason :kill-instance
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
-                                             (update-in ["inst-7" :status-tags] conj :killed))}
-                    {:name "find-instance-to-offer:killing-unhealthy-instance-with-some-unhealthy-instances:exclude-killed-include-ejected"
-                     :expected [instance-4]
-                     :reason :kill-instance
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
-                                             (update-in ["inst-4" :status-tags] conj :ejected)
-                                             (update-in ["inst-7" :status-tags] conj :killed))}
-                    {:name "find-instance-to-offer:killing-unhealthy-instance-with-some-unhealthy-and-excluded-instances"
-                     :expected [instance-4]
-                     :reason :kill-instance
-                     :instance-id->state (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
-                     :exclude-ids-set #{"inst-1" "inst-2" "inst-7" "inst-8"}}
-                    {:name "find-instance-to-offer:killing-healthy-ejected-instance-with-no-unhealthy-instances"
-                     :expected [instance-8]
-                     :reason :kill-instance
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                             (update-in ["inst-8" :status-tags] conj :ejected))}
-                    {:name "find-instance-to-offer:killing-healthy-instance-with-no-unhealthy-instances:exclude-locked-and-killed"
-                     :expected [instance-2]
-                     :reason :kill-instance
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                             (update-in ["inst-2" :status-tags] conj :ejected)
-                                             (update-in ["inst-3" :status-tags] conj :killed)
-                                             (update-in ["inst-8" :status-tags] conj :locked))}
-                    {:name "find-instance-to-offer:killing-healthy-ejected-instance-with-no-unhealthy-instances:exclude-locked-and-killed"
-                     :expected [instance-6]
-                     :reason :kill-instance
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                             (update-in ["inst-3" :status-tags] conj :killed)
-                                             (update-in ["inst-8" :status-tags] conj :locked))}
-                    {:expected [instance-2]
-                     :name "find-instance-to-offer:get-youngest-unhealthy-in-presence-of-expired-and-unhealthy-instances"
-                     :reason :kill-instance
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
-                                             (update-in ["inst-2" :status-tags] conj :expired)
-                                             (update-in ["inst-5" :status-tags] conj :expired))}
-                    {:expected [instance-2]
-                     :name "find-instance-to-offer:select-idle-expired-instance-with-oldest-load-balancing"
-                     :reason :kill-instance
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                             (update-in ["inst-2" :status-tags] conj :expired))}
-                    {:expected [instance-2]
-                     :load-balancing :youngest
-                     :name "find-instance-to-offer:select-idle-expired-instance-with-youngest-load-balancing"
-                     :reason :kill-instance
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                             (update-in ["inst-2" :status-tags] conj :expired))}
-                    {:expected [instance-6]
-                     :name "find-instance-to-offer:oldest-idle-expired-instance"
-                     :reason :kill-instance
-                     :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-linger}}}
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                             (update-in ["inst-2" :status-tags] conj :expired)
-                                             (update-in ["inst-2"] assoc :slots-used 1)
-                                             (update-in ["inst-6" :status-tags] conj :expired)
-                                             (update-in ["inst-8" :status-tags] conj :expired))}
-                    {:expected nil
-                     :name "find-instance-to-offer:no-healthy-instance-in-presence-of-busy-expired-instance"
-                     :reason :kill-instance
-                     :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-active}}}
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                             (update-in ["inst-2" :status-tags] conj :expired)
-                                             (update-in ["inst-2"] assoc :slots-used 1))}
-                    {:expected [instance-2]
-                     :name "find-instance-to-offer:no-healthy-instance-in-presence-of-lingering-expired-instance"
-                     :reason :kill-instance
-                     :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-linger}}}
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                             (update-in ["inst-2" :status-tags] conj :expired)
-                                             (update-in ["inst-2"] assoc :slots-used 1))}
-                    {:expected [instance-6]
-                     :name "find-instance-to-offer:oldest-idle-expired-instance-in-presence-of-lingering-expired-instance"
-                     :reason :kill-instance
-                     :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-linger}}}
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                             (update-in ["inst-2" :status-tags] conj :expired)
-                                             (update-in ["inst-6" :status-tags] conj :expired)
-                                             (update-in ["inst-8" :status-tags] conj :expired)
-                                             (update-in ["inst-2"] assoc :slots-used 1))}
-                    {:exclude-ids-set #{"inst-1" "inst-2" "inst-3"}
-                     :expected [instance-6]
-                     :name "find-instance-to-offer:oldest-acceptable-idle-expired-instance-in-presence-of-lingering-expired-instance"
-                     :reason :kill-instance
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                             (update-in ["inst-2" :status-tags] conj :expired)
-                                             (update-in ["inst-6" :status-tags] conj :expired)
-                                             (update-in ["inst-8" :status-tags] conj :expired))}
-                    {:expected [instance-2]
-                     :name "find-instance-to-offer:oldest-expired-instance-in-presence-of-lingering-expired-instance"
-                     :reason :kill-instance
-                     :instance-id->request-id->use-reason-map {"inst-2" {"req-2" {:cid "cid-2" :request-id "req-2" :reason :serve-request :time time-linger}}
-                                                               "inst-6" {"req-6" {:cid "cid-6" :request-id "req-6" :reason :serve-request :time time-linger}}
-                                                               "inst-8" {"req-8" {:cid "cid-8" :request-id "req-8" :reason :serve-request :time time-linger}}}
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                             (update-in ["inst-2" :status-tags] conj :expired)
-                                             (update-in ["inst-6" :status-tags] conj :expired)
-                                             (update-in ["inst-8" :status-tags] conj :expired)
-                                             (update-in ["inst-2"] assoc :slots-used 1)
-                                             (update-in ["inst-6"] assoc :slots-used 1)
-                                             (update-in ["inst-8"] assoc :slots-used 1))}
-                    {:expected [instance-6]
-                     :name "find-instance-to-offer:youngest-healthy-ejected-instance-in-presence-of-busy-expired-instance"
-                     :reason :kill-instance
-                     :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-active}}}
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                             (update-in ["inst-2" :status-tags] conj :expired)
-                                             (update-in ["inst-2"] assoc :slots-used 1)
-                                             (update-in ["inst-5" :status-tags] conj :ejected)
-                                             (update-in ["inst-6" :status-tags] conj :ejected))}
-                    {:expected [instance-7]
-                     :name "find-instance-to-offer:youngest-unhealthy-instance-in-presence-of-busy-expired-instance"
-                     :reason :kill-instance
-                     :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-active}}}
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
-                                             (update-in ["inst-2" :status-tags] conj :expired)
-                                             (update-in ["inst-2"] assoc :slots-used 1))}
-                    {:expected [instance-4]
-                     :name "find-instance-to-offer:youngest-unhealthy-unlocked-instance-in-presence-of-busy-expired-instance"
-                     :reason :kill-instance
-                     :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-active}}}
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
-                                             (update-in ["inst-2" :status-tags] conj :expired)
-                                             (update-in ["inst-7" :status-tags] conj :locked)
-                                             (update-in ["inst-2"] assoc :slots-used 1))}
-                    {:expected [instance-4]
-                     :name "find-instance-to-offer:youngest-unhealthy-live-instance-in-presence-of-busy-expired-instance"
-                     :reason :kill-instance
-                     :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-active}}}
-                     :instance-id->state (-> (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
-                                             (update-in ["inst-2" :status-tags] conj :expired)
-                                             (update-in ["inst-7" :status-tags] conj :killed)
-                                             (update-in ["inst-2"] assoc :slots-used 1))}
-
-                    {:expected [instance-3]
-                     :name "find-instance-to-offer:only-healthy-and-unknown-ejected-instance"
-                     :reason :kill-instance
-                     :id->instance (pc/map-from-vals :id [instance-2 instance-3])
-                     :instance-id->request-id->use-reason-map {}
-                     :instance-id->state (-> (instance-id->state-fn (map :id [instance-2 instance-3 instance-5]) [])
-                                             (update-in ["inst-5" :status-tags] (constantly #{:ejected}))
-                                             (update-in ["inst-5"] assoc :slots-assigned 0))}
-                    {:expected [instance-9-scaling-down-timeout-reached]
-                     :name "find-instance-to-offer:only-kill-instances-with-prepared-to-scale-down-at-if-they-exist"
-                     :reason :kill-instance
-                     :id->instance (-> (pc/map-from-vals :id [instance-2 instance-9-scaling-down-timeout-reached]))
-                     :instance-id->request-id->use-reason-map {}
-                     :instance-id->state (instance-id->state-fn (map :id [instance-2 instance-9-scaling-down-timeout-reached]) [])}
-
-                    {:expected nil
-                     :name "find-instance-to-offer:kill-instance-provides-no-instances-when-instance-preparing-to-scale-down-is-not-killable"
-                     :reason :kill-instance
-                     :id->instance (-> (pc/map-from-vals :id [instance-2 instance-10-scaling-down]))
-                     :instance-id->request-id->use-reason-map {}
-                     :instance-id->state (instance-id->state-fn (map :id [instance-2 instance-10-scaling-down]) [])})]
+                     {:name "find-instance-to-offer:serving-with-no-healthy-instances"
+                      :expected nil
+                      :reason :serve-request
+                      :id->instance {}
+                      :instance-id->state (instance-id->state-fn [] [])}
+                     {:name "find-instance-to-offer:serving-healthy-instance-with-no-unhealthy-instances"
+                      :expected [instance-2]
+                      :reason :serve-request
+                      :instance-id->state (instance-id->state-fn healthy-instance-ids [])}
+                     {:name "find-instance-to-offer:serving-healthy-unejected-instance-with-no-unhealthy-instances"
+                      :expected [instance-3]
+                      :reason :serve-request
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
+                                              (update-in ["inst-2" :status-tags] conj :ejected))}
+                     {:name "find-instance-to-offer:serving-healthy-unejected-instance-with-no-unhealthy-instances:limited-sorted-instance-ids"
+                      :expected [instance-5]
+                      :reason :serve-request
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
+                                              (update-in ["inst-2" :status-tags] conj :ejected))
+                      :sorted-instance-ids (drop 3 all-sorted-instance-ids)}
+                     {:name "find-instance-to-offer:serving-healthy-unejected-instance-with-no-unhealthy-instances:limited-sorted-instance-ids-2"
+                      :expected [instance-6]
+                      :reason :serve-request
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
+                                              (update-in ["inst-2" :status-tags] conj :ejected))
+                      :sorted-instance-ids (drop 5 all-sorted-instance-ids)}
+                     {:name "find-instance-to-offer:serving-healthy-instance-with-no-unhealthy-instances:exclude-ejected-locked-and-killed"
+                      :expected [instance-6]
+                      :reason :serve-request
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
+                                              (update-in ["inst-2" :status-tags] conj :ejected)
+                                              (update-in ["inst-3" :status-tags] conj :killed)
+                                              (update-in ["inst-5" :status-tags] conj :locked))}
+                     {:name "find-instance-to-offer:serving-healthy-instance-with-no-unhealthy-instances-but-all-excluded"
+                      :expected nil
+                      :reason :serve-request
+                      :instance-id->state (instance-id->state-fn healthy-instance-ids [])
+                      :exclude-ids-set (set (concat healthy-instance-ids unhealthy-instance-ids))}
+                     (let [exclude-ids-set #{"inst-1" "inst-2" "inst-7" "inst-8"}]
+                       {:name "find-instance-to-offer:serving-healthy-instance-with-no-unhealthy-but-excluded-instances"
+                        :expected [instance-3]
+                        :reason :serve-request
+                        :instance-id->state (instance-id->state-fn healthy-instance-ids [])
+                        :exclude-ids-set exclude-ids-set})
+                     {:name "find-instance-to-offer:serving-healthy-instance-with-some-unhealthy-instances"
+                      :expected [instance-2]
+                      :reason :serve-request
+                      :instance-id->state (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)}
+                     (let [exclude-ids-set #{"inst-1" "inst-2" "inst-3" "inst-7" "inst-8"}]
+                       {:name "find-instance-to-offer:serving-healthy-instance-with-some-unhealthy-and-excluded-instances"
+                        :expected [instance-5]
+                        :reason :serve-request
+                        :instance-id->state (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
+                        :exclude-ids-set exclude-ids-set})
+                     (let [exclude-ids-set (set healthy-instance-ids)]
+                       {:name "find-instance-to-offer:exclude-all-healthy-instances"
+                        :expected [nil]
+                        :reason :serve-request
+                        :instance-id->state (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
+                        :exclude-ids-set exclude-ids-set})
+                     {:expected [instance-5]
+                      :name "find-instance-to-offer:select-oldest-healthy-live-instance"
+                      :reason :serve-request
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
+                                              (update-in ["inst-2" :status-tags] conj :expired)
+                                              (update-in ["inst-3" :status-tags] conj :expired)
+                                              (update-in ["inst-8" :status-tags] conj :expired))}
+                     {:expected [instance-8]
+                      :name "find-instance-to-offer:select-youngest-healthy-expired-instance"
+                      :reason :serve-request
+                      :instance-id->state (->> (instance-id->state-fn healthy-instance-ids [])
+                                               (pc/map-vals #(update % :status-tags conj :expired)))}
+                     {:name "find-instance-to-offer:killing-with-no-instances"
+                      :expected nil
+                      :reason :kill-instance
+                      :id->instance {}
+                      :instance-id->state (instance-id->state-fn [] [])}
+                     {:name "find-instance-to-offer:killing-youngest-healthy-instance-with-no-unhealthy-instances"
+                      :expected [instance-8]
+                      :reason :kill-instance
+                      :instance-id->state (instance-id->state-fn healthy-instance-ids [])}
+                     {:name "find-instance-to-offer:killing-oldest-healthy-instance-with-no-unhealthy-instances"
+                      :expected [instance-2]
+                      :load-balancing :youngest
+                      :reason :kill-instance
+                      :instance-id->state (instance-id->state-fn healthy-instance-ids [])}
+                     {:name "find-instance-to-offer:killing-oldest-healthy-instance-with-no-unhealthy-but-excluded-instances"
+                      :expected [instance-6]
+                      :reason :kill-instance
+                      :instance-id->state (instance-id->state-fn healthy-instance-ids [])
+                      :exclude-ids-set #{"inst-1" "inst-2" "inst-7" "inst-8"}}
+                     {:name "find-instance-to-offer:killing-youngest-healthy-instance-with-no-unhealthy-but-excluded-instances"
+                      :expected [instance-3]
+                      :load-balancing :youngest
+                      :reason :kill-instance
+                      :instance-id->state (instance-id->state-fn healthy-instance-ids [])
+                      :exclude-ids-set #{"inst-1" "inst-2" "inst-7" "inst-8"}}
+                     {:name "find-instance-to-offer:killing-healthy-instance-with-no-unhealthy-but-excluded-instances:exclude-busy"
+                      :expected [instance-5]
+                      :reason :kill-instance
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
+                                              (update-in ["inst-6"]
+                                                         assoc :slots-assigned 2 :slots-used 1))
+                      :exclude-ids-set #{"inst-1" "inst-2" "inst-7" "inst-8"}}
+                     {:name "find-instance-to-offer:killing-unhealthy-instance-with-some-unhealthy-instances"
+                      :expected [instance-7]
+                      :reason :kill-instance
+                      :instance-id->state (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)}
+                     {:name "find-instance-to-offer:killing-unhealthy-instance-with-some-unhealthy-instances:exclude-busy"
+                      :expected [instance-4]
+                      :reason :kill-instance
+                      :id->instance all-id->instance
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
+                                              (update-in ["inst-7"]
+                                                         assoc :slots-assigned 0 :slots-used 1))}
+                     {:name "find-instance-to-offer:killing-unhealthy-instance-with-some-unhealthy-instances:exclude-killed"
+                      :expected [instance-4]
+                      :reason :kill-instance
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
+                                              (update-in ["inst-7" :status-tags] conj :killed))}
+                     {:name "find-instance-to-offer:killing-unhealthy-instance-with-some-unhealthy-instances:exclude-killed-include-ejected"
+                      :expected [instance-4]
+                      :reason :kill-instance
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
+                                              (update-in ["inst-4" :status-tags] conj :ejected)
+                                              (update-in ["inst-7" :status-tags] conj :killed))}
+                     {:name "find-instance-to-offer:killing-unhealthy-instance-with-some-unhealthy-and-excluded-instances"
+                      :expected [instance-4]
+                      :reason :kill-instance
+                      :instance-id->state (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
+                      :exclude-ids-set #{"inst-1" "inst-2" "inst-7" "inst-8"}}
+                     {:name "find-instance-to-offer:killing-healthy-ejected-instance-with-no-unhealthy-instances"
+                      :expected [instance-8]
+                      :reason :kill-instance
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
+                                              (update-in ["inst-8" :status-tags] conj :ejected))}
+                     {:name "find-instance-to-offer:killing-healthy-instance-with-no-unhealthy-instances:exclude-locked-and-killed"
+                      :expected [instance-2]
+                      :reason :kill-instance
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
+                                              (update-in ["inst-2" :status-tags] conj :ejected)
+                                              (update-in ["inst-3" :status-tags] conj :killed)
+                                              (update-in ["inst-8" :status-tags] conj :locked))}
+                     {:name "find-instance-to-offer:killing-healthy-ejected-instance-with-no-unhealthy-instances:exclude-locked-and-killed"
+                      :expected [instance-6]
+                      :reason :kill-instance
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
+                                              (update-in ["inst-3" :status-tags] conj :killed)
+                                              (update-in ["inst-8" :status-tags] conj :locked))}
+                     {:expected [instance-2]
+                      :name "find-instance-to-offer:get-youngest-unhealthy-in-presence-of-expired-and-unhealthy-instances"
+                      :reason :kill-instance
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
+                                              (update-in ["inst-2" :status-tags] conj :expired)
+                                              (update-in ["inst-5" :status-tags] conj :expired))}
+                     {:expected [instance-2]
+                      :name "find-instance-to-offer:select-idle-expired-instance-with-oldest-load-balancing"
+                      :reason :kill-instance
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
+                                              (update-in ["inst-2" :status-tags] conj :expired))}
+                     {:expected [instance-2]
+                      :load-balancing :youngest
+                      :name "find-instance-to-offer:select-idle-expired-instance-with-youngest-load-balancing"
+                      :reason :kill-instance
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
+                                              (update-in ["inst-2" :status-tags] conj :expired))}
+                     {:expected [instance-6]
+                      :name "find-instance-to-offer:oldest-idle-expired-instance"
+                      :reason :kill-instance
+                      :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-linger}}}
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
+                                              (update-in ["inst-2" :status-tags] conj :expired)
+                                              (update-in ["inst-2"] assoc :slots-used 1)
+                                              (update-in ["inst-6" :status-tags] conj :expired)
+                                              (update-in ["inst-8" :status-tags] conj :expired))}
+                     {:expected nil
+                      :name "find-instance-to-offer:no-healthy-instance-in-presence-of-busy-expired-instance"
+                      :reason :kill-instance
+                      :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-active}}}
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
+                                              (update-in ["inst-2" :status-tags] conj :expired)
+                                              (update-in ["inst-2"] assoc :slots-used 1))}
+                     {:expected [instance-2]
+                      :name "find-instance-to-offer:no-healthy-instance-in-presence-of-lingering-expired-instance"
+                      :reason :kill-instance
+                      :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-linger}}}
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
+                                              (update-in ["inst-2" :status-tags] conj :expired)
+                                              (update-in ["inst-2"] assoc :slots-used 1))}
+                     {:expected [instance-6]
+                      :name "find-instance-to-offer:oldest-idle-expired-instance-in-presence-of-lingering-expired-instance"
+                      :reason :kill-instance
+                      :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-linger}}}
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
+                                              (update-in ["inst-2" :status-tags] conj :expired)
+                                              (update-in ["inst-6" :status-tags] conj :expired)
+                                              (update-in ["inst-8" :status-tags] conj :expired)
+                                              (update-in ["inst-2"] assoc :slots-used 1))}
+                     {:exclude-ids-set #{"inst-1" "inst-2" "inst-3"}
+                      :expected [instance-6]
+                      :name "find-instance-to-offer:oldest-acceptable-idle-expired-instance-in-presence-of-lingering-expired-instance"
+                      :reason :kill-instance
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
+                                              (update-in ["inst-2" :status-tags] conj :expired)
+                                              (update-in ["inst-6" :status-tags] conj :expired)
+                                              (update-in ["inst-8" :status-tags] conj :expired))}
+                     {:expected [instance-2]
+                      :name "find-instance-to-offer:oldest-expired-instance-in-presence-of-lingering-expired-instance"
+                      :reason :kill-instance
+                      :instance-id->request-id->use-reason-map {"inst-2" {"req-2" {:cid "cid-2" :request-id "req-2" :reason :serve-request :time time-linger}}
+                                                                "inst-6" {"req-6" {:cid "cid-6" :request-id "req-6" :reason :serve-request :time time-linger}}
+                                                                "inst-8" {"req-8" {:cid "cid-8" :request-id "req-8" :reason :serve-request :time time-linger}}}
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
+                                              (update-in ["inst-2" :status-tags] conj :expired)
+                                              (update-in ["inst-6" :status-tags] conj :expired)
+                                              (update-in ["inst-8" :status-tags] conj :expired)
+                                              (update-in ["inst-2"] assoc :slots-used 1)
+                                              (update-in ["inst-6"] assoc :slots-used 1)
+                                              (update-in ["inst-8"] assoc :slots-used 1))}
+                     {:expected [instance-6]
+                      :name "find-instance-to-offer:youngest-healthy-ejected-instance-in-presence-of-busy-expired-instance"
+                      :reason :kill-instance
+                      :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-active}}}
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
+                                              (update-in ["inst-2" :status-tags] conj :expired)
+                                              (update-in ["inst-2"] assoc :slots-used 1)
+                                              (update-in ["inst-5" :status-tags] conj :ejected)
+                                              (update-in ["inst-6" :status-tags] conj :ejected))}
+                     {:expected [instance-7]
+                      :name "find-instance-to-offer:youngest-unhealthy-instance-in-presence-of-busy-expired-instance"
+                      :reason :kill-instance
+                      :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-active}}}
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
+                                              (update-in ["inst-2" :status-tags] conj :expired)
+                                              (update-in ["inst-2"] assoc :slots-used 1))}
+                     {:expected [instance-4]
+                      :name "find-instance-to-offer:youngest-unhealthy-unlocked-instance-in-presence-of-busy-expired-instance"
+                      :reason :kill-instance
+                      :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-active}}}
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
+                                              (update-in ["inst-2" :status-tags] conj :expired)
+                                              (update-in ["inst-7" :status-tags] conj :locked)
+                                              (update-in ["inst-2"] assoc :slots-used 1))}
+                     {:expected [instance-4]
+                      :name "find-instance-to-offer:youngest-unhealthy-live-instance-in-presence-of-busy-expired-instance"
+                      :reason :kill-instance
+                      :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-active}}}
+                      :instance-id->state (-> (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
+                                              (update-in ["inst-2" :status-tags] conj :expired)
+                                              (update-in ["inst-7" :status-tags] conj :killed)
+                                              (update-in ["inst-2"] assoc :slots-used 1))}
+ 
+                     {:expected [instance-3]
+                      :name "find-instance-to-offer:only-healthy-and-unknown-ejected-instance"
+                      :reason :kill-instance
+                      :id->instance (pc/map-from-vals :id [instance-2 instance-3])
+                      :instance-id->request-id->use-reason-map {}
+                      :instance-id->state (-> (instance-id->state-fn (map :id [instance-2 instance-3 instance-5]) [])
+                                              (update-in ["inst-5" :status-tags] (constantly #{:ejected}))
+                                              (update-in ["inst-5"] assoc :slots-assigned 0))}
+                     {:expected [instance-9-scaling-down-timeout-reached]
+                      :name "find-instance-to-offer:only-kill-instances-with-prepared-to-scale-down-at-if-they-exist"
+                      :reason :kill-instance
+                      :id->instance (-> (pc/map-from-vals :id [instance-2 instance-9-scaling-down-timeout-reached]))
+                      :instance-id->request-id->use-reason-map {}
+                      :instance-id->state (instance-id->state-fn (map :id [instance-2 instance-9-scaling-down-timeout-reached]) [])}
+ 
+                     {:expected nil
+                      :name "find-instance-to-offer:kill-instance-provides-no-instances-when-instance-preparing-to-scale-down-is-not-killable"
+                      :reason :kill-instance
+                      :id->instance (-> (pc/map-from-vals :id [instance-2 instance-10-scaling-down]))
+                      :instance-id->request-id->use-reason-map {}
+                      :instance-id->state (instance-id->state-fn (map :id [instance-2 instance-10-scaling-down]) [])})]
     (doseq [{:keys [exclude-ids-set expected id->instance instance-id->request-id->use-reason-map
                     instance-id->state load-balancing name reason sorted-instance-ids]} test-cases]
       (testing (str "Test " name)
@@ -340,13 +340,13 @@
                 load-balancing (or load-balancing :oldest)
                 sorted-instance-ids (or sorted-instance-ids
                                         (let [expired-instance-ids (->> instance-id->state
-                                                                        (filter (fn [[_ state]] (expired? state)))
-                                                                        (map first)
-                                                                        set)]
+                                                                     (filter (fn [[_ state]] (expired? state)))
+                                                                     (map first)
+                                                                     set)]
                                           (->> (keys instance-id->state)
-                                               (map id->instance)
-                                               (sort-instances-for-processing expired-instance-ids)
-                                               (map :id))))
+                                            (map id->instance)
+                                            (sort-instances-for-processing expired-instance-ids)
+                                            (map :id))))
                 acceptable-instance-id? (fn [instance-id] (not (contains? exclude-ids-set instance-id)))
                 instance-id->request-id->use-reason-map (or instance-id->request-id->use-reason-map {})
                 actual (if (= :kill-instance reason)
@@ -354,8 +354,7 @@
                                                  instance-id->request-id->use-reason-map load-balancing
                                                  bypass-grace-buffer-ms bypass-max-eject-time-secs
                                                  lingering-request-threshold-ms)
-                         (find-available-instance sorted-instance-ids id->instance instance-id->state acceptable-instance-id? first))
-                                _ (println "actual and expected:" {:actual actual :expected expected})]
+                         (find-available-instance sorted-instance-ids id->instance instance-id->state acceptable-instance-id? first))]
             (when (or (and (nil? expected) (not (nil? actual)))
                       (and expected (not-any? #(= actual %) expected)))
               (println name)

--- a/waiter/test/waiter/state/responder_test.clj
+++ b/waiter/test/waiter/state/responder_test.clj
@@ -49,6 +49,8 @@
                                  (into {} (map (fn [instance-id] [instance-id {:slots-assigned 1, :slots-used 0, :status-tags #{:healthy}}]) %1))
                                  (into {} (map (fn [instance-id] [instance-id {:slots-assigned 0, :slots-used 0, :status-tags #{:unhealthy}}]) %2)))
         all-id->instance (pc/map-from-vals :id all-instance-combo)
+        bypass-grace-buffer-ms 15000
+        bypass-max-eject-time-secs 120
         lingering-request-threshold-ms 60000
         time-active (->> (- lingering-request-threshold-ms 1000) (t/millis) (t/minus current-time))
         time-linger (->> (+ lingering-request-threshold-ms 1000) (t/millis) (t/minus current-time))
@@ -337,6 +339,7 @@
                 actual (if (= :kill-instance reason)
                          (find-killable-instance id->instance instance-id->state acceptable-instance-id?
                                                  instance-id->request-id->use-reason-map load-balancing
+                                                 bypass-grace-buffer-ms bypass-max-eject-time-secs
                                                  lingering-request-threshold-ms)
                          (find-available-instance sorted-instance-ids id->instance instance-id->state acceptable-instance-id? first))]
             (when (or (and (nil? expected) (not (nil? actual)))

--- a/waiter/test/waiter/state/responder_test.clj
+++ b/waiter/test/waiter/state/responder_test.clj
@@ -29,7 +29,7 @@
            (org.joda.time DateTime)))
 
 (deftest test-find-instance-to-offer-with-concurrency-level-1
-  (let [bypass-grace-buffer-ms 15000
+  (let [bypass-grace-kill-time-ms 15000
         bypass-force-kill-time-ms 120000
         current-time (t/now)
         make-instance (fn [id] {:id (str "inst-" id), :started-at (DateTime. (* id 1000000))})
@@ -360,7 +360,7 @@
                 actual (if (= :kill-instance reason)
                          (find-killable-instance id->all-healthy-instances id->instance instance-id->state acceptable-instance-id?
                                                  instance-id->request-id->use-reason-map load-balancing
-                                                 bypass-grace-buffer-ms bypass-force-kill-time-ms
+                                                 bypass-grace-kill-time-ms bypass-force-kill-time-ms
                                                  lingering-request-threshold-ms)
                          (find-available-instance sorted-instance-ids id->instance instance-id->state acceptable-instance-id? first))]
             (when (or (and (nil? expected) (not (nil? actual)))

--- a/waiter/test/waiter/state/responder_test.clj
+++ b/waiter/test/waiter/state/responder_test.clj
@@ -51,8 +51,8 @@
         all-instance-combo (concat healthy-instance-combo unhealthy-instance-combo)
         all-sorted-instance-ids (sort (map :id all-instance-combo))
         instance-id->state-fn #(merge
-                                (into {} (map (fn [instance-id] [instance-id {:slots-assigned 1, :slots-used 0, :status-tags #{:healthy}}]) %1))
-                                (into {} (map (fn [instance-id] [instance-id {:slots-assigned 0, :slots-used 0, :status-tags #{:unhealthy}}]) %2)))
+                                 (into {} (map (fn [instance-id] [instance-id {:slots-assigned 1, :slots-used 0, :status-tags #{:healthy}}]) %1))
+                                 (into {} (map (fn [instance-id] [instance-id {:slots-assigned 0, :slots-used 0, :status-tags #{:unhealthy}}]) %2)))
         all-id->instance (pc/map-from-vals :id all-instance-combo)
         lingering-request-threshold-ms 60000
         time-active (->> (- lingering-request-threshold-ms 1000) (t/millis) (t/minus current-time))
@@ -71,26 +71,26 @@
                       :expected [instance-3]
                       :reason :serve-request
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                              (update-in ["inst-2" :status-tags] conj :ejected))}
+                                            (update-in ["inst-2" :status-tags] conj :ejected))}
                      {:name "find-instance-to-offer:serving-healthy-unejected-instance-with-no-unhealthy-instances:limited-sorted-instance-ids"
                       :expected [instance-5]
                       :reason :serve-request
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                              (update-in ["inst-2" :status-tags] conj :ejected))
+                                            (update-in ["inst-2" :status-tags] conj :ejected))
                       :sorted-instance-ids (drop 3 all-sorted-instance-ids)}
                      {:name "find-instance-to-offer:serving-healthy-unejected-instance-with-no-unhealthy-instances:limited-sorted-instance-ids-2"
                       :expected [instance-6]
                       :reason :serve-request
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                              (update-in ["inst-2" :status-tags] conj :ejected))
+                                            (update-in ["inst-2" :status-tags] conj :ejected))
                       :sorted-instance-ids (drop 5 all-sorted-instance-ids)}
                      {:name "find-instance-to-offer:serving-healthy-instance-with-no-unhealthy-instances:exclude-ejected-locked-and-killed"
                       :expected [instance-6]
                       :reason :serve-request
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                              (update-in ["inst-2" :status-tags] conj :ejected)
-                                              (update-in ["inst-3" :status-tags] conj :killed)
-                                              (update-in ["inst-5" :status-tags] conj :locked))}
+                                            (update-in ["inst-2" :status-tags] conj :ejected)
+                                            (update-in ["inst-3" :status-tags] conj :killed)
+                                            (update-in ["inst-5" :status-tags] conj :locked))}
                      {:name "find-instance-to-offer:serving-healthy-instance-with-no-unhealthy-instances-but-all-excluded"
                       :expected nil
                       :reason :serve-request
@@ -122,9 +122,9 @@
                       :name "find-instance-to-offer:select-oldest-healthy-live-instance"
                       :reason :serve-request
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                              (update-in ["inst-2" :status-tags] conj :expired)
-                                              (update-in ["inst-3" :status-tags] conj :expired)
-                                              (update-in ["inst-8" :status-tags] conj :expired))}
+                                            (update-in ["inst-2" :status-tags] conj :expired)
+                                            (update-in ["inst-3" :status-tags] conj :expired)
+                                            (update-in ["inst-8" :status-tags] conj :expired))}
                      {:expected [instance-8]
                       :name "find-instance-to-offer:select-youngest-healthy-expired-instance"
                       :reason :serve-request
@@ -159,8 +159,8 @@
                       :expected [instance-5]
                       :reason :kill-instance
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                              (update-in ["inst-6"]
-                                                         assoc :slots-assigned 2 :slots-used 1))
+                                            (update-in ["inst-6"]
+                                                       assoc :slots-assigned 2 :slots-used 1))
                       :exclude-ids-set #{"inst-1" "inst-2" "inst-7" "inst-8"}}
                      {:name "find-instance-to-offer:killing-unhealthy-instance-with-some-unhealthy-instances"
                       :expected [instance-7]
@@ -171,19 +171,19 @@
                       :reason :kill-instance
                       :id->instance all-id->instance
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
-                                              (update-in ["inst-7"]
-                                                         assoc :slots-assigned 0 :slots-used 1))}
+                                            (update-in ["inst-7"]
+                                                       assoc :slots-assigned 0 :slots-used 1))}
                      {:name "find-instance-to-offer:killing-unhealthy-instance-with-some-unhealthy-instances:exclude-killed"
                       :expected [instance-4]
                       :reason :kill-instance
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
-                                              (update-in ["inst-7" :status-tags] conj :killed))}
+                                            (update-in ["inst-7" :status-tags] conj :killed))}
                      {:name "find-instance-to-offer:killing-unhealthy-instance-with-some-unhealthy-instances:exclude-killed-include-ejected"
                       :expected [instance-4]
                       :reason :kill-instance
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
-                                              (update-in ["inst-4" :status-tags] conj :ejected)
-                                              (update-in ["inst-7" :status-tags] conj :killed))}
+                                            (update-in ["inst-4" :status-tags] conj :ejected)
+                                            (update-in ["inst-7" :status-tags] conj :killed))}
                      {:name "find-instance-to-offer:killing-unhealthy-instance-with-some-unhealthy-and-excluded-instances"
                       :expected [instance-4]
                       :reason :kill-instance
@@ -193,77 +193,77 @@
                       :expected [instance-8]
                       :reason :kill-instance
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                              (update-in ["inst-8" :status-tags] conj :ejected))}
+                                            (update-in ["inst-8" :status-tags] conj :ejected))}
                      {:name "find-instance-to-offer:killing-healthy-instance-with-no-unhealthy-instances:exclude-locked-and-killed"
                       :expected [instance-2]
                       :reason :kill-instance
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                              (update-in ["inst-2" :status-tags] conj :ejected)
-                                              (update-in ["inst-3" :status-tags] conj :killed)
-                                              (update-in ["inst-8" :status-tags] conj :locked))}
+                                            (update-in ["inst-2" :status-tags] conj :ejected)
+                                            (update-in ["inst-3" :status-tags] conj :killed)
+                                            (update-in ["inst-8" :status-tags] conj :locked))}
                      {:name "find-instance-to-offer:killing-healthy-ejected-instance-with-no-unhealthy-instances:exclude-locked-and-killed"
                       :expected [instance-6]
                       :reason :kill-instance
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                              (update-in ["inst-3" :status-tags] conj :killed)
-                                              (update-in ["inst-8" :status-tags] conj :locked))}
+                                            (update-in ["inst-3" :status-tags] conj :killed)
+                                            (update-in ["inst-8" :status-tags] conj :locked))}
                      {:expected [instance-2]
                       :name "find-instance-to-offer:get-youngest-unhealthy-in-presence-of-expired-and-unhealthy-instances"
                       :reason :kill-instance
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
-                                              (update-in ["inst-2" :status-tags] conj :expired)
-                                              (update-in ["inst-5" :status-tags] conj :expired))}
+                                            (update-in ["inst-2" :status-tags] conj :expired)
+                                            (update-in ["inst-5" :status-tags] conj :expired))}
                      {:expected [instance-2]
                       :name "find-instance-to-offer:select-idle-expired-instance-with-oldest-load-balancing"
                       :reason :kill-instance
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                              (update-in ["inst-2" :status-tags] conj :expired))}
+                                            (update-in ["inst-2" :status-tags] conj :expired))}
                      {:expected [instance-2]
                       :load-balancing :youngest
                       :name "find-instance-to-offer:select-idle-expired-instance-with-youngest-load-balancing"
                       :reason :kill-instance
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                              (update-in ["inst-2" :status-tags] conj :expired))}
+                                            (update-in ["inst-2" :status-tags] conj :expired))}
                      {:expected [instance-6]
                       :name "find-instance-to-offer:oldest-idle-expired-instance"
                       :reason :kill-instance
                       :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-linger}}}
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                              (update-in ["inst-2" :status-tags] conj :expired)
-                                              (update-in ["inst-2"] assoc :slots-used 1)
-                                              (update-in ["inst-6" :status-tags] conj :expired)
-                                              (update-in ["inst-8" :status-tags] conj :expired))}
+                                            (update-in ["inst-2" :status-tags] conj :expired)
+                                            (update-in ["inst-2"] assoc :slots-used 1)
+                                            (update-in ["inst-6" :status-tags] conj :expired)
+                                            (update-in ["inst-8" :status-tags] conj :expired))}
                      {:expected nil
                       :name "find-instance-to-offer:no-healthy-instance-in-presence-of-busy-expired-instance"
                       :reason :kill-instance
                       :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-active}}}
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                              (update-in ["inst-2" :status-tags] conj :expired)
-                                              (update-in ["inst-2"] assoc :slots-used 1))}
+                                            (update-in ["inst-2" :status-tags] conj :expired)
+                                            (update-in ["inst-2"] assoc :slots-used 1))}
                      {:expected [instance-2]
                       :name "find-instance-to-offer:no-healthy-instance-in-presence-of-lingering-expired-instance"
                       :reason :kill-instance
                       :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-linger}}}
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                              (update-in ["inst-2" :status-tags] conj :expired)
-                                              (update-in ["inst-2"] assoc :slots-used 1))}
+                                            (update-in ["inst-2" :status-tags] conj :expired)
+                                            (update-in ["inst-2"] assoc :slots-used 1))}
                      {:expected [instance-6]
                       :name "find-instance-to-offer:oldest-idle-expired-instance-in-presence-of-lingering-expired-instance"
                       :reason :kill-instance
                       :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-linger}}}
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                              (update-in ["inst-2" :status-tags] conj :expired)
-                                              (update-in ["inst-6" :status-tags] conj :expired)
-                                              (update-in ["inst-8" :status-tags] conj :expired)
-                                              (update-in ["inst-2"] assoc :slots-used 1))}
+                                            (update-in ["inst-2" :status-tags] conj :expired)
+                                            (update-in ["inst-6" :status-tags] conj :expired)
+                                            (update-in ["inst-8" :status-tags] conj :expired)
+                                            (update-in ["inst-2"] assoc :slots-used 1))}
                      {:exclude-ids-set #{"inst-1" "inst-2" "inst-3"}
                       :expected [instance-6]
                       :name "find-instance-to-offer:oldest-acceptable-idle-expired-instance-in-presence-of-lingering-expired-instance"
                       :reason :kill-instance
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                              (update-in ["inst-2" :status-tags] conj :expired)
-                                              (update-in ["inst-6" :status-tags] conj :expired)
-                                              (update-in ["inst-8" :status-tags] conj :expired))}
+                                            (update-in ["inst-2" :status-tags] conj :expired)
+                                            (update-in ["inst-6" :status-tags] conj :expired)
+                                            (update-in ["inst-8" :status-tags] conj :expired))}
                      {:expected [instance-2]
                       :name "find-instance-to-offer:oldest-expired-instance-in-presence-of-lingering-expired-instance"
                       :reason :kill-instance
@@ -271,44 +271,44 @@
                                                                 "inst-6" {"req-6" {:cid "cid-6" :request-id "req-6" :reason :serve-request :time time-linger}}
                                                                 "inst-8" {"req-8" {:cid "cid-8" :request-id "req-8" :reason :serve-request :time time-linger}}}
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                              (update-in ["inst-2" :status-tags] conj :expired)
-                                              (update-in ["inst-6" :status-tags] conj :expired)
-                                              (update-in ["inst-8" :status-tags] conj :expired)
-                                              (update-in ["inst-2"] assoc :slots-used 1)
-                                              (update-in ["inst-6"] assoc :slots-used 1)
-                                              (update-in ["inst-8"] assoc :slots-used 1))}
+                                            (update-in ["inst-2" :status-tags] conj :expired)
+                                            (update-in ["inst-6" :status-tags] conj :expired)
+                                            (update-in ["inst-8" :status-tags] conj :expired)
+                                            (update-in ["inst-2"] assoc :slots-used 1)
+                                            (update-in ["inst-6"] assoc :slots-used 1)
+                                            (update-in ["inst-8"] assoc :slots-used 1))}
                      {:expected [instance-6]
                       :name "find-instance-to-offer:youngest-healthy-ejected-instance-in-presence-of-busy-expired-instance"
                       :reason :kill-instance
                       :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-active}}}
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids [])
-                                              (update-in ["inst-2" :status-tags] conj :expired)
-                                              (update-in ["inst-2"] assoc :slots-used 1)
-                                              (update-in ["inst-5" :status-tags] conj :ejected)
-                                              (update-in ["inst-6" :status-tags] conj :ejected))}
+                                            (update-in ["inst-2" :status-tags] conj :expired)
+                                            (update-in ["inst-2"] assoc :slots-used 1)
+                                            (update-in ["inst-5" :status-tags] conj :ejected)
+                                            (update-in ["inst-6" :status-tags] conj :ejected))}
                      {:expected [instance-7]
                       :name "find-instance-to-offer:youngest-unhealthy-instance-in-presence-of-busy-expired-instance"
                       :reason :kill-instance
                       :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-active}}}
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
-                                              (update-in ["inst-2" :status-tags] conj :expired)
-                                              (update-in ["inst-2"] assoc :slots-used 1))}
+                                            (update-in ["inst-2" :status-tags] conj :expired)
+                                            (update-in ["inst-2"] assoc :slots-used 1))}
                      {:expected [instance-4]
                       :name "find-instance-to-offer:youngest-unhealthy-unlocked-instance-in-presence-of-busy-expired-instance"
                       :reason :kill-instance
                       :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-active}}}
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
-                                              (update-in ["inst-2" :status-tags] conj :expired)
-                                              (update-in ["inst-7" :status-tags] conj :locked)
-                                              (update-in ["inst-2"] assoc :slots-used 1))}
+                                            (update-in ["inst-2" :status-tags] conj :expired)
+                                            (update-in ["inst-7" :status-tags] conj :locked)
+                                            (update-in ["inst-2"] assoc :slots-used 1))}
                      {:expected [instance-4]
                       :name "find-instance-to-offer:youngest-unhealthy-live-instance-in-presence-of-busy-expired-instance"
                       :reason :kill-instance
                       :instance-id->request-id->use-reason-map {"inst-2" {"req-1" {:cid "cid-1" :request-id "req-1" :reason :serve-request :time time-active}}}
                       :instance-id->state (-> (instance-id->state-fn healthy-instance-ids unhealthy-instance-ids)
-                                              (update-in ["inst-2" :status-tags] conj :expired)
-                                              (update-in ["inst-7" :status-tags] conj :killed)
-                                              (update-in ["inst-2"] assoc :slots-used 1))}
+                                            (update-in ["inst-2" :status-tags] conj :expired)
+                                            (update-in ["inst-7" :status-tags] conj :killed)
+                                            (update-in ["inst-2"] assoc :slots-used 1))}
  
                      {:expected [instance-3]
                       :name "find-instance-to-offer:only-healthy-and-unknown-ejected-instance"
@@ -316,8 +316,8 @@
                       :id->instance (pc/map-from-vals :id [instance-2 instance-3])
                       :instance-id->request-id->use-reason-map {}
                       :instance-id->state (-> (instance-id->state-fn (map :id [instance-2 instance-3 instance-5]) [])
-                                              (update-in ["inst-5" :status-tags] (constantly #{:ejected}))
-                                              (update-in ["inst-5"] assoc :slots-assigned 0))}
+                                            (update-in ["inst-5" :status-tags] (constantly #{:ejected}))
+                                            (update-in ["inst-5"] assoc :slots-assigned 0))}
                      {:expected [instance-9-scaling-down-timeout-reached]
                       :name "find-instance-to-offer:only-kill-instances-with-prepared-to-scale-down-at-if-they-exist"
                       :reason :kill-instance


### PR DESCRIPTION
## Changes proposed in this PR

- Two-phase scale down for pods that are part of services in bypass mode
- Kill instance function for k8 will add `waiter/prepared-to-scale-down-at` annotation to the pod that will be scaled down.
- responder will only returns instances with :prepared-to-scale-down-at if they are ready (otherwise return no instances, as the autoscaler must repick the correct instance to fully scale down).
- Added pod cleaner daemon that hard deletes pods after they have reached a certain timeout

## Why are we making these changes?

- Allows for safe scale down of instances that may be receiving requests from external load balancers.
- External load balancers need to get updated that the instance is no longer able to receive new traffic. This is done by respecting the `ejected` flag for the instance

## Followups
- Use the external metrics to confirm that an instance has no in-flight requests when it is chosen for killing
- Eagerly kill instances with no outstanding requests
- Sort which instances are chosen to be killed by the least amount of total outstanding requests (right now we rely on current algorithm in the responder for picking an instance to be killed)
- Optimize the scaling up function to attempt to relabel pods that are preparing to scale down so another pod doesn't need to be started
