### PR TITLE
Add full metric logs to metrics endpoint

### DIFF
--- a/waiter/src/waiter/metrics_sync.clj
+++ b/waiter/src/waiter/metrics_sync.clj
@@ -563,9 +563,7 @@
         (throw-error-response-if-invalid-body
           #(nat-int? %) service-metrics [service-id instance-id "metrics" "active-request-count"] "Must be non-negative integer.")))
 
-    (log/info "received service metrics from external source." {:service-ids-preview (take 10 (keys service-metrics))
-                                                                :service-ids-count (count (keys service-metrics))
-                                                                :service-metrics (take 10 (vals service-metrics))})
+    (log/info "received service metrics from external source." {:service-metric-pairs-preview (take 10 service-metrics)})
     (let [clean-service-metrics (clean-service-id->instance-id->metric query-state-fn service-metrics)]
       (log/info "removed irrelevant services and instances." {:service-ids-preview (take 10 (keys clean-service-metrics))
                                                               :service-ids-count (count (keys clean-service-metrics))})

--- a/waiter/src/waiter/metrics_sync.clj
+++ b/waiter/src/waiter/metrics_sync.clj
@@ -564,8 +564,8 @@
           #(nat-int? %) service-metrics [service-id instance-id "metrics" "active-request-count"] "Must be non-negative integer.")))
 
     (log/info "received service metrics from external source." {:service-ids-preview (take 10 (keys service-metrics))
-                                                                :service-metrics (take 10 (vals service-metrics))
-                                                                :service-ids-count (count (keys service-metrics))})
+                                                                :service-ids-count (count (keys service-metrics))
+                                                                :service-metrics (take 10 (vals service-metrics))})
     (let [clean-service-metrics (clean-service-id->instance-id->metric query-state-fn service-metrics)]
       (log/info "removed irrelevant services and instances." {:service-ids-preview (take 10 (keys clean-service-metrics))
                                                               :service-ids-count (count (keys clean-service-metrics))})

--- a/waiter/src/waiter/metrics_sync.clj
+++ b/waiter/src/waiter/metrics_sync.clj
@@ -564,6 +564,7 @@
           #(nat-int? %) service-metrics [service-id instance-id "metrics" "active-request-count"] "Must be non-negative integer.")))
 
     (log/info "received service metrics from external source." {:service-ids-preview (take 10 (keys service-metrics))
+                                                                :service-metrics (take 10 (vals service-metrics))
                                                                 :service-ids-count (count (keys service-metrics))})
     (let [clean-service-metrics (clean-service-id->instance-id->metric query-state-fn service-metrics)]
       (log/info "removed irrelevant services and instances." {:service-ids-preview (take 10 (keys clean-service-metrics))


### PR DESCRIPTION
## Changes proposed in this PR

- add the actual metrics to the logs with a preview of the first 10 services
```
received service metrics from external source. {:service-metric-pairs-preview ([waiter-service-waimetsyninttestesbypseruseextmetforoutreq1502376634800-a75dcb48473a39fc866422e05ea4a2cf {waiter-service-waimetsyninttestesbypseruseextmetforoutreq1502376634800-a75dcb48473a39fc866422e05ea4a2cf.waimetsyninttestesbypser-a75dcb48473a39fc866422e05ea4a2cf-9rz5s-0 {updated-at 3000-05-31T14:50:44.956Z, metrics {last-request-time 2022-05-31T14:50:44.956Z, active-request-count 4}}}])}
```

## Why are we making these changes?

- this will help if we want to debug and confirm what metrics are being provided
