### PR TITLE
cli tests: ping_token should check the nested response status

### DIFF
--- a/cli/integration/tests/waiter/util.py
+++ b/cli/integration/tests/waiter/util.py
@@ -267,9 +267,11 @@ def ping_token(waiter_url, token_name, expected_status_code=200):
         'x-cid': cid()
     }
     response = session.get(f'{waiter_url}', headers=headers)
-    assert \
-        expected_status_code == response.status_code, \
+    assert expected_status_code == response.status_code, \
         f'Expected {expected_status_code}, got {response.status_code} with body {response.text} '
+    ping_status = response.json()['ping-response']['status']
+    assert expected_status_code == ping_status, \
+        f'Expected {expected_status_code}, got {ping_status} in response {response.text} '
     service_id = response.headers['x-waiter-service-id']
     wait_until_routers_services(waiter_url, lambda services: any(s['service-id'] == service_id for s in services))
     return service_id


### PR DESCRIPTION
## Changes proposed in this PR

`ping_token` util function should check the nested response status

## Why are we making these changes?

`/waiter-ping` is supposed to always return 200 ok, even when the backend fails.

what we actually want to do here is make sure that the nested ping request was also successful.