### PR TITLE
Configurable liveness checks

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -157,6 +157,9 @@
                              (merge (select-keys profile-config-defaults (map keyword sd/service-parameter-keys))
                                     base-service-description
                                     {:profile (name profile)})
+                             (walk/stringify-keys)
+                             (sd/apply-param-to-param-defaults sd/param-to-param-default-mapping)
+                             (walk/keywordize-keys)
                              (merge-parameters extra-parameters))
                            effective-service-description)
                         (str {:extra-parameters extra-parameters

--- a/waiter/integration/waiter/liveness_check_test.clj
+++ b/waiter/integration/waiter/liveness_check_test.clj
@@ -35,42 +35,166 @@
          (assert-response-status response http-400-bad-request)
          (is (str/includes? (str body) error-msg)))))))
 
-;; (deftest ^:parallel ^:integration-fast test-temporarily-unhealthy-instance
-;;   (testing-using-waiter-url
-;;    (when (using-k8s? waiter-url)
-;;      (let [{:keys [cookies instance-id request-headers service-id] :as canary-response}
-;;            (make-request-with-debug-info
-;;             {:x-waiter-cmd (kitchen-cmd "--enable-status-change -p $PORT0")
-;;              :x-waiter-concurrency-level 128
-;;              :x-waiter-health-check-interval-secs 5
-;;              :x-waiter-health-check-max-consecutive-failures 10
-;;              :x-waiter-health-check-url "/status-400"
-;;              :x-waiter-liveness-check-url "/status"
-;;              :x-waiter-min-instances 1
-;;              :x-waiter-name (rand-name)}
-;;             #(make-kitchen-request waiter-url % :path "/hello"))
-;;            check-filtered-instances (fn [target-url healthy-filter-fn]
-;;                                       (let [instance-ids (->> (active-instances target-url service-id :cookies cookies)
-;;                                                               (healthy-filter-fn :healthy?)
-;;                                                               (map :id))]
-;;                                         (and (= 1 (count instance-ids))
-;;                                              (= instance-id (first instance-ids)))))]
-;;        (assert-response-status canary-response http-200-ok)
-;;        (with-service-cleanup
-;;          service-id
-;;          (doseq [[_ router-url] (routers waiter-url)]
-;;            (is (wait-for #(check-filtered-instances router-url filter)))
-;;            (is (= 1 (count (active-instances router-url service-id :cookies cookies)))))
-;;          (let [request-headers (assoc request-headers
-;;                                       :x-kitchen-default-status-timeout 20000
-;;                                       :x-kitchen-default-status-value http-400-bad-request)
-;;                response (make-kitchen-request waiter-url request-headers :path "/hello")]
-;;            (assert-response-status response http-400-bad-request))
-;;          (doseq [[_ router-url] (routers waiter-url)]
-;;            (is (wait-for #(check-filtered-instances router-url remove)))
-;;            (is (= 1 (count (active-instances router-url service-id :cookies cookies)))))
-;;          (let [response (make-kitchen-request waiter-url request-headers :path "/hello")]
-;;            (assert-response-status response http-200-ok))
-;;          (doseq [[_ router-url] (routers waiter-url)]
-;;            (is (wait-for #(check-filtered-instances router-url filter)))
-;;            (is (= 1 (count (active-instances router-url service-id :cookies cookies))))))))))
+(deftest ^:parallel ^:integration-fast test-temporarily-unready-instance
+  (testing-using-waiter-url
+   (when (using-k8s? waiter-url)
+     (let [{:keys [cookies instance-id request-headers service-id] :as canary-response}
+           (make-request-with-debug-info
+            {:x-waiter-cmd (kitchen-cmd "--enable-status-change -p $PORT0")
+             :x-waiter-concurrency-level 128
+             :x-waiter-grace-period-secs 5
+             :x-waiter-health-check-interval-secs 5
+             :x-waiter-health-check-max-consecutive-failures 10
+             :x-waiter-health-check-url "/default-status"           ; depends on ktichen's default-status-value
+             :x-waiter-liveness-check-interval-secs 5
+             :x-waiter-liveness-check-max-consecutive-failures 2
+             :x-waiter-liveness-check-url "/bad-status?status=200"  ; always 200
+             :x-waiter-max-instances 1
+             :x-waiter-min-instances 1
+             :x-waiter-name (rand-name)}
+            #(make-kitchen-request waiter-url % :path "/hello"))
+           check-filtered-instances (fn [target-url healthy-filter-fn]
+                                      (let [instance-ids (->> (active-instances target-url service-id :cookies cookies)
+                                                              (healthy-filter-fn :healthy?)
+                                                              (map :id))]
+                                        (and (= 1 (count instance-ids))
+                                             (= instance-id (first instance-ids)))))]
+       (assert-response-status canary-response http-200-ok)
+       (with-service-cleanup
+         service-id
+         ; wait for instance to show as healthy on all routers
+         (doseq [[_ router-url] (routers waiter-url)]
+           (is (wait-for #(check-filtered-instances router-url filter)))
+           (is (= 1 (count (active-instances router-url service-id :cookies cookies)))))
+         ; set default-status-value to 400 to trigger failing health checks
+         (let [request-headers (assoc request-headers
+                                      :x-kitchen-default-status-timeout 45000
+                                      :x-kitchen-default-status-value http-400-bad-request)
+               response (make-kitchen-request waiter-url request-headers :path "/hello")]
+           (assert-response-status response http-400-bad-request))
+         ; wait for instance to show as unhealthy on all routers
+         (doseq [[_ router-url] (routers waiter-url)]
+           (is (wait-for #(check-filtered-instances router-url remove) :timeout 60 :interval 5))
+           (is (= 1 (count (active-instances router-url service-id :cookies cookies)))))
+         ; issue a request that will be queued until service reports as healthy (waiting on default-status-timeout)
+         (let [response (make-kitchen-request waiter-url request-headers :path "/hello")]
+           (assert-response-status response http-200-ok))
+         ; verify instance shows as healthy on all routers
+         (doseq [[_ router-url] (routers waiter-url)]
+           (is (wait-for #(check-filtered-instances router-url filter)))
+           (is (= 1 (count (active-instances router-url service-id :cookies cookies)))))
+         ; verify instance did not experience restarts
+         (doseq [[_ router-url] (routers waiter-url)]
+           (let [instances (active-instances router-url service-id :cookies cookies)]
+             (is (= 1 (count instances)))
+             (is (zero? (-> instances
+                            first
+                            :k8s/restart-count))))))))))
+
+(deftest ^:parallel ^:integration-fast test-liveness-triggered-restart
+  (testing-using-waiter-url
+   (when (using-k8s? waiter-url)
+     (let [{:keys [cookies instance-id request-headers service-id] :as canary-response}
+           (make-request-with-debug-info
+            {:x-waiter-cmd (kitchen-cmd "--enable-status-change -p $PORT0")
+             :x-waiter-concurrency-level 128
+             :x-waiter-grace-period-secs 5
+             :x-waiter-health-check-interval-secs 5
+             :x-waiter-health-check-max-consecutive-failures 10
+             :x-waiter-health-check-url "/bad-status?status=200"  ; always 200
+             :x-waiter-liveness-check-interval-secs 5
+             :x-waiter-liveness-check-max-consecutive-failures 2
+             :x-waiter-liveness-check-url "/default-status"       ; depends on ktichen's default-status-value
+             :x-waiter-max-instances 1
+             :x-waiter-min-instances 1
+             :x-waiter-name (rand-name)}
+            #(make-kitchen-request waiter-url % :path "/hello"))
+           check-filtered-instances (fn [target-url healthy-filter-fn]
+                                      (let [instance-ids (->> (active-instances target-url service-id :cookies cookies)
+                                                              (healthy-filter-fn :healthy?)
+                                                              (map :id))]
+                                        (and (= 1 (count instance-ids))
+                                             (= instance-id (first instance-ids)))))]
+       (assert-response-status canary-response http-200-ok)
+       (with-service-cleanup
+         service-id
+         ; wait for instance to show as healthy on all routers
+         (doseq [[_ router-url] (routers waiter-url)]
+           (is (wait-for #(check-filtered-instances router-url filter)))
+           (is (= 1 (count (active-instances router-url service-id :cookies cookies)))))
+         ; set default-status-value to 400 to trigger failing liveness checks
+         (let [request-headers (assoc request-headers
+                                      :x-kitchen-default-status-timeout 600000
+                                      :x-kitchen-default-status-value http-400-bad-request)
+               response (make-kitchen-request waiter-url request-headers :path "/hello")]
+           (assert-response-status response http-400-bad-request))
+         ; wait for service to respond 200 (instance should restart before the default-status-timeout above)
+         (is (wait-for #(= http-200-ok (:status (make-kitchen-request waiter-url request-headers :path "/hello")))
+                       :timeout 120))
+         ; verify instance did not experience restarts
+         (doseq [[_ router-url] (routers waiter-url)]
+           (is (wait-for #(let [instances (active-instances router-url service-id :cookies cookies)]
+                             (and (= 1 (count instances))
+                                  (pos? (-> instances
+                                            first
+                                            :k8s/restart-count))))
+                         :timeout 120))))))))
+
+(deftest ^:parallel ^:integration-fast test-liveness-recovers-without-restart
+  (testing-using-waiter-url
+   (when (using-k8s? waiter-url)
+     (let [{:keys [cookies instance-id request-headers service-id] :as canary-response}
+           (make-request-with-debug-info
+            {:x-waiter-cmd (kitchen-cmd "--enable-status-change -p $PORT0")
+             :x-waiter-concurrency-level 128
+             :x-waiter-grace-period-secs 5
+             :x-waiter-health-check-interval-secs 5
+             :x-waiter-health-check-max-consecutive-failures 10
+             :x-waiter-health-check-url "/bad-status?status=200"  ; always 200
+             :x-waiter-liveness-check-interval-secs 5
+             :x-waiter-liveness-check-max-consecutive-failures 36
+             :x-waiter-liveness-check-url "/default-status"       ; depends on ktichen's default-status-value
+             :x-waiter-max-instances 1
+             :x-waiter-min-instances 1
+             :x-waiter-name (rand-name)}
+            #(make-kitchen-request waiter-url % :path "/hello"))
+           check-filtered-instances (fn [target-url healthy-filter-fn]
+                                      (let [instance-ids (->> (active-instances target-url service-id :cookies cookies)
+                                                              (healthy-filter-fn :healthy?)
+                                                              (map :id))]
+                                        (and (= 1 (count instance-ids))
+                                             (= instance-id (first instance-ids)))))]
+       (assert-response-status canary-response http-200-ok)
+       (with-service-cleanup
+         service-id
+         ; wait for instance to show as healthy on all routers
+         (doseq [[_ router-url] (routers waiter-url)]
+           (is (wait-for #(check-filtered-instances router-url filter)))
+           (is (= 1 (count (active-instances router-url service-id :cookies cookies)))))
+         ; set default-status-value to 400 to trigger failing liveness checks
+         (let [request-headers (assoc request-headers
+                                      :x-kitchen-default-status-timeout 20000
+                                      :x-kitchen-default-status-value http-400-bad-request)
+               response (make-kitchen-request waiter-url request-headers :path "/hello")]
+           (assert-response-status response http-400-bad-request))
+         ; wait for service to respond 200 (instance should recover after the default-status-timeout above)
+         (is (wait-for #(= http-200-ok (:status (make-kitchen-request waiter-url request-headers :path "/hello")))
+                       :timeout 35))
+         ; verify instance did not experience restarts
+         (doseq [[_ router-url] (routers waiter-url)]
+           (let [instances (active-instances router-url service-id :cookies cookies)]
+             (is (= 1 (count instances)))
+             (is (zero? (-> instances
+                            first
+                            :k8s/restart-count))))))))))
+
+(deftest ^:parallel ^:integration-fast test-liveness-explicit-proto-conflict-default-port-index
+  (testing-using-waiter-url
+   (when (using-k8s? waiter-url)
+     (let [canary-response
+           (make-request-with-debug-info
+            {:x-waiter-cmd (kitchen-cmd "--enable-status-change -p $PORT0")
+             :x-waiter-liveness-check-proto "https"
+             :x-waiter-name (rand-name)}
+            #(make-kitchen-request waiter-url % :path "/hello"))]
+       (assert-response-status canary-response http-400-bad-request)))))

--- a/waiter/integration/waiter/liveness_check_test.clj
+++ b/waiter/integration/waiter/liveness_check_test.clj
@@ -1,0 +1,76 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns waiter.liveness-check-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
+            [waiter.status-codes :refer :all]
+            [waiter.util.client-tools :refer :all]))
+
+(deftest ^:parallel ^:integration-fast test-invalid-backend-proto-liveness-check-proto-combo
+  (testing-using-waiter-url
+   (let [supported-protocols #{"http" "https" "h2c" "h2"}]
+     (doseq [backend-proto supported-protocols
+             liveness-check-proto (disj supported-protocols backend-proto)
+             liveness-check-port-index [nil 0]]
+       (let [request-headers (cond-> {:x-waiter-backend-proto backend-proto
+                                      :x-waiter-liveness-check-proto liveness-check-proto
+                                      :x-waiter-name (rand-name)}
+                               liveness-check-port-index (assoc :x-waiter-liveness-check-port-index liveness-check-port-index))
+             {:keys [body] :as response} (make-kitchen-request waiter-url request-headers)
+             error-msg (str "The backend-proto (" backend-proto ") and liveness check proto (" liveness-check-proto
+                            ") must match when liveness-check-port-index is zero")]
+         (assert-response-status response http-400-bad-request)
+         (is (str/includes? (str body) error-msg)))))))
+
+;; (deftest ^:parallel ^:integration-fast test-temporarily-unhealthy-instance
+;;   (testing-using-waiter-url
+;;    (when (using-k8s? waiter-url)
+;;      (let [{:keys [cookies instance-id request-headers service-id] :as canary-response}
+;;            (make-request-with-debug-info
+;;             {:x-waiter-cmd (kitchen-cmd "--enable-status-change -p $PORT0")
+;;              :x-waiter-concurrency-level 128
+;;              :x-waiter-health-check-interval-secs 5
+;;              :x-waiter-health-check-max-consecutive-failures 10
+;;              :x-waiter-health-check-url "/status-400"
+;;              :x-waiter-liveness-check-url "/status"
+;;              :x-waiter-min-instances 1
+;;              :x-waiter-name (rand-name)}
+;;             #(make-kitchen-request waiter-url % :path "/hello"))
+;;            check-filtered-instances (fn [target-url healthy-filter-fn]
+;;                                       (let [instance-ids (->> (active-instances target-url service-id :cookies cookies)
+;;                                                               (healthy-filter-fn :healthy?)
+;;                                                               (map :id))]
+;;                                         (and (= 1 (count instance-ids))
+;;                                              (= instance-id (first instance-ids)))))]
+;;        (assert-response-status canary-response http-200-ok)
+;;        (with-service-cleanup
+;;          service-id
+;;          (doseq [[_ router-url] (routers waiter-url)]
+;;            (is (wait-for #(check-filtered-instances router-url filter)))
+;;            (is (= 1 (count (active-instances router-url service-id :cookies cookies)))))
+;;          (let [request-headers (assoc request-headers
+;;                                       :x-kitchen-default-status-timeout 20000
+;;                                       :x-kitchen-default-status-value http-400-bad-request)
+;;                response (make-kitchen-request waiter-url request-headers :path "/hello")]
+;;            (assert-response-status response http-400-bad-request))
+;;          (doseq [[_ router-url] (routers waiter-url)]
+;;            (is (wait-for #(check-filtered-instances router-url remove)))
+;;            (is (= 1 (count (active-instances router-url service-id :cookies cookies)))))
+;;          (let [response (make-kitchen-request waiter-url request-headers :path "/hello")]
+;;            (assert-response-status response http-200-ok))
+;;          (doseq [[_ router-url] (routers waiter-url)]
+;;            (is (wait-for #(check-filtered-instances router-url filter)))
+;;            (is (= 1 (count (active-instances router-url service-id :cookies cookies))))))))))

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1000,7 +1000,8 @@
    :attach-service-defaults-fn (pc/fnk [[:settings metric-group-mappings service-description-defaults]
                                         [:state profile->defaults]]
                                  (fn attach-service-defaults-fn [service-description]
-                                   (sd/merge-defaults service-description service-description-defaults profile->defaults metric-group-mappings)))
+                                   (sd/merge-defaults service-description service-description-defaults profile->defaults metric-group-mappings
+                                                      sd/param-to-param-default-mapping)))
    :attach-token-defaults-fn (pc/fnk [[:settings [:token-config token-defaults]]
                                       [:state profile->defaults]]
                                (fn attach-token-defaults-fn [token-parameters]

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -462,12 +462,11 @@
    another parameter in the service description (the parameter name that the original
    parameter name maps to in the parameter default mapping)."
   [service-description-defaults param-default-mapping]
-  ; TODO verify validation for defaulted + explicit combinations. When does validation occur?
   (let [valid-mapping-parms (map key (filter (fn [[_ mapped-param]] (contains? service-description-defaults mapped-param)) param-default-mapping))
-        all-params (into (sorted-set) (concat (keys service-description-defaults) valid-mapping-parms))]
+        new-params (into (sorted-set) (concat (keys service-description-defaults) valid-mapping-parms))]
     (pc/map-from-keys (fn [param-name] (or (get service-description-defaults param-name)
                                            (get service-description-defaults (get param-default-mapping param-name))))
-                      all-params)))
+                      new-params)))
 
 (defn merge-defaults
   "Merges the defaults into the existing service description."

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -470,24 +470,20 @@
 
 (defn merge-defaults
   "Merges the defaults into the existing service description."
-  ([service-description-without-defaults service-description-defaults profile->defaults metric-group-mappings]
-   (merge-defaults service-description-without-defaults service-description-defaults profile->defaults metric-group-mappings {}))
-  ([{:strs [profile] :as service-description-without-defaults} service-description-defaults profile->defaults metric-group-mappings param-default-mapping]
-   (-> service-description-defaults
-       (compute-service-defaults profile->defaults profile)
-       (adjust-default-min-instances service-description-without-defaults)
-       (merge-parameters service-description-without-defaults)
-       (metric-group-filter metric-group-mappings)
-       (apply-param-to-param-defaults param-default-mapping))))
+  [{:strs [profile] :as service-description-without-defaults} service-description-defaults profile->defaults metric-group-mappings param-default-mapping]
+  (-> service-description-defaults
+      (compute-service-defaults profile->defaults profile)
+      (adjust-default-min-instances service-description-without-defaults)
+      (merge-parameters service-description-without-defaults)
+      (metric-group-filter metric-group-mappings)
+      (apply-param-to-param-defaults param-default-mapping)))
 
 (defn default-and-override
   "Adds defaults and overrides to the provided service-description"
-  ([service-description service-description-defaults profile->defaults metric-group-mappings kv-store service-id]
-   (default-and-override service-description service-description-defaults profile->defaults metric-group-mappings kv-store service-id {}))
-  ([service-description service-description-defaults profile->defaults metric-group-mappings kv-store service-id param-default-mapping]
-   (-> service-description
-       (merge-defaults service-description-defaults profile->defaults metric-group-mappings param-default-mapping)
-       (merge-overrides (:overrides (service-id->overrides kv-store service-id))))))
+  [service-description service-description-defaults profile->defaults metric-group-mappings kv-store service-id param-default-mapping]
+  (-> service-description
+      (merge-defaults service-description-defaults profile->defaults metric-group-mappings param-default-mapping)
+      (merge-overrides (:overrides (service-id->overrides kv-store service-id)))))
 
 (defn parameters->id
   "Generates a deterministic ID from the input parameter map."

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -89,13 +89,19 @@
    ; start-up related
    (s/optional-key "grace-period-secs") (s/both s/Int (s/pred #(<= 0 % (t/in-seconds (t/minutes 60))) 'at-most-60-minutes))
    (s/optional-key "health-check-authentication") schema/valid-health-check-authentication
-   (s/optional-key "health-check-interval-secs") (s/both s/Int (s/pred #(<= 5 % 60) 'between-5-seconds-and-1-minute))
-   (s/optional-key "health-check-max-consecutive-failures") (s/both s/Int (s/pred #(<= 1 % 15) 'at-most-fifteen))
+   (s/optional-key "health-check-interval-secs") (s/both s/Int (s/pred #(<= 5 % 600) 'between-5-seconds-and-10-minutes))
+   (s/optional-key "health-check-max-consecutive-failures") (s/both s/Int (s/pred #(<= 1 % 36) 'at-most-36))
    (s/optional-key "health-check-port-index") schema/valid-health-check-port-index
    (s/optional-key "health-check-proto") schema/valid-health-check-proto
    (s/optional-key "health-check-url") schema/non-empty-string
    (s/optional-key "idle-timeout-mins") (s/both s/Int (s/pred #(<= 0 % (t/in-minutes (t/days 30))) 'between-0-minute-and-30-days))
    (s/optional-key "interstitial-secs") (s/both s/Int (s/pred #(<= 0 % (t/in-seconds (t/minutes 60))) 'at-most-60-minutes))
+   (s/optional-key "liveness-check-authentication") schema/valid-health-check-authentication
+   (s/optional-key "liveness-check-interval-secs") (s/both s/Int (s/pred #(<= 5 % 600) 'between-5-seconds-and-10-minutes))
+   (s/optional-key "liveness-check-max-consecutive-failures") (s/both s/Int (s/pred #(<= 1 % 36) 'at-most-36))
+   (s/optional-key "liveness-check-port-index") schema/valid-health-check-port-index
+   (s/optional-key "liveness-check-proto") schema/valid-health-check-proto
+   (s/optional-key "liveness-check-url") schema/non-empty-string
    (s/optional-key "restart-backoff-factor") schema/positive-number-greater-than-or-equal-to-1
    (s/optional-key "scheduler") schema/non-empty-string
    (s/optional-key "termination-grace-period-secs") (s/both s/Int (s/pred #(<= 0 % (t/in-seconds (t/minutes 5))) 'at-most-5-minutes))

--- a/waiter/test/waiter/auth/authenticator_test.clj
+++ b/waiter/test/waiter/auth/authenticator_test.clj
@@ -139,7 +139,7 @@
                                       "permitted-user" "*"}}
         token-defaults {"fallback-period-secs" 300
                         "https-redirect" false}
-        attach-service-defaults-fn #(sd/merge-defaults % service-description-defaults profile->defaults metric-group-mappings)
+        attach-service-defaults-fn #(sd/merge-defaults % service-description-defaults profile->defaults metric-group-mappings {})
         attach-token-defaults-fn #(sd/attach-token-defaults % token-defaults profile->defaults)
         waiter-hostnames #{"www.waiter-router.com"}
         handler-response (Object.)

--- a/waiter/test/waiter/descriptor_test.clj
+++ b/waiter/test/waiter/descriptor_test.clj
@@ -303,7 +303,7 @@
                                                   {:metric-group-mappings metric-group-mappings
                                                    :profile->defaults profile->defaults
                                                    :service-description-defaults service-description-defaults}))
-                attach-service-defaults-fn #(sd/merge-defaults % service-description-defaults profile->defaults metric-group-mappings)
+                attach-service-defaults-fn #(sd/merge-defaults % service-description-defaults profile->defaults metric-group-mappings {})
                 attach-token-defaults-fn #(sd/attach-token-defaults % token-defaults profile->defaults)]
             (request->descriptor
               assoc-run-as-user-approved? can-run-as? attach-service-defaults-fn attach-token-defaults-fn fallback-state-atom
@@ -525,7 +525,7 @@
       token-defaults {"fallback-period-secs" 300
                       "service-mapping" "legacy"}
       metric-group-mappings []
-      attach-service-defaults-fn #(sd/merge-defaults % service-description-defaults profile->defaults metric-group-mappings)
+      attach-service-defaults-fn #(sd/merge-defaults % service-description-defaults profile->defaults metric-group-mappings {})
       attach-token-defaults-fn #(sd/attach-token-defaults % token-defaults profile->defaults)
       username "test-user"
       metric-group-mappings []

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -341,7 +341,7 @@
             token-defaults {"fallback-period-secs" 300
                             "service-mapping" "legacy"}
             metric-group-mappings []
-            attach-service-defaults-fn #(merge-defaults % service-description-defaults profile->defaults metric-group-mappings)
+            attach-service-defaults-fn #(merge-defaults % service-description-defaults profile->defaults metric-group-mappings {})
             attach-token-defaults-fn #(attach-token-defaults % token-defaults profile->defaults)
             test-cases (list
                          {:name "prepare-service-description-sources:WITH Service Desc specific Waiter Headers except run-as-user"
@@ -885,7 +885,7 @@
         service-description-defaults {}
         profile->defaults {}
         metric-group-mappings []
-        attach-service-defaults-fn #(merge-defaults % service-description-defaults profile->defaults metric-group-mappings)
+        attach-service-defaults-fn #(merge-defaults % service-description-defaults profile->defaults metric-group-mappings {})
         token-defaults {"fallback-period-secs" 300}
         attach-token-defaults-fn #(merge token-defaults %)]
     (testing "authentication-disabled token"
@@ -2769,19 +2769,19 @@
           metric-group-mappings [[#"r.*" "bar"]]]
       (is (= {"cpus" 3 "env" {"AFFINITY" "none"} "mem" 2048 "metric-group" "other" "permitted-user" "john.doe" "version" "v1"}
              (-> {"cpus" 3 "permitted-user" "john.doe" "version" "v1"}
-               (merge-defaults service-description-defaults profile->defaults metric-group-mappings))))
+               (merge-defaults service-description-defaults profile->defaults metric-group-mappings {}))))
       (is (= {"cpus" 3 "env" {"AFFINITY" "none"} "mem" 1024 "metric-group" "other" "permitted-user" "john.doe" "profile" "basic"}
              (-> {"cpus" 3 "permitted-user" "john.doe" "profile" "basic"}
-               (merge-defaults service-description-defaults profile->defaults metric-group-mappings))))
+               (merge-defaults service-description-defaults profile->defaults metric-group-mappings {}))))
       (is (= {"cpus" 3 "env" {"AFFINITY" "none" "REGION" "west" "ZONE" "lax"} "mem" 2048 "metadata" {"style" "grpc"} "metric-group" "other" "permitted-user" "john.doe" "profile" "rpc"}
              (-> {"cpus" 3 "permitted-user" "john.doe" "profile" "rpc"}
-               (merge-defaults service-description-defaults profile->defaults metric-group-mappings))))
+               (merge-defaults service-description-defaults profile->defaults metric-group-mappings {}))))
       (is (= {"concurrency-level" 30 "cpus" 3 "env" {"AFFINITY" "none" "REGION" "central"} "mem" 2048 "metric-group" "other" "permitted-user" "john.doe" "profile" "service"}
              (-> {"cpus" 3 "permitted-user" "john.doe" "profile" "service"}
-               (merge-defaults service-description-defaults profile->defaults metric-group-mappings))))
+               (merge-defaults service-description-defaults profile->defaults metric-group-mappings {}))))
       (is (= {"concurrency-level" 120 "cpus" 3 "env" {"AFFINITY" "none" "REGION" "east"} "mem" 2048 "metadata" {"framework" "spring" "type" "webapp"} "metric-group" "other" "permitted-user" "john.doe" "profile" "webapp"}
              (-> {"cpus" 3 "permitted-user" "john.doe" "profile" "webapp"}
-               (merge-defaults service-description-defaults profile->defaults metric-group-mappings))))))
+               (merge-defaults service-description-defaults profile->defaults metric-group-mappings {}))))))
   (testing "Merging defaults into service description"
     (let [profile->defaults {"webapp" {"concurrency-level" 120
                                        "fallback-period-secs" 100}}
@@ -2792,12 +2792,12 @@
                 "name" "lorem"
                 "profile" "webapp"}
                (merge-defaults {"name" "lorem", "profile" "webapp"} {}
-                               profile->defaults metric-group-mappings))))
+                               profile->defaults metric-group-mappings {}))))
       (testing "should incorporate metric group mappings"
         (is (= {"metric-group" "bar"
                 "name" "foo"}
                (merge-defaults {"name" "foo"} {}
-                               profile->defaults metric-group-mappings))))
+                               profile->defaults metric-group-mappings {}))))
       (testing "should incorporate defaults, profile, and metric-group"
         (is (= {"concurrency-level" 120
                 "metric-group" "bar"
@@ -2805,18 +2805,18 @@
                 "ports" 2
                 "profile" "webapp"}
                (merge-defaults {"name" "foo", "profile" "webapp"} {"concurrency-level" 30, "ports" 2}
-                               profile->defaults metric-group-mappings))))
+                               profile->defaults metric-group-mappings {}))))
       (testing "min-instances default missing but only max-instances provided"
         (is (= {"max-instances" 2
                 "metric-group" "other"}
                (merge-defaults {"max-instances" 2} {}
-                               profile->defaults metric-group-mappings))))
+                               profile->defaults metric-group-mappings {}))))
       (testing "min-instances should be updated when not provided"
         (is (= {"max-instances" 2
                 "metric-group" "other"
                 "min-instances" 2}
                (merge-defaults {"max-instances" 2} {"min-instances" 3}
-                               profile->defaults metric-group-mappings))))
+                               profile->defaults metric-group-mappings {}))))
       (testing "min-instances should be adjusted when only max-instances provided in profile"
         (is (= {"max-instances" 2
                 "metric-group" "other"
@@ -2825,7 +2825,7 @@
                (let [profile->defaults (assoc profile->defaults
                                          "test-profile" {"max-instances" 2})]
                  (merge-defaults {"profile" "test-profile"} {"min-instances" 3}
-                                 profile->defaults metric-group-mappings))))
+                                 profile->defaults metric-group-mappings {}))))
         (is (= {"max-instances" 2
                 "metric-group" "other"
                 "min-instances" 1
@@ -2833,18 +2833,18 @@
                (let [profile->defaults (assoc profile->defaults
                                          "test-profile" {"max-instances" 2})]
                  (merge-defaults {"profile" "test-profile"} {"min-instances" 1}
-                                 profile->defaults metric-group-mappings)))))
+                                 profile->defaults metric-group-mappings {})))))
       (testing "min-instances should not be updated when provided without max-instances"
         (is (= {"metric-group" "other"
                 "min-instances" 4}
                (merge-defaults {"min-instances" 4} {"min-instances" 3}
-                               profile->defaults metric-group-mappings))))
+                               profile->defaults metric-group-mappings {}))))
       (testing "min-instances should not be updated when provided with max-instances"
         (is (= {"max-instances" 2
                 "metric-group" "other"
                 "min-instances" 4}
                (merge-defaults {"max-instances" 2 "min-instances" 4} {"min-instances" 3}
-                               profile->defaults metric-group-mappings)))))))
+                               profile->defaults metric-group-mappings {})))))))
 
 (deftest test-validate-cmd-type
   (testing "DefaultServiceDescriptionBuilder validation"

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -1029,6 +1029,7 @@
         service-id-prefix "test-service-"
         test-token "test-token"
         service-description-defaults {"health-check-url" "/ping"
+                                      "liveness-check-url" "/ping"
                                       "metric-group" "test-group"
                                       "permitted-user" "bob"}
         profile-defaults {"health-check-url" "/pong"
@@ -1221,6 +1222,7 @@
     (testing "only token from host with permitted-user in defaults"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "bob"}
              (service-description {:service-description-template {"cmd" "token-cmd"}}
                                   :expected-run-as-user-source "unknown"
@@ -1230,7 +1232,8 @@
 
     (testing "only token from host without permitted-user in defaults"
       (is (= {"cmd" "token-cmd"
-              "health-check-url" "/ping"}
+              "health-check-url" "/ping"
+              "liveness-check-url" "/ping"}
              (service-description {:service-description-template {"cmd" "token-cmd"}}
                                   :expected-run-as-user-source "unknown"
                                   :profile->defaults {"webapp" {"concurrency-level" 120}}
@@ -1239,6 +1242,7 @@
     (testing "only token from header without permitted-user"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "current-request-user"}
              (service-description {:service-description-template {"cmd" "token-cmd"}}
@@ -1251,6 +1255,7 @@
     (testing "only token from header with permitted-user"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "token-user"
               "run-as-user" "token-user"}
              (service-description {:service-description-template {"cmd" "token-cmd"
@@ -1265,6 +1270,7 @@
     (testing "token and run-as-user from header with permitted-user"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "on-the-fly-ru"}
              (service-description {:headers {"run-as-user" "on-the-fly-ru"}
@@ -1280,7 +1286,8 @@
 
     (testing "only token from host with defaults missing permitted user"
       (is (= {"cmd" "token-cmd"
-              "health-check-url" "/ping"}
+              "health-check-url" "/ping"
+              "liveness-check-url" "/ping"}
              (service-description {:service-description-template {"cmd" "token-cmd"}}
                                   :expected-run-as-user-source "unknown"
                                   :profile->defaults {"webapp" {"concurrency-level" 120}}
@@ -1289,6 +1296,7 @@
     (testing "only token from header with defaults missing permitted user"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "current-request-user"}
              (service-description {:service-description-template {"cmd" "token-cmd"}}
@@ -1299,7 +1307,8 @@
 
     (testing "only token from host with dummy header"
       (is (= {"cmd" "token-cmd"
-              "health-check-url" "/ping"}
+              "health-check-url" "/ping"
+              "liveness-check-url" "/ping"}
              (service-description {:service-description-template {"cmd" "token-cmd"}}
                                   :expected-run-as-user-source "unknown"
                                   :profile->defaults {"webapp" {"concurrency-level" 120}}
@@ -1309,6 +1318,7 @@
     (testing "only on-the-fly"
       (is (= {"cmd" "on-the-fly-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "bob"
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"}}
@@ -1320,6 +1330,7 @@
     (testing "token host with non-intersecting values"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "bob"
               "run-as-user" "current-request-user"
               "version" "on-the-fly-version"}
@@ -1334,6 +1345,7 @@
       (is (= {"cmd" "token-cmd"
               "concurrency-level" 5
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "bob"
               "run-as-user" "current-request-user"
               "version" "on-the-fly-version"}
@@ -1352,6 +1364,7 @@
               "env" {"VAR_1" "VALUE-1"
                      "VAR_2" "VALUE-2"}
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "bob"
               "run-as-user" "current-request-user"
               "version" "on-the-fly-version"}
@@ -1376,6 +1389,7 @@
                      "VAR_3" "VALUE-3p"
                      "VAR_4" "VALUE-4p"}
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "bob"
               "run-as-user" "current-request-user"
               "version" "on-the-fly-version"}
@@ -1401,6 +1415,7 @@
                      "VAR_2" "VALUE-2p"
                      "VAR_3" "VALUE-3p"}
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "bob"
               "run-as-user" "current-request-user"
               "version" "on-the-fly-version"}
@@ -1429,6 +1444,7 @@
                           "env" {"VAR_1" "VALUE-1"
                                  "VAR_2" "VALUE-2"}
                           "health-check-url" "/ping"
+                          "liveness-check-url" "/ping"
                           "permitted-user" "bob"
                           "run-as-user" "test-user"}
                    exclusive-mode? (assoc-in ["env" "WAITER_CONFIG_TOKEN"] test-token))
@@ -1454,6 +1470,7 @@
                                  "VAR_3" "VALUE-3p"
                                  "VAR_4" "VALUE-4p"}
                           "health-check-url" "/ping"
+                          "liveness-check-url" "/ping"
                           "permitted-user" "bob"
                           "run-as-user" "test-user"}
                    exclusive-mode? (assoc-in ["env" "WAITER_CONFIG_TOKEN"] test-token))
@@ -1480,6 +1497,7 @@
                                  "VAR_2" "VALUE-2p"
                                  "VAR_3" "VALUE-3p"}
                           "health-check-url" "/ping"
+                          "liveness-check-url" "/ping"
                           "permitted-user" "bob"
                           "run-as-user" "test-user"}
                    exclusive-mode? (assoc-in ["env" "WAITER_CONFIG_TOKEN"] test-token))
@@ -1502,6 +1520,7 @@
       (is (= {"cmd" "on-the-fly-cmd"
               "concurrency-level" 6
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "bob"
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
@@ -1515,6 +1534,7 @@
     (testing "token header with intersecting values"
       (is (= {"cmd" "on-the-fly-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "bob"
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"}
@@ -1527,6 +1547,7 @@
     (testing "intersecting values with additional fields"
       (is (= {"cmd" "on-the-fly-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "name" "token-name"
               "permitted-user" "bob"
               "run-as-user" "current-request-user"
@@ -1543,6 +1564,7 @@
     (testing "permitted user from token"
       (is (= {"cmd" "on-the-fly-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "token-pu"
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"}
@@ -1554,6 +1576,7 @@
     (testing "permitted user from on-the-fly"
       (is (= {"cmd" "on-the-fly-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "on-the-fly-pu"
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
@@ -1565,6 +1588,7 @@
     (testing "permitted user intersecting"
       (is (= {"cmd" "on-the-fly-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "on-the-fly-pu"
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
@@ -1577,6 +1601,7 @@
     (testing "run as user and permitted user only in token"
       (is (= {"cmd" "on-the-fly-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "token-pu"
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"}
@@ -1589,6 +1614,7 @@
     (testing "run as user and permitted user only in token with run-as-user matching request user"
       (is (= {"cmd" "on-the-fly-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "token-pu"
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"}
@@ -1601,6 +1627,7 @@
     (testing "run as user and permitted user from token and no on-the-fly headers"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "token-pu"
               "run-as-user" "token-ru"}
              (service-description {:service-description-template {"cmd" "token-cmd"
@@ -1613,6 +1640,7 @@
     (testing "missing permitted user in token"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "bob"
               "run-as-user" "token-ru"}
              (service-description {:service-description-template {"cmd" "token-cmd"
@@ -1625,6 +1653,7 @@
     (testing "run as user from on-the-fly"
       (is (= {"cmd" "on-the-fly-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "on-the-fly-ru"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
@@ -1639,6 +1668,7 @@
     (testing "run as user intersecting"
       (is (= {"cmd" "on-the-fly-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "on-the-fly-ru"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
@@ -1654,6 +1684,7 @@
     (testing "run as user provided from on-the-fly header with hostname token"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "chris"}
              (service-description {:headers {"run-as-user" "chris"}
@@ -1668,6 +1699,7 @@
     (testing "run as user star from on-the-fly header with hostname token"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "current-request-user"}
              (service-description {:headers {"run-as-user" "*"}
@@ -1682,6 +1714,7 @@
     (testing "run as user star from hostname token"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "bob"}
              (service-description {:headers {}
                                    :service-description-template {"cmd" "token-cmd"
@@ -1695,6 +1728,7 @@
     (testing "run as user star from on-the-fly token"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "current-request-user"}
              (service-description {:headers {}
@@ -1708,6 +1742,7 @@
     (testing "run as user star from on-the-fly headers without permitted-user"
       (is (= {"cmd" "on-the-fly-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
@@ -1723,6 +1758,7 @@
     (testing "run as user star from on-the-fly headers with permitted-user"
       (is (= {"cmd" "on-the-fly-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "alice"
               "run-as-user" "current-request-user"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
@@ -1740,6 +1776,7 @@
     (testing "run as user in headers with permitted-user * in tokens"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "header-user"}
              (service-description {:headers {"run-as-user" "header-user"}
@@ -1765,6 +1802,7 @@
             {"scale-factor" 0.3})
           (is (= (assoc basic-service-description
                    "health-check-url" "/ping"
+                   "liveness-check-url" "/ping"
                    "permitted-user" "bob"
                    "scale-factor" 0.3)
                  (service-description {:headers {"cmd" "on-the-fly-cmd"
@@ -1783,6 +1821,7 @@
             "current-request-user")
           (is (= (assoc basic-service-description
                    "health-check-url" "/ping"
+                   "liveness-check-url" "/ping"
                    "permitted-user" "bob")
                  (service-description {:headers {"cmd" "on-the-fly-cmd"
                                                  "run-as-user" "on-the-fly-ru"}}
@@ -1795,6 +1834,7 @@
     (testing "override token metadata from headers"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "bob"
               "run-as-user" "current-request-user"
               "metadata" {"e" "f"}}
@@ -1809,6 +1849,7 @@
     (testing "sanitize metadata"
       (is (= {"cmd" "token-cmd"
               "health-check-url" "/ping"
+              "liveness-check-url" "/ping"
               "permitted-user" "current-request-user"
               "run-as-user" "current-request-user"
               "metadata" {"abc" "DEF"}}
@@ -1822,6 +1863,7 @@
     (testing "metric group from token"
       (is (= {"cmd" "on-the-fly-cmd"
               "health-check-url" "/health"
+              "liveness-check-url" "/health"
               "run-as-user" "current-request-user"
               "metric-group" "token-mg"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"}
@@ -1833,6 +1875,7 @@
     (testing "metric group from on-the-fly"
       (is (= {"cmd" "on-the-fly-cmd"
               "health-check-url" "/health"
+              "liveness-check-url" "/health"
               "run-as-user" "current-request-user"
               "metric-group" "on-the-fly-mg"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
@@ -1844,6 +1887,7 @@
     (testing "metric group intersecting"
       (is (= {"cmd" "on-the-fly-cmd"
               "health-check-url" "/health"
+              "liveness-check-url" "/health"
               "run-as-user" "current-request-user"
               "metric-group" "on-the-fly-mg"}
              (service-description {:headers {"cmd" "on-the-fly-cmd"
@@ -1856,6 +1900,7 @@
     (testing "auto-populate run-as-user"
       (is (= {"cmd" "some-cmd"
               "health-check-url" "/health"
+              "liveness-check-url" "/health"
               "run-as-user" "current-request-user"
               "permitted-user" "current-request-user"
               "metric-group" "token-mg"}
@@ -1869,6 +1914,7 @@
     (testing "disable instance-expiry"
       (is (= {"cmd" "some-cmd"
               "health-check-url" "/health"
+              "liveness-check-url" "/health"
               "instance-expiry-mins" 0}
              (service-description {:service-description-template {"cmd" "some-cmd"
                                                                   "instance-expiry-mins" 0}}
@@ -1883,6 +1929,7 @@
         (testing "from token"
           (is (= {"cmd" "web-cmd"
                   "health-check-url" "/ping"
+                  "liveness-check-url" "/ping"
                   "profile" "webapp"}
                  (service-description {:headers {}
                                        :service-description-template {"profile" "webapp"}}
@@ -1891,6 +1938,7 @@
                                       :service-description-defaults service-description-defaults)))
           (is (= {"cmd" "token-cmd"
                   "health-check-url" "/ping"
+                  "liveness-check-url" "/ping"
                   "profile" "webapp"}
                  (service-description {:headers {}
                                        :service-description-template {"cmd" "token-cmd"
@@ -1900,6 +1948,7 @@
                                       :service-description-defaults service-description-defaults)))
           (is (= {"cmd" "on-the-fly-cmd"
                   "health-check-url" "/ping"
+                  "liveness-check-url" "/ping"
                   "profile" "webapp"
                   "run-as-user" "current-request-user"}
                  (service-description {:headers {"cmd" "on-the-fly-cmd"}
@@ -1912,6 +1961,7 @@
         (testing "from on-the-fly"
           (is (= {"cmd" "web-cmd"
                   "health-check-url" "/ping"
+                  "liveness-check-url" "/ping"
                   "profile" "webapp"
                   "run-as-user" "current-request-user"}
                  (service-description {:headers {"profile" "webapp"}}
@@ -1920,6 +1970,7 @@
                                       :service-description-defaults service-description-defaults)))
           (is (= {"cmd" "on-the-fly-cmd"
                   "health-check-url" "/ping"
+                  "liveness-check-url" "/ping"
                   "profile" "webapp"
                   "run-as-user" "current-request-user"}
                  (service-description {:headers {"cmd" "on-the-fly-cmd"
@@ -3733,3 +3784,14 @@
             "permitted-user" "*"
             "service-mapping" "legacy"}
            (token-sequence->merged-data token->token-data ["service" "webapp" "rpc"])))))
+
+(deftest test-apply-param-to-param-defaults
+  (let [data {"alpha" 1 "beta" 2 "gamma" nil}]
+    (is (= (apply-param-to-param-defaults data {"gamma" "beta"})
+           {"alpha" 1 "beta" 2 "gamma" 2}))
+    (is (= (apply-param-to-param-defaults data {"delta" "alpha"})
+           {"alpha" 1 "beta" 2 "gamma" nil "delta" 1}))
+    (is (= (apply-param-to-param-defaults data {"delta" "epsilon"})
+           {"alpha" 1 "beta" 2 "gamma" nil}))
+    (is (= (apply-param-to-param-defaults data {"alpha" "beta"})
+           data))))

--- a/waiter/test/waiter/token_history_test.clj
+++ b/waiter/test/waiter/token_history_test.clj
@@ -53,7 +53,7 @@
          token-defaults {"fallback-period-secs" 300
                          "service-mapping" "legacy"}
          metric-group-mappings []
-         attach-service-defaults-fn #(sd/merge-defaults % service-description-defaults profile->defaults metric-group-mappings)
+         attach-service-defaults-fn #(sd/merge-defaults % service-description-defaults profile->defaults metric-group-mappings {})
          attach-token-defaults-fn #(sd/attach-token-defaults % token-defaults profile->defaults)
          username "test-user"
          assoc-run-as-user-approved? (constantly false)


### PR DESCRIPTION
## Changes proposed in this PR

- Add new parameters for liveness checks (mirroring health-check-* params)

## Why are we making these changes?

When using the kubernetes scheduler, Waiter will implicitly add a livenessProbe using health check parameters (which are also used to create a readinessProbe). There are situations where service may want different behavior for liveness and readiness. This change will enable that flexibility.
