### PR TITLE
makes the token auth failure message configurable

### DIFF
--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -1711,7 +1711,9 @@ class WaiterCliTest(util.WaiterTest):
                 util.delete_token(self.waiter_url, token_name)
         else:
             self.assertEqual(1, cp.returncode, cp.stderr)
-            self.assertIn('Cannot run as user: FAKE_USERNAME', cli.decode(cp.stderr))
+            decoded_stderr = cli.decode(cp.stderr)
+            self.assertIn('cannot run as user', decoded_stderr)
+            self.assertIn('FAKE_USERNAME', decoded_stderr)
 
     def test_create_token_admin_mode(self):
         self.__test_create_update_token_admin_mode('create', self.token_name(), True)

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -352,6 +352,7 @@
               :bad-socket "Backend is closing socket without responding (ensure backend-proto is correctly configured)"
               :bad-startup-command "Invalid startup command"
               :cannot-connect "Unable to connect to run health checks"
+              :cannot-run-as-user "{role} '{role-user}' cannot run as user '{run-as-user}'"
               :cannot-identify-service "Unable to identify service using waiter headers/token"
               :health-check-requires-authentication "Health check requires authentication"
               :health-check-timed-out "Health check timed out"

--- a/waiter/src/waiter/token_validator.clj
+++ b/waiter/src/waiter/token_validator.clj
@@ -4,7 +4,8 @@
             [clojure.tools.logging :as log]
             [waiter.authorization :as authz]
             [waiter.service-description :as sd]
-            [waiter.status-codes :refer :all]))
+            [waiter.status-codes :refer :all]
+            [waiter.util.utils :as utils]))
 
 (defprotocol TokenValidator
   "A protocol for validating a new token configuration"
@@ -112,7 +113,7 @@
           ;; only check run-as-user rules when not running as editor, editor cannot change run-as-user from previous check
           (when (and (not editing?) run-as-user (not= "*" run-as-user))
             (when-not (authz/run-as? entitlement-manager authenticated-user run-as-user)
-              (throw (ex-info (str "Cannot run as user: " run-as-user)
+              (throw (ex-info (utils/formatted-message :cannot-run-as-user {"role" "Authenticated user" "role-user" authenticated-user "run-as-user" run-as-user})
                               {:authenticated-user authenticated-user
                                :run-as-user run-as-user
                                :status http-403-forbidden
@@ -148,7 +149,7 @@
           ;; owner must be able to run as run-as-user
           (when (and run-as-user (not= "*" run-as-user))
             (when-not (authz/own? entitlement-manager owner run-as-user)
-              (throw (ex-info (str "Owner: " owner " cannot run as user: " run-as-user)
+              (throw (ex-info (utils/formatted-message :cannot-run-as-user {"role" "Owner" "role-user" owner "run-as-user" run-as-user})
                               {:authenticated-user authenticated-user
                                :owner owner
                                :run-as-user run-as-user

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -698,6 +698,17 @@
     [key]
     (@messages key))
 
+  (defn formatted-message
+    "Returns the message corresponding to the provided key with placeholders from the context replaced."
+    [key context]
+    (when-let [template-message (message key)]
+      (loop [[[k v] & remaining-context] (seq context)
+             loop-message template-message]
+        (if (nil? k)
+          loop-message
+          (recur remaining-context
+                 (str/replace loop-message (str "{" k "}") v))))))
+
   (defn load-messages
     "Loads m into the messages map"
     [m]


### PR DESCRIPTION
## Changes proposed in this PR

- makes the token auth failure message configurable

## Why are we making these changes?

Making the message configurable allows us to change the message without having to change the associated code.


