### PR TITLE
adds support for predicate function while building error context

### DIFF
--- a/waiter/config-full.edn
+++ b/waiter/config-full.edn
@@ -1131,8 +1131,16 @@
             :tls-error "Unable to complete TLS handshake with backend (ensure backend-proto is correctly configured)"}
 
  ;; Support information used to provide user guidance in error messages
- :support-info [{:label "Email Support Team" :link {:type :email :value "support@example.com"}}
-                {:label "Waiter on GitHub" :link {:type :url :value "http://github.com/twosigma/waiter"}}]
+ :support-info [{:label "Email Support Team"
+                 :link {:type :email :value "support@example.com"}
+                 :predicate-fn 'waiter.util.utils/include-waiter-support-info-predicate}
+                {:label "Waiter on GitHub"
+                 :link {:type :url :value "http://github.com/twosigma/waiter"}
+                 :predicate-fn 'waiter.util.utils/include-always-support-info-predicate}
+                {:label "Contact Service Owner"
+                 :predicate-fn 'waiter.util.utils/include-service-error-support-info-predicate}
+                {:label "Client violates CORS access rules"
+                 :predicate-fn 'waiter.util.utils/include-cors-error-support-info-predicate}]
 
  ;; Sets tolerance level for Waiter when declaring deployment errors
  :deployment-error-config {

--- a/waiter/resources/web/error.html
+++ b/waiter/resources/web/error.html
@@ -168,9 +168,9 @@
     <ul>
       <% (doseq [{label :label {:keys [type value]} :link} support-info] %>
       <li>
-        <%= label %>:
+        <%= label %><%(when value %>:
         <% (when (= type :url) %> <a href="<%= value %>"><%= value %></a><% ) %>
-        <% (when (= type :email) %> <a href="mailto:<%= value %>"><%= value %></a><% ) %>
+        <% (when (= type :email) %> <a href="mailto:<%= value %>"><%= value %></a><% )) %>
       </li>
       <% ) %>
     </ul>

--- a/waiter/resources/web/error.txt
+++ b/waiter/resources/web/error.txt
@@ -27,5 +27,4 @@ Additional Info
 <% ) %><% (when (seq support-info) %>Getting Help
 ============
 <% (doseq [{label :label {:keys [value]} :link} support-info] %>
-  <%= label %>: <%= value %> <% ) %>
-<% ) %>
+  <%= label %><% (when value %>: <%= value %><% ))) %>

--- a/waiter/src/waiter/core.clj
+++ b/waiter/src/waiter/core.clj
@@ -834,6 +834,15 @@
    :start-service-cache (pc/fnk []
                           (cu/cache-factory {:threshold 100
                                              :ttl (-> 1 t/minutes t/in-millis)}))
+   :support-info (pc/fnk [[:settings support-info]]
+                   (->> support-info
+                        (map (fn [entry]
+                               (update entry :predicate-fn
+                                       (fn resolve-support-info-predicate [predicate-fn]
+                                         (if predicate-fn
+                                           (utils/resolve-symbol! predicate-fn)
+                                           utils/include-always-support-info-predicate)))))
+                        (vec)))
    :token-cluster-calculator (pc/fnk [[:settings [:cluster-config name] [:token-config cluster-calculator]]]
                                (utils/create-component
                                  cluster-calculator :context {:default-cluster name}))

--- a/waiter/src/waiter/main.clj
+++ b/waiter/src/waiter/main.clj
@@ -143,8 +143,8 @@
    :settings (pc/fnk dummy-symbol-for-fnk-schema-logic :- settings/settings-schema [] settings)
    :state core/state
    :http-server (pc/fnk [[:routines discover-service-parameters-fn generate-log-url-fn waiter-request?-fn]
-                         [:settings cors-config host port server-options support-info websocket-config]
-                         [:state cors-validator router-id server-name waiter-images-url]
+                         [:settings cors-config host port server-options websocket-config]
+                         [:state cors-validator router-id server-name support-info waiter-images-url]
                          handlers] ; Insist that all systems are running before we start server
                   (let [{:keys [websocket-request-acceptor]} handlers
                         {:keys [drain-request-buffer-size]} server-options

--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -204,8 +204,9 @@
                                           (or dd-agent (and host port)))
                                         "either a :dd-agent map or a statsd :host + :port pair is required"))
    (s/required-key :support-info) [{(s/required-key :label) schema/non-empty-string
-                                    (s/required-key :link) {(s/required-key :type) s/Keyword
-                                                            (s/required-key :value) schema/non-empty-string}}]
+                                    (s/optional-key :link) {(s/required-key :type) s/Keyword
+                                                            (s/required-key :value) schema/non-empty-string}
+                                    (s/optional-key :predicate-fn) s/Symbol}]
    (s/required-key :token-config) {(s/required-key :cluster-calculator) (s/constrained
                                                                           {:kind s/Keyword
                                                                            s/Keyword schema/require-symbol-factory-fn}

--- a/waiter/src/waiter/status_codes.clj
+++ b/waiter/src/waiter/status_codes.clj
@@ -93,6 +93,17 @@
 (def ^:const envoy-upstream-connection-termination "UC")
 (def ^:const envoy-upstream-request-timeout "UT")
 
+;; waiter error cause constants
+(def ^:const error-cause-client-eagerly-closed :client-eagerly-closed)
+(def ^:const error-cause-client-error :client-error)
+(def ^:const error-cause-cors-error :cors-error)
+(def ^:const error-cause-deployment-error :deployment-error)
+(def ^:const error-cause-generic-error :generic-error)
+(def ^:const error-cause-instance-error :instance-error)
+(def ^:const error-cause-server-eagerly-closed :server-eagerly-closed)
+(def ^:const error-cause-service-description-error :service-description-error)
+(def ^:const error-cause-service-error :service-error)
+
 ;; waiter error class constants
 (def ^:const error-class-cors-preflight-forbidden "waiter.CorsPreflightForbidden")
 (def ^:const error-class-cors-request-forbidden "waiter.CorsRequestForbidden")


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for predicate function while building error context

## Why are we making these changes?

We would like to customize the support info entries displayed on error responses. This allows providing more specific instructions to the client on where to reach out for support.


