### PR TITLE
removes support for x-waiter-priority header

### DIFF
--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -1060,8 +1060,8 @@
                                             (partial make-kill-instance-request make-inter-router-requests-sync-fn service-id))))
    :determine-priority-fn (pc/fnk []
                             (let [position-generator-atom (atom 0)]
-                              (fn determine-priority-fn [waiter-headers]
-                                (pr/determine-priority position-generator-atom waiter-headers))))
+                              (fn determine-priority-fn [request]
+                                (pr/determine-priority position-generator-atom request))))
    :discover-service-parameters-fn (pc/fnk [[:settings [:instance-request-properties unsupported-headers]]
                                             [:state kv-store waiter-hostnames]
                                             attach-service-defaults-fn attach-token-defaults-fn]

--- a/waiter/test/waiter/process_request_test.clj
+++ b/waiter/test/waiter/process_request_test.clj
@@ -629,10 +629,11 @@
     (is (nil? (determine-priority position-generator-atom nil)))
     (is (nil? (determine-priority position-generator-atom {})))
     (is (nil? (determine-priority position-generator-atom {"foo" 1})))
-    (is (= [1 -101] (determine-priority position-generator-atom {"x-waiter-priority" 1})))
-    (is (= [2 -102] (determine-priority position-generator-atom {"x-waiter-priority" "2"})))
-    (is (= [4 -103] (determine-priority position-generator-atom {"x-waiter-foo" "2", "x-waiter-priority" "4"})))
+    (is (= [1 -101] (determine-priority position-generator-atom {:priority 1})))
+    (is (= [2 -102] (determine-priority position-generator-atom {:priority 2})))
+    (is (= [4 -103] (determine-priority position-generator-atom {:priority 4 :source 2})))
     (is (nil? (determine-priority position-generator-atom {"priority" 1})))
+    (is (nil? (determine-priority position-generator-atom {:priority "1"})))
     (is (= 103 @position-generator-atom))))
 
 (deftest test-classify-error


### PR DESCRIPTION
## Changes proposed in this PR

- removes support for x-waiter-priority header

## Why are we making these changes?

This feature is not currently in use. We wish to remove support for the feature and leverage code for prioritizing ping requests.


