### PR TITLE
adds support for reporting backend connect errors

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -1058,7 +1058,8 @@
                                :show-locked-synchronizers false}}
 
  ;; Certain messages that Waiter returns can be customized:
- :messages {:backend-request-failed "Request to service backend failed"
+ :messages {:backend-connect-error "Request failed to connect to service backend"
+            :backend-request-failed "Request to service backend failed"
             :backend-request-timed-out "Request to service backend timed out"
             :bad-socket "Backend is closing socket without responding (ensure backend-proto is correctly configured)"
             :bad-startup-command "Invalid startup command"

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -353,7 +353,8 @@
                        :ttl 60}
                :encrypt true
                :relative-path "tokens"}
-   :messages {:backend-request-failed "Request to service backend failed"
+   :messages {:backend-connect-error "Request failed to connect to service backend"
+              :backend-request-failed "Request to service backend failed"
               :backend-request-timed-out "Request to service backend timed out"
               :bad-socket "Backend is closing socket without responding (ensure backend-proto is correctly configured)"
               :bad-startup-command "Invalid startup command"

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -31,6 +31,7 @@
             [waiter.test-helpers :refer :all]
             [waiter.util.utils :as utils])
   (:import (java.io ByteArrayOutputStream IOException)
+           (java.net ConnectException SocketTimeoutException)
            (java.util.concurrent TimeoutException)
            (org.eclipse.jetty.client HttpClient)
            (org.eclipse.jetty.io EofException)
@@ -583,45 +584,52 @@
     (is (= 103 @position-generator-atom))))
 
 (deftest test-classify-error
-  (is (= [:generic-error "Test Exception" http-500-internal-server-error "clojure.lang.ExceptionInfo"]
-         (classify-error (ex-info "Test Exception" {:source :test}))))
-  (is (= [:test-error "Test Exception" http-500-internal-server-error "clojure.lang.ExceptionInfo"]
-         (classify-error (ex-info "Test Exception" {:error-cause :test-error :source :test}))))
-  (is (= [:generic-error "Test Exception" http-400-bad-request "clojure.lang.ExceptionInfo"]
-         (classify-error (ex-info "Test Exception" {:source :test :status http-400-bad-request}))))
-  (is (= [:instance-error nil http-502-bad-gateway "java.io.IOException"]
-         (classify-error (ex-info "Test Exception" {:source :test :status http-400-bad-request} (IOException. "Test")))))
-  (is (= [:instance-error nil http-502-bad-gateway "java.io.IOException"]
-         (classify-error (IOException. "Test"))))
-  (is (= [:client-error "Client action means stream is no longer needed" http-400-bad-request "java.io.IOException"]
-         (classify-error (ex-info "Test Exception" {:source :test :status http-400-bad-request} (IOException. "cancel_stream_error")))))
-  (is (= [:client-error "Client action means stream is no longer needed" http-400-bad-request "java.io.IOException"]
-         (classify-error (IOException. "cancel_stream_error"))))
-  (let [exception (IOException. "internal_error")]
-    (->> (into-array StackTraceElement
-                     [(StackTraceElement. "org.eclipse.jetty.http2.client.http.HttpReceiverOverHTTP2" "onReset" "HttpReceivedOverHTTP2.java" 169)
-                      (StackTraceElement. "org.eclipse.jetty.http2.api.Stream$Listener" "onReset" "Stream.java" 177)
-                      (StackTraceElement. "org.eclipse.jetty.http2.HTTP2Stream" "notifyReset" "HTTP2Stream.java" 574)])
-      (.setStackTrace exception))
-    (is (= [:client-error "Client send invalid data to HTTP/2 backend" http-400-bad-request "java.io.IOException"]
-           (classify-error exception))))
-  (is (= [:instance-error nil http-502-bad-gateway "java.io.IOException"]
-         (classify-error (IOException. "internal_error"))))
-  (is (= [:server-eagerly-closed "Connection eagerly closed by server" http-400-bad-request "java.io.IOException"]
-         (classify-error (IOException. "no_error"))))
-  (is (= [:client-error "Connection unexpectedly closed while streaming request" http-400-bad-request "org.eclipse.jetty.io.EofException"]
-         (classify-error (ex-info "Test Exception" {:source :test :status http-400-bad-request} (EofException. "Test")))))
-  (is (= [:client-eagerly-closed "Connection eagerly closed by client" http-400-bad-request "org.eclipse.jetty.io.EofException"]
-         (classify-error (ex-info "Test Exception" {:source :test :status http-400-bad-request} (EofException. "reset")))))
-  (is (= [:client-eagerly-closed "Connection eagerly closed by client" http-400-bad-request "org.eclipse.jetty.io.EofException"]
-         (classify-error (EofException. "reset"))))
-  (is (= [:instance-error nil http-504-gateway-timeout "java.util.concurrent.TimeoutException"]
-         (classify-error (TimeoutException. "timeout"))))
-  (is (=[:client-error "Timeout receiving bytes from client" http-408-request-timeout "java.util.concurrent.TimeoutException"]
-         (let [timeout-exception (TimeoutException. "timeout")]
-           (.addSuppressed timeout-exception (Throwable. "HttpInput idle timeout"))
-           (classify-error timeout-exception))))
-  (is (= [:client-error "Failed to upgrade to websocket connection" http-400-bad-request "org.eclipse.jetty.websocket.api.UpgradeException"]
-         (classify-error (UpgradeException. nil http-400-bad-request "websocket upgrade failed"))))
-  (is (= [:instance-error nil http-502-bad-gateway "java.lang.Exception"]
-         (classify-error (Exception. "Test Exception")))))
+  (with-redefs [utils/message name]
+    (is (= [:generic-error "Test Exception" http-500-internal-server-error "clojure.lang.ExceptionInfo"]
+           (classify-error (ex-info "Test Exception" {:source :test}))))
+    (is (= [:test-error "Test Exception" http-500-internal-server-error "clojure.lang.ExceptionInfo"]
+           (classify-error (ex-info "Test Exception" {:error-cause :test-error :source :test}))))
+    (is (= [:generic-error "Test Exception" http-400-bad-request "clojure.lang.ExceptionInfo"]
+           (classify-error (ex-info "Test Exception" {:source :test :status http-400-bad-request}))))
+    (is (= [:instance-error "backend-request-failed" http-502-bad-gateway "java.io.IOException"]
+           (classify-error (ex-info "Test Exception" {:source :test :status http-400-bad-request} (IOException. "Test")))))
+    (is (= [:instance-error "backend-request-failed" http-502-bad-gateway "java.io.IOException"]
+           (classify-error (IOException. "Test"))))
+    (is (= [:client-error "Client action means stream is no longer needed" http-400-bad-request "java.io.IOException"]
+           (classify-error (ex-info "Test Exception" {:source :test :status http-400-bad-request} (IOException. "cancel_stream_error")))))
+    (is (= [:client-error "Client action means stream is no longer needed" http-400-bad-request "java.io.IOException"]
+           (classify-error (IOException. "cancel_stream_error"))))
+    (let [exception (IOException. "internal_error")]
+      (->> (into-array StackTraceElement
+                       [(StackTraceElement. "org.eclipse.jetty.http2.client.http.HttpReceiverOverHTTP2" "onReset" "HttpReceivedOverHTTP2.java" 169)
+                        (StackTraceElement. "org.eclipse.jetty.http2.api.Stream$Listener" "onReset" "Stream.java" 177)
+                        (StackTraceElement. "org.eclipse.jetty.http2.HTTP2Stream" "notifyReset" "HTTP2Stream.java" 574)])
+           (.setStackTrace exception))
+      (is (= [:client-error "Client send invalid data to HTTP/2 backend" http-400-bad-request "java.io.IOException"]
+             (classify-error exception))))
+    (is (= [:instance-error "backend-request-failed" http-502-bad-gateway "java.io.IOException"]
+           (classify-error (IOException. "internal_error"))))
+    (is (= [:server-eagerly-closed "Connection eagerly closed by server" http-400-bad-request "java.io.IOException"]
+           (classify-error (IOException. "no_error"))))
+    (is (= [:client-error "Connection unexpectedly closed while streaming request" http-400-bad-request "org.eclipse.jetty.io.EofException"]
+           (classify-error (ex-info "Test Exception" {:source :test :status http-400-bad-request} (EofException. "Test")))))
+    (is (= [:client-eagerly-closed "Connection eagerly closed by client" http-400-bad-request "org.eclipse.jetty.io.EofException"]
+           (classify-error (ex-info "Test Exception" {:source :test :status http-400-bad-request} (EofException. "reset")))))
+    (is (= [:client-eagerly-closed "Connection eagerly closed by client" http-400-bad-request "org.eclipse.jetty.io.EofException"]
+           (classify-error (EofException. "reset"))))
+    (is (= [:instance-error "backend-request-timed-out" http-504-gateway-timeout "java.util.concurrent.TimeoutException"]
+           (classify-error (TimeoutException. "timeout"))))
+    (is (= [:client-error "Timeout receiving bytes from client" http-408-request-timeout "java.util.concurrent.TimeoutException"]
+           (let [timeout-exception (TimeoutException. "timeout")]
+             (.addSuppressed timeout-exception (Throwable. "HttpInput idle timeout"))
+             (classify-error timeout-exception))))
+    (is (= [:client-error "Failed to upgrade to websocket connection" http-400-bad-request "org.eclipse.jetty.websocket.api.UpgradeException"]
+           (classify-error (UpgradeException. nil http-400-bad-request "websocket upgrade failed"))))
+    (is (= [:instance-error "backend-connect-error" http-502-bad-gateway "java.net.ConnectException"]
+           (classify-error (ConnectException. "Connection refused"))))
+    (is (= [:instance-error "backend-connect-error" http-502-bad-gateway "java.net.SocketTimeoutException"]
+           (classify-error (SocketTimeoutException. "Connect Timeout"))))
+    (is (= [:instance-error "backend-request-failed" http-502-bad-gateway "java.net.SocketTimeoutException"]
+           (classify-error (SocketTimeoutException. "Connection refused"))))
+    (is (= [:instance-error "backend-request-failed" http-502-bad-gateway "java.lang.Exception"]
+           (classify-error (Exception. "Test Exception"))))))


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for reporting backend connect errors

## Why are we making these changes?

We would like to be able to distinguish the cause of 502 responses, in particular, be able to determine that the error was due to a connect error. Such errors provide a signal to clients that it is safe to retry operations if they so choose to.


