### PR TITLE
adds support for expiring an instance via the CLI

### DIFF
--- a/cli/waiter/cli.py
+++ b/cli/waiter/cli.py
@@ -25,9 +25,15 @@ actions = {
     'delete': {
         'run-function': delete.register(subparsers.add_parser)
     },
+    'ensure-ssl': {
+        'run-function': ssl.register(subparsers.add_parser)
+    },
     'init': {
         'run-function': init.register(subparsers.add_parser),
         'implicit-args-function': init.add_implicit_arguments
+    },
+    'instance': {
+        'run-function': instance.register(subparsers.add_parser)
     },
     'kill': {
         'run-function': kill.register(subparsers.add_parser)
@@ -37,12 +43,6 @@ actions = {
     },
     'ping': {
         'run-function': ping.register(subparsers.add_parser)
-    },
-    'ensure-ssl': {
-        'run-function': ssl.register(subparsers.add_parser)
-    },
-    'instance': {
-        'run-function': instance.register(subparsers.add_parser)
     },
     'ready': {
         'run-function': ready.register(subparsers.add_parser)

--- a/cli/waiter/subcommands/instance.py
+++ b/cli/waiter/subcommands/instance.py
@@ -5,7 +5,7 @@ from waiter.instance_select import Destination, get_instance_id_from_destination
 from waiter.util import check_positive, guard_no_cluster, logging
 
 
-def kill_instance(clusters, args, _, enforce_cluster):
+def _signal_instance_helper(clusters, args, _, enforce_cluster, operation):
     guard_no_cluster(clusters)
 
     token_or_service_id_or_instance_id = args.pop('token-or-service-id-or-instance-id')
@@ -22,15 +22,20 @@ def kill_instance(clusters, args, _, enforce_cluster):
 
     query_params = {'force': force_flag}
     if timeout_secs is not None:
-        query_params['timeout'] = timeout_secs
-    success = process_signal_request(clusters, instance_id, "kill", query_params)
+        query_params['timeout'] = int(timeout_secs * 1000)
+    success = process_signal_request(clusters, instance_id, operation, query_params)
     return 0 if success else 1
 
 
-def register_kill(add_parser):
-    """Adds this sub-command's parser and returns the action function"""
-    parser = add_parser('kill', help='sends kill to selected instance')
+def expire_instance(clusters, args, _, enforce_cluster):
+    _signal_instance_helper(clusters, args, _, enforce_cluster, "expire")
 
+
+def kill_instance(clusters, args, _, enforce_cluster):
+    _signal_instance_helper(clusters, args, _, enforce_cluster, "kill")
+
+
+def _register_token_or_service_id_or_instance_id(parser):
     parser.add_argument('token-or-service-id-or-instance-id')
     id_group = parser.add_mutually_exclusive_group(required=False)
     id_group.add_argument('--token', '-t', dest='signal_destination', action='store_const', const=Destination.TOKEN,
@@ -40,8 +45,26 @@ def register_kill(add_parser):
     id_group.add_argument('--instance-id', '-i', dest='signal_destination', action='store_const',
                           const=Destination.INSTANCE_ID, help='signal directly to instance id')
 
-    parser.add_argument('--force', '-f', help='kill all services, never prompt', dest='force', action='store_true')
-    parser.add_argument('--timeout', help='timeout (in seconds) for kill to complete',
+
+def register_expire(add_parser):
+    """Adds the expire sub-command's parser and returns the action function"""
+    parser = add_parser('expire', help='expires the selected instance')
+
+    _register_token_or_service_id_or_instance_id(parser)
+    parser.add_argument('--timeout', help='timeout (in seconds) for expire operation to complete',
+                        required=False, type=check_positive)
+    parser.set_defaults(sub_func=expire_instance)
+
+    return expire_instance
+
+
+def register_kill(add_parser):
+    """Adds the kill sub-command's parser and returns the action function"""
+    parser = add_parser('kill', help='kills the selected instance')
+
+    _register_token_or_service_id_or_instance_id(parser)
+    parser.add_argument('--force', '-f', help='force kill instance', dest='force', action='store_true')
+    parser.add_argument('--timeout', help='timeout (in seconds) for kill operation to complete',
                         required=False, type=check_positive)
     parser.set_defaults(sub_func=kill_instance)
 
@@ -66,5 +89,6 @@ def register(add_parser):
                         help='manage instance(s) for a token or service',
                         description='Manage instance(s) for a token or service.')
     subparsers = parser.add_subparsers()
+    register_expire(subparsers.add_parser)
     register_kill(subparsers.add_parser)
     return partial(signal_instance, parser)

--- a/waiter/src/waiter/handler.clj
+++ b/waiter/src/waiter/handler.clj
@@ -1328,7 +1328,7 @@
         options-map (-> query-params
                         (update "force" utils/parse-boolean)
                         (update "timeout" utils/parse-int))]
-    (log/info "received request to kill instance" instance-id "with query parameters" query-params)
+    (log/info "received request to" (name operation) "instance" instance-id "with query parameters" query-params)
     (cond
       (not= request-method :post)
       (do
@@ -1338,7 +1338,7 @@
 
       (not (allowed-to-manage-service?-fn service-id auth-user))
       (utils/exception->response
-        (ex-info "User not allowed to send signal to instance"
+        (ex-info (str "User not allowed to " (name operation) " instance")
                  {:current-user auth-user
                   :instance-id instance-id
                   :log-level :info

--- a/waiter/test/waiter/handler_test.clj
+++ b/waiter/test/waiter/handler_test.clj
@@ -2138,6 +2138,7 @@
                         :max-eject-time-ms 60000}
         service-id->service-description-fn (constantly {})
         scale-service-thread-pool (Executors/newFixedThreadPool 1)]
+
     (testing "signal-handler:success-true"
       (let [scheduler (reify scheduler/ServiceScheduler
                         (signal-instance [_ service-id instance-id _ _]
@@ -2160,6 +2161,7 @@
         (let [body-json (json/read-str (str body))]
           (is (= {"message" (str "kill successfully sent to " test-instance-id) "success" true}
                  (get body-json "signal-response"))))))
+
     (testing "signal-handler:User not Auth"
       (let [scheduler (reify scheduler/ServiceScheduler
                         (signal-instance [_ service-id instance-id _ _]
@@ -2175,7 +2177,8 @@
             (instance-signal-handler notify-instance-killed-fn allowed-to-manage-service?-fn scheduler
                                      timeout-config scale-service-thread-pool :kill request)]
         (is (= http-403-forbidden status))
-        (is (str/includes? (str body) "User not allowed to send signal to instance"))))
+        (is (str/includes? (str body) "User not allowed to kill instance"))))
+
     (testing "signal-handler:Request Method Not Allowed"
       (let [scheduler (reify scheduler/ServiceScheduler
                         (signal-instance [_ service-id instance-id _ _]
@@ -2194,6 +2197,7 @@
         (is (= http-405-method-not-allowed status))
         (is (= "application/json" (get headers "content-type")))
         (is (= {"message" "Method not allowed"} (json/read-str (str body))))))
+
     (testing "signal-handler:success-false"
       (let [scheduler (reify scheduler/ServiceScheduler
                         (signal-instance [_ service-id instance-id _ _]


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for expiring an instance via the CLI
- fixes messaging around instance signal operations
- refactors CLI kill signal tests

## Why are we making these changes?

Allows users to expire individual instances using the CLI. Expired instances are replaced by Waiter after preparing a healthy replacement first. This incremental instance replacement avoids downtime for the service.


