### PR TITLE
adds support for expected version and image parameters in ready command

### DIFF
--- a/cli/integration/tests/waiter/cli.py
+++ b/cli/integration/tests/waiter/cli.py
@@ -367,9 +367,9 @@ def ready(waiter_url=None, token_name=None, flags=None, ready_flags=None):
     """Checks if a token is ready for traffic via the CLI"""
     if not ready_flags:
         ready_flags = ''
-    if '--timeout' not in ready_flags:
-        ready_flags += f' --timeout {int(util.DEFAULT_TIMEOUT_MS/1000)}'
-    args = f'ready {token_name or ""} {ready}'
+    if '--ping-timeout' not in ready_flags:
+        ready_flags += f' --ping-timeout {int(util.DEFAULT_TIMEOUT_MS/1000)}'
+    args = f'ready {token_name or ""} {ready_flags}'
     cp = cli(args, waiter_url, flags)
     return cp
 

--- a/cli/integration/tests/waiter/test_cli.py
+++ b/cli/integration/tests/waiter/test_cli.py
@@ -616,6 +616,51 @@ class WaiterCliTest(util.WaiterTest):
         finally:
             util.delete_token(self.waiter_url, token_name, kill_services=True)
 
+    def test_ready_expected_version_failure(self):
+        token_name = self.token_name()
+        service_description = util.minimal_service_description()
+        util.post_token(self.waiter_url, token_name, service_description)
+        try:
+            self.assertEqual(0, len(util.services_for_token(self.waiter_url, token_name)))
+            version = "foo-bar"
+            cp = cli.ready(self.waiter_url, token_name, ready_flags=f'--version {version}')
+            self.assertEqual(1, cp.returncode, cp.stderr)
+            self.assertIn('Pinging token', cli.stdout(cp))
+            self.assertIn(f'version has value of "{service_description["version"]}", require it to be "{version}"',
+                          cli.stderr(cp))
+            self.assertEqual(1, len(util.services_for_token(self.waiter_url, token_name)))
+        finally:
+            util.delete_token(self.waiter_url, token_name, kill_services=True)
+
+    @unittest.skipIf('WAITER_TEST_CLI_TLS' not in os.environ, 'waiter tokens may not support tls.')
+    def test_ready_expected_version_lazy_update_success(self):
+        token_name = self.token_name()
+        service_description = util.minimal_service_description()
+        util.post_token(self.waiter_url, token_name, service_description)
+        version = "foo-bar"
+
+        try:
+            def update_expected_version_test_ready_expected_version_lazy_update_success():
+                inner_service_description = service_description.copy()
+                inner_service_description["version"] = version
+                util.post_token(self.waiter_url, token_name, inner_service_description)
+
+            # update the token version after a delay
+            threading.Timer(15, update_expected_version_test_ready_expected_version_lazy_update_success).start()
+
+            self.assertEqual(0, len(util.services_for_token(self.waiter_url, token_name)))
+            cp = cli.ready(self.waiter_url, token_name, ready_flags=f'--version {version}')
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            self.assertIn('Pinging token', cli.stdout(cp))
+            self.assertIn('successful', cli.stdout(cp))
+            self.assertIn('Service is currently', cli.stdout(cp))
+            self.assertTrue(any(s in cli.stdout(cp) for s in ['Running', 'Starting']))
+            self.assertIn('Successfully connected to', cli.stdout(cp))
+            self.assertIn(f'{token_name}:443', cli.stdout(cp))
+            util.wait_until_services_for_token(self.waiter_url, token_name, 2)
+        finally:
+            util.delete_token(self.waiter_url, token_name, kill_services=True)
+
     def test_kill_token_and_then_ping(self):
         token_name = self.token_name()
         util.post_token(self.waiter_url, token_name, util.minimal_service_description())

--- a/cli/waiter/subcommands/kill.py
+++ b/cli/waiter/subcommands/kill.py
@@ -15,8 +15,9 @@ def kill(clusters, args, _, __):
     if success and ping_token_name_or_service_id:
         ping_timeout_secs = args.get('ping_timeout')
         ping_wait = args.get('ping_wait', True)
+        expected_parameters = {}
         ping_success = process_ping_request(clusters, token_name_or_service_id, is_service_id,
-                                            ping_timeout_secs, ping_wait)
+                                            expected_parameters, ping_timeout_secs, ping_wait)
         return 0 if ping_success else 1
     else:
         return 0 if success else 1

--- a/cli/waiter/subcommands/maintenance.py
+++ b/cli/waiter/subcommands/maintenance.py
@@ -113,7 +113,9 @@ def stop_maintenance(clusters, args, _, enforce_cluster):
     if return_code == 0:
         if ping_token:
             if token_etag:
-                success = ping_token_on_cluster(cluster, token_name, timeout, wait_for_ping, token_etag)
+                expected_parameters = {}
+                success = ping_token_on_cluster(cluster, token_name, expected_parameters,
+                                                timeout, wait_for_ping, token_etag)
                 return 0 if success else 1
             else:
                 logging.debug(f'Not pinging token {token_name} in {cluster} as token ETag is missing.')

--- a/cli/waiter/subcommands/ping.py
+++ b/cli/waiter/subcommands/ping.py
@@ -10,8 +10,9 @@ def ping(clusters, args, _, __):
     is_service_id = args.get('is-service-id', False)
     timeout_secs = args.get('timeout', None)
     wait_for_request = args.get('wait', True)
+    expected_parameters = {}
     ping_success = process_ping_request(clusters, token_name_or_service_id, is_service_id,
-                                        timeout_secs, wait_for_request)
+                                        expected_parameters, timeout_secs, wait_for_request)
     return 0 if ping_success else 1
 
 


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for expected version and image parameters in the ready command

## Why are we making these changes?

Waiter services can run different versions of their services without modifying tokens by specifying certain parameters, e.g. their version and image parameters. This feature allows users to specify the specific parameter (image or version) of the service that they expect the ready command to end up starting.

