### PR TITLE
adds support for dynamically generating support-info links

### DIFF
--- a/waiter/src/waiter/settings.clj
+++ b/waiter/src/waiter/settings.clj
@@ -206,7 +206,8 @@
    (s/required-key :support-info) [{(s/required-key :label) schema/non-empty-string
                                     (s/optional-key :link) {(s/required-key :type) s/Keyword
                                                             (s/required-key :value) schema/non-empty-string}
-                                    (s/optional-key :predicate-fn) s/Symbol}]
+                                    (s/optional-key :predicate-fn) s/Symbol
+                                    (s/optional-key :variables) [s/Keyword]}]
    (s/required-key :token-config) {(s/required-key :cluster-calculator) (s/constrained
                                                                           {:kind s/Keyword
                                                                            s/Keyword schema/require-symbol-factory-fn}


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for dynamically generating support-info links

## Why are we making these changes?

We wish to be able to dynamically generate support links on error pages to be able to better point clients to support locations.


