### PR TITLE
ensures scale-service handles integer values during scaling

### DIFF
--- a/waiter/src/waiter/scaling.clj
+++ b/waiter/src/waiter/scaling.clj
@@ -197,7 +197,7 @@
 
 (defn compute-scale-amount-restricted-by-quanta
   "Computes the new scale amount subject to quanta restrictions.
-   The returned value is guaranteed to be at least 1."
+   The returned value is guaranteed to be at least 1 and an integer."
   [service-description quanta-constraints scale-amount]
   {:pre [(seq service-description)
          (pos? scale-amount)
@@ -206,7 +206,8 @@
   (-> scale-amount
       (min (quot (:cpus quanta-constraints) (get service-description "cpus"))
            (quot (:mem quanta-constraints) (get service-description "mem")))
-      (max 1)))
+      (max 1)
+      (int)))
 
 (defn service-scaling-executor
   "The scaling executor that scales individual services up or down.

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -1025,12 +1025,12 @@
   (scale-service [this service-id scale-to-instances _]
     (ss/try+
       (if-let [service (service-id->service this service-id)]
-        (do
-          (scale-service-up-to this service scale-to-instances)
+        (let [scale-to-instances-int (int scale-to-instances)]
+          (scale-service-up-to this service scale-to-instances-int)
           {:success true
            :status http-200-ok
            :result :scaled
-           :message (str "Scaled to " scale-to-instances)})
+           :message (str "Scaled to " scale-to-instances-int)})
         (do
           (log/error "cannot scale missing service" service-id)
           {:success false

--- a/waiter/test/waiter/scaling_test.clj
+++ b/waiter/test/waiter/scaling_test.clj
@@ -249,6 +249,7 @@
 (deftest test-compute-scale-amount-restricted-by-quanta
   (is (= 1 (compute-scale-amount-restricted-by-quanta {"cpus" 10 "mem" 1024} {:cpus 32 :mem 4608} 1)))
   (is (= 3 (compute-scale-amount-restricted-by-quanta {"cpus" 10 "mem" 1024} {:cpus 32 :mem 4608} 3)))
+  (is (= 3 (compute-scale-amount-restricted-by-quanta {"cpus" 10.0 "mem" 1024} {:cpus 32.0 :mem 4608} 3)))
   (is (= 4 (compute-scale-amount-restricted-by-quanta {"cpus" 5 "mem" 1024} {:cpus 32 :mem 4608} 8)))
   (is (= 3 (compute-scale-amount-restricted-by-quanta {"cpus" 10 "mem" 1024} {:cpus 32 :mem 4608} 8)))
   (is (= 2 (compute-scale-amount-restricted-by-quanta {"cpus" 10 "mem" 2048} {:cpus 32 :mem 4608} 8)))


### PR DESCRIPTION
## Changes proposed in this PR

- ensures scale-service handles integer values during scaling

## Why are we making these changes?

The kubernetes scheduler needs to operate on integer values when requesting to scale up the replica count in a ReplicaSet. The Kubernetes API requires the `replica` value to be an integer.
https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/replica-set-v1/

<img width="719" alt="Screen Shot 2022-08-23 at 10 23 58 AM" src="https://user-images.githubusercontent.com/6611249/186198076-4ff229cf-078d-49b8-9a00-7d6c0db1f684.png">



