### PR TITLE
throttles queue length and deployment error responses

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -890,6 +890,16 @@
                                ;; The HTTP connect timeout (milliseconds) for instance requests:
                                :connection-timeout-ms 5000
 
+                               ;; Configures the delay introduced in generating some error responses to clients
+                               ;; e.g. using the below settings, an error rate of 500 would introduce a delay of 250 ms
+                               ;; while an error rate of 3000 would introduce a delay of 2000 ms.
+                               :error-response-throttle { ;; the maximum delay in generating the error response
+                                                         :max-delay-ms 2000
+                                                         ;; the increment in delay per step
+                                                         :step-delay-ms 50
+                                                         ;; step size used for per minute error rate
+                                                         :step-size-per-min 100}
+
                                ;; The HTTP idle timeout (milliseconds) for instance requests:
                                :initial-socket-timeout-ms 900000
 

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1708,22 +1708,23 @@
                                                  instance-request-properties determine-priority-fn process-response-fn
                                                  pr/abort-http-request-callback-factory local-usage-agent request))))
    :process-request-wrapper-fn (pc/fnk [[:routines wrap-service-discovery-fn]
+                                        [:settings [:instance-request-properties error-response-throttle]]
                                         [:state interstitial-state-atom]
                                         wrap-descriptor-fn wrap-secure-request-fn]
                                  ; If adding new middleware for process-request-wrapper-fn, consider adding the same middleware to
                                  ; websocket-request-acceptor for websocket upgrade requests
                                  (fn process-handler-wrapper-fn [handler]
                                    (-> handler
-                                     pr/wrap-too-many-requests
-                                     pr/wrap-suspended-service
-                                     pr/wrap-response-status-metrics
-                                     (interstitial/wrap-interstitial interstitial-state-atom)
-                                     wrap-descriptor-fn
-                                     wrap-secure-request-fn
-                                     auth/wrap-auth-bypass
-                                     handler/wrap-https-redirect
-                                     pr/wrap-maintenance-mode
-                                     wrap-service-discovery-fn)))
+                                       (pr/wrap-too-many-requests error-response-throttle)
+                                       pr/wrap-suspended-service
+                                       pr/wrap-response-status-metrics
+                                       (interstitial/wrap-interstitial interstitial-state-atom)
+                                       wrap-descriptor-fn
+                                       wrap-secure-request-fn
+                                       auth/wrap-auth-bypass
+                                       handler/wrap-https-redirect
+                                       pr/wrap-maintenance-mode
+                                       wrap-service-discovery-fn)))
    :profile-list-handler-fn (pc/fnk [[:state profile->defaults]
                                      wrap-secure-request-fn]
                               (wrap-secure-request-fn

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -76,6 +76,9 @@
                                                   (s/required-key :client-buffer-size) schema/positive-int
                                                   (s/required-key :client-connection-idle-timeout-ms) schema/positive-int
                                                   (s/required-key :connection-timeout-ms) schema/positive-int
+                                                  (s/required-key :error-response-throttle) {(s/required-key :max-delay-ms) schema/positive-int
+                                                                                             (s/required-key :step-delay-ms) schema/positive-int
+                                                                                             (s/required-key :step-size-per-min) schema/positive-int}
                                                   (s/required-key :initial-socket-timeout-ms) schema/positive-int
                                                   (s/required-key :lingering-request-threshold-ms) schema/positive-int
                                                   (s/required-key :output-buffer-size) schema/positive-int
@@ -340,6 +343,9 @@
                                  :client-buffer-size 32768 ;; 32 KiB
                                  :client-connection-idle-timeout-ms 10000 ; 10 seconds
                                  :connection-timeout-ms 5000 ; 5 seconds
+                                 :error-response-throttle {:max-delay-ms 2000
+                                                           :step-delay-ms 50
+                                                           :step-size-per-min 100}
                                  :initial-socket-timeout-ms 900000 ; 15 minutes
                                  :lingering-request-threshold-ms 60000 ; 1 minute
                                  :output-buffer-size 4096 ;; 4 KiB

--- a/waiter/src/waiter/util/async_utils.clj
+++ b/waiter/src/waiter/util/async_utils.clj
@@ -244,3 +244,12 @@
                    (finally
                      (async/close! task-complete-chan))))))
     task-complete-chan))
