### PR TITLE
Add ensure-ssl cli command

### DIFF
--- a/cli/waiter/action.py
+++ b/cli/waiter/action.py
@@ -90,6 +90,18 @@ def ping_on_cluster(cluster, timeout, wait_for_request, token_name, service_exis
             print(f'Service is currently {format_status(service_status)}.')
     return succeeded
 
+def check_ssl(token_name, timeout_seconds):
+    """Returns true if a request to the token's DNS name doesn't encounter an SSL error"""
+    timeout_millis = timeout_seconds * 1000
+    try:
+        http_util.__get(f"https://{token_name}", read_timeout=timeout_millis)
+    # Any exception indicates an issue connecting to or handshaking the backend service
+    # This exception is the base exception type that requests.get throws for connection, timeout or SSL related errors
+    except requests.exceptions.RequestException as e:
+        print(f'Request to {token_name} failed with exception {e}')
+        return False
+    return True
+
 
 def token_has_current_service(cluster, token_name, current_token_etag):
     """If the given token has a "current" service, returns that service else None"""

--- a/cli/waiter/cli.py
+++ b/cli/waiter/cli.py
@@ -3,7 +3,7 @@ import logging
 from urllib.parse import urlparse
 
 from waiter import configuration, http_util, metrics, version
-from waiter.subcommands import create, delete, init, kill, maintenance, ping, show, ssh, tokens, update
+from waiter.subcommands import create, delete, ssl, init, kill, maintenance, ping, show, ssh, tokens, update
 import waiter.plugins as waiter_plugins
 
 parser = argparse.ArgumentParser(description='waiter is the Waiter CLI')
@@ -37,6 +37,9 @@ actions = {
     },
     'ping': {
         'run-function': ping.register(subparsers.add_parser)
+    },
+    'ensure-ssl': {
+        'run-function': ssl.register(subparsers.add_parser)
     },
     'show': {
         'run-function': show.register(subparsers.add_parser)

--- a/cli/waiter/subcommands/ssl.py
+++ b/cli/waiter/subcommands/ssl.py
@@ -1,0 +1,22 @@
+
+from waiter.action import check_ssl
+from waiter.util import check_positive
+
+
+def ensureSSL(_, args, __, ___):
+    """Checks the state of SSL for the provided token."""
+    token_name = args.get('token')
+    timeout_secs = args.get('timeout', None)
+    ssl_success = check_ssl(token_name, timeout_secs)
+    return 0 if ssl_success else 1
+
+
+def register(add_parser):
+    """Adds this sub-command's parser and returns the action function"""
+    default_timeout = 300
+    parser = add_parser('ensure-ssl', help='checks if the specified token has SSL set up')
+    parser.add_argument('token')
+    parser.add_argument('--timeout', '-t', help=f'read timeout (in seconds) for SSL verification request (default is '
+                                                f'{default_timeout} seconds)',
+                        type=check_positive, default=default_timeout)
+    return ensureSSL


### PR DESCRIPTION
## Changes proposed in this PR

- Adds a command to check SSL for a provided token

## Why are we making these changes?

Provide a common method for clients to ensure that SSL has been set up for newly created tokens.  Necessary for CI/CD improvements

