### PR TITLE
reports 403 error on OIDC too many cookies

### DIFF
--- a/waiter/src/waiter/auth/spnego.clj
+++ b/waiter/src/waiter/auth/spnego.clj
@@ -58,7 +58,7 @@
       (encode-output-token output-token))))
 
 (defn- response-http-401-unauthorized
-  [request cause]
+  [request cause spnego-disabled?]
   (log/info "triggering 401 response for spnego authentication" cause)
   (counters/inc! (metrics/waiter-counter "core" "response-status" "401"))
   (meters/mark! (metrics/waiter-meter "core" "response-status-rate" "401"))
@@ -68,13 +68,14 @@
            :status http-401-unauthorized}
         (utils/data->error-response request)
         (cookies/cookies-response))
+      true (assoc :waiter/auth-disabled? spnego-disabled?)
       waiter-token (assoc :waiter/token waiter-token))))
 
 (defn response-http-401-unauthorized-negotiate
   "Tell the client you'd like them to use kerberos"
   [request]
   (log/info "triggering 401 negotiate for spnego authentication")
-  (-> (response-http-401-unauthorized request "for negotiation")
+  (-> (response-http-401-unauthorized request "for negotiation" false)
     (assoc :error-class error-class-kerberos-negotiate)
     (assoc-in [:headers "www-authenticate"] (str/trim negotiate-prefix))))
 
@@ -82,7 +83,7 @@
   "Tell the client you'd like them to not use kerberos.
    Does not send the www-authenticate header, relies on upstream handlers to handle the missing negotiate header."
   [request]
-  (response-http-401-unauthorized request "as it is disabled"))
+  (response-http-401-unauthorized request "as it is disabled" true))
 
 (defn response-http-503-service-unavailable-temporarily-unavailable
   "Tell the client you're overloaded and would like them to try later"

--- a/waiter/src/waiter/auth/spnego.clj
+++ b/waiter/src/waiter/auth/spnego.clj
@@ -68,6 +68,7 @@
            :status http-401-unauthorized}
         (utils/data->error-response request)
         (cookies/cookies-response))
+      ;; communicate upstream when spnego auth has been disabled.
       true (assoc :waiter/auth-disabled? spnego-disabled?)
       waiter-token (assoc :waiter/token waiter-token))))
 

--- a/waiter/test/waiter/auth/oidc_test.clj
+++ b/waiter/test/waiter/auth/oidc_test.clj
@@ -560,7 +560,6 @@
                         :processed-by :oidc-updater
                         :status http-401-unauthorized
                         :waiter-api-call? false
-                        :waiter/auth-disabled? true
                         :waiter/response-source :waiter}
                        response))))
             (let [cookie-header (str/join ";" (take (inc num-challenge-cookies-allowed-in-request) challenge-cookies))]

--- a/waiter/test/waiter/auth/oidc_test.clj
+++ b/waiter/test/waiter/auth/oidc_test.clj
@@ -428,7 +428,10 @@
                                              (assoc response :processed-by :oidc-updater))]
     (let [request-handler (fn [request] (assoc request
                                           :processed-by :request-handler
-                                          :waiter/response-source :waiter))]
+                                          :waiter/response-source :waiter))
+          auth-disabled-request-handler (fn [request]
+                                          (-> (request-handler request)
+                                              (assoc :processed-by :oidc-auth-disabled-updater :waiter/auth-disabled? true)))]
 
       (testing "allow oidc authentication combinations"
         (doseq [allow-oidc-auth-api? [false true]]
@@ -531,6 +534,35 @@
                                                    "host" "www.test.com:1234"}
                                          :status http-401-unauthorized
                                          :waiter-api-call? false}))))
+            (let [oidc-auth-handler (wrap-auth-handler oidc-authenticator auth-disabled-request-handler)]
+              (let [cookie-header (str/join ";" (take (inc num-challenge-cookies-allowed-in-request) challenge-cookies))
+                    response (oidc-auth-handler {:headers {"cookie" cookie-header
+                                                           "host" "www.test.com:1234"}
+                                                 :status http-401-unauthorized
+                                                 :waiter-api-call? false})]
+                (is (str/includes? (get response :body)
+                                   (str "Too many OIDC challenge cookies "
+                                        "(allowed: " num-challenge-cookies-allowed-in-request
+                                        ", provided: " (inc num-challenge-cookies-allowed-in-request) ")")))
+                (is (= {:headers {"content-type" "text/plain"}
+                        :processed-by :oidc-auth-disabled-updater
+                        :status http-403-forbidden
+                        :waiter-api-call? false
+                        :waiter/response-source :waiter}
+                       (select-keys response [:headers :processed-by :status :waiter-api-call? :waiter/response-source]))))
+              (let [cookie-header (str/join ";" (take num-challenge-cookies-allowed-in-request challenge-cookies))
+                    response (oidc-auth-handler {:headers {"cookie" cookie-header
+                                                           "host" "www.test.com:1234"}
+                                                 :status http-401-unauthorized
+                                                 :waiter-api-call? false})]
+                (is (= {:headers {"cookie" cookie-header
+                                  "host" "www.test.com:1234"}
+                        :processed-by :oidc-updater
+                        :status http-401-unauthorized
+                        :waiter-api-call? false
+                        :waiter/auth-disabled? true
+                        :waiter/response-source :waiter}
+                       response))))
             (let [cookie-header (str/join ";" (take (inc num-challenge-cookies-allowed-in-request) challenge-cookies))]
               (is (= {:headers {"cookie" cookie-header
                                 "host" "www.test.com:1234"}

--- a/waiter/test/waiter/auth/spnego_test.clj
+++ b/waiter/test/waiter/auth/spnego_test.clj
@@ -42,6 +42,7 @@
                                :headers {"content-type" "text/plain"
                                          "www-authenticate" "Negotiate"}
                                :status http-401-unauthorized
+                               :waiter/auth-disabled? false
                                :waiter/response-source :waiter}]
 
     (with-redefs [utils/error-context->text-body (fn mocked-error-context->text-body [data-map _] (-> data-map :message str))]
@@ -53,6 +54,7 @@
             (is (= {:body "Unauthorized"
                     :headers {"content-type" "text/plain"}
                     :status http-401-unauthorized
+                    :waiter/auth-disabled? true
                     :waiter/response-source :waiter}
                    (handler request))))))
 


### PR DESCRIPTION
## Changes proposed in this PR

- reports 403 error on OIDC too many cookies

## Why are we making these changes?

Makes the error for an unauthenticated OIDC request clearer.