+
+(defmacro sleep!
+  "Helper macro that wraps sleep call inside an async/go block."
+  [sleep-ms sleep-cause]
+  `(let [sleep-ms# ~sleep-ms
+         sleep-cause# ~sleep-cause]
+     (when (pos? sleep-ms#)
+       (log/info "sleeping for" sleep-ms# "ms due to" sleep-cause#)
+       (async/<! (async/timeout sleep-ms#)))))

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -1009,3 +1009,8 @@
   (let [class-loader (.getContextClassLoader (Thread/currentThread))
         resource-stream (.getResourceAsStream class-loader resource-path)]
     (slurp-bytes resource-stream)))
+
+(defn compute-error-delay-ms
+  "Computes the delay in milliseconds that will be introduced into an error response."
+  [{:keys [max-delay-ms step-delay-ms step-size-per-min]} errors-per-min]
+  (-> errors-per-min (/ step-size-per-min) (int) (* step-delay-ms) (min max-delay-ms)))

--- a/waiter/test/waiter/util/utils_test.clj
+++ b/waiter/test/waiter/util/utils_test.clj
@@ -948,3 +948,19 @@
              (formatted-message input-key {"role" "Authenticated user"
                                            "role-user" "john"
                                            "run-as-user" "jane"}))))))
+
+(deftest test-compute-error-delay-ms
+  (let [error-response-throttle {:max-delay-ms 1000
+                                 :step-delay-ms 50
+                                 :step-size-per-min 100}]
+    (is (= 0 (compute-error-delay-ms error-response-throttle 10)))
+    (is (= 0 (compute-error-delay-ms error-response-throttle 50)))
+    (is (= 50 (compute-error-delay-ms error-response-throttle 100)))
+    (is (= 50 (compute-error-delay-ms error-response-throttle 150)))
+    (is (= 100 (compute-error-delay-ms error-response-throttle 200)))
+    (is (= 250 (compute-error-delay-ms error-response-throttle 550)))
+    (is (= 500 (compute-error-delay-ms error-response-throttle 1000)))
+    (is (= 750 (compute-error-delay-ms error-response-throttle 1500)))
+    (is (= 1000 (compute-error-delay-ms error-response-throttle 2000)))
+    (is (= 1000 (compute-error-delay-ms error-response-throttle 2500)))
+    (is (= 1000 (compute-error-delay-ms error-response-throttle 3000)))))


### PR DESCRIPTION
## Changes proposed in this PR

- throttles queue length and deployment error responses

## Why are we making these changes?

Certain clients retry requests in a tight loop without backoff. This can trigger a high load on the waiter routers to constantly report error responses. One strategy to address this client behavior is to throttle the response rate on the server to slow down the request rate from the client.

### Example output
```
2022-11-04 10:27:15,268 INFO  waiter.process-request [qtp723365249-263] - [CID=15a27069e322d-5bc97b3d56451607] max queue length exceeded {:current-queue-length 40, :error-class waiter.QueueLength, :max-queue-length 10, :outstanding-requests 40, :service-id w9091-kitchen-7454ab74f68b4d1e42714ae862ee5d0d}
2022-11-04 10:27:15,268 INFO  waiter.process-request [async-dispatch-1] - [CID=15a27069e322d-5bc97b3d56451607] sleeping for 850 ms due to frequent queue length exceeded requests

2022-11-04 10:31:44,669 INFO  waiter.process-request [async-dispatch-3] - [CID=15a65a22ead6b-5d34f0b8de5e7073] sleeping for 100 ms due to frequent deployment error failures
2022-11-04 10:31:44,773 ERROR waiter.process-request [async-dispatch-30] - [CID=15a65a22ead6b-5d34f0b8de5e7073] error during process Deployment error: Invalid startup command
2022-11-04 10:31:44,773 INFO  waiter.util.utils [async-dispatch-30] - [CID=15a65a22ead6b-5d34f0b8de5e7073] Deployment error: Invalid startup command
```


