### PR TITLE
moves maintenance mode handling earlier in the ping handler chain

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1606,7 +1606,8 @@
             (is (str/includes? body custom-maintenance-message))))
 
         (testing "request to /waiter-ping should report error with custom maintenance message"
-          (let [{:keys [body] :as response}
+          (let [request-headers (assoc request-headers "accept" "application/json")
+                {:keys [body] :as response}
                 (make-request waiter-url "/waiter-ping" :headers request-headers)]
             (assert-response-status response http-200-ok)
             (assert-waiter-response response)


### PR DESCRIPTION
## Changes proposed in this PR

- moves maintenance mode handling earlier in the ping handler chain

## Why are we making these changes?

Previously, the maintenance mode was handled too late in the handler chain. This allowed the creation of service ID and service description pointing to a stale service. Worse, the stale service was associated with references for the token in maintenance mode even though requests  would eventually 503 due to the token being in maintenance mode. In particular, the creation of the references meant that the stale service GC logic was impacted as it identified a service using the current version of the maintenance mode token. This prevented stale services from being GC-ed as the GC logic would identify the service as not stale (with a reference pointing to the latest version of the service).


