### PR TITLE
adds api support for expiring an instance

### DIFF
--- a/waiter/src/waiter/scheduler.clj
+++ b/waiter/src/waiter/scheduler.clj
@@ -1435,6 +1435,16 @@
 (defn supported-signal-type?
   "Returns true if the signal-type is supported."
   [signal-type]
+  (contains? #{:signal/expire :signal/force-kill :signal/soft-kill} signal-type))
+
+(defn expire-signal-type?
+  "Returns true if the signal-type represents an expire operation."
+  [signal-type]
+  (contains? #{:signal/expire} signal-type))
+
+(defn kill-signal-type?
+  "Returns true if the signal-type represents a kill operation."
+  [signal-type]
   (contains? #{:signal/force-kill :signal/soft-kill} signal-type))
 
 (defn resolve-signal-type
@@ -1444,4 +1454,5 @@
   (cond
     (= :kill operation) (if (-> force (str) (Boolean/valueOf))
                           :signal/force-kill
-                          :signal/soft-kill)))
+                          :signal/soft-kill)
+    (= :expire operation) :signal/expire))

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -2153,8 +2153,8 @@
                      :query-string (str "timeout=" 1000)}
             {:keys [body headers status]}
             (async/<!!
-              (instance-kill-signal-handler notify-instance-killed-fn allowed-to-manage-service?-fn scheduler
-                                            timeout-config service-id->service-description-fn scale-service-thread-pool request))]
+              (instance-signal-handler notify-instance-killed-fn allowed-to-manage-service?-fn scheduler
+                                       timeout-config scale-service-thread-pool :kill request))]
         (is (= http-200-ok status))
         (is (= "application/json" (get headers "content-type")))
         (let [body-json (json/read-str (str body))]
@@ -2172,8 +2172,8 @@
                      :basic-authentication {:src-router-id src-router-id}
                      :query-string (str "timeout=" 1000)}
             {:keys [body status]}
-            (instance-kill-signal-handler notify-instance-killed-fn allowed-to-manage-service?-fn scheduler
-                                          timeout-config service-id->service-description-fn scale-service-thread-pool request)]
+            (instance-signal-handler notify-instance-killed-fn allowed-to-manage-service?-fn scheduler
+                                     timeout-config scale-service-thread-pool :kill request)]
         (is (= http-403-forbidden status))
         (is (str/includes? (str body) "User not allowed to send signal to instance"))))
     (testing "signal-handler:Request Method Not Allowed"
@@ -2188,8 +2188,8 @@
                      :basic-authentication {:src-router-id src-router-id}
                      :query-string (str "timeout=" 1000)}
             signal-handler (core/wrap-error-handling
-                             #(instance-kill-signal-handler notify-instance-killed-fn allowed-to-manage-service?-fn scheduler
-                                                            timeout-config service-id->service-description-fn scale-service-thread-pool %))
+                             #(instance-signal-handler notify-instance-killed-fn allowed-to-manage-service?-fn scheduler
+                                                       timeout-config scale-service-thread-pool :kill %))
             {:keys [body headers status]} (signal-handler request)]
         (is (= http-405-method-not-allowed status))
         (is (= "application/json" (get headers "content-type")))
@@ -2208,8 +2208,8 @@
                      :query-string (str "timeout=" 1000)}
             {:keys [body headers status]}
             (async/<!!
-              (instance-kill-signal-handler notify-instance-killed-fn allowed-to-manage-service?-fn scheduler
-                                            timeout-config service-id->service-description-fn scale-service-thread-pool request))]
+              (instance-signal-handler notify-instance-killed-fn allowed-to-manage-service?-fn scheduler
+                                       timeout-config scale-service-thread-pool :kill request))]
         (is (= http-500-internal-server-error status))
         (is (= "application/json" (get headers "content-type")))
         (let [body-json (json/read-str (str body))]


### PR DESCRIPTION
## Changes proposed in this PR

- adds api support for expiring an instance

## Why are we making these changes?

We have had the need to expire instances, e.g. due to the node/container running the pod going bad. Exposing the ability to expire such instances in the API enables users to expire their instances when they detect such bad instances.

