### PR TITLE
makes the 401 error message configurable

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -1082,6 +1082,7 @@
             :environment-variable-error-info "Error in environment variables"
             :health-check-requires-authentication "Health check requires authentication"
             :health-check-timed-out "Health check timed out"
+            :http-401-spnego "Unauthorized"
             :invalid-health-check-response "Health check returned an invalid response"
             :invalid-service-description "Service description using waiter headers/token improperly configured"
             :metadata-error-info "Error in metadata"

--- a/waiter/src/waiter/auth/spnego.clj
+++ b/waiter/src/waiter/auth/spnego.clj
@@ -64,7 +64,7 @@
   (meters/mark! (metrics/waiter-meter "core" "response-status-rate" "401"))
   (let [waiter-token (get-in request [:waiter-discovery :token])]
     (cond->
-      (-> {:message "Unauthorized"
+      (-> {:message (utils/message :http-401-spnego)
            :status http-401-unauthorized}
         (utils/data->error-response request)
         (cookies/cookies-response))

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -366,6 +366,7 @@
               :cannot-identify-service "Unable to identify service using waiter headers/token"
               :health-check-requires-authentication "Health check requires authentication"
               :health-check-timed-out "Health check timed out"
+              :http-401-spnego "Unauthorized"
               :invalid-health-check-response "Health check returned an invalid response"
               :invalid-service-description "Service description using waiter headers/token improperly configured"
               :not-enough-memory "Not enough memory allocated"

--- a/waiter/test/waiter/auth/spnego_test.clj
+++ b/waiter/test/waiter/auth/spnego_test.clj
@@ -44,7 +44,8 @@
                                :status http-401-unauthorized
                                :waiter/response-source :waiter}]
 
-    (with-redefs [utils/error-context->text-body (fn mocked-error-context->text-body [data-map _] (-> data-map :message str))]
+    (with-redefs [utils/error-context->text-body (fn mocked-error-context->text-body [data-map _] (-> data-map :message str))
+                  utils/message (fn mocked-message [key] (if (= key :http-401-spnego) "Unauthorized" "Unknown"))]
 
       (testing "spnego authentication disabled"
         (with-redefs [too-many-pending-auth-requests? (constantly true)]


### PR DESCRIPTION
## Changes proposed in this PR

- makes the 401 error message configurable

## Why are we making these changes?

We would like to customize the error message displayed to users when Kerberos auth fails with a 401 response.


