### PR TITLE
add pod preStop command for more graceful termination of pod

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -533,12 +533,12 @@
                                               ;; This command prevents the SIGTERM signal from reaching or doing various cleanup work
                                               ;; preStop commands do not log anywhere by default in k8s, so append logs to the containers main process stdout
                                               ;; which is symlinked with "/proc/1/fd/1" https://github.com/kubernetes/kubernetes/issues/54247#issuecomment-827694001
-                                              pre-stop-cmd ["/bin/sh"
-                                                            "-c"
-                                                            "echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: sleeping for ${WAITER_BYPASS_FORCE_SIGTERM_SECS} secs >> /proc/1/fd/1 ; sleep ${WAITER_BYPASS_FORCE_SIGTERM_SECS} ; echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: ending sleep, and container will receive SIGTERM shortly >> /proc/1/fd/1"]
+                                              :pre-stop-cmd ["/bin/sh"
+                                                             "-c"
+                                                             "echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: sleeping for ${WAITER_BYPASS_FORCE_SIGTERM_SECS} secs >> /proc/1/fd/1 ; sleep ${WAITER_BYPASS_FORCE_SIGTERM_SECS} ; echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: ending sleep, and container will receive SIGTERM shortly >> /proc/1/fd/1"]
 
                                               ;; The grace period that allows containers to handle SIGTERM before getting fully deleted.
-                                              sigterm-grace-period-secs 30}
+                                              :sigterm-grace-period-secs 30}
 
                                  ;; The number of seconds between the SIGTERM and SIGKILL signals sent to a pod on shutdown.
                                  ;; This value should be placed in the terminationGracePeriodSeconds field in the pod template.

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -531,6 +531,8 @@
 
                                  ;; The preStop command put on all containers that gets configured for pods of bypass services
                                  ;; This command prevents the SIGTERM signal from reaching or doing various cleanup work
+                                 ;; preStop commands do not log anywhere by default in k8s, so append logs to the containers main process stdout
+                                 ;; which is symlinked with "/proc/1/fd/1" https://github.com/kubernetes/kubernetes/issues/54247#issuecomment-827694001
                                  :pod-bypass-pre-stop-cmd ["/bin/sh"
                                                            "-c"
                                                            "echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: sleeping for ${WAITER_BYPASS_FORCE_SIGTERM_SECS} secs >> /proc/1/fd/1 ; sleep ${WAITER_BYPASS_FORCE_SIGTERM_SECS} ; echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: ending sleep, and container will receive SIGTERM shortly >> /proc/1/fd/1"]

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -525,20 +525,20 @@
                                  ;; e.g., if pod-base-port is 31000, and the random offset was 390, then $PORT0==31390 and $PORT9==31399:
                                  :pod-base-port 31000
 
-                                 ;; The maximum amount of time before the SIGTERM signal will be sent in each container of the pod.
-                                 ;; This will allow requests to drain during this period without killing any containers.
-                                 :pod-bypass-force-sigterm-secs 120
+                                 :pod-bypass {;; The maximum amount of time before the SIGTERM signal will be sent in each container of the pod.
+                                              ;; This will allow requests to drain during this period without killing any containers.
+                                              :force-sigterm-secs 120
 
-                                 ;; The preStop command put on all containers that gets configured for pods of bypass services
-                                 ;; This command prevents the SIGTERM signal from reaching or doing various cleanup work
-                                 ;; preStop commands do not log anywhere by default in k8s, so append logs to the containers main process stdout
-                                 ;; which is symlinked with "/proc/1/fd/1" https://github.com/kubernetes/kubernetes/issues/54247#issuecomment-827694001
-                                 :pod-bypass-pre-stop-cmd ["/bin/sh"
-                                                           "-c"
-                                                           "echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: sleeping for ${WAITER_BYPASS_FORCE_SIGTERM_SECS} secs >> /proc/1/fd/1 ; sleep ${WAITER_BYPASS_FORCE_SIGTERM_SECS} ; echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: ending sleep, and container will receive SIGTERM shortly >> /proc/1/fd/1"]
+                                              ;; The preStop command put on all containers that gets configured for pods of bypass services
+                                              ;; This command prevents the SIGTERM signal from reaching or doing various cleanup work
+                                              ;; preStop commands do not log anywhere by default in k8s, so append logs to the containers main process stdout
+                                              ;; which is symlinked with "/proc/1/fd/1" https://github.com/kubernetes/kubernetes/issues/54247#issuecomment-827694001
+                                              pre-stop-cmd ["/bin/sh"
+                                                            "-c"
+                                                            "echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: sleeping for ${WAITER_BYPASS_FORCE_SIGTERM_SECS} secs >> /proc/1/fd/1 ; sleep ${WAITER_BYPASS_FORCE_SIGTERM_SECS} ; echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: ending sleep, and container will receive SIGTERM shortly >> /proc/1/fd/1"]
 
-                                 ;; The grace period that allows containers to handle SIGTERM before getting fully deleted.
-                                 :pod-bypass-sigterm-grace-period-secs 30
+                                              ;; The grace period that allows containers to handle SIGTERM before getting fully deleted.
+                                              sigterm-grace-period-secs 30}
 
                                  ;; The number of seconds between the SIGTERM and SIGKILL signals sent to a pod on shutdown.
                                  ;; This value should be placed in the terminationGracePeriodSeconds field in the pod template.

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -525,6 +525,13 @@
                                  ;; e.g., if pod-base-port is 31000, and the random offset was 390, then $PORT0==31390 and $PORT9==31399:
                                  :pod-base-port 31000
 
