### PR TITLE
Use x-waiter-token header instead of host header in test-token-administer-unaffected-by-run-as-user-permissions

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -769,7 +769,7 @@
                                        :name service-id-prefix
                                        :owner (retrieve-username)
                                        :token token}
-                    response (post-token waiter-url token-description :headers {"host" token})]
+                    response (post-token waiter-url token-description :token token)]
                 (assert-response-status response http-200-ok))
 
               (let [{:keys [body headers]} (get-token waiter-url token)


### PR DESCRIPTION
## Changes proposed in this PR

- use x-waiter-token instead of the host header

## Why are we making these changes?

- when the token gets created it does not trigger the cluster calculator to use the `waiter-url` because the host header is the token. The cluster calculator falls back on the `default-cluster` which may be configured differently than the `waiter-url`.
