### PR TITLE
cli: release version 1.5.7

### DIFF
--- a/cli/waiter/version.py
+++ b/cli/waiter/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.5.7'
+VERSION = '1.5.8-dev0'

--- a/cli/waiter/version.py
+++ b/cli/waiter/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.5.7-dev0'
+VERSION = '1.5.7'


### PR DESCRIPTION
## Changes proposed in this PR

- [cli: release version 1.5.7](https://github.com/twosigma/waiter/commit/ff5d9b21b4bb13cdfdcf908920718149b78003de)
- [cli: bump waiter-cli version to 1.5.8-dev0](https://github.com/twosigma/waiter/commit/d6993d964e6932feb5ef27cb01d139c033bc3dad)

## Why are we making these changes?

Releases a new version of the CLI.
