### PR TITLE
upgrades python for github actions to 3.9

### DIFF
--- a/.github/workflows/cd-waiter-cli.yml
+++ b/.github/workflows/cd-waiter-cli.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python 3.6
+    - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.6.x'
+        python-version: '3.9.x'
     - name: Install pypa/build
       run: |
         python3 -m pip install --upgrade build

--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.6.x'
+          python-version: '3.9.x'
       - name: Cache pip
         uses: actions/cache@v2
         with:

--- a/.github/workflows/test-apps.yml
+++ b/.github/workflows/test-apps.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.6.x'
+          python-version: '3.9.x'
       - name: Cache pip
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
## Changes proposed in this PR

- upgrades python for github actions to 3.9

## Why are we making these changes?

The current setup reports the following error:
```
Set up Python

Run actions/setup-python@v2
Version 3.6.x was not found in the local cache
Error: Version 3.[6](https://github.com/twosigma/waiter/actions/runs/3835220727/jobs/6528287578#step:3:7).x with arch x64 not found
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```