+                                 ;; The maximum amount of time before the SIGTERM signal will be sent in each container of the pod.
+                                 ;; This will allow requests to drain during this period without killing any containers.
+                                 :pod-bypass-force-sigterm-secs 120
+
+                                 ;; The grace period that allows containers to handle SIGTERM before getting fully deleted.
+                                 :pod-bypass-sigterm-grace-period-secs 30
+
                                  ;; The number of seconds between the SIGTERM and SIGKILL signals sent to a pod on shutdown.
                                  ;; This value should be placed in the terminationGracePeriodSeconds field in the pod template.
                                  ;; Should be set between 0 and 300 seconds, inclusive.

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -529,6 +529,12 @@
                                  ;; This will allow requests to drain during this period without killing any containers.
                                  :pod-bypass-force-sigterm-secs 120
 
+                                 ;; The preStop command put on all containers that gets configured for pods of bypass services
+                                 ;; This command prevents the SIGTERM signal from reaching or doing various cleanup work
+                                 :pod-bypass-pre-stop-cmd ["/bin/sh"
+                                                           "-c"
+                                                           "echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: sleeping for ${WAITER_BYPASS_FORCE_SIGTERM_SECS} secs >> /proc/1/fd/1 ; sleep ${WAITER_BYPASS_FORCE_SIGTERM_SECS} ; echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: ending sleep, and container will receive SIGTERM shortly >> /proc/1/fd/1"]
+
                                  ;; The grace period that allows containers to handle SIGTERM before getting fully deleted.
                                  :pod-bypass-sigterm-grace-period-secs 30
 

