### PR TITLE
reference updates support on tokens endpoint

### DIFF
--- a/waiter/integration/waiter/token_request_test.clj
+++ b/waiter/integration/waiter/token_request_test.clj
@@ -1672,6 +1672,7 @@
                     "etag" nil
                     "maintenance" true
                     "owner" (retrieve-username)
+                    "reference-type->reference-name" {}
                     "token" token}
                    (dissoc token-index "last-update-time")))))
 

--- a/waiter/integration/waiter/token_watch_integration_test.clj
+++ b/waiter/integration/waiter/token_watch_integration_test.clj
@@ -61,6 +61,7 @@
                               "last-update-time" last-update-time
                               "maintenance" false
                               "owner" (retrieve-username)
+                              "reference-type->reference-name" {}
                               "token" token})))]
           (assert-response-status response 200)
           (is (await-goal-response-for-all-routers goal-fn watch-state-request-fn router_urls))))
@@ -80,6 +81,7 @@
                               "last-update-time" last-update-time
                               "maintenance" false
                               "owner" (retrieve-username)
+                              "reference-type->reference-name" {}
                               "token" token})))]
           (assert-response-status response 200)
           (is (await-goal-response-for-all-routers goal-fn watch-state-request-fn router_urls))))
@@ -96,6 +98,7 @@
                               "etag" nil
                               "maintenance" false
                               "owner" (retrieve-username)
+                              "reference-type->reference-name" {}
                               "token" token})))]
           (is (await-goal-response-for-all-routers goal-fn watch-state-request-fn router_urls))))
 
