### PR TITLE
promotes common request timeout headers to token parameters

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -884,8 +884,7 @@
                                :output-buffer-size 4096
 
                                ;; The default amount of time (milliseconds) each request will wait in
-                               ;; the Waiter queue before an instance is available to process it. This
-                               ;; can be overriden in the service description:
+                               ;; the Waiter queue before an instance is available to process it.
                                :queue-timeout-ms 300000
 
                                ;; Configures the idle timeout (milliseconds) in the response output stream:
@@ -1146,10 +1145,20 @@
                                  ;; By default, Waiter allows non-secure HTTP requests from clients to services.
                                  "https-redirect" false
 
+                                 ;; The amount of time (milliseconds) each request will wait in
+                                 ;; the Waiter queue before an instance is available to process it.
+                                 "queue-timeout-ms" 300000
+
+                                 ;; The HTTP idle timeout (milliseconds) for initial response bytes from the backend.
+                                 "socket-timeout-ms" 900000
+
                                  ;; Stale services are detected by looking at the version of the
                                  ;; token used to create them, such services will have their idle timeout
                                  ;; reduced to stale-timeout-mins + fallback-period-secs.
-                                 "stale-timeout-mins" 15}}
+                                 "stale-timeout-mins" 15
+
+                                 ;; The HTTP idle timeout (milliseconds) between successive bytes in the response output stream.
+                                 "streaming-timeout-ms" 20000}}
 
  ;; Waiter provides watch endpoints to listen on changes of a resource
  ;; This configures various watch providers for different resources

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1068,13 +1068,16 @@
    :make-basic-auth-fn (pc/fnk []
                          (fn make-basic-auth-fn [uri username password]
                            (BasicAuthentication$BasicResult. (URI. uri) username password)))