--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -535,7 +535,7 @@
                                               ;; which is symlinked with "/proc/1/fd/1" https://github.com/kubernetes/kubernetes/issues/54247#issuecomment-827694001
                                               :pre-stop-cmd ["/bin/sh"
                                                              "-c"
-                                                             "echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: sleeping for ${WAITER_BYPASS_FORCE_SIGTERM_SECS} secs >> /proc/1/fd/1 ; sleep ${WAITER_BYPASS_FORCE_SIGTERM_SECS} ; echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: ending sleep, and container will receive SIGTERM shortly >> /proc/1/fd/1"]
+                                                             "echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: sleeping for ${WAITER_CONFIG_BYPASS_FORCE_SIGTERM_SECS} secs >> /proc/1/fd/1 ; sleep ${WAITER_CONFIG_BYPASS_FORCE_SIGTERM_SECS} ; echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: ending sleep, and container will receive SIGTERM shortly >> /proc/1/fd/1"]
 
                                               ;; The grace period that allows containers to handle SIGTERM before getting fully deleted.
                                               :sigterm-grace-period-secs 30}

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -1452,11 +1452,10 @@
         ;; Services that are in bypass will need to safely scale down. Configuring 'preStop' will delay the sigterm for each contianer.
         bypass-enabled? (sd/service-description-bypass-enabled? service-description)
         add-lifecycle-configs-fn (fn add-lifecycle-config [container-configs]
-                                   (->> container-configs
-                                       (map #(as-> % container-config
-                                               (assoc-in container-config [:lifecycle :preStop :exec :command] pod-bypass-pre-stop-cmd)
-                                               (update container-config :env conj {:name "WAITER_BYPASS_FORCE_SIGTERM_SECS" :value (str pod-bypass-force-sigterm-secs)})))
-                                        vec))]
+                                   (mapv #(as-> % container-config
+                                            (assoc-in container-config [:lifecycle :preStop :exec :command] pod-bypass-pre-stop-cmd)
+                                            (update container-config :env conj {:name "WAITER_BYPASS_FORCE_SIGTERM_SECS" :value (str pod-bypass-force-sigterm-secs)}))
+                                         container-configs))]
     (cond->
       {:kind "ReplicaSet"
        :apiVersion replicaset-api-version

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -1457,11 +1457,11 @@
                                            (update container-config :env conj {:name "WAITER_BYPASS_FORCE_SIGTERM_SECS" :value (str pod-bypass-force-sigterm-secs)}))
                                         container-configs))]
     (cond->
-     {:kind "ReplicaSet"
-      :apiVersion replicaset-api-version
-      :metadata {:annotations (cond-> {:waiter/revision-timestamp revision-timestamp
-                                       :waiter/revision-version revision-version
-                                       :waiter/run-as-user-source run-as-user-source
+      {:kind "ReplicaSet"
+       :apiVersion replicaset-api-version
+       :metadata {:annotations (cond-> {:waiter/revision-timestamp revision-timestamp
+                                        :waiter/revision-version revision-version
+                                        :waiter/run-as-user-source run-as-user-source
                                         ;; Since there are length restrictions on Kubernetes label values,
                                         ;; we store just the 32-char hash portion of the service-id as a searchable label,
                                         ;; but store the full service-id as an annotation.
@@ -1565,12 +1565,12 @@
            :env (into [{:name "WAITER_FILESERVER_PORT" :value (str port)}
                        {:name "WAITER_GRACE_SECS" :value (str configured-pod-sigkill-delay-secs)}]
                       (concat
-                       (for [[k v] base-env
-                             :when (str/starts-with? k "WAITER_")]
-                         {:name k :value v})
-                       (when base-bucket-url
-                         [{:name "WAITER_LOG_BUCKET_URL"
-                           :value (str base-bucket-url "/" run-as-user "/" service-id)}])))
+                        (for [[k v] base-env
+                              :when (str/starts-with? k "WAITER_")]
+                          {:name k :value v})
+                        (when base-bucket-url
+                          [{:name "WAITER_LOG_BUCKET_URL"
+                            :value (str base-bucket-url "/" run-as-user "/" service-id)}])))
            :image image
            :imagePullPolicy "IfNotPresent"
            :name waiter-fileserver-sidecar-name

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -2060,12 +2060,12 @@
 (defn kubernetes-scheduler
   "Returns a new KubernetesScheduler with the provided configuration. Validates the
    configuration against kubernetes-scheduler-schema and throws if it's not valid."
-  [{:keys [authenticate-health-checks? authentication authorizer cluster-name container-running-grace-secs custom-options
+  [{:keys [authenticate-health-checks? authentication authorizer cluster-name container-running-grace-secs custom-options 
            fetch-events-k8s-object-minimum-age-secs http-options determine-replicaset-namespace-fn kube-context leader?-fn log-bucket-sync-secs
            log-bucket-url max-patch-retries max-name-length namespace pdb-api-version pdb-spec-builder pod-base-port pod-sigkill-delay-secs
            pod-suffix-length replicaset-api-version response->deployment-error-msg-fn restart-expiry-threshold restart-kill-threshold
-           raven-sidecar scheduler-name scheduler-state-chan scheduler-syncer-interval-secs service-id->service-description-fn service-id->password-fn
-           start-scheduler-syncer-fn url watch-chan-throttle-interval-ms watch-connect-timeout-ms watch-init-timeout-ms
+           raven-sidecar scheduler-name scheduler-state-chan scheduler-syncer-interval-secs service-id->service-description-fn
+           service-id->password-fn start-scheduler-syncer-fn url watch-chan-throttle-interval-ms watch-connect-timeout-ms watch-init-timeout-ms
            watch-retries watch-socket-timeout-ms watch-validate-ssl]
     {fileserver-port :port fileserver-scheme :scheme :as fileserver} :fileserver
     {:keys [default-namespace] :as replicaset-spec-builder} :replicaset-spec-builder

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -1505,12 +1505,12 @@
                                               :name waiter-primary-container-name
                                               :ports [{:containerPort port0}]
                                               :readinessProbe (-> (prepare-health-check-probe
-                                                                   service-id->password-fn service-id
-                                                                   authenticate-health-check?
-                                                                   readiness-scheme health-check-url
-                                                                   (+ service-port health-check-port-index)
-                                                                   health-check-interval-secs)
-                                                                  (assoc :failureThreshold 1))
+                                                                    service-id->password-fn service-id
+                                                                    authenticate-health-check?
+                                                                    readiness-scheme health-check-url
+                                                                    (+ service-port health-check-port-index)
+                                                                    health-check-interval-secs)
+                                                                (assoc :failureThreshold 1))
                                               :resources {:limits {:memory memory}
                                                           :requests {:cpu cpus
                                                                      :memory memory}}

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -1355,17 +1355,19 @@
 (defn add-pre-stop-config-for-bypass-service
   "Returns a new vector of container configurations that include the desired preStop command and environment variables
    that will be used by the preStop command to know how long to delay the SIGTERM signal to the container."
-  [container-configs pre-stop-cmd force-sigterm-secs]
+  [container-configs pre-stop-cmd force-sigterm-secs sigterm-grace-period-secs]
   (mapv #(-> %
              (assoc-in [:lifecycle :preStop :exec :command] pre-stop-cmd)
-             (update :env conj {:name "WAITER_BYPASS_FORCE_SIGTERM_SECS" :value (str force-sigterm-secs)}))
+             (assoc :env (get % :env []))
+             (update :env conj {:name "WAITER_BYPASS_FORCE_SIGTERM_SECS" :value (str force-sigterm-secs)})
+             (update :env conj {:name "WAITER_BYPASS_SIGTERM_GRACE_PERIOD_SECS" :value (str sigterm-grace-period-secs)}))
         container-configs))
 
 (defn default-replicaset-builder
   "Factory function which creates a Kubernetes ReplicaSet spec for the given Waiter Service."
   [{:keys [cluster-name determine-replicaset-namespace-fn fileserver pod-base-port pod-sigkill-delay-secs
            replicaset-api-version raven-sidecar service-id->password-fn]
-    {:keys [force-sigterm-secs pre-stop-cmd]} :pod-bypass
+    {:keys [force-sigterm-secs pre-stop-cmd sigterm-grace-period-secs]} :pod-bypass
     :as scheduler}
    service-id
    {:strs [backend-proto cmd cpus grace-period-secs health-check-interval-secs
@@ -1589,7 +1591,7 @@
 
       ;; When bypass is enabled, we should attach a preStop command to all containers to delay SIGTERM to be handled for a period of time
       bypass-enabled?
-      (update-in [:spec :template :spec :containers] add-pre-stop-config-for-bypass-service pre-stop-cmd force-sigterm-secs))))
+      (update-in [:spec :template :spec :containers] add-pre-stop-config-for-bypass-service pre-stop-cmd force-sigterm-secs sigterm-grace-period-secs))))
 
 (defn default-pdb-spec-builder
   "Factory function which creates a Kubernetes PodDisruptionBudget spec for the given ReplicaSet."

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -2060,12 +2060,13 @@
 (defn kubernetes-scheduler
   "Returns a new KubernetesScheduler with the provided configuration. Validates the
    configuration against kubernetes-scheduler-schema and throws if it's not valid."
-  [{:keys [authenticate-health-checks? authentication authorizer cluster-name container-running-grace-secs custom-options 
+  [{:keys [authenticate-health-checks? authentication authorizer cluster-name container-running-grace-secs custom-options
            fetch-events-k8s-object-minimum-age-secs http-options determine-replicaset-namespace-fn kube-context leader?-fn log-bucket-sync-secs
-           log-bucket-url max-patch-retries max-name-length namespace pdb-api-version pdb-spec-builder pod-base-port pod-sigkill-delay-secs pod-suffix-length replicaset-api-version
-           response->deployment-error-msg-fn restart-expiry-threshold restart-kill-threshold raven-sidecar scheduler-name scheduler-state-chan
-           scheduler-syncer-interval-secs service-id->service-description-fn service-id->password-fn start-scheduler-syncer-fn url
-           watch-chan-throttle-interval-ms watch-connect-timeout-ms watch-init-timeout-ms watch-retries watch-socket-timeout-ms watch-validate-ssl]
+           log-bucket-url max-patch-retries max-name-length namespace pdb-api-version pdb-spec-builder pod-base-port pod-sigkill-delay-secs
+           pod-suffix-length replicaset-api-version response->deployment-error-msg-fn restart-expiry-threshold restart-kill-threshold
+           raven-sidecar scheduler-name scheduler-state-chan scheduler-syncer-interval-secs service-id->service-description-fn service-id->password-fn
+           start-scheduler-syncer-fn url watch-chan-throttle-interval-ms watch-connect-timeout-ms watch-init-timeout-ms
+           watch-retries watch-socket-timeout-ms watch-validate-ssl]
     {fileserver-port :port fileserver-scheme :scheme :as fileserver} :fileserver
     {:keys [default-namespace] :as replicaset-spec-builder} :replicaset-spec-builder
     {service-id->deployment-error-cache-threshold :threshold service-id->deployment-error-cache-ttl-sec :ttl} :service-id->deployment-error-cache

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -1359,10 +1359,10 @@
   (mapv #(-> %
              (assoc-in [:lifecycle :preStop :exec :command] pre-stop-cmd)
              (assoc :env (get % :env []))
-             (update :env conj {:name "WAITER_BYPASS_FORCE_SIGTERM_SECS"
-                                :value (get base-env "WAITER_BYPASS_FORCE_SIGTERM_SECS" (str force-sigterm-secs))})
-             (update :env conj {:name "WAITER_BYPASS_SIGTERM_GRACE_PERIOD_SECS"
-                                :value (get base-env "WAITER_BYPASS_SIGTERM_GRACE_PERIOD_SECS" (str sigterm-grace-period-secs))}))
+             (update :env conj {:name "WAITER_CONFIG_BYPASS_FORCE_SIGTERM_SECS"
+                                :value (get base-env "WAITER_CONFIG_BYPASS_FORCE_SIGTERM_SECS" (str force-sigterm-secs))})
+             (update :env conj {:name "WAITER_CONFIG_BYPASS_SIGTERM_GRACE_PERIOD_SECS"
+                                :value (get base-env "WAITER_CONFIG_BYPASS_SIGTERM_GRACE_PERIOD_SECS" (str sigterm-grace-period-secs))}))
         container-configs))
 
 (defn default-replicaset-builder

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -1452,10 +1452,11 @@
         ;; Services that are in bypass will need to safely scale down. Configuring 'preStop' will delay the sigterm for each contianer.
         bypass-enabled? (sd/service-description-bypass-enabled? service-description)
         add-lifecycle-configs-fn (fn add-lifecycle-config [container-configs]
-                                   (map #(as-> % container-config
-                                           (assoc-in container-config [:lifecycle :preStop :exec :command] pod-bypass-pre-stop-cmd)
-                                           (update container-config :env conj {:name "WAITER_BYPASS_FORCE_SIGTERM_SECS" :value (str pod-bypass-force-sigterm-secs)}))
-                                        container-configs))]
+                                   (->> container-configs
+                                       (map #(as-> % container-config
+                                               (assoc-in container-config [:lifecycle :preStop :exec :command] pod-bypass-pre-stop-cmd)
+                                               (update container-config :env conj {:name "WAITER_BYPASS_FORCE_SIGTERM_SECS" :value (str pod-bypass-force-sigterm-secs)})))
+                                        vec))]
     (cond->
       {:kind "ReplicaSet"
        :apiVersion replicaset-api-version

--- a/waiter/src/waiter/scheduler/kubernetes.clj
+++ b/waiter/src/waiter/scheduler/kubernetes.clj
@@ -801,6 +801,8 @@
         ;; We have to add both of these durations together because K8s gracePeriodSeconds countdown is done
         ;; in parallel with the preStop hook and issuing the SIGTERM signal.
         ;; https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
+        force-sigterm-secs (utils/parse-int (get-in desc ["env" "WAITER_CONFIG_BYPASS_FORCE_SIGTERM_SECS"] (str force-sigterm-secs)))
+        sigterm-grace-period-secs (utils/parse-int (get-in desc ["env" "WAITER_CONFIG_BYPASS_SIGTERM_GRACE_PERIOD_SECS"] (str sigterm-grace-period-secs)))
         total-bypass-grace-period-secs (+ force-sigterm-secs sigterm-grace-period-secs)
         grace-period-seconds (if bypass-enabled? total-bypass-grace-period-secs 300)]
     (when bypass-enabled?

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -420,11 +420,11 @@
                                    :max-patch-retries 5
                                    :max-name-length 63
                                    :pod-base-port 31000
-                                   :pod-bypass-force-sigterm-secs 120
-                                   :pod-bypass-pre-stop-cmd ["/bin/sh"
-                                                             "-c"
-                                                             "echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: sleeping for ${WAITER_BYPASS_FORCE_SIGTERM_SECS} secs >> /proc/1/fd/1 ; sleep ${WAITER_BYPASS_FORCE_SIGTERM_SECS} ; echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: ending sleep, and container will receive SIGTERM shortly >> /proc/1/fd/1"]
-                                   :pod-bypass-sigterm-grace-period-secs 30
+                                   :pod-bypass {:force-sigterm-secs 120
+                                                :pre-stop-cmd ["/bin/sh"
+                                                               "-c"
+                                                               "echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: sleeping for ${WAITER_BYPASS_FORCE_SIGTERM_SECS} secs >> /proc/1/fd/1 ; sleep ${WAITER_BYPASS_FORCE_SIGTERM_SECS} ; echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: ending sleep, and container will receive SIGTERM shortly >> /proc/1/fd/1"]
+                                                :sigterm-grace-period-secs 30}
                                    ; Marathon also defaults this value to 3 seconds:
                                    ; https://mesosphere.github.io/marathon/docs/health-checks.html#taskkillgraceperiodseconds
                                    :pod-sigkill-delay-secs 3

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -423,7 +423,7 @@
                                    :pod-bypass {:force-sigterm-secs 120
                                                 :pre-stop-cmd ["/bin/sh"
                                                                "-c"
-                                                               "echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: sleeping for ${WAITER_BYPASS_FORCE_SIGTERM_SECS} secs >> /proc/1/fd/1 ; sleep ${WAITER_BYPASS_FORCE_SIGTERM_SECS} ; echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: ending sleep, and container will receive SIGTERM shortly >> /proc/1/fd/1"]
+                                                               "echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: sleeping for ${WAITER_CONFIG_BYPASS_FORCE_SIGTERM_SECS} secs >> /proc/1/fd/1 ; sleep ${WAITER_CONFIG_BYPASS_FORCE_SIGTERM_SECS} ; echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: ending sleep, and container will receive SIGTERM shortly >> /proc/1/fd/1"]
                                                 :sigterm-grace-period-secs 30}
                                    ; Marathon also defaults this value to 3 seconds:
                                    ; https://mesosphere.github.io/marathon/docs/health-checks.html#taskkillgraceperiodseconds

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -420,6 +420,8 @@
                                    :max-patch-retries 5
                                    :max-name-length 63
                                    :pod-base-port 31000
+                                   :pod-bypass-force-sigterm-secs 120
+                                   :pod-bypass-sigterm-grace-period-secs 30
                                    ; Marathon also defaults this value to 3 seconds:
                                    ; https://mesosphere.github.io/marathon/docs/health-checks.html#taskkillgraceperiodseconds
                                    :pod-sigkill-delay-secs 3

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -421,6 +421,9 @@
                                    :max-name-length 63
                                    :pod-base-port 31000
                                    :pod-bypass-force-sigterm-secs 120
+                                   :pod-bypass-pre-stop-cmd ["/bin/sh"
+                                                             "-c"
+                                                             "echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: sleeping for ${WAITER_BYPASS_FORCE_SIGTERM_SECS} secs >> /proc/1/fd/1 ; sleep ${WAITER_BYPASS_FORCE_SIGTERM_SECS} ; echo $(date +%Y-%m-%dT%H:%M:%S.%3NZ) INFO preStop: ending sleep, and container will receive SIGTERM shortly >> /proc/1/fd/1"]
                                    :pod-bypass-sigterm-grace-period-secs 30
                                    ; Marathon also defaults this value to 3 seconds:
                                    ; https://mesosphere.github.io/marathon/docs/health-checks.html#taskkillgraceperiodseconds

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -160,20 +160,20 @@
           force-sigterm-secs 1
           sigterm-grace-period-secs 2
           actual-configs (add-pre-stop-config-for-bypass-service container-configs base-env pre-stop-cmd force-sigterm-secs sigterm-grace-period-secs)
-          expected-configs (vec (repeat 3 {:env [{:name "WAITER_BYPASS_FORCE_SIGTERM_SECS" :value "1"}
-                                                 {:name "WAITER_BYPASS_SIGTERM_GRACE_PERIOD_SECS" :value "2"}]
+          expected-configs (vec (repeat 3 {:env [{:name "WAITER_CONFIG_BYPASS_FORCE_SIGTERM_SECS" :value "1"}
+                                                 {:name "WAITER_CONFIG_BYPASS_SIGTERM_GRACE_PERIOD_SECS" :value "2"}]
                                            :lifecycle {:preStop {:exec {:command pre-stop-cmd}}}}))]
       (assert-data-equal expected-configs actual-configs)))
   (testing "service description environment variables override the defaults"
-    (let [base-env {"WAITER_BYPASS_FORCE_SIGTERM_SECS" "this value overrides defaults"
-                    "WAITER_BYPASS_SIGTERM_GRACE_PERIOD_SECS" "this value overrides defaults"}
+    (let [base-env {"WAITER_CONFIG_BYPASS_FORCE_SIGTERM_SECS" "this value overrides defaults"
+                    "WAITER_CONFIG_BYPASS_SIGTERM_GRACE_PERIOD_SECS" "this value overrides defaults"}
           container-configs (vec (repeat 3 {}))
           pre-stop-cmd ["this" "is" "a" "test"]
           force-sigterm-secs 1
           sigterm-grace-period-secs 2
           actual-configs (add-pre-stop-config-for-bypass-service container-configs base-env pre-stop-cmd force-sigterm-secs sigterm-grace-period-secs)
-          expected-configs (vec (repeat 3 {:env [{:name "WAITER_BYPASS_FORCE_SIGTERM_SECS" :value "this value overrides defaults"}
-                                                 {:name "WAITER_BYPASS_SIGTERM_GRACE_PERIOD_SECS" :value "this value overrides defaults"}]
+          expected-configs (vec (repeat 3 {:env [{:name "WAITER_CONFIG_BYPASS_FORCE_SIGTERM_SECS" :value "this value overrides defaults"}
+                                                 {:name "WAITER_CONFIG_BYPASS_SIGTERM_GRACE_PERIOD_SECS" :value "this value overrides defaults"}]
                                            :lifecycle {:preStop {:exec {:command pre-stop-cmd}}}}))]
       (assert-data-equal expected-configs actual-configs))))
 
@@ -199,8 +199,8 @@
           replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler "test-service-id" service-description rs-spec-builder-context)]
       (doseq [container (get-in replicaset-spec [:spec :template :spec :containers])]
         (is (= {:exec {:command ["test" "pre-stop" "cmd" "config"]}} (get-in container [:lifecycle :preStop])))
-        (is (contains? (set (:env container)) {:name "WAITER_BYPASS_FORCE_SIGTERM_SECS" :value "120"}))
-        (is (contains? (set (:env container)) {:name "WAITER_BYPASS_SIGTERM_GRACE_PERIOD_SECS" :value "30"}))))))
+        (is (contains? (set (:env container)) {:name "WAITER_CONFIG_BYPASS_FORCE_SIGTERM_SECS" :value "120"}))
+        (is (contains? (set (:env container)) {:name "WAITER_CONFIG_BYPASS_SIGTERM_GRACE_PERIOD_SECS" :value "30"}))))))
 
 (deftest test-replicaset-spec-fileserver-container-and-metadata
   (let [current-time (t/now)]

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -2117,6 +2117,20 @@
             (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-base-port "8080"))))
             (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-base-port 1234567890)))))
 
