### PR TITLE
adds support for configuring the byte buffer pool used in http clients

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -853,6 +853,15 @@
                                ;; x-waiter-async-request-timeout request header:
                                :async-request-timeout-ms 60000
 
+                               ;; The capacity factor (an int) of the MappedByteBufferPool.
+                               :byte-buffer-capacity-factor 2048
+
+                               ;; The percentage of the JVM heap that can be used in the MappedByteBufferPool max heap memory in individual clients.
+                               :byte-buffer-heap-percent 0.25
+
+                               ;; The maximum MappedByteBufferPool queue length.
+                               :byte-buffer-max-queue-length 32
+
                                ;; Size in the size of the buffer used to write/read individual request/response fragments to/from the backend.
                                ;; The value must be a positive integer, defaults to 32 KiB.
                                :client-buffer-size 32768

--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -45,7 +45,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20220407_144841-gd100014"
+                 [twosigma/jet "0.7.10-20220829_161214-g1f873ca"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -681,8 +681,13 @@
                             (utils/create-component entitlement-config :context context)))
    :fallback-state-atom (pc/fnk [] (atom {:available-service-ids #{}
                                           :healthy-service-ids #{}}))
-   :http-client-properties (pc/fnk [[:settings [:instance-request-properties client-buffer-size client-connection-idle-timeout-ms connection-timeout-ms]]]
-                             {:client-name "waiter-client"
+   :http-client-properties (pc/fnk [[:settings [:instance-request-properties
+                                                byte-buffer-capacity-factor byte-buffer-heap-percent byte-buffer-max-queue-length
+                                                client-buffer-size client-connection-idle-timeout-ms connection-timeout-ms]]]
+                             {:byte-buffer-capacity-factor byte-buffer-capacity-factor
+                              :byte-buffer-heap-percent byte-buffer-heap-percent
+                              :byte-buffer-max-queue-length byte-buffer-max-queue-length
+                              :client-name "waiter-client"
                               :conn-timeout connection-timeout-ms
                               :follow-redirects? false
                               :request-buffer-size client-buffer-size

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -71,7 +71,7 @@
                                                   (s/required-key :async-request-max-timeout-ms) schema/positive-int
                                                   (s/required-key :async-request-timeout-ms) schema/positive-int
                                                   (s/required-key :byte-buffer-capacity-factor) (s/maybe schema/non-negative-int)
-                                                  (s/required-key :byte-buffer-heap-percent) (s/maybe schema/positive-num)
+                                                  (s/required-key :byte-buffer-heap-percent) (s/maybe schema/positive-fraction-less-than-or-equal-to-1)
                                                   (s/required-key :byte-buffer-max-queue-length) (s/maybe schema/non-negative-int)
                                                   (s/required-key :client-buffer-size) schema/positive-int
                                                   (s/required-key :client-connection-idle-timeout-ms) schema/positive-int

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -70,6 +70,9 @@
                                                   (s/required-key :async-request-max-status-checks) schema/positive-int
                                                   (s/required-key :async-request-max-timeout-ms) schema/positive-int
                                                   (s/required-key :async-request-timeout-ms) schema/positive-int
+                                                  (s/required-key :byte-buffer-capacity-factor) (s/maybe schema/non-negative-int)
+                                                  (s/required-key :byte-buffer-heap-percent) (s/maybe schema/positive-num)
+                                                  (s/required-key :byte-buffer-max-queue-length) (s/maybe schema/non-negative-int)
                                                   (s/required-key :client-buffer-size) schema/positive-int
                                                   (s/required-key :client-connection-idle-timeout-ms) schema/positive-int
                                                   (s/required-key :connection-timeout-ms) schema/positive-int
@@ -327,6 +330,9 @@
                                  :async-request-max-status-checks 50
                                  :async-request-max-timeout-ms (-> 4 t/hours t/in-millis)
                                  :async-request-timeout-ms 60000
+                                 :byte-buffer-capacity-factor nil
+                                 :byte-buffer-heap-percent nil
+                                 :byte-buffer-max-queue-length nil
                                  :client-buffer-size 32768 ;; 32 KiB
                                  :client-connection-idle-timeout-ms 10000 ; 10 seconds
                                  :connection-timeout-ms 5000 ; 5 seconds

--- a/waiter/src/waiter/util/http_utils.clj
+++ b/waiter/src/waiter/util/http_utils.clj
@@ -169,7 +169,8 @@
     :or {clear-content-decoders true}
     :as config}]
   (let [^HttpClient client
-        (http/client (cond-> (select-keys config [:client-name :follow-redirects? :request-buffer-size :response-buffer-size :transport])
+        (http/client (cond-> (select-keys config [:byte-buffer-capacity-factor :byte-buffer-heap-percent :byte-buffer-max-queue-length
+                                                  :client-name :follow-redirects? :request-buffer-size :response-buffer-size :transport])
                        (some? conn-timeout) (assoc :connect-timeout conn-timeout)
                        (some? socket-timeout) (assoc :idle-timeout socket-timeout)))]
     ;; disable checks on www-authenticate header on 401 responses


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for configuring the byte buffer pool used in http clients

## Why are we making these changes?

We wish to limit the size of the underlying MappedByteBufferPool in the jetty http clients.

Uses changes from https://github.com/twosigma/jet/pull/60


