### PR TITLE
adds support for reading new routing-mode parameter in service-description-bypass-enabled?

### DIFF
--- a/waiter/integration/waiter/metrics_sync_integration_test.clj
+++ b/waiter/integration/waiter/metrics_sync_integration_test.clj
@@ -509,6 +509,8 @@
                            :x-waiter-metadata-waiter-proxy-bypass-opt-in "true"
                            :x-waiter-min-instances 1
                            :x-waiter-name (rand-name)
+                           ; force outstanding metrics to use external metrics for outstanding metrics calculation
+                           :x-waiter-routing-mode "ingress-distributed"
                            ; used for assertions on scale-to-instances target
                            :x-waiter-scale-up-factor 0.99
                            :x-waiter-scale-down-factor 0.99}

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -1889,6 +1889,6 @@
 
 (defn service-description-bypass-enabled?
   "Returns true if the provided service description has bypass enabled and false otherwise."
-  [service-desc]
-  (= "true"
-     (get-in service-desc ["metadata" "waiter-proxy-bypass-opt-in"])))
+  [{:strs [routing-mode] :as service-desc}]
+  (or (contains? #{"headless" "ingress-centralized" "ingress-distributed"} routing-mode)
+      (= "true" (get-in service-desc ["metadata" "waiter-proxy-bypass-opt-in"]))))

--- a/waiter/test/waiter/metrics_sync_test.clj
+++ b/waiter/test/waiter/metrics_sync_test.clj
@@ -566,9 +566,9 @@
           time-5 (du/str-to-date "2000-01-01T00:00:05.000Z")
           service-id->desc {"s3" {}
                             "s4" {"metadata" {}}
-                            "s5" {"metadata" {"waiter-proxy-bypass-opt-in" "false"}}
-                            "s6" {"metadata" {"waiter-proxy-bypass-opt-in" "true"}}
-                            "s7" {"metadata" {"waiter-proxy-bypass-opt-in" "true"}}}
+                            "s5" {"routing-mode" "default"}
+                            "s6" {"routing-mode" "ingress-distributed"}
+                            "s7" {"routing-mode" "ingress-distributed"}}
           service-id->service-description-fn (fn service-id->service-description [service-id & {}]
                                                (get service-id->desc service-id))
           in-router-metrics-state {:external-metrics {"s6" {"s6.i1" {"metrics" {"active-request-count" 3

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -185,7 +185,7 @@
     (let [custom-raven-flag "MY_RAVEN_FLAG"
           service-description (assoc dummy-service-description
                                      "env" {custom-raven-flag "true"}
-                                     "metadata" {"waiter-proxy-bypass-opt-in" "true"})
+                                     "routing-mode" "ingress-distributed")
           scheduler (make-dummy-scheduler ["test-service-id"]
                                           {:raven-sidecar {:cmd ["/opt/waiter/raven/bin/raven-start"]
                                                            :env-vars {:defaults {"PORT0" "P0"
@@ -1618,7 +1618,7 @@
                         :status http-200-ok)
                  actual))))
       (testing "successful-delete: bypass"
-        (let [dummy-scheduler (assoc dummy-scheduler :service-id->service-description-fn (constantly {"metadata" {"waiter-proxy-bypass-opt-in" "true"}}))
+        (let [dummy-scheduler (assoc dummy-scheduler :service-id->service-description-fn (constantly {"routing-mode" "ingress-distributed"}))
               api-call-count-atom (atom 0)
               expected-api-call-count 2 ;; should make one request for deleting the pod and one request for update the replicas count
               pod-delete-grace-period-atom (atom nil)
@@ -1643,7 +1643,7 @@
       (testing "successful-delete: bypass with WAITER_CONFIG_BYPASS_FORCE_SIGTERM_SECS and WAITER_CONFIG_BYPASS_SIGTERM_GRACE_PERIOD_SECS overrides"
         (let [dummy-scheduler (assoc dummy-scheduler :service-id->service-description-fn (constantly {"env" {"WAITER_CONFIG_BYPASS_FORCE_SIGTERM_SECS" "3"
                                                                                                              "WAITER_CONFIG_BYPASS_SIGTERM_GRACE_PERIOD_SECS" "4"}
-                                                                                                      "metadata" {"waiter-proxy-bypass-opt-in" "true"}}))
+                                                                                                      "routing-mode" "ingress-distributed"}))
               api-call-count-atom (atom 0)
               expected-api-call-count 2 ;; should make one request for deleting the pod and one request for update the replicas count
               pod-delete-grace-period-atom (atom nil)


### PR DESCRIPTION

## Changes proposed in this PR

- adds support for reading new routing-mode parameter in service-description-bypass-enabled?

## Why are we making these changes?

The function `service-description-bypass-enabled?` needs to prepare for the new routing-mode parameter and scenarios where services will not be configuring metadata to reflect router bypass modes.

