### PR TITLE
adds labels to logs from classify-error for simplified debugging

### DIFF
--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -620,19 +620,19 @@
 (deftest test-classify-error
   (with-redefs [utils/message name]
     (is (= [:generic-error "Test Exception" http-500-internal-server-error "clojure.lang.ExceptionInfo"]
-           (classify-error (ex-info "Test Exception" {:source :test}))))
+           (classify-error "test-classify-error" (ex-info "Test Exception" {:source :test}))))
     (is (= [:test-error "Test Exception" http-500-internal-server-error "clojure.lang.ExceptionInfo"]
-           (classify-error (ex-info "Test Exception" {:error-cause :test-error :source :test}))))
+           (classify-error "test-classify-error" (ex-info "Test Exception" {:error-cause :test-error :source :test}))))
     (is (= [:generic-error "Test Exception" http-400-bad-request "clojure.lang.ExceptionInfo"]
-           (classify-error (ex-info "Test Exception" {:source :test :status http-400-bad-request}))))
+           (classify-error "test-classify-error" (ex-info "Test Exception" {:source :test :status http-400-bad-request}))))
     (is (= [:instance-error "backend-request-failed" http-502-bad-gateway "java.io.IOException"]
-           (classify-error (ex-info "Test Exception" {:source :test :status http-400-bad-request} (IOException. "Test")))))
+           (classify-error "test-classify-error" (ex-info "Test Exception" {:source :test :status http-400-bad-request} (IOException. "Test")))))
     (is (= [:instance-error "backend-request-failed" http-502-bad-gateway "java.io.IOException"]
-           (classify-error (IOException. "Test"))))
+           (classify-error "test-classify-error" (IOException. "Test"))))
     (is (= [:client-error "Client action means stream is no longer needed" http-400-bad-request "java.io.IOException"]
-           (classify-error (ex-info "Test Exception" {:source :test :status http-400-bad-request} (IOException. "cancel_stream_error")))))
+           (classify-error "test-classify-error" (ex-info "Test Exception" {:source :test :status http-400-bad-request} (IOException. "cancel_stream_error")))))
     (is (= [:client-error "Client action means stream is no longer needed" http-400-bad-request "java.io.IOException"]
-           (classify-error (IOException. "cancel_stream_error"))))
+           (classify-error "test-classify-error" (IOException. "cancel_stream_error"))))
     (let [exception (IOException. "internal_error")]
       (->> (into-array StackTraceElement
                        [(StackTraceElement. "org.eclipse.jetty.http2.client.http.HttpReceiverOverHTTP2" "onReset" "HttpReceivedOverHTTP2.java" 169)
@@ -640,30 +640,30 @@
                         (StackTraceElement. "org.eclipse.jetty.http2.HTTP2Stream" "notifyReset" "HTTP2Stream.java" 574)])
            (.setStackTrace exception))
       (is (= [:client-error "Client send invalid data to HTTP/2 backend" http-400-bad-request "java.io.IOException"]
-             (classify-error exception))))
+             (classify-error "test-classify-error" exception))))
     (is (= [:instance-error "backend-request-failed" http-502-bad-gateway "java.io.IOException"]
-           (classify-error (IOException. "internal_error"))))
+           (classify-error "test-classify-error" (IOException. "internal_error"))))
     (is (= [:server-eagerly-closed "Connection eagerly closed by server" http-400-bad-request "java.io.IOException"]
-           (classify-error (IOException. "no_error"))))
+           (classify-error "test-classify-error" (IOException. "no_error"))))
     (is (= [:client-error "Connection unexpectedly closed while streaming request" http-400-bad-request "org.eclipse.jetty.io.EofException"]
-           (classify-error (ex-info "Test Exception" {:source :test :status http-400-bad-request} (EofException. "Test")))))
+           (classify-error "test-classify-error" (ex-info "Test Exception" {:source :test :status http-400-bad-request} (EofException. "Test")))))
     (is (= [:client-eagerly-closed "Connection eagerly closed by client" http-400-bad-request "org.eclipse.jetty.io.EofException"]
-           (classify-error (ex-info "Test Exception" {:source :test :status http-400-bad-request} (EofException. "reset")))))
+           (classify-error "test-classify-error" (ex-info "Test Exception" {:source :test :status http-400-bad-request} (EofException. "reset")))))
     (is (= [:client-eagerly-closed "Connection eagerly closed by client" http-400-bad-request "org.eclipse.jetty.io.EofException"]
-           (classify-error (EofException. "reset"))))
+           (classify-error "test-classify-error" (EofException. "reset"))))
     (is (= [:instance-error "backend-request-timed-out" http-504-gateway-timeout "java.util.concurrent.TimeoutException"]
-           (classify-error (TimeoutException. "timeout"))))
+           (classify-error "test-classify-error" (TimeoutException. "timeout"))))
     (is (= [:client-error "Timeout receiving bytes from client" http-408-request-timeout "java.util.concurrent.TimeoutException"]
            (let [timeout-exception (TimeoutException. "timeout")]
              (.addSuppressed timeout-exception (Throwable. "HttpInput idle timeout"))
-             (classify-error timeout-exception))))
+             (classify-error "test-classify-error" timeout-exception))))
     (is (= [:client-error "Failed to upgrade to websocket connection" http-400-bad-request "org.eclipse.jetty.websocket.api.UpgradeException"]
-           (classify-error (UpgradeException. nil http-400-bad-request "websocket upgrade failed"))))
+           (classify-error "test-classify-error" (UpgradeException. nil http-400-bad-request "websocket upgrade failed"))))
     (is (= [:instance-error "backend-connect-error" http-502-bad-gateway "java.net.ConnectException"]
-           (classify-error (ConnectException. "Connection refused"))))
+           (classify-error "test-classify-error" (ConnectException. "Connection refused"))))
     (is (= [:instance-error "backend-connect-error" http-502-bad-gateway "java.net.SocketTimeoutException"]
-           (classify-error (SocketTimeoutException. "Connect Timeout"))))
+           (classify-error "test-classify-error" (SocketTimeoutException. "Connect Timeout"))))
     (is (= [:instance-error "backend-request-failed" http-502-bad-gateway "java.net.SocketTimeoutException"]
-           (classify-error (SocketTimeoutException. "Connection refused"))))
+           (classify-error "test-classify-error" (SocketTimeoutException. "Connection refused"))))
     (is (= [:instance-error "backend-request-failed" http-502-bad-gateway "java.lang.Exception"]
-           (classify-error (Exception. "Test Exception"))))))
+           (classify-error "test-classify-error" (Exception. "Test Exception"))))))


### PR DESCRIPTION
## Changes proposed in this PR

- adds labels to logs from classify-error for simplified debugging

## Why are we making these changes?

When debugging it helps to know the path taken while invoking `classify-error` to debug the request control flow during error handling.


