### PR TITLE
adds hostname for service instances created by kubernetes

### DIFF
--- a/waiter/integration/waiter/health_check_test.clj
+++ b/waiter/integration/waiter/health_check_test.clj
@@ -44,6 +44,8 @@
         (is (not (str/blank? (get-in ping-response [:instance :host]))) (str ping-response))
         (is (not (str/blank? (get-in ping-response [:instance :id]))) (str ping-response))
         (is (number? (get-in ping-response [:instance :port])) (str ping-response))
+        (when (using-k8s? waiter-url)
+          (is (not (str/blank? (get-in ping-response [:instance :k8s/hostname]))) (str ping-response)))
         (if (utils/param-contains? query-params "exclude" "service-state")
           (is (= {:result "excluded" :service-id service-id} service-state))
           (is (= {:exists? true :healthy? true :service-id service-id :status "Running"} service-state))))

--- a/waiter/src/waiter/process_request.clj
+++ b/waiter/src/waiter/process_request.clj
@@ -1188,9 +1188,7 @@
               {:ping-response (cond-> (-> ping-response
                                           (select-keys [:body :headers :status])
                                           (assoc :result response-result))
-                                response-instance (assoc :instance {:host (:host response-instance)
-                                                                    :id (:id response-instance)
-                                                                    :port (:port response-instance)}))
+                                response-instance (assoc :instance (select-keys response-instance [:host :id :k8s/hostname :port])))
                :service-description core-service-description
                :service-state service-state}
               :headers (if redirect-ping? (:headers redirect-response) {})

--- a/waiter/test/waiter/scheduler/kubernetes_test.clj
+++ b/waiter/test/waiter/scheduler/kubernetes_test.clj
@@ -1426,6 +1426,7 @@
                                                 :restart-count 0
                                                 :state :waiting
                                                 :type :app}]
+                      :k8s/hostname "test-app-1234-abcd0.p.myself.svc."
                       :k8s/node-name "node-0.k8s.com"
                       :k8s/pod-phase "Pending"
                       :k8s/revision-timestamp "2020-09-22T20:00:00.000Z"
@@ -1444,6 +1445,7 @@
                                                 :restart-count 0
                                                 :state :running
                                                 :type :app}]
+                      :k8s/hostname "test-app-1234-abcd1.p.myself.svc."
                       :k8s/pod-phase "Running"
                       :k8s/revision-timestamp "2020-09-22T20:11:11.000Z"
                       :k8s/revision-version "0"
@@ -1461,6 +1463,7 @@
                                                 :ready true
                                                 :restart-count 0
                                                 :type :app}]
+                      :k8s/hostname "test-app-1234-abcd2.p.myself.svc."
                       :k8s/node-name "node-2.k8s.com"
                       :k8s/revision-timestamp "2020-09-22T20:22:22.000Z"
                       :k8s/revision-version "1"
@@ -1480,6 +1483,7 @@
                                                 :restart-count 0
                                                 :state :running
                                                 :type :app}]
+                      :k8s/hostname "test-app-1234-abcd3.p.myself.svc."
                       :k8s/pod-phase "Failed"
                       :k8s/revision-timestamp "2020-09-22T20:11:11.000Z"
                       :log-directory "/home/myself/r0"
@@ -1508,6 +1512,7 @@
                                                 :ready true
                                                 :restart-count 0
                                                 :type :app}]
+                      :k8s/hostname "test-app-6789-abcd1.p.myself.svc."
                       :log-directory "/home/myself/r0"
                       :port 8080
                       :service-id "test-app-6789"
@@ -1520,6 +1525,7 @@
                       :k8s/container-statuses [{:name waiter-primary-container-name
                                                 :restart-count 1
                                                 :type :app}]
+                      :k8s/hostname "test-app-6789-abcd2.p.myself.svc."
                       :log-directory "/home/myself/r1"
                       :port 8080
                       :service-id "test-app-6789"
@@ -1532,6 +1538,7 @@
                       :k8s/container-statuses [{:name waiter-primary-container-name
                                                 :restart-count 0
                                                 :type :app}]
+                      :k8s/hostname "test-app-6789-abcd3.p.myself.svc."
                       :log-directory "/home/myself/r0"
                       :port 8080
                       :service-id "test-app-6789"
@@ -1549,6 +1556,7 @@
                                                 :ready false
                                                 :restart-count 200
                                                 :type :init}]
+                      :k8s/hostname "test-app-6789-abcd4.p.myself.svc."
                       :log-directory "/home/myself/r0"
                       :port 8080
                       :service-id "test-app-6789"
@@ -1563,6 +1571,7 @@
                       :k8s/container-statuses [{:name waiter-primary-container-name
                                                 :restart-count 1
                                                 :type :app}]
+                      :k8s/hostname "test-app-6789-abcd2.p.myself.svc."
                       :log-directory "/home/myself/r0"
                       :port 8080
                       :service-id "test-app-6789"
@@ -3013,6 +3022,7 @@
                       :started-at (timestamp-str->datetime pod-start-time-k8s-str)
                       :k8s/api-server-url api-server-url
                       :k8s/app-name service-id
+                      :k8s/hostname "test-app-1234-abcd1.p.myself.svc."
                       :k8s/container-statuses [{:name waiter-primary-container-name
                                                 :ready true
                                                 :restart-count 9


### PR DESCRIPTION
## Changes proposed in this PR

- adds hostname for service instances created by kubernetes
- includes k8s hostname in ping response

## Why are we making these changes?

Exposing the hostname allows users of the IP to not need to use reverse DNS when trying to determine the name of the host. This name may be need for TLS certificate validation.