+          (testing "bad pod-bypass-force-sigterm-secs"
+            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-bypass-force-sigterm-secs -1))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-bypass-force-sigterm-secs "10")))))
+
+          (testing "bad pod-bypass-pre-stop-cmd"
+            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-bypass-pre-stop-cmd [1 2 3 4]))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-bypass-pre-stop-cmd 5))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-bypass-pre-stop-cmd '("testing")))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-bypass-pre-stop-cmd "10")))))
+
+          (testing "bad pod-bypass-sigterm-grace-period-secs"
+            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-bypass-sigterm-grace-period-secs -1))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-bypass-sigterm-grace-period-secs "10")))))
+
           (testing "bad pod termination grace period"
             (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-sigkill-delay-secs -1))))
             (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-sigkill-delay-secs "10"))))

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -82,9 +82,9 @@
      :pdb-api-version "policy/v1beta1"
      :pdb-spec-builder-fn waiter.scheduler.kubernetes/default-pdb-spec-builder
      :pod-base-port 8080
-     :pod-bypass-force-sigterm-secs 120
-     :pod-bypass-pre-stop-cmd ["test" "pre-stop" "cmd" "config"]
-     :pod-bypass-sigterm-grace-period-secs 30
+     :pod-bypass {:force-sigterm-secs 120
+                  :pre-stop-cmd ["test" "pre-stop" "cmd" "config"]
+                  :sigterm-grace-period-secs 30}
      :pod-sigkill-delay-secs 3
      :pod-suffix-length default-pod-suffix-length
      :replicaset-api-version "apps/v1"
