### PR TITLE
adds waiter token and service owner to the error page

### DIFF
--- a/waiter/resources/web/error.html
+++ b/waiter/resources/web/error.html
@@ -128,9 +128,19 @@
         <td class="field">Principal</td><td class="code"><%= principal %></td>
       </tr>
       <% ) %>
+      <% (when waiter-token %>
+      <tr>
+        <td class="field">Waiter Token</td><td class="code"><%= waiter-token %></td>
+      </tr>
+      <% ) %>
+      <% (when service-owner %>
+      <tr>
+        <td class="field">Service Owner</td><td class="code"><%= service-owner %></td>
+      </tr>
+      <% ) %>
       <% (when service-id %>
       <tr>
-      <td class="field">Service Id</td><td class="code"><%= service-id %></td>
+        <td class="field">Service Id</td><td class="code"><%= service-id %></td>
       </tr>
       <% ) %>
       <% (when instance-id %>

--- a/waiter/resources/web/error.txt
+++ b/waiter/resources/web/error.txt
@@ -13,7 +13,9 @@ Request Info
         Method: <%= request-method %>
            CID: <%= cid %>
           Time: <%= timestamp %><% (when principal %>
-     Principal: <%= principal %><% ) %><% (when service-id %>
+     Principal: <%= principal %><% ) %><% (when waiter-token %>
+  Waiter Token: <%= waiter-token %><% ) %><% (when service-owner %>
+ Service Owner: <%= service-owner %><% ) %><% (when service-id %>
     Service Id: <%= service-id %><% ) %><% (when instance-id %>
    Instance Id: <%= instance-id %><% ) %>
 


### PR DESCRIPTION
## Changes proposed in this PR

- adds waiter token and service owner to the error page

## Why are we making these changes?

Provides additional information to the client when an error occurs about which service failed and who owns the service.


