### PR TITLE
adds support for hard-deleting sync opt-out tokens

### DIFF
--- a/token-syncer/integration/token_syncer/basic_test.clj
+++ b/token-syncer/integration/token_syncer/basic_test.clj
@@ -444,7 +444,7 @@
           (cleanup-token waiter-api waiter-urls token-name))))))
 
 (deftest ^:integration test-token-update-skip-on-latest-metadata-opt-out
-  (testing "token sync update"
+  (testing "skip token update on sync opt out"
     (let [waiter-urls (waiter-urls)
           {:keys [load-token store-token] :as waiter-api} (waiter-api)
           limit 10
@@ -501,6 +501,236 @@
                                     "etag" token-etag-2}
                           :status 200
                           :token-etag token-etag-2}
+                         (load-token waiter-url token-name))))))))
+        (finally
+          (cleanup-token waiter-api waiter-urls token-name))))))
+
+(deftest ^:integration test-token-update-skip-on-some-delete-latest-metadata-opt-out
+  (testing "skip token update on sync opt out"
+    (let [waiter-urls (waiter-urls)
+          {:keys [load-token store-token] :as waiter-api} (waiter-api)
+          limit 10
+          opt-out-metadata-name "sync-opt-out"
+          token-name (str "test-token-update-" (UUID/randomUUID))]
+      (try
+        ;; ARRANGE
+        (let [current-time-ms (System/currentTimeMillis)
+              token-metadata (basic-token-metadata current-time-ms)
+              token-description-1 (merge basic-description token-metadata {"metadata" {"sync-opt-out" "true"}})
+              last-update-time-ms (- current-time-ms 10000)
+              token-description-2 (assoc token-description-1
+                                    "cpus" 2
+                                    "deleted" true
+                                    "mem" 2048
+                                    "metadata" {"sync-opt-out" "false"}
+                                    "last-update-time" last-update-time-ms)]
+
+          (do
+            (store-token (first waiter-urls) token-name nil token-description-1)
+            (doseq [waiter-url (rest waiter-urls)]
+              (store-token waiter-url token-name nil token-description-2)))
+
+          (let [token-etag-1 (token->etag waiter-api (first waiter-urls) token-name)
+                token-etag-2 (token->etag waiter-api (last waiter-urls) token-name)]
+
+            ;; ACT
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit opt-out-metadata-name)]
+
+              ;; ASSERT
+              (let [waiter-sync-result (constantly {:code :success/skip-opt-out})
+                    expected-result {:details {token-name {:latest {:cluster-url (first waiter-urls)
+                                                                    :description token-description-1
+                                                                    :token-etag token-etag-1}
+                                                           :sync-result (pc/map-from-keys waiter-sync-result (rest waiter-urls))}}
+                                     :summary {:sync {:failed #{}
+                                                      :unmodified #{}
+                                                      :updated #{token-name}}
+                                               :tokens {:pending {:count 1 :value #{token-name}}
+                                                        :previously-synced {:count 0 :value #{}}
+                                                        :processed {:count 1 :value #{token-name}}
+                                                        :selected {:count 1 :value #{token-name}}
+                                                        :total {:count 1 :value #{token-name}}}}}]
+                (is (= expected-result actual-result))
+                (let [waiter-url (first waiter-urls)]
+                  (is (= {:description token-description-1
+                          :headers {"content-type" "application/json"
+                                    "etag" token-etag-1}
+                          :status 200
+                          :token-etag token-etag-1}
+                         (load-token waiter-url token-name))))
+                (doseq [waiter-url (rest waiter-urls)]
+                  (is (= {:description token-description-2
+                          :headers {"content-type" "application/json"}
+                          :status 200}
+                         (load-token waiter-url token-name))))))))
+        (finally
+          (cleanup-token waiter-api waiter-urls token-name))))))
+
+(deftest ^:integration test-token-hard-delete-on-delete-latest-metadata-opt-in
+  (testing "hard-delete soft-deleted tokens despite sync opt out"
+    (let [waiter-urls (waiter-urls)
+          {:keys [load-token store-token] :as waiter-api} (waiter-api)
+          limit 10
+          opt-out-metadata-name "sync-opt-out"
+          token-name (str "test-token-update-" (UUID/randomUUID))]
+      (try
+        ;; ARRANGE
+        (let [current-time-ms (System/currentTimeMillis)
+              token-metadata (basic-token-metadata current-time-ms)
+              token-description-1 (merge basic-description token-metadata {"metadata" {"sync-opt-out" "true"}})
+              last-update-time-ms (- current-time-ms 10000)
+              token-description-2 (assoc token-description-1
+                                    "cpus" 2
+                                    "deleted" true
+                                    "mem" 2048
+                                    "metadata" {"sync-opt-out" "true"}
+                                    "last-update-time" last-update-time-ms)]
+
+          (do
+            (store-token (first waiter-urls) token-name nil token-description-1)
+            (doseq [waiter-url (rest waiter-urls)]
+              (store-token waiter-url token-name nil token-description-2)))
+
+          (let [token-etag-1 (token->etag waiter-api (first waiter-urls) token-name)
+                token-etag-2 (token->etag waiter-api (last waiter-urls) token-name)]
+
+            ;; ACT
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit opt-out-metadata-name)]
+
+              ;; ASSERT
+              (let [waiter-sync-result (constantly {:code :success/hard-delete
+                                                    :details {:etag ""
+                                                              :status 200}})
+                    expected-result {:details {token-name {:latest {:cluster-url (first waiter-urls)
+                                                                    :description token-description-1
+                                                                    :token-etag token-etag-1}
+                                                           :sync-result (pc/map-from-keys waiter-sync-result (rest waiter-urls))}}
+                                     :summary {:sync {:failed #{}
+                                                      :unmodified #{}
+                                                      :updated #{token-name}}
+                                               :tokens {:pending {:count 1 :value #{token-name}}
+                                                        :previously-synced {:count 0 :value #{}}
+                                                        :processed {:count 1 :value #{token-name}}
+                                                        :selected {:count 1 :value #{token-name}}
+                                                        :total {:count 1 :value #{token-name}}}}}]
+                (is (= expected-result actual-result))
+                (let [waiter-url (first waiter-urls)]
+                  (is (= {:description token-description-1
+                          :headers {"content-type" "application/json"
+                                    "etag" token-etag-1}
+                          :status 200
+                          :token-etag token-etag-1}
+                         (load-token waiter-url token-name))))
+                (doseq [waiter-url (rest waiter-urls)]
+                  (is (= {:description {}
+                          :headers {"content-type" "application/json"}
+                          :status 404}
+                         (load-token waiter-url token-name))))))))
+        (finally
+          (cleanup-token waiter-api waiter-urls token-name))))))
+
+(deftest ^:integration test-token-hard-delete-on-all-latest-metadata-opt-in
+  (testing "hard-delete all soft-deleted tokens despite sync opt out"
+    (let [waiter-urls (waiter-urls)
+          {:keys [load-token store-token] :as waiter-api} (waiter-api)
+          limit 10
+          opt-out-metadata-name "sync-opt-out"
+          token-name (str "test-token-delete-" (UUID/randomUUID))]
+      (try
+        ;; ARRANGE
+        (let [current-time-ms (System/currentTimeMillis)
+              token-metadata (basic-token-metadata current-time-ms)
+              token-description-1 (merge basic-description
+                                         token-metadata
+                                         {"deleted" true "metadata" {"sync-opt-out" "true"}})
+              last-update-time-ms (- current-time-ms 10000)
+              token-description-2 (assoc token-description-1
+                                    "cpus" 2
+                                    "mem" 2048
+                                    "last-update-time" last-update-time-ms)]
+
+          (do
+            (store-token (first waiter-urls) token-name nil token-description-1)
+            (doseq [waiter-url (rest waiter-urls)]
+              (store-token waiter-url token-name nil token-description-2)))
+
+          (let [token-etag-1 (token->etag waiter-api (first waiter-urls) token-name)
+                token-etag-2 (token->etag waiter-api (last waiter-urls) token-name)]
+
+            ;; ACT
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit opt-out-metadata-name)]
+
+              ;; ASSERT
+              (let [waiter-sync-result (constantly {:code :success/hard-delete
+                                                    :details {:etag ""
+                                                              :status 200}})
+                    expected-result {:details {token-name {:latest {:cluster-url (first waiter-urls)
+                                                                    :description token-description-1
+                                                                    :token-etag token-etag-1}
+                                                           :sync-result (pc/map-from-keys waiter-sync-result waiter-urls)}}
+                                     :summary {:sync {:failed #{}
+                                                      :unmodified #{}
+                                                      :updated #{token-name}}
+                                               :tokens {:pending {:count 1 :value #{token-name}}
+                                                        :previously-synced {:count 0 :value #{}}
+                                                        :processed {:count 1 :value #{token-name}}
+                                                        :selected {:count 1 :value #{token-name}}
+                                                        :total {:count 1 :value #{token-name}}}}}]
+                (is (= expected-result actual-result))
+                (doseq [waiter-url waiter-urls]
+                  (is (= {:description {}
+                          :headers {"content-type" "application/json"}
+                          :status 404}
+                         (load-token waiter-url token-name))))))))
+        (finally
+          (cleanup-token waiter-api waiter-urls token-name))))))
+
+(deftest ^:integration test-token-hard-delete-on-single-latest-metadata-opt-out
+  (testing "token sync hard delete"
+    (let [waiter-urls (waiter-urls)
+          {:keys [load-token store-token] :as waiter-api} (waiter-api)
+          limit 10
+          opt-out-metadata-name "sync-opt-out"
+          token-name (str "test-token-delete-" (UUID/randomUUID))]
+      (try
+        ;; ARRANGE
+        (let [current-time-ms (System/currentTimeMillis)
+              token-metadata (basic-token-metadata current-time-ms)
+              token-description-1 (merge basic-description
+                                         token-metadata
+                                         {"deleted" true "metadata" {"sync-opt-out" "true"}})]
+
+          (store-token (first waiter-urls) token-name nil token-description-1)
+
+          (let [token-etag-1 (token->etag waiter-api (first waiter-urls) token-name)]
+
+            ;; ACT
+            (let [actual-result (syncer/sync-tokens waiter-api waiter-urls limit opt-out-metadata-name)]
+
+              ;; ASSERT
+              (let [waiter-sync-result (constantly {:code :success/skip-hard-delete
+                                                    :details {:message "Token not soft-deleted in cluster"
+                                                              :soft-deleted nil}})
+                    expected-result {:details {token-name {:latest {:cluster-url (first waiter-urls)
+                                                                    :description token-description-1
+                                                                    :token-etag token-etag-1}
+                                                           :sync-result (-> (pc/map-from-keys waiter-sync-result (rest waiter-urls))
+                                                                            (assoc (first waiter-urls) {:code :success/hard-delete
+                                                                                                        :details {:etag ""
+                                                                                                                  :status 200}}))}}
+                                     :summary {:sync {:failed #{}
+                                                      :unmodified #{}
+                                                      :updated #{token-name}}
+                                               :tokens {:pending {:count 1 :value #{token-name}}
+                                                        :previously-synced {:count 0 :value #{}}
+                                                        :processed {:count 1 :value #{token-name}}
+                                                        :selected {:count 1 :value #{token-name}}
+                                                        :total {:count 1 :value #{token-name}}}}}]
+                (is (= expected-result actual-result))
+                (doseq [waiter-url waiter-urls]
+                  (is (= {:description {}
+                          :headers {"content-type" "application/json"}
+                          :status 404}
                          (load-token waiter-url token-name))))))))
         (finally
           (cleanup-token waiter-api waiter-urls token-name))))))


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for hard-deleting sync opt-out tokens

## Why are we making these changes?

Tokens that opt out of token syncing report sync failures if they are left soft-deleted on a single cluster. Instead, we should hard-delete such tokens and report sync success.

