### PR TITLE
adds service description validation to override api

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1760,13 +1760,15 @@
                                       retrieve-token-based-fallback-fn service-id->service-description-fn
                                       service-id->metrics-fn service-id->references-fn service-id->source-tokens-entries-fn
                                       token->token-hash request)))))
-   :service-override-handler-fn (pc/fnk [[:routines allowed-to-manage-service?-fn make-inter-router-requests-sync-fn]
+   :service-override-handler-fn (pc/fnk [[:routines allowed-to-manage-service?-fn make-inter-router-requests-sync-fn
+                                          validate-service-description-fn]
                                          [:state kv-store]
                                          wrap-secure-request-fn]
                                   (wrap-secure-request-fn
                                     (fn service-override-handler-fn [{:as request {:keys [service-id]} :route-params}]
                                       (handler/override-service-handler kv-store allowed-to-manage-service?-fn
-                                                                        make-inter-router-requests-sync-fn service-id request))))
+                                                                        make-inter-router-requests-sync-fn validate-service-description-fn
+                                                                        service-id request))))
    :service-refresh-handler-fn (pc/fnk [[:state kv-store]
                                         wrap-router-auth-fn]
                                  (wrap-router-auth-fn

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -107,8 +107,8 @@
    (s/optional-key "load-balancing") schema/valid-load-balancing
    (s/optional-key "max-instances") (s/both s/Int (s/pred #(<= minimum-min-instances % 1000) 'between-one-and-1000))
    (s/optional-key "min-instances") (s/both s/Int (s/pred #(<= minimum-min-instances % 1000) 'between-one-and-1000))
-   (s/optional-key "scale-factor") schema/positive-fraction-less-than-or-equal-to-2
    (s/optional-key "scale-down-factor") schema/positive-fraction-less-than-1
+   (s/optional-key "scale-factor") schema/positive-fraction-less-than-or-equal-to-2
    (s/optional-key "scale-up-factor") schema/positive-fraction-less-than-1
    ; per-request related
    (s/optional-key "max-queue-length") schema/positive-int
@@ -649,6 +649,12 @@
                                              parameter->issues :profile
                                              (str "profile must be a non-empty string"
                                                   (compute-valid-profiles-str profile->defaults)))
+                                           (attach-error-message-for-parameter
+                                             parameter->issues :scale-down-factor "scale-down-factor must be a double in the range (0, 1).")
+                                           (attach-error-message-for-parameter
+                                             parameter->issues :scale-factor "scale-factor must be a double in the range (0, 2].")
+                                           (attach-error-message-for-parameter
+                                             parameter->issues :scale-up-factor "scale-up-factor must be a double in the range (0, 1).")
                                            (attach-error-message-for-parameter
                                              parameter->issues :termination-grace-period-secs
                                              "termination-grace-period-secs must be an integer in the range [0, 300].")

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -53,6 +53,11 @@
                  m))
              {} m))
 
+(defn keyset
+  "Returns a set that contains the keys of the map."
+  [m]
+  (-> m (keys) (set)))
+
 (defn keys->nested-map
   "Takes a map with string keys and returns a map with a nested structure where
    the string keys were split using the regex `key-split` to create the nested

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -2490,6 +2490,17 @@
         (assoc valid-description "cmd" (str/join "" (repeat 150 "c")))
         constraints-schema profile->defaults config "cmd must be at most 100 characters"))
 
+    (testing "testing scaling parameters"
+      (run-validate-schema-test
+        (assoc valid-description "scale-down-factor" 10)
+        constraints-schema profile->defaults config "scale-down-factor must be a double in the range (0, 1)")
+      (run-validate-schema-test
+        (assoc valid-description "scale-factor" 10)
+        constraints-schema profile->defaults config "scale-factor must be a double in the range (0, 2]")
+      (run-validate-schema-test
+        (assoc valid-description "scale-up-factor" 10)
+        constraints-schema profile->defaults config "scale-up-factor must be a double in the range (0, 1)"))
+
     (testing "testing grace-period-secs"
       (doseq [grace-period-secs [9000 "5" -1]]
         (run-validate-schema-test


### PR DESCRIPTION
## Changes proposed in this PR

- adds service description validation to override api

## Why are we making these changes?

There are other regions of code that assume service description, formed after merging in overrides, is a valid service description as per the schema. Such assumptions fail when the override api allows registering invalid values.


