### PR TITLE
Fix cluster calculation in token integration test

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -48,6 +48,7 @@
         cluster-calculator-config (-> settings-json
                                       (get-in [:token-config :cluster-calculator])
                                       (update :kind keyword)
+                                      (update-in [:configured :host->cluster] walk/stringify-keys)
                                       (as-> $ (update-in $ [(:kind $) :factory-fn] symbol)))
         cluster-calculator (utils/create-component cluster-calculator-config
                                                    :context {:default-cluster default-cluster})]


### PR DESCRIPTION
## Changes proposed in this PR

- The host->cluster map gets keywordized by the `waiter-settings` fn when it should be a string map

## Why are we making these changes?

- This is a bug in how we calculate the cluster in our integration tests
