### PR TITLE
classifies client session closed as an HTTP 500 internal server error

### DIFF
--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -90,6 +90,8 @@
                                                        (= http-400-bad-request error-status) error-image-400-bad-request
                                                        (= http-500-internal-server-error error-status) error-image-500-internal-server-error))]
                                  [error-cause error-message error-status error-image error-class]))
+                             (and (instance? IllegalStateException error) (= "session closed" error-message))
+                             [:generic-error "Internal error: session already closed" http-500-internal-server-error error-image-500-internal-server-error error-class]
                              (instance? IllegalStateException error)
                              [:generic-error error-message http-400-bad-request error-image-400-bad-request error-class]
                              ;; internal_error due to reset stream for http/1 requests means client send bad data to server

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -657,6 +657,10 @@
            (classify-error "test-classify-error" (ex-info "Test Exception" {:source :test :status http-400-bad-request} (IOException. "cancel_stream_error")))))
     (is (= [:client-error "Client action means stream is no longer needed" http-400-bad-request error-image-400-bad-request "java.io.IOException"]
            (classify-error "test-classify-error" (IOException. "cancel_stream_error"))))
+    (is (= [:generic-error "Internal error: session already closed" http-500-internal-server-error error-image-500-internal-server-error "java.lang.IllegalStateException"]
+           (classify-error "test-classify-error" (IllegalStateException. "session closed"))))
+    (is (= [:generic-error "invalid state" http-400-bad-request error-image-400-bad-request "java.lang.IllegalStateException"]
+           (classify-error "test-classify-error" (IllegalStateException. "invalid state"))))
     (let [exception (IOException. "internal_error")]
       (->> (into-array StackTraceElement
                        [(StackTraceElement. "org.eclipse.jetty.http2.client.http.HttpReceiverOverHTTP2" "onReset" "HttpReceivedOverHTTP2.java" 169)


### PR DESCRIPTION
## Changes proposed in this PR

- classifies client session closed as an HTTP 500 internal server error

## Why are we making these changes?

The Jetty client reporting session closed is an internal error and not a client (HTTP 400) error as is currently reported before the fix.


