### PR TITLE
fixes test-basic-health-check-port-index for shell scheduler

### DIFF
--- a/waiter/integration/waiter/basic_test.clj
+++ b/waiter/integration/waiter/basic_test.clj
@@ -526,10 +526,12 @@
         service-id
         (if (utils/raven-proxy-response? response)
           (assert-response-status response http-503-service-unavailable)
-          (do
+          (let [expected-error-message (if (using-shell? waiter-url)
+                                         "Request failed to connect to service backend"
+                                         "Request to service backend failed")]
             (assert-response-status response http-502-bad-gateway)
-            (is (str/includes? (-> response :body str) "Request to service backend failed"))
-            (is (str/includes? (-> response :headers (get "server")) "waiter/"))))
+            (is (str/includes? (-> response :body str) expected-error-message) (-> response :body str))
+            (is (str/includes? (-> response :headers (get "server")) "waiter/")) (-> response :headers str)))
         (let [{:keys [service-description]} (service-settings waiter-url service-id)
               {:keys [cmd health-check-port-index ports]} service-description]
           (is (= kitchen-command cmd))

--- a/waiter/src/waiter/util/client_tools.clj
+++ b/waiter/src/waiter/util/client_tools.clj
@@ -1141,7 +1141,7 @@
 (defn using-shell?
   "Returns true if Waiter is configured to use Shell Scheduler for scheduling"
   [waiter-url]
-  (= "shell" (retrieve-default-scheduler-name waiter-url)))
+  (str/includes? (retrieve-default-scheduler-name waiter-url) "shell"))
 
 (defn using-raven?
   "Returns true if Waiter is configured to use Kubernetes and the Raven sidecar proxy"


### PR DESCRIPTION
## Changes proposed in this PR

- fixes test-basic-health-check-port-index for shell scheduler

## Why are we making these changes?