@@ -2087,9 +2087,9 @@
                     :max-patch-retries 5
                     :max-name-length 63
                     :pod-base-port 8080
-                    :pod-bypass-force-sigterm-secs 120
-                    :pod-bypass-pre-stop-cmd ["test" "pre-stop" "cmd" "config"]
-                    :pod-bypass-sigterm-grace-period-secs 30
+                    :pod-bypass {:force-sigterm-secs 120
+                                 :pre-stop-cmd ["test" "pre-stop" "cmd" "config"]
+                                 :sigterm-grace-period-secs 30}
                     :pod-sigkill-delay-secs 3
                     :pod-suffix-length default-pod-suffix-length
                     :replicaset-api-version "apps/v1"
@@ -2142,18 +2142,18 @@
             (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-base-port 1234567890)))))
 
           (testing "bad pod-bypass-force-sigterm-secs"
-            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-bypass-force-sigterm-secs -1))))
-            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-bypass-force-sigterm-secs "10")))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config [:pod-bypass :force-sigterm-secs] -1))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config [:pod-bypass :force-sigterm-secs] "10")))))
 
           (testing "bad pod-bypass-pre-stop-cmd"
-            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-bypass-pre-stop-cmd [1 2 3 4]))))
-            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-bypass-pre-stop-cmd 5))))
-            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-bypass-pre-stop-cmd '("testing")))))
-            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-bypass-pre-stop-cmd "10")))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config [:pod-bypass :pre-stop-cmd] [1 2 3 4]))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config [:pod-bypass :pre-stop-cmd] 5))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config [:pod-bypass :pre-stop-cmd] '("testing")))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config [:pod-bypass :pre-stop-cmd] "10")))))
 
           (testing "bad pod-bypass-sigterm-grace-period-secs"
-            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-bypass-sigterm-grace-period-secs -1))))
-            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-bypass-sigterm-grace-period-secs "10")))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config [:pod-bypass :sigterm-grace-period-secs] -1))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config [:pod-bypass :sigterm-grace-period-secs] "10")))))
 
           (testing "bad pod termination grace period"
             (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-sigkill-delay-secs -1))))

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -82,6 +82,8 @@
      :pdb-api-version "policy/v1beta1"
      :pdb-spec-builder-fn waiter.scheduler.kubernetes/default-pdb-spec-builder
      :pod-base-port 8080
