### PR TITLE
avoids reporting error while syncing deleted short-lived tokens

### DIFF
--- a/token-syncer/src/token_syncer/commands/syncer.clj
+++ b/token-syncer/src/token_syncer/commands/syncer.clj
@@ -106,6 +106,10 @@
                       {:code :error/token-read
                        :details {:message "status missing from response"}}
 
+                      ;; short-lived token which was deleted between the index retrieval and token info retrieval
+                      (and (empty? latest-token-description) (empty? description))
+                      {:code :success/skip-missing}
+
                       (nil? latest-root)
                       {:code :error/token-read
                        :details {:message "token root missing from latest token description"}}

--- a/token-syncer/test/token_syncer/commands/syncer_test.clj
+++ b/token-syncer/test/token_syncer/commands/syncer_test.clj
@@ -567,7 +567,7 @@
                                                :status 200}}}
                (sync-token-on-clusters waiter-api cluster-urls test-token token-description opt-out-metadata-name cluster-url->token-data)))))
 
-    (testing "sync cluster successfully when token missing"
+    (testing "sync cluster successfully when token missing on one cluster"
       (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
             test-token "test-token-1"
             token-description {"last-update-user" "john.doe"
@@ -585,6 +585,16 @@
                 "www.cluster-2.com" {:code :success/sync-update
                                      :details {:etag ".new"
                                                :status 200}}}
+               (sync-token-on-clusters waiter-api cluster-urls test-token token-description opt-out-metadata-name cluster-url->token-data)))))
+
+    (testing "sync cluster successfully when token missing on all clusters"
+      (let [cluster-urls ["www.cluster-1.com" "www.cluster-2.com"]
+            test-token "test-token-1"
+            token-description {}
+            cluster-url->token-data {"www.cluster-1.com" {:status 404}
+                                     "www.cluster-2.com" {:status 404}}]
+        (is (= {"www.cluster-1.com" {:code :success/skip-missing}
+                "www.cluster-2.com" {:code :success/skip-missing}}
                (sync-token-on-clusters waiter-api cluster-urls test-token token-description opt-out-metadata-name cluster-url->token-data)))))
 
     (testing "sync cluster error"


### PR DESCRIPTION
## Changes proposed in this PR

- avoids reporting error while syncing deleted short-lived tokens

## Why are we making these changes?

The token syncer reports failures when a short-lived token is deleted between fetching the token index and fetching individual token details. Instead, we should handle such short-lived tokens without reporting error.

The error messages on such failures report that the index has the token, but later individual info retrieval has no data:
```
not synced across clusters" {:deleted (false nil) :etags (E-1234 nil)}
...
error when syncing token descriptions: {:code :error/token-read :current-token-description {} :latest-token-description {}}
```