-   :make-http-request-fn (pc/fnk [[:settings instance-request-properties]
+   :make-http-request-fn (pc/fnk [[:settings [:token-config token-defaults] instance-request-properties]
                                   [:state http-clients]
                                   make-basic-auth-fn service-id->password-fn]
-                           (let [make-request-fn pr/make-request]
+                           (let [make-request-fn pr/make-request
+                                 prepare-request-properties-fn (fn prepare-request-properties-fn [instance-request-properties waiter-headers]
+                                                                 (pr/prepare-request-properties
+                                                                   instance-request-properties waiter-headers token-defaults))]
                              (handler/async-make-request-helper
                                http-clients instance-request-properties make-basic-auth-fn service-id->password-fn
-                               pr/prepare-request-properties make-request-fn)))
+                               prepare-request-properties-fn make-request-fn)))
    :make-inter-router-requests-async-fn (pc/fnk [[:settings [:instance-request-properties initial-socket-timeout-ms]]
                                                  [:state discovery http-clients passwords router-id]
                                                  make-basic-auth-fn]

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -201,8 +201,11 @@
                                    (s/required-key :limit-per-owner) schema/positive-int
                                    (s/required-key :token-defaults) {(s/required-key "fallback-period-secs") schema/non-negative-int
                                                                      (s/required-key "https-redirect") s/Bool
+                                                                     (s/required-key "queue-timeout-ms") schema/non-negative-int
                                                                      (s/optional-key "service-mapping") schema/non-empty-string
-                                                                     (s/required-key "stale-timeout-mins") schema/non-negative-int}
+                                                                     (s/required-key "socket-timeout-ms") schema/non-negative-int
+                                                                     (s/required-key "stale-timeout-mins") schema/non-negative-int
+                                                                     (s/required-key "streaming-timeout-ms") schema/non-negative-int}
                                    (s/required-key :validator) (s/constrained
                                                                  {:kind s/Keyword
                                                                   s/Keyword schema/require-symbol-factory-fn}
@@ -518,8 +521,11 @@
                   :limit-per-owner 1000
                   :token-defaults {"fallback-period-secs" (-> 5 t/minutes t/in-seconds)
                                    "https-redirect" false
+                                   "queue-timeout-ms" 300000
                                    "service-mapping" "legacy"
-                                   "stale-timeout-mins" 15}
+                                   "socket-timeout-ms" 900000
+                                   "stale-timeout-mins" 15
+                                   "streaming-timeout-ms" 20000}
                   :validator {:kind :default
                               :default {:factory-fn 'waiter.token-validator/create-default-token-validator}}}
    :watch-config {:tokens {:channels-update-chan-buffer-size 1024

--- a/waiter/src/waiter/util/date_utils.clj
+++ b/waiter/src/waiter/util/date_utils.clj
@@ -20,6 +20,8 @@
             [clojure.tools.logging :as log])
   (:import (org.joda.time DateTime ReadablePeriod)))
 
+(def ^:const one-hour-in-millis (t/in-millis (t/hours 1)))
+
 (def formatter-iso8601 (:date-time f/formatters))
 (def formatter-rfc822 (:rfc822 f/formatters))
 (def formatter-year-month-day (:year-month-day f/formatters))

--- a/waiter/src/waiter/util/http_utils.clj
+++ b/waiter/src/waiter/util/http_utils.clj
@@ -286,3 +286,10 @@
   [user-agent-products request]
   (when-let [user-agent (some-> request (get-in [:headers "user-agent"]) str/lower-case)]
     (some #(str/includes? user-agent %) user-agent-products)))
+
+(defn merge-response-headers
+  "Attaches provided headers into the response."
+  [response kvm]
+  (->> kvm
+       (pc/map-vals str)
+       (update response :headers merge)))

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -40,83 +40,107 @@
   (let [test-cases (list
                      {:name "test-prepare-request-properties:nil-inputs"
                       :input {:request-properties nil :waiter-headers nil}
-                      :expected {:async-check-interval-ms nil, :async-request-timeout-ms nil, :initial-socket-timeout-ms nil, :queue-timeout-ms nil, :streaming-timeout-ms nil}
+                      :expected {:async-check-interval-ms nil :async-request-timeout-ms nil :initial-socket-timeout-ms nil :queue-timeout-ms nil :streaming-timeout-ms nil}
                       }
                      {:name "test-prepare-request-properties:empty-nil-inputs"
                       :input {:request-properties {} :waiter-headers nil}
-                      :expected {:async-check-interval-ms nil, :async-request-timeout-ms nil, :initial-socket-timeout-ms nil, :queue-timeout-ms nil, :streaming-timeout-ms nil}
+                      :expected {:async-check-interval-ms nil :async-request-timeout-ms nil :initial-socket-timeout-ms nil :queue-timeout-ms nil :streaming-timeout-ms nil}
                       }
                      {:name "test-prepare-request-properties:nil-empty-inputs"
                       :input {:request-properties nil :waiter-headers {}}
-                      :expected {:async-check-interval-ms nil, :async-request-timeout-ms nil, :initial-socket-timeout-ms nil, :queue-timeout-ms nil, :streaming-timeout-ms nil}
+                      :expected {:async-check-interval-ms nil :async-request-timeout-ms nil :initial-socket-timeout-ms nil :queue-timeout-ms nil :streaming-timeout-ms nil}
                       }
                      {:name "test-prepare-request-properties:empty-inputs"
                       :input {:request-properties {} :waiter-headers {}}
-                      :expected {:async-check-interval-ms nil, :async-request-timeout-ms nil, :initial-socket-timeout-ms nil, :queue-timeout-ms nil, :streaming-timeout-ms nil}
+                      :expected {:async-check-interval-ms nil :async-request-timeout-ms nil :initial-socket-timeout-ms nil :queue-timeout-ms nil :streaming-timeout-ms nil}
                       }
                      {:name "test-prepare-request-properties:missing-timeout-header-1"
                       :input {:request-properties {:fie "foe"} :waiter-headers {:foo "bar"}}
-                      :expected {:fie "foe", :async-check-interval-ms nil, :async-request-timeout-ms nil, :initial-socket-timeout-ms nil, :queue-timeout-ms nil, :streaming-timeout-ms nil}
+                      :expected {:fie "foe" :async-check-interval-ms nil :async-request-timeout-ms nil :initial-socket-timeout-ms nil :queue-timeout-ms nil :streaming-timeout-ms nil}
                       }
                      {:name "test-prepare-request-properties:missing-timeout-header-2"
-                      :input {:request-properties {:fie "foe", :initial-socket-timeout-ms 100, :streaming-timeout-ms 200}
+                      :input {:request-properties {:fie "foe" :initial-socket-timeout-ms 100 :streaming-timeout-ms 200}
                               :waiter-headers {:foo "bar"}}
-                      :expected {:fie "foe", :async-check-interval-ms nil, :async-request-timeout-ms nil, :initial-socket-timeout-ms 100, :queue-timeout-ms nil, :streaming-timeout-ms 200}
+                      :expected {:fie "foe" :async-check-interval-ms nil :async-request-timeout-ms nil :initial-socket-timeout-ms 100 :queue-timeout-ms nil :streaming-timeout-ms 200}
                       }
                      {:name "test-prepare-request-properties:invalid-timeout-header"
-                      :input {:request-properties {:fie "foe", :initial-socket-timeout-ms 100, :queue-timeout-ms 150, :streaming-timeout-ms nil}
+                      :input {:request-properties {:fie "foe" :initial-socket-timeout-ms 100 :queue-timeout-ms 150 :streaming-timeout-ms nil}
                               :waiter-headers {"timeout" "bar"}}
-                      :expected {:fie "foe", :async-check-interval-ms nil, :async-request-timeout-ms nil, :initial-socket-timeout-ms 100, :queue-timeout-ms 150, :streaming-timeout-ms nil}
+                      :expected {:fie "foe" :async-check-interval-ms nil :async-request-timeout-ms nil :initial-socket-timeout-ms 100 :queue-timeout-ms 150 :streaming-timeout-ms nil}
                       }
                      {:name "test-prepare-request-properties:negative-timeout-header"
-                      :input {:request-properties {:fie "foe", :initial-socket-timeout-ms 100}
+                      :input {:request-properties {:fie "foe" :initial-socket-timeout-ms 100}
                               :waiter-headers {"timeout" -50}}
-                      :expected {:fie "foe", :async-check-interval-ms nil, :async-request-timeout-ms nil, :initial-socket-timeout-ms 100, :queue-timeout-ms nil, :streaming-timeout-ms nil}
+                      :expected {:fie "foe" :async-check-interval-ms nil :async-request-timeout-ms nil :initial-socket-timeout-ms 100 :queue-timeout-ms nil :streaming-timeout-ms nil}
                       }
                      {:name "test-prepare-request-properties:valid-timeout-header"
-                      :input {:request-properties {:fie "foe", :initial-socket-timeout-ms 100, :streaming-timeout-ms 200}
-                              :waiter-headers {"timeout" 50, "streaming-timeout" 250}}
-                      :expected {:fie "foe", :async-check-interval-ms nil, :async-request-timeout-ms nil, :initial-socket-timeout-ms 50, :queue-timeout-ms nil, :streaming-timeout-ms 250}
+                      :input {:request-properties {:fie "foe" :initial-socket-timeout-ms 100 :streaming-timeout-ms 200}
+                              :waiter-headers {"timeout" 50 "streaming-timeout" 250}}
+                      :expected {:fie "foe" :async-check-interval-ms nil :async-request-timeout-ms nil :initial-socket-timeout-ms 50 :queue-timeout-ms nil :streaming-timeout-ms 250}
                       }
                      {:name "test-prepare-request-properties:invalid-queue-timeout-header"
-                      :input {:request-properties {:fie "foe", :queue-timeout-ms 150}
+                      :input {:request-properties {:fie "foe" :queue-timeout-ms 150}
                               :waiter-headers {"queue-timeout" "bar"}}
-                      :expected {:fie "foe", :async-check-interval-ms nil, :async-request-timeout-ms nil, :initial-socket-timeout-ms nil, :queue-timeout-ms 150, :streaming-timeout-ms nil}
+                      :expected {:fie "foe" :async-check-interval-ms nil :async-request-timeout-ms nil :initial-socket-timeout-ms nil :queue-timeout-ms 150 :streaming-timeout-ms nil}
                       }
                      {:name "test-prepare-request-properties:negative-queue-timeout-header"
-                      :input {:request-properties {:fie "foe", :queue-timeout-ms 150}
+                      :input {:request-properties {:fie "foe" :queue-timeout-ms 150}
                               :waiter-headers {"queue-timeout" -50}}
-                      :expected {:fie "foe", :async-check-interval-ms nil, :async-request-timeout-ms nil, :initial-socket-timeout-ms nil, :queue-timeout-ms 150, :streaming-timeout-ms nil}
+                      :expected {:fie "foe" :async-check-interval-ms nil :async-request-timeout-ms nil :initial-socket-timeout-ms nil :queue-timeout-ms 150 :streaming-timeout-ms nil}
                       }
                      {:name "test-prepare-request-properties:valid-queue-timeout-header"
-                      :input {:request-properties {:fie "foe", :queue-timeout-ms 150, :streaming-timeout-ms nil}
+                      :input {:request-properties {:fie "foe" :queue-timeout-ms 150 :streaming-timeout-ms nil}
                               :waiter-headers {"queue-timeout" 50}}
-                      :expected {:fie "foe", :async-check-interval-ms nil, :async-request-timeout-ms nil, :initial-socket-timeout-ms nil, :queue-timeout-ms 50, :streaming-timeout-ms nil}
+                      :expected {:fie "foe" :async-check-interval-ms nil :async-request-timeout-ms nil :initial-socket-timeout-ms nil :queue-timeout-ms 50 :streaming-timeout-ms nil}
                       }
                      {:name "test-prepare-request-properties:valid-both-timeout-headers"
-                      :input {:request-properties {:fie "foe", :initial-socket-timeout-ms 100, :queue-timeout-ms 150}
-                              :waiter-headers {"timeout" 75, "queue-timeout" 50}}
-                      :expected {:fie "foe", :async-check-interval-ms nil, :async-request-timeout-ms nil, :initial-socket-timeout-ms 75, :queue-timeout-ms 50, :streaming-timeout-ms nil}
+                      :input {:request-properties {:fie "foe" :initial-socket-timeout-ms 100 :queue-timeout-ms 150}
+                              :waiter-headers {"queue-timeout" 50 "timeout" 75}}
+                      :expected {:fie "foe" :async-check-interval-ms nil :async-request-timeout-ms nil :initial-socket-timeout-ms 75 :queue-timeout-ms 50 :streaming-timeout-ms nil}
                       }
                      {:name "test-prepare-request-properties:invalid-async-headers"
-                      :input {:request-properties {:fie "foe", :async-check-interval-ms 100, :async-request-timeout-ms 200}
-                              :waiter-headers {"async-check-interval" -50, "async-request-timeout" "foo"}}
-                      :expected {:fie "foe", :async-check-interval-ms 100, :async-request-timeout-ms 200, :initial-socket-timeout-ms nil, :queue-timeout-ms nil, :streaming-timeout-ms nil}
+                      :input {:request-properties {:fie "foe" :async-check-interval-ms 100 :async-request-timeout-ms 200}
+                              :waiter-headers {"async-check-interval" -50 "async-request-timeout" "foo"}}
+                      :expected {:fie "foe" :async-check-interval-ms 100 :async-request-timeout-ms 200 :initial-socket-timeout-ms nil :queue-timeout-ms nil :streaming-timeout-ms nil}
                       }
                      {:name "test-prepare-request-properties:valid-async-headers"
-                      :input {:request-properties {:fie "foe", :async-check-interval-ms 100, :async-request-timeout-ms 200}
-                              :waiter-headers {"async-check-interval" 50, "async-request-timeout" 250}}
-                      :expected {:fie "foe", :async-check-interval-ms 50, :async-request-timeout-ms 250, :initial-socket-timeout-ms nil, :queue-timeout-ms nil, :streaming-timeout-ms nil}
+                      :input {:request-properties {:fie "foe" :async-check-interval-ms 100 :async-request-timeout-ms 200}
+                              :waiter-headers {"async-check-interval" 50 "async-request-timeout" 250}}
+                      :expected {:fie "foe" :async-check-interval-ms 50 :async-request-timeout-ms 250 :initial-socket-timeout-ms nil :queue-timeout-ms nil :streaming-timeout-ms nil}
                       }
                      {:name "test-prepare-request-properties:too-large-async-request-timeout-header"
-                      :input {:request-properties {:fie "foe", :async-check-interval-ms 100, :async-request-max-timeout-ms 100000 :async-request-timeout-ms 200}
+                      :input {:request-properties {:fie "foe" :async-check-interval-ms 100 :async-request-max-timeout-ms 100000 :async-request-timeout-ms 200}
                               :waiter-headers {"async-request-timeout" 101000}}
-                      :expected {:fie "foe", :async-check-interval-ms 100, :async-request-max-timeout-ms 100000 :async-request-timeout-ms 100000, :initial-socket-timeout-ms nil, :queue-timeout-ms nil, :streaming-timeout-ms nil}
+                      :expected {:fie "foe" :async-check-interval-ms 100 :async-request-max-timeout-ms 100000 :async-request-timeout-ms 100000 :initial-socket-timeout-ms nil :queue-timeout-ms nil :streaming-timeout-ms nil}
+                      }
+                     {:name "test-prepare-request-properties:too-large-async-request-timeout-header"
+                      :input {:request-properties {:fie "foe" :async-check-interval-ms 100 :async-request-max-timeout-ms 100000 :async-request-timeout-ms 200}
+                              :waiter-headers {"async-request-timeout" 101000}}
+                      :expected {:fie "foe" :async-check-interval-ms 100 :async-request-max-timeout-ms 100000 :async-request-timeout-ms 100000 :initial-socket-timeout-ms nil :queue-timeout-ms nil :streaming-timeout-ms nil}
+                      }
+                     {:name "test-prepare-request-properties:empty-request-properties-with-token-defaults"
+                      :input {:request-properties {:initial-socket-timeout-ms 100 :queue-timeout-ms 150 :streaming-timeout-ms nil}
+                              :token-metadata {"queue-timeout-ms" 300000 "socket-timeout-ms" 900000 "streaming-timeout-ms" 20000}
+                              :waiter-headers nil}
+                      :expected {:async-check-interval-ms nil :async-request-timeout-ms nil :initial-socket-timeout-ms 900000 :queue-timeout-ms 300000 :streaming-timeout-ms 20000}
+                      }
+                     {:name "test-prepare-request-properties:empty-request-properties-with-token-defaults-and-some-headers"
+                      :input {:request-properties {:initial-socket-timeout-ms 100 :queue-timeout-ms 150 :streaming-timeout-ms nil}
+                              :token-metadata {"queue-timeout-ms" 300000 "socket-timeout-ms" 900000 "streaming-timeout-ms" 20000}
+                              :waiter-headers {"queue-timeout" 50 "timeout" 75}}
+                      :expected {:async-check-interval-ms nil :async-request-timeout-ms nil :initial-socket-timeout-ms 75 :queue-timeout-ms 50 :streaming-timeout-ms 20000}
+                      }
+                     {:name "test-prepare-request-properties:empty-request-properties-with-token-defaults-and-most-timeout-headers"
+                      :input {:request-properties {:initial-socket-timeout-ms 100 :queue-timeout-ms 150 :streaming-timeout-ms nil}
+                              :token-metadata {"queue-timeout-ms" 300000 "socket-timeout-ms" 900000 "streaming-timeout-ms" 20000}
+                              :waiter-headers {"queue-timeout" 50 "streaming-timeout" 95 "timeout" 75}}
+                      :expected {:async-check-interval-ms nil :async-request-timeout-ms nil :initial-socket-timeout-ms 75 :queue-timeout-ms 50 :streaming-timeout-ms 95}
                       })]
     (doseq [{:keys [name input expected]} test-cases]
       (testing (str "Test " name)
-        (let [actual (prepare-request-properties (:request-properties input)
-                                                 (pc/map-keys #(str headers/waiter-header-prefix %) (:waiter-headers input)))]
+        (let [{:keys [request-properties token-metadata waiter-headers]} input
+              waiter-headers' (pc/map-keys #(str headers/waiter-header-prefix %) waiter-headers)
+              actual (prepare-request-properties request-properties waiter-headers' token-metadata)]
           (is (= expected actual)))))))
 
 (deftest test-prepare-grpc-compliant-request-properties
@@ -125,7 +149,7 @@
                                  :initial-socket-timeout-ms 1030
                                  :queue-timeout-ms 1040
                                  :streaming-timeout-ms 1050}]
-    (doseq [{:keys [backend-proto request-headers request-properties-expected] :as test-case}
+    (doseq [{:keys [backend-proto request-headers request-properties-expected token-metadata] :as test-case}
             [{:backend-proto "h2c"
               :request-headers {"x-waiter-async-check-interval" "2100"
                                 "x-waiter-async-request-timeout" "2200"
@@ -162,10 +186,20 @@
               :request-headers {"content-type" "application/grpc"
                                 "grpc-timeout" "3S"
                                 "x-waiter-queue-timeout" "2000"}
-              :request-properties-expected {:queue-timeout-ms 2000}}]]
+              :request-properties-expected {:queue-timeout-ms 2000}}
+             {:backend-proto "h2c"
+              :request-headers {"content-type" "application/grpc"
+                                "grpc-timeout" "3S"
+                                "x-waiter-queue-timeout" "2000"}
+              :request-properties-expected {:initial-socket-timeout-ms 900000
+                                            :queue-timeout-ms 2000
+                                            :streaming-timeout-ms 20000}
+              :token-metadata {"queue-timeout-ms" 300000
+                               "socket-timeout-ms" 900000
+                               "streaming-timeout-ms" 20000}}]]
       (let [{:keys [passthrough-headers waiter-headers]} (headers/split-headers request-headers)
             request-properties-actual  (prepare-grpc-compliant-request-properties
-                                         request-properties-base backend-proto passthrough-headers waiter-headers)]
+                                         request-properties-base backend-proto passthrough-headers waiter-headers token-metadata)]
         (is (= (merge request-properties-base request-properties-expected) request-properties-actual) (str test-case))))))
 
 (deftest test-stream-http-response-configure-idle-timeout


### PR DESCRIPTION
## Changes proposed in this PR

- promotes common request timeout headers to token parameters

## Why are we making these changes?

In some scenarios, services want different defaults for request timeouts than those provided by Waiter. Promoting these timeouts to such configurable token parameters makes such use cases possible.

### Implementation notes

- Implementation continues to be backward compatible as service ID does not change when timeouts are configured
- Values provided in request headers continue to be used with the highest priority.