@@ -203,17 +206,21 @@
             (let [watch (start-tokens-watch waiter-url cookies :query-params {"watch" "true"})]
               (assert-watch-token-index-entry watch timeout-secs token-1 {"token" token-1
                                                                           "owner" (retrieve-username)
-                                                                          "maintenance" false})
+                                                                          "maintenance" false
+                                                                          "reference-type->reference-name" {}})
               (assert-watch-token-index-entry watch timeout-secs token-2 {"token" token-2
                                                                           "owner" (retrieve-username)
-                                                                          "maintenance" false})
+                                                                          "maintenance" false
+                                                                          "reference-type->reference-name" {}})
               (post-token waiter-url (assoc (kitchen-params) :token token-1 :version "update-1"))
               (assert-watch-token-index-entry-does-not-change watch timeout-secs token-1 {"token" token-1
                                                                                           "owner" (retrieve-username)
-                                                                                          "maintenance" false})
+                                                                                          "maintenance" false
+                                                                                          "reference-type->reference-name" {}})
               (assert-watch-token-index-entry-does-not-change watch timeout-secs token-2 {"token" token-2
                                                                                           "owner" (retrieve-username)
-                                                                                          "maintenance" false})
+                                                                                          "maintenance" false
+                                                                                          "reference-type->reference-name" {}})
               (stop-tokens-watch watch))
             (finally
               (delete-token-and-assert waiter-url token-1)
@@ -232,12 +239,14 @@
             (let [watch (start-tokens-watch waiter-url cookies :query-params {"maintenance" "false" "watch" "true"})]
               (assert-watch-token-index-entry watch timeout-secs token-1 {"token" token-1
                                                                           "owner" (retrieve-username)
-                                                                          "maintenance" false})
+                                                                          "maintenance" false
+                                                                          "reference-type->reference-name" {}})
               (assert-watch-token-index-entry watch timeout-secs token-2 nil)
               (post-token waiter-url (assoc (kitchen-params) :token token-1 :maintenance {:message "maintenance message"}))
               (assert-watch-token-index-entry-does-not-change watch timeout-secs token-1 {"token" token-1
                                                                                           "owner" (retrieve-username)
-                                                                                          "maintenance" false})
+                                                                                          "maintenance" false
+                                                                                          "reference-type->reference-name" {}})
               (assert-watch-token-index-entry-does-not-change watch timeout-secs token-2 nil)
               (stop-tokens-watch watch))
             (finally
@@ -258,15 +267,18 @@
               (assert-watch-token-index-entry watch timeout-secs token-1 nil)
               (assert-watch-token-index-entry watch timeout-secs token-2 {"token" token-2
                                                                           "owner" (retrieve-username)
-                                                                          "maintenance" true})
+                                                                          "maintenance" true
+                                                                          "reference-type->reference-name" {}})
               (post-token waiter-url (assoc (kitchen-params) :token token-1 :maintenance {:message "maintenance message"}))
               (post-token waiter-url (assoc (kitchen-params) :token token-2))
               (assert-watch-token-index-entry watch timeout-secs token-1 {"token" token-1
                                                                           "owner" (retrieve-username)
-                                                                          "maintenance" true})
+                                                                          "maintenance" true
+                                                                          "reference-type->reference-name" {}})
               (assert-watch-token-index-entry-does-not-change watch timeout-secs token-2 {"token" token-2
                                                                                           "owner" (retrieve-username)
-                                                                                          "maintenance" true})
+                                                                                          "maintenance" true
+                                                                                          "reference-type->reference-name" {}})
               (stop-tokens-watch watch))
             (finally
               (delete-token-and-assert waiter-url token-1)

--- a/waiter/src/waiter/service_description.clj
+++ b/waiter/src/waiter/service_description.clj
@@ -872,6 +872,14 @@
     "Returns a map of reference type to stale function for references of the specified type.
      The values are functions that have the following signature (fn reference-entry)")
 
+  (extract-reference-type->reference-name [this service-description]
+    "Returns a map of reference type to reference name for references used in the service-description.
+     The values are names of the references that are independently tracked for updates by separate subsystems.")
+
+  (handle-reference-update! [this reference-event]
+    "Acts as a listener for reference update events.
+     Returns true when the notification is handled successfully.")
+
   (state [this include-flags]
     "Returns the global (i.e. non-service-specific) state the service description builder is maintaining")
 
@@ -1021,6 +1029,16 @@
 
   (retrieve-reference-type->stale-info-fn [_ {:keys [token->token-hash token->token-parameters]}]
     {:token (fn [{:keys [sources]}] (retrieve-token-stale-info token->token-hash token->token-parameters sources))})
+
+  (extract-reference-type->reference-name [_ service-description]
+    (let [waiter-token (get-in service-description waiter-config-token-path)]
+      (cond-> {}
+        waiter-token (assoc :token waiter-token))))
+
+  (handle-reference-update!
+    [_ {:keys [reference-type] :as reference-event}]
+    (log/info "handled reference update event" reference-event)
+    (= :token reference-type))
 
   (state [_ _]
     {})

--- a/waiter/src/waiter/token_watch.clj
+++ b/waiter/src/waiter/token_watch.clj
@@ -1,26 +1,82 @@
 (ns waiter.token-watch
   (:require [clojure.core.async :as async]
             [clojure.data :as data]
+            [clojure.string :as str]
             [clojure.tools.logging :as log]
+            [clojure.walk :as walk]
             [metrics.counters :as counters]
             [metrics.meters :as meters]
             [metrics.timers :as timers]
             [waiter.correlation-id :as cid]
             [waiter.metrics :as metrics]
+            [waiter.status-codes :refer :all]
             [waiter.token :as token]
+            [waiter.util.async-utils :as au]
+            [waiter.util.http-utils :as hu]
+            [waiter.util.ring-utils :as ru]
             [waiter.util.utils :as utils]))
 
 (defn make-index-event
   "Create an event for watch endpoints"
-  [type object & {:keys [id]}]
+  [type object & {:keys [id reference-type]}]
   (cond->
     {:object object :type type}
-    id (assoc :id id)))
+    id (assoc :id id)
+    reference-type (assoc :reference-type reference-type)))
+
+(defn- update-token-references
+  "Updates the map that tracks the references used by the specified token using the provided update-fn."
+  [reference-type->reference-name->tokens token reference-type->reference-name update-fn]
+  (reduce (fn update-token-references-helper
+            [reference-type->reference-name->tokens [reference-type reference-name]]
+            (update-in reference-type->reference-name->tokens
+              [reference-type reference-name] (fnil update-fn #{}) token))
+          reference-type->reference-name->tokens
+          (seq reference-type->reference-name)))
+
+(defn assoc-token-references
+  "Updates the map that tracks usage of references to include the specified token."
+  [reference-type->reference-name->tokens token reference-type->reference-name]
+  (update-token-references
+    reference-type->reference-name->tokens token reference-type->reference-name conj))
+
+(defn dissoc-token-references
+  "Updates the map that tracks usage of references to exclude the specified token."
+  [reference-type->reference-name->tokens token reference-type->reference-name]
+  (update-token-references
+    reference-type->reference-name->tokens token reference-type->reference-name disj))
+
+(defn adjust-token-references
+  "Updates the map that tracks usage of references to exclude the specified token."
+  [reference-type->reference-name->tokens token old-reference-type->reference-name new-reference-type->reference-name]
+  (let [reference-type->reference-name-changed? (not= old-reference-type->reference-name new-reference-type->reference-name)]
+    (cond-> reference-type->reference-name->tokens
+      reference-type->reference-name-changed? (dissoc-token-references token old-reference-type->reference-name)
+      reference-type->reference-name-changed? (assoc-token-references token new-reference-type->reference-name))))
+
+(defn extract-reference-update-tokens
+  "Extracts tokens based on the reference that has been updated.
+   The token->index map is consulted to confirm that entries in reference-type->reference-name->tokens are not stale and tokens indeed need to be updated."
+  [{:keys [reference-type->reference-name->last-update-time reference-type->reference-name->tokens]}
+   {:keys [reference-type reference-name update-time]}]
+  (let [last-update-time (get-in reference-type->reference-name->last-update-time [reference-type reference-name] 0)]
+    (when (> update-time last-update-time)
+      (get-in reference-type->reference-name->tokens [reference-type reference-name]))))
+
+(defn calculate-reference-type->reference-name->tokens
+  "Recalculates the reference-type->reference-name->tokens map based on the token index."
+  [token->index]
+  (reduce (fn calculate-reference-type->reference-name->tokens-helper
+            [reference-type->reference-name->tokens [token {:keys [reference-type->reference-name]}]]
+            (assoc-token-references reference-type->reference-name->tokens token reference-type->reference-name))
+          {}
+          token->index))
 
 (defn start-token-watch-maintainer
   "Starts daemon thread that maintains token watches and process/filters internal token events to be streamed to
   clients through the watch handlers. Returns map of various channels and state functions to control the daemon."
-  [kv-store clock tokens-update-chan-buffer-size channels-update-chan-buffer-size watch-refresh-timer-chan]
+  [extract-reference-type->reference-name-fn kv-store clock tokens-update-chan-buffer-size channels-update-chan-buffer-size
+   reference-update-chan watch-refresh-timer-chan]
   (cid/with-correlation-id
     "token-watch-maintainer"
     (let [exit-chan (async/promise-chan)
@@ -29,20 +85,28 @@
           tokens-watch-channels-update-chan-buffer (async/buffer channels-update-chan-buffer-size)
           tokens-watch-channels-update-chan (async/chan tokens-watch-channels-update-chan-buffer)
           query-chan (async/chan)
-          state-atom (atom {:last-update-time (clock)
-                            :token->index (token/get-token->index kv-store :refresh true)
-                            :watch-chans #{}})
+          state-atom (atom (let [token->index (token/get-token->index kv-store :refresh true)
+                                 reference-type->reference-name->tokens (calculate-reference-type->reference-name->tokens token->index)]
+                             {:last-update-time (clock)
+                              :reference-type->reference-name->last-update-time {}
+                              :reference-type->reference-name->tokens reference-type->reference-name->tokens
+                              :token->index token->index
+                              :watch-chans #{}}))
           query-state-fn
           (fn tokens-watch-query-state-fn
             [include-flags]
-            (let [{:keys [last-update-time token->index watch-chans]} @state-atom]
+            (let [{:keys [last-update-time reference-type->reference-name->last-update-time reference-type->reference-name->tokens token->index watch-chans]} @state-atom]
               (cond-> {:last-update-time last-update-time
                        :watch-count (count watch-chans)}
-                      (contains? include-flags "token->index")
-                      (assoc :token->index token->index)
-                      (contains? include-flags "buffer-state")
-                      (assoc :buffer-state {:update-chan-count (.count tokens-update-chan-buffer)
-                                            :watch-channels-update-chan-count (.count tokens-watch-channels-update-chan-buffer)}))))
+                (contains? include-flags "reference-type->reference-name->last-update-time")
+                (assoc :reference-type->reference-name->last-update-time reference-type->reference-name->last-update-time)
+                (contains? include-flags "reference-type->reference-name->tokens")
+                (assoc :reference-type->reference-name->tokens reference-type->reference-name->tokens)
+                (contains? include-flags "token->index")
+                (assoc :token->index token->index)
+                (contains? include-flags "buffer-state")
+                (assoc :buffer-state {:update-chan-count (.count tokens-update-chan-buffer)
+                                      :watch-channels-update-chan-count (.count tokens-watch-channels-update-chan-buffer)}))))
           go-chan
           (async/go
             (try
@@ -50,7 +114,7 @@
                 (reset! state-atom current-state)
                 (let [external-event-cid (utils/unique-identifier)
                       [msg current-chan]
-                      (async/alts! [exit-chan tokens-update-chan tokens-watch-channels-update-chan
+                      (async/alts! [exit-chan tokens-update-chan reference-update-chan tokens-watch-channels-update-chan
                                     watch-refresh-timer-chan query-chan]
                                    :priority true)
                       next-state
@@ -64,28 +128,60 @@
                         tokens-update-chan
                         (timers/start-stop-time!
                           (metrics/waiter-timer "core" "token-watch-maintainer" "token-update")
-                          (let [{:keys [token cid] :as internal-event} msg]
+                          (let [{:keys [cid token] :as internal-event} msg]
                             (cid/with-correlation-id
                               (str "token-watch-maintainer" "." cid "." external-event-cid)
                               (log/info "received an internal index event" internal-event)
-                              (let [token-index-entry (token/get-token-index kv-store token :refresh true)
+                              (let [token-index-entry (token/get-token-index extract-reference-type->reference-name-fn kv-store token :refresh true)
                                     local-token-index-entry (get token->index token)]
                                 (if (= token-index-entry local-token-index-entry)
                                   ; There is no change detected, so no event to be reported
                                   current-state
-                                  (let [[index-event next-state]
+                                  (let [{:keys [reference-type->reference-name]} token-index-entry
+                                        local-reference-type->reference-name (get local-token-index-entry :reference-type->reference-name)
+                                        [index-event next-state]
                                         (if (some? token-index-entry)
                                           ; If index-entry retrieved from kv-store exists then treat as UPDATE
                                           ; (includes token creation and soft deletion)
                                           [(make-index-event :UPDATE token-index-entry)
-                                           (assoc-in current-state [:token->index token] token-index-entry)]
+                                           (-> (assoc-in current-state [:token->index token] token-index-entry)
+                                               (update :reference-type->reference-name->tokens
+                                                       adjust-token-references token local-reference-type->reference-name reference-type->reference-name))]
                                           ; index-entry doesn't exist then treat as DELETE
                                           [(make-index-event :DELETE {:token token})
-                                           (assoc current-state :token->index (dissoc token->index token))])
+                                           (-> current-state
+                                               (assoc :token->index (dissoc token->index token))
+                                               (update :reference-type->reference-name->tokens dissoc-token-references token reference-type->reference-name))])
                                         _ (log/info "sending a token event to watches" {:event index-event})
-                                        open-chans (->> (make-index-event :EVENTS [index-event] :id external-event-cid)
+                                        open-chans (->> (make-index-event :EVENTS [index-event] :id external-event-cid :reference-type :token)
                                                         (utils/send-event-to-channels! watch-chans))]
                                     (assoc next-state :watch-chans open-chans)))))))
+
+                        reference-update-chan
+                        (timers/start-stop-time!
+                          (metrics/waiter-timer "core" "token-watch-maintainer" "reference-update")
+                          (let [{:keys [cid] :as internal-event} msg]
+                            (cid/with-correlation-id
+                              (str "token-watch-maintainer" "." cid "." external-event-cid)
+                              (log/info "received a reference update event" internal-event)
+                              (let [{:keys [reference-name reference-type update-time]} internal-event
+                                    current-update-time (get-in current-state [:reference-type->reference-name->last-update-time reference-type reference-name])]
+                                (if (or (nil? current-update-time) (< current-update-time update-time))
+                                  ;; calculate reference update events and emit them to the watch channels
+                                  (let [candidate-tokens (extract-reference-update-tokens current-state internal-event)
+                                        open-chans (if (seq candidate-tokens)
+                                                     (let [index-events (map #(make-index-event :UPDATE (get token->index %) :reference-type reference-type) candidate-tokens)]
+                                                       (log/info "sending token update events due to reference update" {:tokens candidate-tokens})
+                                                       (->> (make-index-event :EVENTS index-events :id external-event-cid :reference-type reference-type)
+                                                            (utils/send-event-to-channels! watch-chans)))
+                                                     watch-chans)]
+                                    ;; update the reference-type->reference-name->update-time entry
+                                    (-> current-state
+                                        (assoc-in [:reference-type->reference-name->last-update-time reference-type reference-name] update-time)
+                                        (assoc :watch-chans open-chans)))
+                                  (do
+                                    (log/info "skipping stale reference update event" {:current-update-time current-update-time :event-update-time update-time})
+                                    current-state))))))
 
                         tokens-watch-channels-update-chan
                         (timers/start-stop-time!
@@ -97,7 +193,7 @@
                                   initial-event
                                   (timers/start-stop-time!
                                     (metrics/waiter-timer "core" "token-watch-maintainer" "channel-update-build-event")
-                                    (make-index-event :INITIAL (doall (or (vals token->index) [])) :id external-event-cid))]
+                                    (make-index-event :INITIAL (doall (or (vals token->index) [])) :id external-event-cid :reference-type :token))]
                               (timers/start-stop-time!
                                 (metrics/waiter-timer "core" "token-watch-maintainer" "channel-update-forward-event")
                                 (async/put! watch-chan initial-event))
@@ -111,6 +207,7 @@
                             (str "token-watch-maintainer" "." external-event-cid)
                             (log/info "refresh starting...")
                             (let [next-token->index (token/get-token->index kv-store :refresh true)
+                                  reference-type->reference-name->tokens (calculate-reference-type->reference-name->tokens next-token->index)
                                   [only-old-indexes only-next-indexes _] (data/diff token->index next-token->index)
                                   ; if token in old-indexes and not in only-next-indexes, then those token indexes were deleted
                                   delete-events
@@ -124,7 +221,7 @@
                                   events (concat delete-events update-events)
                                   ; send events event if empty, which will serve as a heartbeat
                                   open-chans
-                                  (utils/send-event-to-channels! watch-chans (make-index-event :EVENTS events :id external-event-cid))]
+                                  (utils/send-event-to-channels! watch-chans (make-index-event :EVENTS events :id external-event-cid :reference-type :token))]
                               (when (not-empty events)
                                 (counters/inc! (metrics/waiter-counter "core" "token-watch-maintainer" "refresh-sync"))
                                 (meters/mark! (metrics/waiter-meter "core" "token-watch-maintainer" "refresh-sync-rate"))
@@ -135,7 +232,8 @@
                                            :only-in-next only-next-indexes
                                            :token-count (count token->index)}))
                               (log/info "refresh ended.")
-                              (assoc current-state :token->index next-token->index
+                              (assoc current-state :reference-type->reference-name->tokens reference-type->reference-name->tokens
+                                                   :token->index next-token->index
                                                    :watch-chans open-chans))))
 
                         query-chan
@@ -160,3 +258,111 @@
        :query-state-fn query-state-fn
        :tokens-update-chan tokens-update-chan
        :tokens-watch-channels-update-chan tokens-watch-channels-update-chan})))
+
+(defn watch-for-reference-updates
+  "Watches for reference update notifications and propagates it to peer routers."
+  [make-inter-router-requests-async-fn reference-update-chan router-id]
+  (async/go-loop []
+    (let [{:keys [cid response-chan] :as update-event} (async/<! reference-update-chan)
+          correlation-id (or cid (utils/unique-identifier))]
+      (cond
+        (nil? update-event)
+        (log/info "exiting watch for reference updates go-loop")
+
+        (not= router-id (get update-event :router-id))
+        (do
+          (log/info "not propagating remote update event to peer routers" update-event)
+          (recur))
+
+        :else
+        (do
+          (cid/with-correlation-id
+            correlation-id
+            (do
+              (log/info "sending reference update to peer routers" update-event)
+              (let [router-id->response-chan (make-inter-router-requests-async-fn
+                                               "reference/notify"
+                                               :body (-> update-event
+                                                         (select-keys [:reference-name :reference-type :update-time])
+                                                         (assoc :router-id router-id)
+                                                         (utils/clj->json))
+                                               :config {:headers {"content-type" "application/json"
+                                                                  "x-cid" correlation-id}}
+                                               :method :post)]
+                (log/info "sent reference update to" (count router-id->response-chan) "peer routers")
+                (async/go
+                  (let [router-id->response-atom (atom {})]
+                    (doseq [[router-id response-chan] (seq router-id->response-chan)]
+                      (let [{:keys [body status] :as response} (async/<! response-chan)
+                            successful? (hu/status-2XX? status)
+                            response (cond-> response
+                                       (not successful?)
+                                       (assoc :body (if (au/chan? body) (async/<! body) body)))
+                            response-keys (cond-> [:headers :status]
+                                            (not successful?) (conj :body))]
+                        (log/info "response from" router-id (select-keys response response-keys))
+                        (swap! router-id->response-atom assoc router-id response)))
+                    (when (au/chan? response-chan)
+                      (async/>! response-chan @router-id->response-atom)))))))
+          (recur))))))
+
+(defn reference-notify-handler
+  "Handler that receives reference update notifications and propagates it to the reference-listener-chan channel."
+  [reference-listener-chan router-id {:keys [request-method] :as request}]
+  (async/go
+    (try
+      (case request-method
+        :post (let [correlation-id (cid/get-correlation-id)
+                    {:keys [reference-name reference-type update-time] :as update-event} (-> request ru/json-request :body walk/keywordize-keys)]
+                (log/info "received reference update" update-event)
+                (when (or (str/blank? reference-name)
+                          (str/blank? reference-type)
+                          (not (pos-int? update-time)))
+                  (throw (ex-info "reference-name, reference-type and integer update-time must be provided"
+                                  {:log-level :info
+                                   :request-method request-method
+                                   :status http-400-bad-request
+                                   :update-event update-event})))
+                (let [reference-event (-> update-event
+                                          (update :reference-type keyword)
+                                          (assoc :cid correlation-id ))
+                      success? (async/put! reference-listener-chan reference-event)]
+                  (log/info (if success? "success" "failure") "in propagating reference update")
+                  (-> update-event
+                      (select-keys [:reference-name :reference-type :update-time])
+                      (assoc :cid correlation-id :router-id router-id :success success?)
+                      (utils/clj->json-response))))
+        (utils/exception->response
+          (ex-info "Only POST supported" {:log-level :info
+                                          :request-method request-method
+                                          :status http-405-method-not-allowed})
+          request))
+      (catch Exception ex
+        (utils/exception->response ex request)))))
+
+(defn start-reference-notify-forwarder
+  "Intercepts reference update events from reference-listener-chan to invoke the notification function
+   before propagating the event along the reference-notifier-chan."
+  [reference-listener-chan reference-update-chan pre-notify-fn]
+  (async/go
+    (cid/with-correlation-id
+      "reference-notify-forwarder"
+      (log/info "starting reference notify forwarder")
+      (loop []
+        (let [{:keys [cid response-chan] :as reference-event} (async/<! reference-listener-chan)]
+          (if (nil? reference-event)
+            (log/info "exiting reference notify forwarder")
+            (let [correlation-id (or cid (cid/get-correlation-id))]
+              (log/info "processing reference event" reference-event)
+              (async/thread
+                (cid/with-correlation-id
+                  correlation-id
+                  (try
+                    (let [success? (pre-notify-fn reference-event)]
+                      (log/info (if success? "success" "failure") "in notifying reference update"))
+                    (catch Throwable th
+                      (log/error th "error in processing reference event" reference-event)))
+                  (let [success? (async/put! reference-update-chan reference-event)]
+                    (log/info (if success? "success" "failure") "in forwarding reference update")
+                    (some-> response-chan (async/put! {:success success?})))))
+              (recur))))))))

--- a/waiter/src/waiter/util/utils.clj
+++ b/waiter/src/waiter/util/utils.clj
@@ -221,6 +221,11 @@
     :key-fn stringify-keys
     :value-fn stringify-elements))
 
+(defn clj->json-stream
+  "Convert the input Clojure data structure into a json string input stream."
+  [data-map]
+  (-> data-map (clj->json) (str) (.getBytes) (ByteArrayInputStream.)))
+
 (defn clj->json-response
   "Convert the input data into a json response."
   [data-map & {:keys [headers status] :or {headers {} status http-200-ok }}]

--- a/waiter/test/waiter/core_test.clj
+++ b/waiter/test/waiter/core_test.clj
@@ -1241,6 +1241,8 @@
            (exec-routes-mapper "/not-found"))) ; any path that isn't mapped
     (is (= {:handler :oidc-callback-handler-fn}
            (exec-routes-mapper "/oidc/v1/callback")))
+    (is (= {:handler :reference-notify-handler-fn}
+           (exec-routes-mapper "/reference/notify")))
     (is (= {:handler :not-found-handler-fn}
            (exec-routes-mapper "/secrun")))
     (is (= {:handler :service-id-handler-fn}

--- a/waiter/test/waiter/scheduler_test.clj
+++ b/waiter/test/waiter/scheduler_test.clj
@@ -53,6 +53,10 @@
     (locking lock
       (f))))
 
+(defn- extract-reference-type->reference-name-helper
+  [_]
+  {})
+
 (deftest test-record-Service
   (let [test-instance-1 (->Service "service1-id" 100 100 {:running 0, :healthy 0, :unhealthy 0, :staged 0})
         test-instance-2 (make-Service {:id "service2-id" :instances 200 :task-count 200})
@@ -1207,7 +1211,7 @@
   "Helper function for tests to store a service-description for token in provided 'kv-store'"
   [kv-store token service-desc token-metadata]
   (tk/store-service-description-for-token
-    synchronize-fn kv-store history-length limit-per-owner token service-desc token-metadata))
+    synchronize-fn extract-reference-type->reference-name-helper kv-store history-length limit-per-owner token service-desc token-metadata))
 
 (deftest test-make-token-is-not-run-as-requester-or-parameterized?-fn
   (let [correlation-id (cid/get-correlation-id)

--- a/waiter/test/waiter/service_description_test.clj
+++ b/waiter/test/waiter/service_description_test.clj
@@ -2878,6 +2878,17 @@
       (is (thrown-with-msg? Exception #"Command type invalid is not supported"
                             (validate (create-default-service-description-builder {}) {"cmd-type" "invalid"} {}))))))
 
+(deftest test-extract-reference-type->reference-name
+  (let [builder (create-default-service-description-builder {})]
+    (is (= {} (extract-reference-type->reference-name builder {})))
+    (is (= {} (extract-reference-type->reference-name builder {"env" {"FOO" "bar"}})))
+    (is (= {:token "foo"} (extract-reference-type->reference-name builder {"env" {"WAITER_CONFIG_TOKEN" "foo"}})))))
+
+(deftest test-handle-reference-update!
+  (let [builder (create-default-service-description-builder {})]
+    (is (true? (handle-reference-update! builder {:reference-type :token})))
+    (is (false? (handle-reference-update! builder {:reference-type :unknown})))))
+
 (deftest test-consent-cookie-value
   (let [current-time (t/now)
         current-time-ms (.getMillis ^DateTime current-time)

--- a/waiter/test/waiter/token_watch_test.clj
+++ b/waiter/test/waiter/token_watch_test.clj
@@ -17,12 +17,15 @@
   (:require [clj-time.core :as t]
             [clojure.core.async :as async]
             [clojure.test :refer :all]
+            [clojure.walk :as walk]
+            [waiter.correlation-id :as cid]
             [waiter.kv :as kv]
             [waiter.service-description :as sd]
             [waiter.status-codes :refer :all]
             [waiter.test-helpers :refer :all]
             [waiter.token :refer :all]
             [waiter.token-watch :refer :all]
+            [waiter.util.async-utils :as au]
             [waiter.util.utils :as utils])
   (:import (org.joda.time DateTime)))
 
@@ -34,6 +37,10 @@
     [_ f]
     (locking lock
       (f))))
+
+(defn- extract-reference-type->reference-name-helper
+  [_]
+  {})
 
 (let [current-time (t/now)]
   (defn- clock [] current-time)
@@ -105,9 +112,9 @@
         (assert-channels-next-message open-chans event)))))
 
 (let [get-token-hash (fn [kv-store token] (sd/token-data->token-hash (kv/fetch kv-store token)))
-      get-latest-state (fn [query-chan]
+      get-latest-state (fn [query-chan & {:keys [include-flags] :or {include-flags #{"token->index"}}}]
                          (let [temp-chan (async/promise-chan)]
-                           (async/>!! query-chan {:include-flags #{"token->index"}
+                           (async/>!! query-chan {:include-flags include-flags
                                                   :response-chan temp-chan})
                            (async/<!! temp-chan)))
       add-watch-chans (fn [tokens-watch-channels-update-chan watch-chans]
@@ -121,8 +128,8 @@
       stop-token-watch-maintainer (fn [go-chan exit-chan]
                                     (async/>!! exit-chan :exit)
                                     (async/<!! go-chan))
-      make-aggregate-index-events (fn [object]
-                                    (make-index-event :EVENTS [object]))
+      make-aggregate-index-events (fn [object & {:keys [reference-type] :or {reference-type :token}}]
+                                    (make-index-event :EVENTS [object] :reference-type reference-type))
       auth-user "auth-user"
       token1-metadata {"cluster" "c1" "last-update-time" 1000 "owner" "owner1"}
       token1-service-desc {"cpus" 1}
@@ -130,13 +137,16 @@
                     :last-update-time (get token1-metadata "last-update-time")
                     :maintenance false
                     :owner (get token1-metadata "owner")
+                    :reference-type->reference-name {}
                     :token "token1"}]
 
   (deftest test-start-token-watch-maintainer-empty-starting-state
     (let [kv-store (kv/->LocalKeyValueStore (atom {}))
           watch-chans (create-watch-chans 10)
+          reference-update-chan (au/latest-chan)
+          watch-refresh-timer-chan (async/chan)
           {:keys [exit-chan go-chan query-chan tokens-watch-channels-update-chan]}
-          (start-token-watch-maintainer kv-store clock 1 1 (async/chan))]
+          (start-token-watch-maintainer extract-reference-type->reference-name-helper kv-store clock 1 1 reference-update-chan watch-refresh-timer-chan)]
       (is (= {:last-update-time (clock)
               :token->index {}
               :watch-count 0}
@@ -148,17 +158,19 @@
                 :token->index {}
                 :watch-count 10}
                (get-latest-state query-chan)))
-        (assert-channels-next-event watch-chans (make-index-event :INITIAL [])))
+        (assert-channels-next-event watch-chans (make-index-event :INITIAL [] :reference-type :token)))
 
       (stop-token-watch-maintainer go-chan exit-chan)))
 
   (deftest test-start-token-watch-maintainer-non-empty-starting-state
     (let [kv-store (kv/->LocalKeyValueStore (atom {}))
           watch-chans (create-watch-chans 10)
+          reference-update-chan (au/latest-chan)
+          watch-refresh-timer-chan (async/chan)
           _ (store-service-description-for-token
-              synchronize-fn kv-store history-length limit-per-owner "token1" token1-service-desc token1-metadata)
+              synchronize-fn extract-reference-type->reference-name-helper kv-store history-length limit-per-owner "token1" token1-service-desc token1-metadata)
           {:keys [exit-chan go-chan query-chan tokens-watch-channels-update-chan]}
-          (start-token-watch-maintainer kv-store clock 1 1 (async/chan))
+          (start-token-watch-maintainer extract-reference-type->reference-name-helper kv-store clock 1 1 reference-update-chan watch-refresh-timer-chan)
           token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1"))
           expected-token->index {"token1" token-cur-index}]
       (is (= {:last-update-time (clock)
@@ -182,18 +194,20 @@
   (deftest test-start-token-watch-maintainer-watch-channels-updates
     (let [kv-store (kv/->LocalKeyValueStore (atom {}))
           watch-chans (create-watch-chans 10)
+          reference-update-chan (au/latest-chan)
+          watch-refresh-timer-chan (async/chan)
           {:keys [exit-chan go-chan tokens-update-chan query-chan tokens-watch-channels-update-chan]}
-          (start-token-watch-maintainer kv-store clock 1 1 (async/chan))]
+          (start-token-watch-maintainer extract-reference-type->reference-name-helper kv-store clock 1 1 reference-update-chan watch-refresh-timer-chan)]
 
       (testing "watch-channels get UPDATE event for added tokens"
         (add-watch-chans tokens-watch-channels-update-chan watch-chans)
         (is (= {:last-update-time (clock) :token->index {} :watch-count 10}
                (get-latest-state query-chan)))
         (store-service-description-for-token
-          synchronize-fn kv-store history-length limit-per-owner "token1" token1-service-desc token1-metadata)
+          synchronize-fn extract-reference-type->reference-name-helper kv-store history-length limit-per-owner "token1" token1-service-desc token1-metadata)
         (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1"))
               expected-token->index {"token1" token-cur-index}]
-          (assert-channels-next-event watch-chans (make-index-event :INITIAL []))
+          (assert-channels-next-event watch-chans (make-index-event :INITIAL [] :reference-type :token))
           (send-internal-index-event tokens-update-chan "token1")
           (assert-channels-next-event watch-chans (make-aggregate-index-events (make-index-event :UPDATE token-cur-index)))
           (is (= {:last-update-time (clock)
@@ -203,7 +217,7 @@
 
       (testing "watch-channels get UPDATE event for modified tokens"
         (store-service-description-for-token
-          synchronize-fn kv-store history-length limit-per-owner "token1" (assoc token1-service-desc "cpus" 2) token1-metadata)
+          synchronize-fn extract-reference-type->reference-name-helper kv-store history-length limit-per-owner "token1" (assoc token1-service-desc "cpus" 2) token1-metadata)
         (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1"))
               expected-token->index {"token1" token-cur-index}]
           (send-internal-index-event tokens-update-chan "token1")
@@ -222,7 +236,7 @@
                    (get-latest-state query-chan))))))
 
       (testing "watch-channels get UPDATE event for soft deleted tokens"
-        (delete-service-description-for-token clock synchronize-fn kv-store history-length "token1"
+        (delete-service-description-for-token clock synchronize-fn extract-reference-type->reference-name-helper kv-store history-length "token1"
                                               (get token1-index :owner) auth-user)
         (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1")
                                                   :last-update-time (clock-millis)
@@ -236,7 +250,7 @@
                  (get-latest-state query-chan)))))
 
       (testing "watch-channels get DELETE event for hard deleted tokens"
-        (delete-service-description-for-token clock synchronize-fn kv-store history-length "token1"
+        (delete-service-description-for-token clock synchronize-fn extract-reference-type->reference-name-helper kv-store history-length "token1"
                                               (get token1-index :owner) auth-user :hard-delete true)
         (send-internal-index-event tokens-update-chan "token1")
         (assert-channels-next-event watch-chans
@@ -262,8 +276,9 @@
           watch-refresh-timer-chan (async/chan)
           watch-chans-1 (create-watch-chans 10)
           watch-chans-2 (create-watch-chans 10)
+          reference-update-chan (au/latest-chan)
           {:keys [exit-chan go-chan tokens-watch-channels-update-chan query-chan]}
-          (start-token-watch-maintainer kv-store clock 1 1 watch-refresh-timer-chan)]
+          (start-token-watch-maintainer extract-reference-type->reference-name-helper kv-store clock 1 1 reference-update-chan watch-refresh-timer-chan)]
       (is (= {:last-update-time (clock)
               :token->index {}
               :watch-count 0}
@@ -275,13 +290,13 @@
                 :token->index {}
                 :watch-count 10}
                (get-latest-state query-chan)))
-        (assert-channels-next-event watch-chans-1 (make-index-event :INITIAL []))
+        (assert-channels-next-event watch-chans-1 (make-index-event :INITIAL [] :reference-type :token))
         (add-watch-chans tokens-watch-channels-update-chan watch-chans-2)
         (is (= {:last-update-time (clock)
                 :token->index {}
                 :watch-count 20}
                (get-latest-state query-chan)))
-        (assert-channels-next-event watch-chans-2 (make-index-event :INITIAL [])))
+        (assert-channels-next-event watch-chans-2 (make-index-event :INITIAL [] :reference-type :token)))
 
       (testing "watch-count should decrement when daemon process is refreshed"
         (remove-watch-chans watch-chans-1)
@@ -303,9 +318,10 @@
   (deftest test-start-token-watch-maintainer-refresh-timeout
     (let [kv-store (kv/->LocalKeyValueStore (atom {}))
           watch-chans (create-watch-chans 10)
+          reference-update-chan (au/latest-chan)
           watch-refresh-timer-chan (async/chan)
           {:keys [exit-chan go-chan tokens-watch-channels-update-chan query-chan]}
-          (start-token-watch-maintainer kv-store clock 1 1 watch-refresh-timer-chan)]
+          (start-token-watch-maintainer extract-reference-type->reference-name-helper kv-store clock 1 1 reference-update-chan watch-refresh-timer-chan)]
       (is (= {:last-update-time (clock)
               :token->index {}
               :watch-count 0}
@@ -319,11 +335,11 @@
                (get-latest-state query-chan))))
 
       (add-watch-chans tokens-watch-channels-update-chan watch-chans)
-      (assert-channels-next-event watch-chans (make-index-event :INITIAL []))
+      (assert-channels-next-event watch-chans (make-index-event :INITIAL [] :reference-type :token))
 
       (testing "refresh-timeout should update current-state and watchers if token is added to kv-store"
         (store-service-description-for-token
-          synchronize-fn kv-store history-length limit-per-owner "token1" token1-service-desc token1-metadata)
+          synchronize-fn extract-reference-type->reference-name-helper kv-store history-length limit-per-owner "token1" token1-service-desc token1-metadata)
         (trigger-token-watch-refresh watch-refresh-timer-chan)
         (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1"))
               expected-token->index {"token1" token-cur-index}]
@@ -335,7 +351,7 @@
 
       (testing "refresh-timeout should update current-state and watchers if token is out of date"
         (store-service-description-for-token
-          synchronize-fn kv-store history-length limit-per-owner "token1" (assoc token1-service-desc "cpus" 2)
+          synchronize-fn extract-reference-type->reference-name-helper kv-store history-length limit-per-owner "token1" (assoc token1-service-desc "cpus" 2)
           token1-metadata)
         (trigger-token-watch-refresh watch-refresh-timer-chan)
         (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1"))
@@ -347,7 +363,7 @@
           (assert-channels-next-event watch-chans (make-aggregate-index-events (make-index-event :UPDATE token-cur-index)))))
 
       (testing "refresh-timeout should update current-state and watchers if token is soft deleted"
-        (delete-service-description-for-token clock synchronize-fn kv-store history-length "token1"
+        (delete-service-description-for-token clock synchronize-fn extract-reference-type->reference-name-helper kv-store history-length "token1"
                                               (get token1-index :owner) auth-user)
         (trigger-token-watch-refresh watch-refresh-timer-chan)
         (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1")
@@ -361,7 +377,7 @@
           (assert-channels-next-event watch-chans (make-aggregate-index-events (make-index-event :UPDATE token-cur-index)))))
 
       (testing "refresh-timeout should update current-state and watchers if token is hard deleted"
-        (delete-service-description-for-token clock synchronize-fn kv-store history-length "token1"
+        (delete-service-description-for-token clock synchronize-fn extract-reference-type->reference-name-helper kv-store history-length "token1"
                                               (get token1-index :owner) auth-user :hard-delete true)
         (trigger-token-watch-refresh watch-refresh-timer-chan)
         (is (= {:last-update-time (clock)
@@ -377,8 +393,10 @@
 
   (deftest test-start-token-watch-maintainer-query-state
     (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+          reference-update-chan (au/latest-chan)
+          watch-refresh-timer-chan (async/chan)
           {:keys [exit-chan go-chan query-state-fn]}
-          (start-token-watch-maintainer kv-store clock 1 1 (async/chan))]
+          (start-token-watch-maintainer extract-reference-type->reference-name-helper kv-store clock 1 1 reference-update-chan watch-refresh-timer-chan)]
 
       (testing "query-state-fn provides current state with default fields"
         (is (= {:last-update-time (clock)
@@ -397,8 +415,10 @@
 
   (deftest test-start-token-watch-maintainer-slow-channel
     (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+          reference-update-chan (au/latest-chan)
+          watch-refresh-timer-chan (async/chan)
           {:keys [exit-chan go-chan tokens-update-chan tokens-watch-channels-update-chan query-chan]}
-          (start-token-watch-maintainer kv-store clock 1 1 (async/chan))]
+          (start-token-watch-maintainer extract-reference-type->reference-name-helper kv-store clock 1 1 reference-update-chan watch-refresh-timer-chan)]
 
       (testing "sending 5000 internal events does not halt daemon process with a slow watch-channel"
         (let [buffer-size 1
@@ -414,7 +434,7 @@
                 (for [i (range msg-count)]
                   (do
                     (store-service-description-for-token
-                      synchronize-fn kv-store history-length limit-per-owner "token1" token1-service-desc
+                      synchronize-fn extract-reference-type->reference-name-helper kv-store history-length limit-per-owner "token1" token1-service-desc
                       (assoc token1-metadata "last-update-time" i))
                     (send-internal-index-event tokens-update-chan "token1")
                     (let [token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1")
@@ -429,15 +449,17 @@
             (is (not (async/put! slow-chan "temp")))
             (let [{:keys [id] :as event} (async/<!! slow-chan)]
               (is (not (nil? id)))
-              (is (= {:object [] :type :INITIAL}
+              (is (= {:object [] :type :INITIAL :reference-type :token}
                      (dissoc event :id)))))))
 
       (stop-token-watch-maintainer go-chan exit-chan)))
 
   (deftest test-start-token-watch-maintainer-buffer-state
     (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+          reference-update-chan (au/latest-chan)
+          watch-refresh-timer-chan (async/chan)
           {:keys [exit-chan go-chan tokens-update-chan tokens-watch-channels-update-chan query-state-fn]}
-          (start-token-watch-maintainer kv-store clock 1000 1000 (async/chan))
+          (start-token-watch-maintainer extract-reference-type->reference-name-helper kv-store clock 1000 1000 reference-update-chan watch-refresh-timer-chan)
           expected-buffer-count 123]
       (stop-token-watch-maintainer go-chan exit-chan)
 
@@ -457,4 +479,368 @@
                                :watch-channels-update-chan-count expected-buffer-count}
                 :last-update-time (clock)
                 :watch-count 0}
-               (query-state-fn #{"buffer-state"})))))))
+               (query-state-fn #{"buffer-state"}))))))
+
+  (deftest test-start-token-watch-maintainer-token-reference-update
+    (let [kv-store (kv/->LocalKeyValueStore (atom {}))
+          token1-service-desc {"cpus" 1 "version" "v1"}
+          extract-reference-type->reference-name-fn (fn [{:strs [version]}] {:version version})
+          watch-chans-count 5
+          watch-chans (create-watch-chans watch-chans-count)
+          reference-update-chan (async/chan 100)
+          watch-refresh-timer-chan (async/chan)
+          _ (store-service-description-for-token
+              synchronize-fn extract-reference-type->reference-name-fn kv-store history-length limit-per-owner "token1" token1-service-desc token1-metadata)
+          {:keys [exit-chan go-chan query-chan tokens-watch-channels-update-chan]}
+          (start-token-watch-maintainer extract-reference-type->reference-name-fn kv-store clock 1 1 reference-update-chan watch-refresh-timer-chan)
+          token-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1") :reference-type->reference-name {:version "v1"})
+          expected-token->index {"token1" token-cur-index}]
+
+      (is (= {:last-update-time (clock)
+              :token->index expected-token->index
+              :reference-type->reference-name->last-update-time {}
+              :reference-type->reference-name->tokens {:version {"v1" #{"token1"}}}
+              :watch-count 0}
+             (get-latest-state query-chan :include-flags #{"reference-type->reference-name->last-update-time" "reference-type->reference-name->tokens" "token->index"})))
+
+      (add-watch-chans tokens-watch-channels-update-chan watch-chans)
+      (is (= {:last-update-time (clock)
+              :token->index expected-token->index
+              :reference-type->reference-name->last-update-time {}
+              :reference-type->reference-name->tokens {:version {"v1" #{"token1"}}}
+              :watch-count watch-chans-count}
+             (get-latest-state query-chan :include-flags #{"reference-type->reference-name->last-update-time" "reference-type->reference-name->tokens" "token->index"})))
+
+      (assert-channels-next-event watch-chans (make-index-event :INITIAL [token-cur-index] :reference-type :token))
+
+      (async/>!! reference-update-chan {:cid (str "r-" (System/currentTimeMillis)) :reference-type :version :reference-name "v2" :update-time 100000})
+
+      (is (= {:last-update-time (clock)
+              :token->index expected-token->index
+              :reference-type->reference-name->last-update-time {:version {"v2" 100000}}
+              :reference-type->reference-name->tokens {:version {"v1" #{"token1"}}}
+              :watch-count watch-chans-count}
+             (get-latest-state query-chan :include-flags #{"reference-type->reference-name->last-update-time" "reference-type->reference-name->tokens" "token->index"})))
+
+      (async/>!! reference-update-chan {:cid (str "r-" (System/currentTimeMillis)) :reference-type :version :reference-name "v1" :update-time 120000})
+      (async/>!! reference-update-chan {:cid (str "r-" (System/currentTimeMillis)) :reference-type :version :reference-name "v3" :update-time 140000})
+
+      (is (= {:last-update-time (clock)
+              :token->index expected-token->index
+              :reference-type->reference-name->last-update-time {:version {"v1" 120000 "v2" 100000 "v3" 140000}}
+              :reference-type->reference-name->tokens {:version {"v1" #{"token1"}}}
+              :watch-count watch-chans-count}
+             (get-latest-state query-chan :include-flags #{"reference-type->reference-name->last-update-time" "reference-type->reference-name->tokens" "token->index"})))
+
+      (assert-channels-next-event watch-chans (make-aggregate-index-events (make-index-event :UPDATE token-cur-index :reference-type :version) :reference-type :version))
+
+      (let [token1-service-desc {"cpus" 1 "mem" 1024 "version" "v3"}
+            _ (store-service-description-for-token
+                synchronize-fn extract-reference-type->reference-name-fn kv-store history-length limit-per-owner "token1" token1-service-desc token1-metadata)
+            token1-cur-index (assoc token1-index :etag (get-token-hash kv-store "token1") :reference-type->reference-name {:version "v3"})
+            expected-token->index {"token1" token1-cur-index}]
+
+        (async/put! watch-refresh-timer-chan :trigger)
+        (is (= {:last-update-time (clock)
+                :token->index expected-token->index
+                :reference-type->reference-name->last-update-time {:version {"v1" 120000 "v2" 100000 "v3" 140000}}
+                :reference-type->reference-name->tokens {:version {"v3" #{"token1"}}}
+                :watch-count watch-chans-count}
+               (get-latest-state query-chan :include-flags #{"reference-type->reference-name->last-update-time" "reference-type->reference-name->tokens" "token->index"})))
+
+        (assert-channels-next-event watch-chans (make-aggregate-index-events (make-index-event :UPDATE token1-cur-index)))
+
+        (async/>!! reference-update-chan {:cid (str "r-" (System/currentTimeMillis)) :reference-type :image :reference-name "i1" :update-time 110000})
+        (async/>!! reference-update-chan {:cid (str "r-" (System/currentTimeMillis)) :reference-type :version :reference-name "v1" :update-time 110000})
+        (async/>!! reference-update-chan {:cid (str "r-" (System/currentTimeMillis)) :reference-type :version :reference-name "v3" :update-time 120000})
+        (async/>!! reference-update-chan {:cid (str "r-" (System/currentTimeMillis)) :reference-type :version :reference-name "v3" :update-time 160000})
+        (assert-channels-next-event watch-chans (make-aggregate-index-events (make-index-event :UPDATE token1-cur-index :reference-type :version) :reference-type :version))
+
+        (is (= {:last-update-time (clock)
+                :token->index expected-token->index
+                :reference-type->reference-name->last-update-time {:image {"i1" 110000}
+                                                                   :version {"v1" 120000 "v2" 100000 "v3" 160000}}
+                :reference-type->reference-name->tokens {:version {"v3" #{"token1"}}}
+                :watch-count watch-chans-count}
+               (get-latest-state query-chan :include-flags #{"reference-type->reference-name->last-update-time" "reference-type->reference-name->tokens" "token->index"})))
+
+        (let [token2-service-desc {"cpus" 1 "mem" 1024 "version" "v4"}
+              token2-metadata {"cluster" "c1" "last-update-time" 2000 "owner" "owner2"}
+              _ (store-service-description-for-token
+                  synchronize-fn extract-reference-type->reference-name-fn kv-store history-length limit-per-owner "token2" token2-service-desc token2-metadata)
+              token2-index {:deleted false
+                            :etag (get-token-hash kv-store "token2")
+                            :last-update-time (get token2-metadata "last-update-time")
+                            :maintenance false
+                            :owner (get token2-metadata "owner")
+                            :reference-type->reference-name {:version "v4"}
+                            :token "token2"}
+              expected-token->index {"token1" token1-cur-index
+                                     "token2" token2-index}]
+
+          (async/put! watch-refresh-timer-chan :trigger)
+          (is (= {:last-update-time (clock)
+                  :token->index expected-token->index
+                  :reference-type->reference-name->last-update-time {:image {"i1" 110000}
+                                                                     :version {"v1" 120000 "v2" 100000 "v3" 160000}}
+                  :reference-type->reference-name->tokens {:version {"v3" #{"token1"} "v4" #{"token2"}}}
+                  :watch-count watch-chans-count}
+                 (get-latest-state query-chan :include-flags #{"reference-type->reference-name->last-update-time" "reference-type->reference-name->tokens" "token->index"})))
+
+          (assert-channels-next-event watch-chans (make-aggregate-index-events (make-index-event :UPDATE token2-index)))
+
+          (async/>!! reference-update-chan {:cid (str "r-" (System/currentTimeMillis)) :reference-type :version :reference-name "v4" :update-time 180000})
+          (assert-channels-next-event watch-chans (make-aggregate-index-events (make-index-event :UPDATE token2-index :reference-type :version) :reference-type :version))))
+
+      (stop-token-watch-maintainer go-chan exit-chan))))
+
+(deftest test-assoc-token-references
+  (let [reference-type->reference-name->tokens {:image {"image-1" #{"t1a" "t1b"}
+                                                        "image-2" #{"t2a" "t2b"}
+                                                        "image-3" #{"t3a"}}
+                                                :version {"ver-1" #{"t1a"}
+                                                          "ver-2" #{"t2a" "t2b"}
+                                                          "ver-4" #{"t4a"}}}]
+    (is (= reference-type->reference-name->tokens
+           (assoc-token-references
+             reference-type->reference-name->tokens "t1a" {:image "image-1" :version "ver-1"})))
+    (is (= (-> reference-type->reference-name->tokens
+               (update-in [:image "image-2"] conj "t1a"))
+           (assoc-token-references
+             reference-type->reference-name->tokens "t1a" {:image "image-2" :version "ver-1"})))
+    (is (= (-> reference-type->reference-name->tokens
+               (update-in [:version "ver-2"] conj "t1a"))
+           (assoc-token-references
+             reference-type->reference-name->tokens "t1a" {:image "image-1" :version "ver-2"})))
+    (is (= (-> reference-type->reference-name->tokens
+               (update-in [:image "image-2"] conj "t1a")
+               (update-in [:version "ver-2"] conj "t1a"))
+           (assoc-token-references
+             reference-type->reference-name->tokens "t1a" {:image "image-2" :version "ver-2"})))
+    (is (= (-> reference-type->reference-name->tokens
+               (assoc-in [:image "image-5"] #{"t1a"})
+               (assoc-in [:version "ver-5"] #{"t1a"}))
+           (assoc-token-references
+             reference-type->reference-name->tokens "t1a" {:image "image-5" :version "ver-5"})))))
+
+(deftest test-dissoc-token-references
+  (let [reference-type->reference-name->tokens {:image {"image-1" #{"t1a" "t1b"}
+                                                        "image-2" #{"t2a" "t2b"}
+                                                        "image-3" #{"t3a"}}
+                                                :version {"ver-1" #{"t1a"}
+                                                          "ver-2" #{"t2a" "t2b"}
+                                                          "ver-4" #{"t4a"}}}]
+    (is (= (-> reference-type->reference-name->tokens
+               (update-in [:image "image-1"] disj "t1a")
+               (update-in [:version "ver-1"] disj "t1a"))
+           (dissoc-token-references
+             reference-type->reference-name->tokens "t1a" {:image "image-1" :version "ver-1"})))
+    (is (= (-> reference-type->reference-name->tokens
+               (update-in [:version "ver-1"] disj "t1a"))
+           (dissoc-token-references
+             reference-type->reference-name->tokens "t1a" {:image "image-2" :version "ver-1"})))
+    (is (= (-> reference-type->reference-name->tokens
+               (update-in [:image "image-1"] disj "t1a"))
+           (dissoc-token-references
+             reference-type->reference-name->tokens "t1a" {:image "image-1" :version "ver-2"})))
+    (is (= reference-type->reference-name->tokens
+           (dissoc-token-references
+             reference-type->reference-name->tokens "t1a" {:image "image-2" :version "ver-2"})))
+    (is (= (-> reference-type->reference-name->tokens
+               (assoc-in [:image "image-5"] #{})
+               (assoc-in [:version "ver-5"] #{}))
+           (dissoc-token-references
+             reference-type->reference-name->tokens "t1a" {:image "image-5" :version "ver-5"})))))
+
+(deftest test-adjust-token-references
+  (let [reference-type->reference-name->tokens {:image {"image-1" #{"t1a" "t1b"}
+                                                        "image-2" #{"t2a" "t2b"}
+                                                        "image-3" #{"t3a"}}
+                                                :version {"ver-1" #{"t1a"}
+                                                          "ver-2" #{"t2a" "t2b"}
+                                                          "ver-4" #{"t4a"}}}]
+    (is (= reference-type->reference-name->tokens
+           (adjust-token-references reference-type->reference-name->tokens "t1a"
+                                    {:image "image-1" :version "ver-1"} {:image "image-1" :version "ver-1"})))
+    (is (= (-> reference-type->reference-name->tokens
+               (assoc-in [:version "ver-1"] #{})
+               (update-in [:version "ver-2"] conj "t1a"))
+           (adjust-token-references reference-type->reference-name->tokens "t1a"
+                                    {:image "image-1" :version "ver-1"} {:image "image-1" :version "ver-2"})))
+    (is (= (-> reference-type->reference-name->tokens
+               (update-in [:image "image-1"] disj "t1a")
+               (update-in [:image "image-2"] conj "t1a")
+               (assoc-in [:version "ver-1"] #{})
+               (update-in [:version "ver-2"] conj "t1a"))
+           (adjust-token-references reference-type->reference-name->tokens "t1a"
+                                    {:image "image-1" :version "ver-1"} {:image "image-2" :version "ver-2"})))))
+
+(deftest test-extract-reference-update-tokens
+  (let [state {:reference-type->reference-name->last-update-time {:image {"image-1" 1500
+                                                                          "image-2" 2500}
+                                                                  :version {"ver-1" 1400
+                                                                            "ver-2" 2600}}
+               :reference-type->reference-name->tokens {:image {"image-1" #{"t1a" "t1b"}
+                                                                "image-2" #{"t2a" "t2b"}}
+                                                        :version {"ver-1" #{"t1a"}
+                                                                  "ver-2" #{"t2a" "t2b"}}}}]
+    (is (nil? (extract-reference-update-tokens state {:reference-type :image :reference-name "image-0" :update-time 1400})))
+    (is (nil? (extract-reference-update-tokens state {:reference-type :image :reference-name "image-1" :update-time 1400})))
+    (is (nil? (extract-reference-update-tokens state {:reference-type :image :reference-name "image-1" :update-time 1500})))
+    (is (= #{"t1a" "t1b"} (extract-reference-update-tokens state {:reference-type :image :reference-name "image-1" :update-time 1600})))))
+
+(deftest test-calculate-reference-type->reference-name->tokens
+  (is (= {:image {"i2" #{"t2" "t4"}
+                  "i5" #{"t5"}
+                  "i6" #{"t6"}}
+          :version {"v3" #{"t3" "t4"}
+                    "v5" #{"t5"}}}
+         (calculate-reference-type->reference-name->tokens {"t1" {:etag "e1"}
+                                                            "t2" {:etag "e2" :reference-type->reference-name {:image "i2"}}
+                                                            "t3" {:etag "e3" :reference-type->reference-name {:version "v3"}}
+                                                            "t4" {:etag "e4" :reference-type->reference-name {:image "i2" :version "v3"}}
+                                                            "t5" {:etag "e5" :reference-type->reference-name {:image "i5" :version "v5"}}
+                                                            "t6" {:etag "e6" :reference-type->reference-name {:image "i6"}}}))))
+
+(deftest test-watch-for-reference-updates
+  (let [correlation-id (str "test-watch-for-reference-updates-" (System/currentTimeMillis))
+        router-id "test-router-id"
+        reference-update-chan (au/sliding-buffer-chan 1)
+        make-inter-router-requests-async-fn (fn [endpoint & {:keys [body config method]}]
+                                              (is (= "reference/notify" endpoint))
+                                              (is (= "application/json" (get-in config [:headers "content-type"])))
+                                              (is (= correlation-id (get-in config [:headers "x-cid"])))
+                                              (is (= :post method))
+                                              (let [response-chan (async/promise-chan)]
+                                                (async/>!! response-chan {:body (-> body (utils/try-parse-json) (walk/keywordize-keys))})
+                                                {"peer-router-id" response-chan}))
+        response-chan (async/promise-chan)
+        update-event {:cid correlation-id
+                      :reference-name "test-reference-name"
+                      :reference-type :test-reference-type
+                      :response-chan response-chan
+                      :router-id router-id
+                      :update-time 12000}]
+    (async/>!! reference-update-chan update-event)
+    (watch-for-reference-updates make-inter-router-requests-async-fn reference-update-chan router-id)
+    (is (= {"peer-router-id" {:body (-> update-event
+                                        (select-keys [:reference-name :reference-type :update-time])
+                                        (update :reference-type name)
+                                        (assoc :router-id router-id))}}
+           (async/<!! response-chan)))
+    (async/close! reference-update-chan)))
+
+(deftest test-reference-notify-handler
+  (let [correlation-id (str "test-watch-for-reference-updates-" (System/currentTimeMillis))
+        router-id "test-router-id"
+        reference-name "test-reference-name"
+        reference-type :test-reference-type
+        update-time 12000]
+    (cid/with-correlation-id
+      correlation-id
+
+      (is (= {:headers {"content-type" "text/plain"}
+              :status http-405-method-not-allowed}
+             (-> (reference-notify-handler nil router-id {:request-method :get})
+                 (async/<!!)
+                 (select-keys [:headers :status]))))
+
+      (is (= {:headers {"content-type" "text/plain"}
+              :status http-400-bad-request}
+             (-> (reference-notify-handler nil router-id {:body (utils/clj->json-stream {})
+                                                          :request-method :post})
+                 (async/<!!)
+                 (select-keys [:headers :status]))))
+
+      (is (= {:headers {"content-type" "text/plain"}
+              :status http-400-bad-request}
+             (-> (reference-notify-handler nil router-id {:body (utils/clj->json-stream {:reference-name reference-name :reference-type reference-type})
+                                                          :request-method :post})
+                 (async/<!!)
+                 (select-keys [:headers :status]))))
+
+      (is (= {:headers {"content-type" "text/plain"}
+              :status http-400-bad-request}
+             (-> (reference-notify-handler nil router-id {:body (utils/clj->json-stream {:reference-name reference-name :update-time 12000})
+                                                          :request-method :post})
+                 (async/<!!)
+                 (select-keys [:headers :status]))))
+
+      (is (= {:headers {"content-type" "text/plain"}
+              :status http-400-bad-request}
+             (-> (reference-notify-handler nil router-id {:body (utils/clj->json-stream {:reference-type reference-type :update-time 12000})
+                                                          :request-method :post})
+                 (async/<!!)
+                 (select-keys [:headers :status]))))
+
+      (is (= {:headers {"content-type" "text/plain"}
+              :status http-400-bad-request}
+             (-> (reference-notify-handler nil router-id {:body (utils/clj->json-stream {:reference-name reference-name :reference-type reference-type :update-time "12000"})
+                                                          :request-method :post})
+                 (async/<!!)
+                 (select-keys [:headers :status]))))
+
+      (let [reference-update-chan (async/promise-chan)]
+        (is (= {:body {:cid correlation-id
+                       :reference-name reference-name
+                       :reference-type (name reference-type)
+                       :router-id router-id
+                       :success true
+                       :update-time update-time}
+                :headers {"content-type" "application/json"}
+                :status http-200-ok}
+               (-> (reference-notify-handler reference-update-chan router-id {:body (utils/clj->json-stream {:reference-name reference-name :reference-type reference-type :update-time update-time})
+                                                                              :request-method :post})
+                   (async/<!!)
+                   (select-keys [:body :headers :status])
+                   (update :body #(-> % (utils/try-parse-json) (walk/keywordize-keys))))))
+        (is (= {:cid correlation-id
+                :reference-name reference-name
+                :reference-type reference-type
+                :update-time update-time}
+               (async/<!! reference-update-chan)))))))
+
+(deftest test-start-reference-notify-forwarder
+  (let [num-events 10
+        reference-listener-chan (async/chan num-events)
+        reference-update-chan (async/chan num-events)
+        track-event (fn [events-atom {:keys [event-id] :as reference-event}]
+                      (->> (assoc reference-event :event-time (System/currentTimeMillis))
+                           (swap! events-atom assoc event-id)))
+        notified-events-atom (atom {})
+        forwarded-events-atom (atom {})
+        pre-notify-fn (fn [reference-event]
+                        (track-event notified-events-atom reference-event))
+        event-ids (map #(str "event-" % "-" (System/currentTimeMillis)) (range num-events))
+        event-response-chans (map (fn [_] (async/promise-chan)) (range num-events))]
+    (async/go-loop []
+      (if-let [reference-event (async/<! reference-update-chan)]
+        (do
+          (track-event forwarded-events-atom reference-event)
+          (recur))))
+
+    ;; produce the events for the reference notify forwarder
+    (doseq [index (range num-events)]
+      (let [event-id (nth event-ids index)
+            response-chan (nth event-response-chans index)]
+        (async/>!! reference-listener-chan {:cid (str "cid-" event-id)
+                                            :event-id event-id
+                                            :response-chan response-chan})))
+    (async/close! reference-listener-chan)
+
+    ;; consume the events inside the reference notify forwarder
+    (async/<!! (start-reference-notify-forwarder reference-listener-chan reference-update-chan pre-notify-fn))
+
+    (doseq [index (range num-events)]
+      (let [event-id (nth event-ids index)
+            response-chan (nth event-response-chans index)
+            ;; await processing of the events by the reference notify forwarder
+            [value channel] (async/alts!! [response-chan (async/timeout 1000)])
+            notified-event-time (get-in @notified-events-atom [event-id :event-time])
+            forwarded-event-time (get-in @forwarded-events-atom [event-id :event-time])]
+        (is (= {:success true} value))
+        (is (= response-chan channel) (str value))
+        (is (and forwarded-event-time notified-event-time (<= notified-event-time forwarded-event-time))
+            (str {:event-id event-id :forwarded-event-time forwarded-event-time :notified-event-time notified-event-time}))))
+
+    (async/close! reference-update-chan)))


### PR DESCRIPTION
## Changes proposed in this PR

- adds a new `reference-update-chan` which reference tracking components can send update notifications on
- adds a new `/reference/notify` endpoint to receive and process reference update notifications from peers
- updates the service description builder to calculate references from the token definition
- updates the token index (can be triggered by `/tokens/reindex` endpoint) to include references in the token metadata/index
- adds support for handling reference update notifications by extending builder interface
- updates the token watch component to listen for reference updates and trigger events on the tokens watches when reference updates for tokens.

## Why are we making these changes?

We would like to be able to propagate new service IDs for tokens when underlying references for a token update.