+     :pod-bypass-force-sigterm-secs 120
+     :pod-bypass-sigterm-grace-period-secs 30
      :pod-sigkill-delay-secs 3
      :pod-suffix-length default-pod-suffix-length
      :replicaset-api-version "apps/v1"
@@ -2037,6 +2039,8 @@
                     :max-patch-retries 5
                     :max-name-length 63
                     :pod-base-port 8080
+                    :pod-bypass-force-sigterm-secs 120
+                    :pod-bypass-sigterm-grace-period-secs 30
                     :pod-sigkill-delay-secs 3
                     :pod-suffix-length default-pod-suffix-length
                     :replicaset-api-version "apps/v1"

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -83,6 +83,7 @@
      :pdb-spec-builder-fn waiter.scheduler.kubernetes/default-pdb-spec-builder
      :pod-base-port 8080
      :pod-bypass-force-sigterm-secs 120
+     :pod-bypass-pre-stop-cmd []
      :pod-bypass-sigterm-grace-period-secs 30
      :pod-sigkill-delay-secs 3
      :pod-suffix-length default-pod-suffix-length
@@ -2040,6 +2041,7 @@
                     :max-name-length 63
                     :pod-base-port 8080
                     :pod-bypass-force-sigterm-secs 120
+                    :pod-bypass-pre-stop-cmd []
                     :pod-bypass-sigterm-grace-period-secs 30
                     :pod-sigkill-delay-secs 3
                     :pod-suffix-length default-pod-suffix-length

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -1640,6 +1640,31 @@
                  actual))
           (is (= expected-api-call-count @api-call-count-atom))
           (is (= expected-delete-grace-period @pod-delete-grace-period-atom))))
