### PR TITLE
upgrades to jetty version 9.4.49.v20220914

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -45,7 +45,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20220829_161214-g1f873ca"
+                 [twosigma/jet "0.7.10-20220917_061811-g0d23827"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]


### PR DESCRIPTION
## Changes proposed in this PR

- upgrades to jetty version 9.4.49.v20220914

## Related jet PR:

- https://github.com/twosigma/jet/pull/62

## Why are we making these changes?

The upgrade addresses JVM heap issues we have been having with `MappedByteBufferPool` and WebSocket and gRPC streaming requests.

