### PR TITLE
adds support for an endpoint that decodes the consent cookie

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -165,6 +165,7 @@
                      "waiter-auth" :waiter-auth-handler-fn
                      "waiter-consent" {"" :waiter-acknowledge-consent-handler-fn
                                        ["/" [#".*" :path]] :waiter-request-consent-handler-fn}
+                     "waiter-consent-cookie" :waiter-consent-cookie-handler-fn
                      "waiter-interstitial" {["/" [#".*" :path]] :waiter-request-interstitial-handler-fn}
                      "waiter-kill-instance" {["/" :service-id] :kill-instance-handler-fn}
                      "waiter-ping" :ping-service-handler
@@ -2074,6 +2075,17 @@
                                               "x-waiter-auth-principal" (str principal)
                                               "x-waiter-auth-user" (str user)}
                                     :status http-200-ok}))))
+   :waiter-consent-cookie-handler-fn (pc/fnk [[:routines wrap-service-discovery-fn]
+                                              [:state passwords]
+                                              wrap-ignore-disabled-auth-fn wrap-secure-request-fn]
+                                       (let [password (first passwords)]
+                                         (->
+                                           (fn inner-waiter-consent-cookie-handler-fn [request]
+                                             (cookie-support/consent-cookie-handler
+                                               password "x-waiter-consent" sd/consent-cookie->map request))
+                                           wrap-secure-request-fn
+                                           wrap-ignore-disabled-auth-fn
+                                           wrap-service-discovery-fn)))
    :waiter-request-consent-handler-fn (pc/fnk [[:routines request->consent-service-id token->service-description-template wrap-service-discovery-fn]
                                                [:settings consent-expiry-days]
                                                wrap-ignore-disabled-auth-fn wrap-secure-request-fn]

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -1507,6 +1507,17 @@
                   nil))
         (vec))))
 
+(defn consent-cookie->map
+  "Converts the consent cookie value to a map"
+  [cookie-value]
+  (let [[mode issue-time service-id-or-token owner] cookie-value]
+    (cond-> {}
+      issue-time (assoc "issue-time" issue-time)
+      mode (assoc "mode" mode)
+      (= mode "service") (assoc "service-id" service-id-or-token)
+      (= mode "token") (assoc "token" service-id-or-token)
+      owner (assoc "owner" owner))))
+
 (defn assoc-run-as-user-approved?
   "Deconstructs the decoded cookie and validates whether the service has been pre-approved.
    The validation step includes:

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -2770,6 +2770,19 @@
     (is (= ["token" current-time-ms] (consent-cookie-value clock "token" nil "token-id" {})))
     (is (= ["token" current-time-ms "token-id" "user"] (consent-cookie-value clock "token" nil "token-id" {"owner" "user"})))))
 
+(deftest test-consent-cookie->map
+  (let [current-time (t/now)
+        current-time-ms (.getMillis ^DateTime current-time)]
+    (is (= {} (consent-cookie->map nil)))
+    (is (= {"issue-time" current-time-ms "mode" "unknown"}
+           (consent-cookie->map ["unknown" current-time-ms])))
+    (is (= {"issue-time" current-time-ms "mode" "service" "service-id" "service-id-1"}
+           (consent-cookie->map ["service" current-time-ms "service-id-1"])))
+    (is (= {"issue-time" current-time-ms "mode" "token" "token" "token-1"}
+           (consent-cookie->map ["token" current-time-ms "token-1"])))
+    (is (= {"issue-time" current-time-ms "mode" "token" "owner" "john" "token" "token-1"}
+           (consent-cookie->map ["token" current-time-ms "token-1" "john"])))))
+
 (deftest test-assoc-run-as-user-approved?
   (let [current-time (t/now)
         current-time-ms (.getMillis ^DateTime current-time)


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for an endpoint that decodes the consent cookie

## Why are we making these changes?

We wish to provide the ability for hosted services to be able to determine the contents of the consent cookie.