+      (testing "successful-delete: bypass with WAITER_CONFIG_BYPASS_FORCE_SIGTERM_SECS and WAITER_CONFIG_BYPASS_SIGTERM_GRACE_PERIOD_SECS overrides"
+        (let [dummy-scheduler (assoc dummy-scheduler :service-id->service-description-fn (constantly {"env" {"WAITER_CONFIG_BYPASS_FORCE_SIGTERM_SECS" "3"
+                                                                                                             "WAITER_CONFIG_BYPASS_SIGTERM_GRACE_PERIOD_SECS" "4"}
+                                                                                                      "metadata" {"waiter-proxy-bypass-opt-in" "true"}}))
+              api-call-count-atom (atom 0)
+              expected-api-call-count 2 ;; should make one request for deleting the pod and one request for update the replicas count
+              pod-delete-grace-period-atom (atom nil)
+              expected-delete-grace-period 7 ;; should be the pod-bypass-force-sigterm-secs + pod-bypass-sigterm-grace-period-secs (env variables overrides 3 + 4)
+              actual (with-redefs [api-request (fn mock-api-request [resource-url _ & {:keys [body]}]
+                                                 (when (some-> resource-url (str/includes? "/pods/"))
+                                                   (some->> body
+                                                            ct/try-parse-json
+                                                            walk/keywordize-keys
+                                                            :gracePeriodSeconds
+                                                            (reset! pod-delete-grace-period-atom)))
+                                                 (swap! api-call-count-atom inc)
+                                                 {:status "OK"})]
+                       (scheduler/kill-instance dummy-scheduler instance))]
+          (is (= (assoc partial-expected
+                        :killed? true
+                        :message "Successfully killed instance"
+                        :status http-200-ok)
+                 actual))
+          (is (= expected-api-call-count @api-call-count-atom))
+          (is (= expected-delete-grace-period @pod-delete-grace-period-atom))))
       (testing "unsuccessful-delete: forbidden"
         (let [actual (with-redefs [api-request (fn mocked-api-request [_ _ & {:keys [request-method]}]
                                                  (when (= request-method :delete)

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -2142,18 +2142,18 @@
             (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-base-port 1234567890)))))
 
           (testing "bad pod-bypass-force-sigterm-secs"
-            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config [:pod-bypass :force-sigterm-secs] -1))))
-            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config [:pod-bypass :force-sigterm-secs] "10")))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc-in base-config [:pod-bypass :force-sigterm-secs] -1))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc-in base-config [:pod-bypass :force-sigterm-secs] "10")))))
 
           (testing "bad pod-bypass-pre-stop-cmd"
-            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config [:pod-bypass :pre-stop-cmd] [1 2 3 4]))))
-            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config [:pod-bypass :pre-stop-cmd] 5))))
-            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config [:pod-bypass :pre-stop-cmd] '("testing")))))
-            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config [:pod-bypass :pre-stop-cmd] "10")))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc-in base-config [:pod-bypass :pre-stop-cmd] [1 2 3 4]))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc-in base-config [:pod-bypass :pre-stop-cmd] 5))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc-in base-config [:pod-bypass :pre-stop-cmd] '("testing")))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc-in base-config [:pod-bypass :pre-stop-cmd] "10")))))
 
           (testing "bad pod-bypass-sigterm-grace-period-secs"
-            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config [:pod-bypass :sigterm-grace-period-secs] -1))))
-            (is (thrown? Throwable (kubernetes-scheduler (assoc base-config [:pod-bypass :sigterm-grace-period-secs] "10")))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc-in base-config [:pod-bypass :sigterm-grace-period-secs] -1))))
+            (is (thrown? Throwable (kubernetes-scheduler (assoc-in base-config [:pod-bypass :sigterm-grace-period-secs] "10")))))
 
           (testing "bad pod termination grace period"
             (is (thrown? Throwable (kubernetes-scheduler (assoc base-config :pod-sigkill-delay-secs -1))))

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -152,6 +152,18 @@
         (clojure.data/diff expected# actual#)))
      (is (= expected# actual#))))
 
+(deftest test-add-pre-stop-config-for-bypass-service
+  (testing "adds expected environment variables and prestop command to configs"
+    (let [container-configs (repeat 3 {})
+          pre-stop-cmd ["this" "is" "a" "test"]
+          force-sigterm-secs 1
+          sigterm-grace-period-secs 2
+          actual-configs (add-pre-stop-config-for-bypass-service container-configs pre-stop-cmd force-sigterm-secs sigterm-grace-period-secs)
+          expected-configs (vec (repeat 3 {:env [{:name "WAITER_BYPASS_FORCE_SIGTERM_SECS" :value "1"}
+                                                 {:name "WAITER_BYPASS_SIGTERM_GRACE_PERIOD_SECS" :value "2"}]
+                                           :lifecycle {:preStop {:exec {:command pre-stop-cmd}}}}))]
+      (assert-data-equal expected-configs actual-configs))))
+
 (deftest test-replicaset-spec-pre-stop-cmd
   (with-redefs [config/retrieve-cluster-name (constantly "test-cluster")
                 config/retrieve-request-log-request-headers (constantly  #{})
@@ -174,7 +186,8 @@
           replicaset-spec ((:replicaset-spec-builder-fn scheduler) scheduler "test-service-id" service-description rs-spec-builder-context)]
       (doseq [container (get-in replicaset-spec [:spec :template :spec :containers])]
         (is (= {:exec {:command ["test" "pre-stop" "cmd" "config"]}} (get-in container [:lifecycle :preStop])))
-        (is (contains? (set (:env container)) {:name "WAITER_BYPASS_FORCE_SIGTERM_SECS" :value "120"}))))))
+        (is (contains? (set (:env container)) {:name "WAITER_BYPASS_FORCE_SIGTERM_SECS" :value "120"}))
+        (is (contains? (set (:env container)) {:name "WAITER_BYPASS_SIGTERM_GRACE_PERIOD_SECS" :value "30"}))))))
 
 (deftest test-replicaset-spec-fileserver-container-and-metadata
   (let [current-time (t/now)]


### PR DESCRIPTION
## Changes proposed in this PR

- adds preStop command for services in bypass mode
- Logs look like this:
```
waiter-fileserver 2022-09-08T15:08:32. INFO preStop: sleeping for 120 secs
waiter-app 2022-09-08T15:08:32.111Z INFO preStop: sleeping for 120 secs
waiter-raven-sidecar 2022-09-08T15:08:32. INFO preStop: sleeping for 120 secs
waiter-fileserver 2022-09-08T15:10:32. INFO preStop: ending sleep, and container will receive SIGTERM shortly                                                                                        waiter-raven-sidecar 2022-09-08T15:10:32. INFO preStop: ending sleep, and container will receive SIGTERM shortly
waiter-app 2022-09-08T15:10:32.168Z INFO preStop: ending sleep, and container will receive SIGTERM shortly
```

## Why are we making these changes?

- this will allow for pods in bypass to gracefully terminate

## Followup PRs

- preStop command stops sleeping eagerly when the pod is not receiving any requests.
