### PR TITLE
includes the ping response error message in CLI output

### DIFF
--- a/cli/waiter/util.py
+++ b/cli/waiter/util.py
@@ -75,14 +75,14 @@ def str2bool(v):
         return None
 
 
-def response_message(resp_json):
+def response_message(resp_json, default_message='Encountered unexpected error.'):
     """Pulls the error message out of a Waiter response"""
     if 'waiter-error' in resp_json and 'message' in resp_json['waiter-error']:
         message = resp_json['waiter-error']['message']
         if not message.endswith('.'):
             message = f'{message}.'
     else:
-        message = 'Encountered unexpected error.'
+        message = default_message
     return message
 
 


### PR DESCRIPTION
## Changes proposed in this PR

- includes the ping response error message in CLI output

## Why are we making these changes?

Improves the user experience and debuggability by reporting the error message in the CLI output.

## Examples

### Before:
```
$ waiter --url http://localhost:9091 ping kitchen.localtest.me --timeout 10
Pinging token kitchen.localtest.me in http://localhost:9091...
Encountered error while pinging in http://localhost:9091.

$ waiter --url http://localhost:9091 ping kitchen.localtest.me
Pinging token kitchen.localtest.me in http://localhost:9091...
Ping responded with non-200 status 503.
Deployment error: Invalid startup command

$ waiter --url http://localhost:9091 ping kitchen.localtest.me
Pinging token kitchen.localtest.me in http://localhost:9091...
Ping responded with non-200 status 400.
Service description using waiter headers/token improperly configured
cmd must be a non-empty string.
mem must be a positive number.
version must be a non-empty string.
```

### After:
```
$ waiter --url http://localhost:9091 ping kitchen.localtest.me --timeout 10
Pinging token kitchen.localtest.me in http://localhost:9091...
Encountered error while pinging in http://localhost:9091: HTTPConnectionPool(host='localhost', port=9091): Read timed out. (read timeout=10).

$ waiter --url http://localhost:9091 ping kitchen.localtest.me
Pinging token kitchen.localtest.me in http://localhost:9091...
Ping responded with non-200 status 503.
Deployment error: Invalid startup command.

$ waiter --url http://localhost:9091 ping kitchen.localtest.me
Pinging token kitchen.localtest.me in http://localhost:9091...
Ping responded with non-200 status 400.
Service description using waiter headers/token improperly configured
cmd must be a non-empty string.
mem must be a positive number.
version must be a non-empty string.
```
