### PR TITLE
Waiter cli ready

### DIFF
--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -363,6 +363,17 @@ def ping(waiter_url=None, token_name_or_service_id=None, flags=None, ping_flags=
     return cp
 
 
+def ready(waiter_url=None, token_name=None, flags=None, ready_flags=None):
+    """Checks if a token is ready for traffic via the CLI"""
+    if not ready_flags:
+        ready_flags = ''
+    if '--timeout' not in ready_flags:
+        ready_flags += f' --timeout {int(util.DEFAULT_TIMEOUT_MS/1000)}'
+    args = f'ready {token_name or ""} {ready}'
+    cp = cli(args, waiter_url, flags)
+    return cp
+
+
 def kill(waiter_url=None, token_name_or_service_id=None, flags=None, kill_flags=None):
     """Kills services using a token via the CLI"""
     args = f'kill {token_name_or_service_id} {kill_flags or ""}'

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -8,12 +8,12 @@ requirements = [
     'humanfriendly>=4.18',
     'pyyaml>=3.13',
     'requests>=2.20.0',
+    'retrying>=1.3.3',
     'tabulate>=0.8.3'
 ]
 
 test_requirements = [
     'pytest',
-    'retrying'
 ]
 
 extras = {

--- a/cli/waiter/cli.py
+++ b/cli/waiter/cli.py
@@ -3,7 +3,7 @@ import logging
 from urllib.parse import urlparse
 
 from waiter import configuration, http_util, metrics, version
-from waiter.subcommands import create, delete, init, instance, kill, maintenance, ping, show, ssh, ssl, tokens, update
+from waiter.subcommands import create, delete, init, instance, kill, maintenance, ping, ready, show, ssh, ssl, tokens, update
 import waiter.plugins as waiter_plugins
 
 parser = argparse.ArgumentParser(description='waiter is the Waiter CLI')
@@ -43,6 +43,9 @@ actions = {
     },
     'instance': {
         'run-function': instance.register(subparsers.add_parser)
+    },
+    'ready': {
+        'run-function': ready.register(subparsers.add_parser)
     },
     'show': {
         'run-function': show.register(subparsers.add_parser)

--- a/cli/waiter/subcommands/ready.py
+++ b/cli/waiter/subcommands/ready.py
@@ -1,0 +1,48 @@
+
+from retrying import retry, RetryError
+from waiter import terminal
+from waiter.action import check_ssl, process_ping_request
+from waiter.util import check_positive, guard_no_cluster, print_error
+
+_default_timeout = 300
+
+def ready(clusters, args, _, __):
+    """Ensure the Waiter service is ready for traffic."""
+    guard_no_cluster(clusters)
+    port = 443
+    token_name = args.get('token')
+    token_host = f'{token_name}:{port}'
+    ping_timeout_secs = args.get('ping_timeout', _default_timeout)
+    ssl_timeout_secs = args.get('connect_timeout', _default_timeout)
+    wait_secs = 10 if ssl_timeout_secs > 10 else 1
+    if not process_ping_request(clusters, token_name, False, ping_timeout_secs, True):
+        return 1
+    retry_options = {
+        'retry_on_result': lambda r: not r,
+        'stop_max_delay': ssl_timeout_secs * 1000,
+        'wait_fixed': wait_secs * 1000,
+    }
+    print(f'Awaiting successful connection to {terminal.bold(token_host)}')
+    check_ssl_with_retries = retry(**retry_options)(check_ssl)
+    try:
+        check_ssl_with_retries(token_name, port, ssl_timeout_secs)
+    # Any exception indicates an issue connecting to or handshaking the backend service
+    except Exception as e:
+        print_error(e)
+        print_error(f'Failed to connect to {token_host} after {ssl_timeout_secs} seconds')
+        return 1
+    return 0
+
+
+def register(add_parser):
+    """Adds this sub-command's parser and returns the action function"""
+    parser = add_parser('ready', help='ensure the target token is ready for traffic')
+    parser.add_argument('token')
+    parser.add_argument('--ping-timeout', help=f'timeout (in seconds) for ping request via waiter api'
+                        f' (default is {_default_timeout} seconds)',
+                        type=check_positive, default=_default_timeout)
+    parser.add_argument('--connect-timeout', help=f'timeout (in seconds) for tls connection to service'
+                        f' (default is {_default_timeout} seconds)',
+                        type=check_positive, default=_default_timeout)
+    return ready
+

--- a/cli/waiter/subcommands/ssl.py
+++ b/cli/waiter/subcommands/ssl.py
@@ -1,14 +1,21 @@
 
 from waiter.action import check_ssl
-from waiter.util import check_positive
+from waiter.util import check_positive, print_error
 
 
 def ensureSSL(_, args, __, ___):
     """Checks the state of SSL for the provided token."""
+    port=443
     token_name = args.get('token')
     timeout_secs = args.get('timeout', None)
-    ssl_success = check_ssl(token_name, timeout_secs)
-    return 0 if ssl_success else 1
+    try:
+        check_ssl(token_name, port, timeout_secs)
+    # Any exception indicates an issue connecting to or handshaking the backend service
+    except Exception as e:
+        print_error(e)
+        print_error(f'Connection to {token_name}:{port} failed')
+        return 1
+    return 0
 
 
 def register(add_parser):

--- a/cli/waiter/version.py
+++ b/cli/waiter/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.5.5-dev0'
+VERSION = '1.5.6'

--- a/cli/waiter/version.py
+++ b/cli/waiter/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.5.6'
+VERSION = '1.5.7-dev0'


### PR DESCRIPTION
## Changes proposed in this PR

Add `ready` subcommand to waiter cli, which both pings the service, and ensures it's reachable via `https://${TOKEN_NAME}/`.

## Why are we making these changes?

Make it easier for users to automate ensuring their app is all ready to receive traffic.