### PR TITLE
Revert "upgrades to jetty version 9.4.49.v20220914 (#1664)"

### DIFF
--- a/waiter/project.clj
+++ b/waiter/project.clj
@@ -45,7 +45,7 @@
                  [io.grpc/grpc-core "1.20.0"
                   :exclusions [com.google.guava/guava]
                   :scope "test"]
-                 [twosigma/jet "0.7.10-20220917_061811-g0d23827"
+                 [twosigma/jet "0.7.10-20220829_161214-g1f873ca"
                   :exclusions [org.mortbay.jetty.alpn/alpn-boot]]
                  [twosigma/clj-http "1.0.2-20180124_201819-gcdf23e5"
                   :exclusions [commons-codec commons-io org.clojure/tools.reader potemkin slingshot]]


### PR DESCRIPTION

## Changes proposed in this PR

- This reverts commit b71ffa9df39be1b9056ebd4a208f60678dc9a19c.

## Why are we making these changes?

There are errors with the HTTP/2 Jetty client ([webtide jira](https://github.com/webtide/two-sigma-support/issues/34)), so we are reverting to the last known good Jetty version. This is the relevant stack trace:
```
Caused by: java.lang.IllegalStateException: session closed
	at org.eclipse.jetty.http2.HTTP2Session$StreamsState.reserveSlot(HTTP2Session.java:2126)
	at org.eclipse.jetty.http2.HTTP2Session$StreamsState.newLocalStream(HTTP2Session.java:2021)
	at org.eclipse.jetty.http2.HTTP2Session$StreamsState.access$600(HTTP2Session.java:1436)
	at org.eclipse.jetty.http2.HTTP2Session.newStream(HTTP2Session.java:578)
	at org.eclipse.jetty.http2.client.http.HttpSenderOverHTTP2.sendHeaders(HttpSenderOverHTTP2.java:110)
	at org.eclipse.jetty.client.HttpSender.send(HttpSender.java:212)
	at org.eclipse.jetty.http2.client.http.HttpChannelOverHTTP2.send(HttpChannelOverHTTP2.java:98)
	at org.eclipse.jetty.client.HttpChannel.send(HttpChannel.java:125)
	at org.eclipse.jetty.client.HttpConnection.send(HttpConnection.java:241)
	at org.eclipse.jetty.http2.client.http.HttpConnectionOverHTTP2.send(HttpConnectionOverHTTP2.java:102)
	at org.eclipse.jetty.http2.client.http.HttpDestinationOverHTTP2.send(HttpDestinationOverHTTP2.java:38)
	at org.eclipse.jetty.client.HttpDestination.process(HttpDestination.java:438)
	at org.eclipse.jetty.client.HttpDestination.process(HttpDestination.java:393)
	at org.eclipse.jetty.client.HttpDestination.send(HttpDestination.java:372)
	at org.eclipse.jetty.client.HttpDestination.send(HttpDestination.java:366)
	at org.eclipse.jetty.client.HttpDestination.send(HttpDestination.java:343)
	at org.eclipse.jetty.client.HttpDestination.send(HttpDestination.java:323)
	at org.eclipse.jetty.client.HttpClient.send(HttpClient.java:627)
	at org.eclipse.jetty.client.HttpRequest.sendAsync(HttpRequest.java:780)
	at org.eclipse.jetty.client.HttpRequest.send(HttpRequest.java:767)
	at qbits.jet.client.http$request.invokeStatic(http.clj:488)
	at qbits.jet.client.http$request.invoke(http.clj:336)
	at waiter.process_request$make_http_request.invokeStatic(process_request.clj:472)
	at waiter.process_request$make_http_request.invoke(process_request.clj:460)
	at waiter.process_request$make_request.invokeStatic(process_request.clj:522)
	at waiter.process_request$make_request.invoke(process_request.clj:490)
	at waiter.core$fn__60433$fnk60427_positional__60434$make_request_fn__60435.invoke(core.clj:1701)
	at waiter.process_request$fn__39895$process__39897$fn__40158$state_machine__6290__auto____40211$fn__40214.invoke(process_request.clj:904)
	... 13 more
```
