### PR TITLE
adds waiter token for 401 and 403 responses to the request log

### DIFF
--- a/waiter/src/waiter/auth/authentication.clj
+++ b/waiter/src/waiter/auth/authentication.clj
@@ -202,14 +202,15 @@
         (let [auth-header (select-auth-header request #(str/starts-with? % single-user-prefix))
               {:strs [x-waiter-single-user]} headers
               auth-path (when auth-header
-                          (str/trim (subs auth-header (count single-user-prefix))))]
+                          (str/trim (subs auth-header (count single-user-prefix))))
+              waiter-token (utils/request->discovered-token request)]
           (cond
             (or (= "unauthorized" x-waiter-single-user) (= "unauthorized" auth-path))
             (utils/attach-waiter-source
-              {:headers {"www-authenticate" "SingleUser"} :status http-401-unauthorized})
+              {:headers {"www-authenticate" "SingleUser"} :status http-401-unauthorized :waiter/token waiter-token})
             (or (= "forbidden" x-waiter-single-user) (= "forbidden" auth-path))
             (utils/attach-waiter-source
-              {:headers {} :status http-403-forbidden})
+              {:headers {} :status http-403-forbidden :waiter/token waiter-token})
             (str/blank? auth-path)
             (let [auth-params-map (build-auth-params-map :single-user run-as-user)]
               (handle-request-auth request-handler request auth-params-map password nil true))

--- a/waiter/src/waiter/auth/oidc.clj
+++ b/waiter/src/waiter/auth/oidc.clj
@@ -269,7 +269,7 @@
     (utils/exception->response
       (throw (ex-info "OIDC authentication disabled" {:status http-501-not-implemented}))
       request)
-    (let [client-id (or (get-in request [:waiter-discovery :token])
+    (let [client-id (or (utils/request->discovered-token request)
                         (some-> request utils/request->host utils/authority->host))
           waiter-host? (contains? waiter-hostnames client-id)
           enabled? (if waiter-host?
@@ -347,7 +347,8 @@
       (promote-401-to-403? response)
       (merge (-> {:message (str "Too many OIDC challenge cookies (allowed: "
                                 num-allowed ", provided: " (count-challenge-cookies request) ")")
-                  :status http-403-forbidden}
+                  :status http-403-forbidden
+                  :waiter/token (utils/request->discovered-token request)}
                  (utils/data->error-response request)
                  (cookies/cookies-response))))))
 

--- a/waiter/src/waiter/auth/spnego.clj
+++ b/waiter/src/waiter/auth/spnego.clj
@@ -155,7 +155,8 @@
               (async/>!! response-chan
                          {:error (ex-info "Error during Kerberos authentication"
                                           {:details (.getMessage ex)
-                                           :status http-403-forbidden}
+                                           :status http-403-forbidden
+                                           :waiter/token (utils/request->discovered-token request)}
                                           ex)}))
             (catch Throwable th
               (log/error th "error while performing kerberos auth")

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -793,6 +793,11 @@
   [request]
   (get-in request [:headers "host"]))
 
+(defn request->discovered-token
+  "Extracts the discovered token from the request."
+  [request]
+  (get-in request [:waiter-discovery :token]))
+
 (defn same-origin
   "Returns true if the host and origin are non-nil and are equivalent."
   [{:keys [headers] :as request}]

--- a/waiter/test/waiter/util/utils_test.clj
+++ b/waiter/test/waiter/util/utils_test.clj
@@ -189,13 +189,23 @@
         (is (= expected-text-response-headers headers))
         (is (str/includes? body "TestCase Exception"))))
     (testing "json response"
-      (let [{:keys [body headers status]}
+      (let [{:keys [body headers status waiter/token]}
             (exception->response
               (ex-info "TestCase Exception" (map->TestResponse {:status http-500-internal-server-error}))
               (assoc-in request [:headers "accept"] "application/json"))]
         (is (= http-500-internal-server-error status))
         (is (= expected-json-response-headers headers))
-        (is (str/includes? body "TestCase Exception"))))))
+        (is (str/includes? body "TestCase Exception"))
+        (is (nil? token))))
+    (testing "waiter token"
+      (let [{:keys [body headers status waiter/token]}
+            (exception->response
+              (ex-info "TestCase Exception" (map->TestResponse {:status http-500-internal-server-error :waiter/token "foo-bar"}))
+              (assoc-in request [:headers "accept"] "application/json"))]
+        (is (= http-500-internal-server-error status))
+        (is (= expected-json-response-headers headers))
+        (is (str/includes? body "TestCase Exception"))
+        (is (= "foo-bar" token))))))
 
 (deftest test-log-and-suppress-when-exception-thrown
   (let [counter-atom (atom 0)


### PR DESCRIPTION
## Changes proposed in this PR

- adds waiter token for 401 and 403 responses to the request log

## Why are we making these changes?

Improves debuggability by allowing simpler tracking of 401/403 responses for specific tokens.
